### PR TITLE
Fixing a bug where Firefox replays a video on ending

### DIFF
--- a/video.js
+++ b/video.js
@@ -544,8 +544,8 @@ var VideoJS = JRClass.extend({
 
   // When the video ends
   onEnded: function(event){
-    this.video.pause();
     this.video.currentTime = 0;
+    this.video.pause();
     this.showPoster();
     this.showBigPlayButton();
     this.onPause();


### PR DESCRIPTION
Hi, in Firefox videos are currently replaying from the beginning once they complete. I believe setting the current time of the video to 0 before pausing it (as opposed to the other way around) fixes the bug.

Thanks!
-Gabriel
