### PR TITLE
CSS re-order

### DIFF
--- a/skins/hu.css
+++ b/skins/hu.css
@@ -12,8 +12,8 @@ Version 2.0.0
 .hu-css .vjs-controls > div {
   top: 0;
   background: none;
-  border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0;
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 
 /* Top Level Items */
@@ -46,9 +46,9 @@ Version 2.0.0
   height: 19px; border: none;
   margin: 0px 0px 0 0px; /* Placement within the progress control item */
   background: #000;
-  border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0;
+  -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;
 }
-.hu-css .vjs-progress-holder div { height: 13px; margin-top: 3px; border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0; }
+.hu-css .vjs-progress-holder div { height: 13px; margin-top: 3px; -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0; }
 .hu-css .vjs-play-progress {
   /* Default */ background: #777;
   /* Webkit  */ background: -webkit-gradient(linear, left top, left bottom, from(#999), to(#777));
@@ -97,15 +97,15 @@ Version 2.0.0
 .hu-css div.vjs-big-play-button {
   width: 76px; height: 70px; margin: -35px 0 0 -38px;
   border: 1px solid #ccc; opacity: 0.8;
-  border-radius: 0px; -webkit-border-radius: 0px; -moz-border-radius: 0px;
+  -webkit-border-radius: 0px; -moz-border-radius: 0px; border-radius: 0px;
 
   background: rgba(50,50,50,0.8);
 
   /* CSS Shadows */
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 .hu-css div.vjs-big-play-button:hover {
-  box-shadow: 0px 0px 80px #fff; -webkit-box-shadow: 0px 0px 80px #fff; -moz-box-shadow: 0px 0px 80px #fff;
+  -webkit-box-shadow: 0px 0px 80px #fff; -moz-box-shadow: 0px 0px 80px #fff; box-shadow: 0px 0px 80px #fff;
 }
 .hu-css div.vjs-big-play-button span {
   margin: 16px 0 0 21px;

--- a/skins/tube.css
+++ b/skins/tube.css
@@ -15,8 +15,8 @@ Version 2.0.0
 .tube-css .vjs-controls > div {
   height: 23px; margin: 0; background: none; top: 0;
   border: 1px solid #b1b1b1; border-left-color: #eee;
-  border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0;
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 
 /* Placement of Control Items */
@@ -52,9 +52,9 @@ Version 2.0.0
   background: #b1b1b1 -webkit-gradient(linear, left top, left bottom, from(#b1b1b1), to(#cacaca)) left top;
   background: #b1b1b1 -moz-linear-gradient(top,  #b1b1b1,  #cacaca) left top;
   border-color: #CACACA; border-bottom-color: #eaeaea;
-  border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0;
+  -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;
 }
-.tube-css .vjs-progress-control .vjs-load-progress { background: #C89191; border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0; }
+.tube-css .vjs-progress-control .vjs-load-progress { background: #C89191; -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0; }
 .tube-css .vjs-progress-control .vjs-play-progress { background: #f33; background: -webkit-gradient(linear, left top, left bottom, from(#f33), to(#CF1A1A)); background: -moz-linear-gradient(top,  #f33,  #CF1A1A); -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0; }
 
 /* Volume
@@ -89,7 +89,7 @@ Version 2.0.0
 .tube-css div.vjs-big-play-button { 
   width: 84px; height: 58px; margin: -29px 0 0 -42px;
   border: 2px solid #ccc; opacity: 0.9;
-  border-radius: 10px; -webkit-border-radius: 10px; -moz-border-radius: 10px;
+  -webkit-border-radius: 10px; -moz-border-radius: 10px; border-radius: 10px;
 
   /* CSS Background Gradients */
   /* Default */ background-color: #333;
@@ -97,7 +97,7 @@ Version 2.0.0
   /* Firefox */ background: #000 -moz-linear-gradient(top,  #000,  #333) left 29px;
 
   /* CSS Shadows */
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 .tube-css div.vjs-big-play-button:hover {
   opacity: 1;

--- a/skins/vim.css
+++ b/skins/vim.css
@@ -8,8 +8,8 @@ Version 2.0.0
 }
 .vim-css .vjs-controls > div {
   height: 32px; top: 18px; padding: 0; text-align: center; background: rgba(23, 35, 34, 0.746094);
-  border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0;
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 /* Placement of Control Items */
 .vim-css .vjs-controls > div.vjs-play-control       { width: 65px; left: 10px; }
@@ -20,17 +20,17 @@ Version 2.0.0
 
 /* Play/Pause
 -------------------------------------------------------------------------------- */
-.vim-css .vjs-controls .vjs-play-control { top: 10px; margin: 0; height: 40px;  border-radius: 5px; -webkit-border-radius: 5px; -moz-border-radius: 5px; }
+.vim-css .vjs-controls .vjs-play-control { top: 10px; margin: 0; height: 40px;  -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; }
 .vim-css .vjs-play-control:hover { background: #00ADEF; }
 .vim-css.vjs-paused .vjs-play-control span { border-left-color: #fff; border-top-width: 9px; border-left-width: 18px; border-bottom-width: 9px; margin: 11px 0 0 24px; }
 .vim-css.vjs-playing .vjs-play-control span { width: 5px; height: 18px; margin: 5px auto 0; border-left: 5px solid #fff; border-right: 5px solid #fff; margin: 11px 0 0 24px; }
 
 /* Progress
 -------------------------------------------------------------------------------- */
-.vim-css .vjs-controls .vjs-progress-control { border-radius: 5px 0 0 5px; -webkit-border-radius: 5px 0 0 5px; -moz-border-radius: 5px 0 0 5px; }
-.vim-css .vjs-progress-control .vjs-progress-holder { height: 8px; padding: 1px; margin: 10px 5px 0 10px; border-color: #666666; border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0; }
-.vim-css .vjs-progress-control .vjs-play-progress { height: 8px; background: #00ADEF; border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0; }
-.vim-css .vjs-progress-control .vjs-load-progress { height: 8px; background: #898F8F; border-radius: 0; -webkit-border-radius: 0; -moz-border-radius: 0; }
+.vim-css .vjs-controls .vjs-progress-control { -webkit-border-radius: 5px 0 0 5px; -moz-border-radius: 5px 0 0 5px; border-radius: 5px 0 0 5px;}
+.vim-css .vjs-progress-control .vjs-progress-holder { height: 8px; padding: 1px; margin: 10px 5px 0 10px; border-color: #666666; -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0;}
+.vim-css .vjs-progress-control .vjs-play-progress { height: 8px; background: #00ADEF; -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0; }
+.vim-css .vjs-progress-control .vjs-load-progress { height: 8px; background: #898F8F; -webkit-border-radius: 0; -moz-border-radius: 0; border-radius: 0; }
 
 /* Time Display
 -------------------------------------------------------------------------------- */
@@ -50,7 +50,7 @@ Version 2.0.0
 /* Fullscreen
 -------------------------------------------------------------------------------- */
 .vim-css .vjs-fullscreen-control div { margin: 10px 0 0 0; }
-.vim-css .vjs-controls .vjs-fullscreen-control { border-radius: 0 5px 5px 0; -webkit-border-radius: 0 5px 5px 0; -moz-border-radius: 0 5px 5px 0; }
+.vim-css .vjs-controls .vjs-fullscreen-control { -webkit-border-radius: 0 5px 5px 0; -moz-border-radius: 0 5px 5px 0; border-radius: 0 5px 5px 0; }
 /* Making default fullscreen icon smaller */
 .vim-css .vjs-fullscreen-control div span:nth-child(1) { margin: 0 4px 4px 0; border: none; border-top: 4px solid #fff; border-right: 4px solid rgba(0,0,0,0); }
 .vim-css .vjs-fullscreen-control div span:nth-child(2) { border: none; border-top: 4px solid #fff; border-left: 4px solid rgba(0,0,0,0); }
@@ -69,12 +69,12 @@ Version 2.0.0
 .vim-css div.vjs-big-play-button {
   width: 130px; height: 80px; margin: -40px 0 0 -65px;
   border: none; opacity: 0.9;
-  border-radius: 10px; -webkit-border-radius: 10px; -moz-border-radius: 10px;
+  -webkit-border-radius: 10px; -moz-border-radius: 10px; border-radius: 10px;
 
   background: rgba(23, 35, 34, 0.746094);
 
   /* CSS Shadows */
-  box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none;
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
 }
 .vim-css div.vjs-big-play-button:hover {
   background: #00ADEF;

--- a/video-js.css
+++ b/video-js.css
@@ -66,10 +66,10 @@ so you can upgrade to newer versions easier. */
   /* Firefox */ background: #1F3744 -moz-linear-gradient(top,  #0B151A,  #1F3744) left 12px;
 
   /* CSS Curved Corners */
-  border-radius: 5px; -webkit-border-radius: 5px; -moz-border-radius: 5px;
+  -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px;
 
   /* CSS Shadows */
-  box-shadow: 1px 1px 2px #000; -webkit-box-shadow: 1px 1px 2px #000; -moz-box-shadow: 1px 1px 2px #000;
+  -webkit-box-shadow: 1px 1px 2px #000; -moz-box-shadow: 1px 1px 2px #000; box-shadow: 1px 1px 2px #000;
 }
 
 /* Placement of Control Items 
@@ -84,12 +84,12 @@ so you can upgrade to newer versions easier. */
 
 /* Removing curved corners on progress control and time control to join them. */
 .vjs-controls > div.vjs-progress-control {
-  border-top-right-radius: 0; -webkit-border-top-right-radius: 0; -moz-border-radius-topright: 0;
-  border-bottom-right-radius: 0; -webkit-border-bottom-right-radius: 0; -moz-border-radius-bottomright: 0;
+  -webkit-border-top-right-radius: 0; -moz-border-radius-topright: 0; border-top-right-radius: 0;
+  -webkit-border-bottom-right-radius: 0; -moz-border-radius-bottomright: 0; border-bottom-right-radius: 0;
 }
 .vjs-controls > div.vjs-time-control { 
-  border-top-left-radius: 0; -webkit-border-top-left-radius: 0; -moz-border-radius-topleft: 0;
-  border-bottom-left-radius: 0; -webkit-border-bottom-left-radius: 0; -moz-border-radius-bottomleft: 0;
+  -webkit-border-top-left-radius: 0; -moz-border-radius-topleft: 0; border-top-left-radius: 0;
+  -webkit-border-bottom-left-radius: 0; -moz-border-radius-bottomleft: 0; border-bottom-left-radius: 0;
 }
 
 /* Play/Pause
@@ -116,11 +116,11 @@ so you can upgrade to newer versions easier. */
   position: relative; padding: 0; overflow:hidden; cursor: pointer !important;
   height: 9px; border: 1px solid #777;
   margin: 7px 1px 0 5px; /* Placement within the progress control item */
-  border-radius: 5px; -webkit-border-radius: 5px; -moz-border-radius: 5px;
+  -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px;
 }
 .vjs-progress-holder div { /* Progress Bars */
   position: absolute; display: block; width: 0; height: 9px; margin: 0; padding: 0;
-  border-radius: 5px; -webkit-border-radius: 5px; -moz-border-radius: 5px;
+  -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px;
 }
 .vjs-play-progress {
   /* CSS Gradient */
@@ -196,7 +196,7 @@ div.vjs-big-play-button {
   display: none; /* Start hidden */ z-index: 2;
   position: absolute; top: 50%; left: 50%; width: 80px; height: 80px; margin: -43px 0 0 -43px; text-align: center; vertical-align: center; cursor: pointer !important;
   border: 3px solid #fff; opacity: 0.9;
-  border-radius: 20px; -webkit-border-radius: 20px; -moz-border-radius: 20px;
+  -webkit-border-radius: 20px; -moz-border-radius: 20px; border-radius: 20px;
   
   /* CSS Background Gradients */
   /* Default */ background-color: #0B151A;
@@ -204,10 +204,10 @@ div.vjs-big-play-button {
   /* Firefox */ background: #1F3744 -moz-linear-gradient(top,  #0B151A,  #1F3744) left 40px;
 
   /* CSS Shadows */
-  box-shadow: 4px 4px 8px #000; -webkit-box-shadow: 4px 4px 8px #000; -moz-box-shadow: 4px 4px 8px #000;
+  -webkit-box-shadow: 4px 4px 8px #000; -moz-box-shadow: 4px 4px 8px #000; box-shadow: 4px 4px 8px #000;
 }
 div.vjs-big-play-button:hover {
-  box-shadow: 0px 0px 80px #fff; -webkit-box-shadow: 0px 0px 80px #fff; -moz-box-shadow: 0px 0px 80px #fff;
+  -webkit-box-shadow: 0px 0px 80px #fff; -moz-box-shadow: 0px 0px 80px #fff; box-shadow: 0px 0px 80px #fff;
 }
 
 div.vjs-big-play-button span {
@@ -224,19 +224,19 @@ div.vjs-big-play-button span {
 /* CSS Spinners by Kilian Valkhof - http://kilianvalkhof.com/2010/css-xhtml/css3-loading-spinners-without-images/ */
 .vjs-spinner { display: none; position: absolute; top: 50%; left: 50%; width: 100px; height: 100px; z-index: 1; margin: -50px 0 0 -50px;
   /* Scaling makes the circles look smoother. */
-  transform: scale(0.5); -webkit-transform:scale(0.5); -moz-transform:scale(0.5);
+  -webkit-transform:scale(0.5); -moz-transform:scale(0.5); transform: scale(0.5);
 }
 /* Spinner circles */
 .vjs-spinner div { position:absolute; left: 40px; top: 40px; width: 20px; height: 20px; background: #fff;
-  border-radius: 20px; -webkit-border-radius: 20px; -moz-border-radius: 20px;
+  -webkit-border-radius: 20px; -moz-border-radius: 20px; border-radius: 20px;
   border: 1px solid #ccc; /* Added border so can be visible on white backgrounds */
 }
 /* Each circle */
-.vjs-spinner div:nth-child(1) { opacity: 0.12; transform: rotate(000deg) translate(0, -40px) scale(0.1); -webkit-transform: rotate(000deg) translate(0, -40px) scale(0.1); -moz-transform: rotate(000deg) translate(0, -40px) scale(0.1); }
-.vjs-spinner div:nth-child(2) { opacity: 0.25; transform: rotate(045deg) translate(0, -40px) scale(0.2); -webkit-transform: rotate(045deg) translate(0, -40px) scale(0.2); -moz-transform: rotate(045deg) translate(0, -40px) scale(0.2); }
-.vjs-spinner div:nth-child(3) { opacity: 0.37; transform: rotate(090deg) translate(0, -40px) scale(0.4); -webkit-transform: rotate(090deg) translate(0, -40px) scale(0.4); -moz-transform: rotate(090deg) translate(0, -40px) scale(0.4); }
-.vjs-spinner div:nth-child(4) { opacity: 0.50; transform: rotate(135deg) translate(0, -40px) scale(0.6); -webkit-transform: rotate(135deg) translate(0, -40px) scale(0.6); -moz-transform: rotate(135deg) translate(0, -40px) scale(0.6); }
-.vjs-spinner div:nth-child(5) { opacity: 0.62; transform: rotate(180deg) translate(0, -40px) scale(0.8); -webkit-transform: rotate(180deg) translate(0, -40px) scale(0.8); -moz-transform: rotate(180deg) translate(0, -40px) scale(0.8); }
-.vjs-spinner div:nth-child(6) { opacity: 0.75; transform: rotate(225deg) translate(0, -40px) scale(1.0); -webkit-transform: rotate(225deg) translate(0, -40px) scale(1.0); -moz-transform: rotate(225deg) translate(0, -40px) scale(1.0); }
-.vjs-spinner div:nth-child(7) { opacity: 0.87; transform: rotate(270deg) translate(0, -40px) scale(1.1); -webkit-transform: rotate(270deg) translate(0, -40px) scale(1.1); -moz-transform: rotate(270deg) translate(0, -40px) scale(1.1); }
-.vjs-spinner div:nth-child(8) { opacity: 1.00; transform: rotate(315deg) translate(0, -40px) scale(1.3); -webkit-transform: rotate(315deg) translate(0, -40px) scale(1.3); -moz-transform: rotate(315deg) translate(0, -40px) scale(1.3); }
+.vjs-spinner div:nth-child(1) { opacity: 0.12; -webkit-transform: rotate(000deg) translate(0, -40px) scale(0.1); -moz-transform: rotate(000deg) translate(0, -40px) scale(0.1); transform: rotate(000deg) translate(0, -40px) scale(0.1); }
+.vjs-spinner div:nth-child(2) { opacity: 0.25; -webkit-transform: rotate(045deg) translate(0, -40px) scale(0.2); -moz-transform: rotate(045deg) translate(0, -40px) scale(0.2); transform: rotate(045deg) translate(0, -40px) scale(0.2); }
+.vjs-spinner div:nth-child(3) { opacity: 0.37; -webkit-transform: rotate(090deg) translate(0, -40px) scale(0.4); -moz-transform: rotate(090deg) translate(0, -40px) scale(0.4); transform: rotate(090deg) translate(0, -40px) scale(0.4); }
+.vjs-spinner div:nth-child(4) { opacity: 0.50; -webkit-transform: rotate(135deg) translate(0, -40px) scale(0.6); -moz-transform: rotate(135deg) translate(0, -40px) scale(0.6); transform: rotate(135deg) translate(0, -40px) scale(0.6); }
+.vjs-spinner div:nth-child(5) { opacity: 0.62; -webkit-transform: rotate(180deg) translate(0, -40px) scale(0.8); -moz-transform: rotate(180deg) translate(0, -40px) scale(0.8); transform: rotate(180deg) translate(0, -40px) scale(0.8); }
+.vjs-spinner div:nth-child(6) { opacity: 0.75; -webkit-transform: rotate(225deg) translate(0, -40px) scale(1.0); -moz-transform: rotate(225deg) translate(0, -40px) scale(1.0); transform: rotate(225deg) translate(0, -40px) scale(1.0); }
+.vjs-spinner div:nth-child(7) { opacity: 0.87; -webkit-transform: rotate(270deg) translate(0, -40px) scale(1.1); -moz-transform: rotate(270deg) translate(0, -40px) scale(1.1); transform: rotate(270deg) translate(0, -40px) scale(1.1); }
+.vjs-spinner div:nth-child(8) { opacity: 1.00; -webkit-transform: rotate(315deg) translate(0, -40px) scale(1.3); -moz-transform: rotate(315deg) translate(0, -40px) scale(1.3); transform: rotate(315deg) translate(0, -40px) scale(1.3); }


### PR DESCRIPTION
Re-ordered the CSS for that the browser vendor prefixed elements were before the non-prefixed ones. This is the best way to "future-proof" the cascade as far as I know.
