### PR TITLE
Fix playback in Firefox for Android

### DIFF
--- a/dev/src/main.js
+++ b/dev/src/main.js
@@ -279,7 +279,7 @@ VideoJS.extend({
     var match = navigator.userAgent.match(/OS (\d+)_/i);
     if (match && match[1]) { return match[1]; }
   },
-  isAndroid: function(){ return navigator.userAgent.match(/Android/i) !== null; },
+  isAndroid: function(){ return navigator.userAgent.match(/Android.*AppleWebKit/i) !== null; },
   androidVersion: function() {
     var match = navigator.userAgent.match(/Android (\d+)\./i);
     if (match && match[1]) { return match[1]; }


### PR DESCRIPTION
This patch adds a stricter test for Android WebKit browsers. The previous test mistakenly used Android-WebKit-specific code for other browsers, like Opera and Firefox on Android.

(Firefox can play WebM and Theora but not H.264.  Current versions of VideoJS force it to try to play H.264.)
