### PR TITLE
Don't set invalid width/height if they're undefined

### DIFF
--- a/dev/src/html5.js
+++ b/dev/src/html5.js
@@ -329,8 +329,10 @@ VideoJS.fn.extend({
         this.element.style.height = (this.box.offsetHeight - this.controls.offsetHeight) + "px";
       }
     } else {
-      this.box.style.width = this.width() + "px";
-      this.element.style.height=this.height()+"px";
+      var width = this.width(),
+         height = this.height();
+      if (width) { this.box.style.width = width + "px"; }
+      if (height) { this.element.style.height = height + "px"; }
       if (this.options.controlsBelow) {
         this.element.style.height = "";
         // this.box.style.height = this.video.offsetHeight + this.controls.offsetHeight + "px";


### PR DESCRIPTION
I'm using Flowplayer which is placed inside a div and doesn't have a width or height attribute and is thus causing an error. This little fix makes sure not to attempt to set the width/height to "undefinedpx".
