### PR TITLE
Fixed Firefox/IE9 fullWindow bug 

### DIFF
--- a/design/video-js.css
+++ b/design/video-js.css
@@ -25,9 +25,12 @@ body.vjs-full-window {
   padding: 0; margin: 0;
   height: 100%; overflow-y: auto; /* Fix for IE6 full-window. http://www.cssplay.co.uk/layouts/fixed.html */
 }
-.video-js.vjs-fullscreen, .video-js:-webkit-full-screen {
+.video-js.vjs-fullscreen {
   position: fixed; overflow: hidden; z-index: 1000; left: 0; top: 0; bottom: 0; right: 0; width: 100% !important; height: 100% !important;
   _position: absolute; /* IE6 Full-window (underscore hack) */
+}
+.video-js:-webkit-full-screen {
+  width: 100% !important; height: 100% !important;
 }
 
 /* Subtiles Style */


### PR DESCRIPTION
Fixed bug preventing enterFullWindow from applying the .vjs-fullscreen style in Firefox/IE9
