### PR TITLE
Ensure that tracking progress and time progress will stop after destroy

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -107,7 +107,12 @@ _V_.Player = _V_.Component.extend({
   // Cache for video property values.
   values: {},
 
-  destroy: function(){},
+  destroy: function(){
+    // Ensure that tracking progress and time progress will stop and plater deleted
+    this.stopTrackingProgress();
+    this.stopTrackingCurrentTime();
+    delete _V_.players[this.id]
+  },
 
   createElement: function(type, options){
 


### PR DESCRIPTION
When player is played in dialog (say ui dialog) and dialog is closed it still send events and console show multiple errors. 
Calling destroy in dialog close code and proposed fix will ensure that player events will be stopped.

This happen with flash fallback only, but code is still useful because it delete element from players collection.
