### PR TITLE
Auto rewind on big button play click

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -167,6 +167,7 @@ _V_.BigPlayButton = _V_.Button.extend({
   },
 
   onClick: function(){
+    this.player.currentTime(0);
     this.player.play();
   }
 });


### PR DESCRIPTION
When video stops big button show.
But click does nothing. So I've added rewind to start.

Ideally, on ended event marker should be set to rewind on click and check this marker on click. 
But if big button is designed to be show only on start and end - it is enough to just rewind
