### PR TITLE
Hotfix: event-layer-x-deprecation-fix

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -288,7 +288,7 @@ _V_.Event.prototype = {
   isPropagationStopped: returnFalse,
   isImmediatePropagationStopped: returnFalse
 };
-_V_.Event.props = "altKey attrChange attrName bubbles button cancelable charCode clientX clientY ctrlKey currentTarget data detail eventPhase fromElement handler keyCode layerX layerY metaKey newValue offsetX offsetY pageX pageY prevValue relatedNode relatedTarget screenX screenY shiftKey srcElement target toElement view wheelDelta which".split(" ");
+_V_.Event.props = "altKey attrChange attrName bubbles button cancelable charCode clientX clientY ctrlKey currentTarget data detail eventPhase fromElement handler keyCode metaKey newValue offsetX offsetY pageX pageY prevValue relatedNode relatedTarget screenX screenY shiftKey srcElement target toElement view wheelDelta which".split(" ");
 
 function returnTrue(){ return true; }
 function returnFalse(){ return false; }


### PR DESCRIPTION
Removed event.layerX and layerY event props because they were throwing deprecation warnings.
