### PR TITLE
Changed checking whether fullscreen API is available or not.  Firefox 9 ...

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -743,7 +743,7 @@ _V_.Player = _V_.Component.extend({
 
     _V_.each(["moz", "webkit"], function(prefix){
 
-      if (document[prefix + "CancelFullScreen"] !== undefined) {
+      if ((prefix != "moz" || document.mozFullScreenEnabled) && document[prefix + "CancelFullScreen"] !== undefined) {
         requestFn = prefix + "RequestFullScreen";
         cancelFn = prefix + "CancelFullScreen";
         eventName = prefix + "fullscreenchange";


### PR DESCRIPTION
...will be handled as "not possible" (`document.mozFullScreenEnabled` not implemented, fullscreen API deactivated by default) and Firefox 10 can be handled according its config (`document.mozFullScreenEnabled` represent the current config).

Additional info:
- https://bugzilla.mozilla.org/show_bug.cgi?id=694690
- https://developer.mozilla.org/en/DOM/document.mozFullScreenEnabled
