### PR TITLE
Flash src api call autoplay fix

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -463,7 +463,7 @@ _V_.flash = _V_.PlaybackTech.extend({
 
     // Currently the SWF doesn't autoplay if you load a source later.
     // e.g. Load player w/ no source, wait 2s, set src.
-    if (this.player.autoplay) {
+    if (this.player.autoplay()) {
       var tech = this;
       setTimeout(function(){ tech.play(); }, 0);
     }


### PR DESCRIPTION
Thanks for making video.js!

Flash _src_ api all checked for existence of the autoplay() function, rather than calling it. So flash always autoplays for that api call. Fixed.
