### PR TITLE
Fixed two bugs

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -60,7 +60,7 @@ _V_.Player = _V_.Component.extend({
     if (tag.hasChildNodes()) {
       var nrOfChildNodes = tag.childNodes.length;
       for (var i=0,j=tag.childNodes;i<nrOfChildNodes;i++) {
-        if (j[0].nodeName == "SOURCE" || j[0].nodeName == "TRACK") {
+        if (j[0].nodeName.toLowerCase() == "source" || j[0].nodeName.toLowerCase() == "track") {
           tag.removeChild(j[0]);
         }
       }
@@ -142,7 +142,7 @@ _V_.Player = _V_.Component.extend({
     if (this.tag.hasChildNodes()) {
       for (var c,i=0,j=this.tag.childNodes;i<j.length;i++) {
         c = j[i];
-        if (c.nodeName == "SOURCE") {
+        if (c.nodeName.toLowerCase() == "source") {
           options.sources.push({
             src: c.getAttribute('src'),
             type: c.getAttribute('type'),
@@ -150,7 +150,7 @@ _V_.Player = _V_.Component.extend({
             title: c.getAttribute('title')
           });
         }
-        if (c.nodeName == "TRACK") {
+        if (c.nodeName.toLowerCase() == "track") {
           options.tracks.push({
             src: c.getAttribute("src"),
             kind: c.getAttribute("kind"),


### PR DESCRIPTION
Hi,

I was integrating videojs player to my drupal site, and found these small bugs which caused the following problems:
- flash-fallback could not pick up sources from <video><source> tags, since the code was not case-insensitive, so the src of the video could not be included into flashvars.
- the code could not completely remove  the <source> tags after processing them, because the loop was based on a dynamically changing condition, making it end prematurely (before it could remove all the source tags from video tag)

Please review these changes.
Thanks 
