### PR TITLE
Requesting https version of videoJS files doesn't serve up https version of .swf

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -43,6 +43,9 @@ _V_ = VideoJS,
 // CDN Version. Used to target right flash swf.
 CDN_VERSION = "GENERATED_CDN_VSN";
 
+// Assign http: or https:
+PROTOCOL = document.location.protocol;
+
 VideoJS.players = {};
 
 VideoJS.options = {
@@ -52,7 +55,7 @@ VideoJS.options = {
   // techOrder: ["flash","html5"],
 
   html5: {},
-  flash: { swf: "http://vjs.zencdn.net/c/video-js.swf" },
+  flash: { swf: PROTOCOL+"//vjs.zencdn.net/c/video-js.swf" },
 
   // Default of web browser is 300x150. Should rely on source width/height.
   width: 300,
@@ -112,5 +115,5 @@ VideoJS.options = {
 
 // Set CDN Version of swf
 if (CDN_VERSION != "GENERATED_CDN_VSN") {
-  _V_.options.flash.swf = "http://vjs.zencdn.net/"+CDN_VERSION+"/video-js.swf"
+  _V_.options.flash.swf = PROTOCOL+"//vjs.zencdn.net/"+CDN_VERSION+"/video-js.swf"
 }


### PR DESCRIPTION
when I do flash fallback, I've noticed that when requesting files from VideoJS CDN over HTTPS, the actual .swf file is loaded over http. I looked at the code and it looks like it's hard-coded in video.js. I added a couple lines to make this dynamic based on the current protocol of the page. 

https://www.evernote.com/shard/s190/sh/806c70ec-3579-4750-9286-43a582a39734/fd99f8b9835fb23d72dddc8a5fba3541
