### PR TITLE
Fix build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,9 @@
 # Combines Source Files. In terminal, sh build.sh
 # It will put a new video.js file under dist/
 
-# Create dist directory if it doesn't already exist
-rm -rf dist; mkdir -p dist;
+# Clean and create dist directory
+rm -rf dist;
+mkdir dist;
 
 # FILES=../src/*
 # for f in $FILES

--- a/src/tracks.js
+++ b/src/tracks.js
@@ -778,3 +778,4 @@ _V_.merge(_V_.ControlBar.prototype.options.components, {
 //     this._super(player, options);
 //   }
 // });
+

--- a/tech/html5/html5.js
+++ b/tech/html5/html5.js
@@ -1,4 +1,3 @@
-
 /* HTML5 Playback Technology - Wrapper for HTML5 Media API
 ================================================================================ */
 _V_.html5 = _V_.PlaybackTech.extend({
@@ -227,3 +226,4 @@ if (_V_.isAndroid()) {
     };
   }
 }
+


### PR DESCRIPTION
When pull request #215 (heff/jhurliman-youtube) was merged it seems to have broke
the build script (build.sh). There is two issues this resolves:
1. video-js.swf was moved under tech and not updated in the build
2. html5.js does not have a leading linebreak in the file. When this file
   is concat'ed on it results in a javascript error.

```
// _V_.Cue = _V_.Component.extend({
//   init: function(player, options){
//     this._super(player, options);
//   }
// });/* HTML5 Playback Technology - Wrapper for HTML5 Media API
================================================================================ */
```
