### PR TITLE
Chrome persisting loading spinner even after successful seek

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -239,6 +239,12 @@ _V_.LoadingSpinner = _V_.Component.extend({
     player.addEvent("playing", _V_.proxy(this, this.hide));
 
     player.addEvent("seeking", _V_.proxy(this, this.show));
+
+    // in some browsers seeking does not trigger the 'playing' event,
+    // so we also need to trap 'seeked' if we are going to set a
+    // 'seeking' event
+    player.addEvent("seeked", _V_.proxy(this, this.hide));
+
     player.addEvent("error", _V_.proxy(this, this.show));
 
     // Not showing spinner on stalled any more. Browsers may stall and then not trigger any events that would remove the spinner.


### PR DESCRIPTION
Expected:
1. Load up videojs.com
2. hit play.
3. In the console in Chrome enter the following:
_V_.players.home_video.currentTime("30")
4. The video seeks to the time, plays, and dismisses the spinner

Actual:
1. Load up videojs.com
2. hit play
3. In the console in Chrome enter the following:
_V_.players.home_video.currentTime("30")
4. The video seeks to the time, plays, and the spinner persists

Analysis:
Chrome is not firing the 'playing' event.  If we are going to hook the 'seeking' event we should also hook the 'seeked' event.

Sorry for the duplicate issue with #239.  I tried associating this pull request with it using the '[hub](https://github.com/defunkt/hub)' command line tool but it didn't work properly.
