### PR TITLE
Document _V_(domElement) init

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,7 @@ The Video.js API allows you to interact with the video through Javascript, wheth
 Referencing the Player
 ----------------------
 To use the API functions, you need access to the player object. Luckily this is easy to get. You just need to make sure your video tag has an ID. The example embed code has an ID of "example\_video_1". If you have multiple videos on one page, make sure every video tag has a unique ID.
+
 ```js
 var myPlayer = _V_("example_video_1");
 ```
@@ -16,6 +17,7 @@ The player may also be referenced using a DOM element as an argument,  so `_V_(d
 Wait Until the Player is Ready
 ------------------------------
 The time it takes Video.js to set up the video and API will vary depending on the playback technology being used (HTML5 will often be much faster to load than Flash). For that reason we want to use the player's 'ready' function to trigger any code that requires the player's API.
+
 ```javascript
 _V_("example_video_1").ready(function(){
 
@@ -33,6 +35,7 @@ Now that you have access to a ready player, you can control the video, get value
 
 ### play() ###
 Start video playback. Returns the player object.
+
 ```js
 myPlayer.play();
 ```
@@ -40,6 +43,7 @@ myPlayer.play();
 
 ### pause() ###
 Pause the video playback. Returns the player object
+
 ```js
 myPlayer.pause();
 ```
@@ -47,6 +51,7 @@ myPlayer.pause();
 
 ### paused() ###
 Returns false if the video is currently playing, or true otherwise. ()
+
 ```js
 var isPaused = myPlayer.paused();
 var isPlaying = !myPlayer.paused();
@@ -57,16 +62,19 @@ var isPlaying = !myPlayer.paused();
 The source function updates the video source. There are three types of variables you can pass as the argument.
 
 **URL String**: A URL to the the video file. Use this method if you're sure the current playback technology (HTML5/Flash) can support the source you provide. Currently only MP4 files can be used in both HTML5 and Flash.
+
 ```js
 myPlayer.src("http://www.example.com/path/to/video.mp4");
 ```
 
 **Source Object (or element):** A javascript object containing information about the source file. Use this method if you want the player to determine if it can support the file using the type information.
+
 ```js
 myPlayer.src({ type: "video/mp4", src: "http://www.example.com/path/to/video.mp4" });
 ```
 
 **Array of Source Objects:** To provide multiple versions of the source so that it can be played using HTML5 across browsers you can use an array of source objects. Video.js will detect which version is supported and load that file.
+
 ```js
 myPlayer.src([
   { type: "video/mp4", src: "http://www.example.com/path/to/video.mp4" },
@@ -80,6 +88,7 @@ Returns the player object.
 
 ### currentTime() ###
 Returns the current time of the video in seconds.
+
 ```js
 var whereYouAt = myPlayer.currentTime();
 ```
@@ -87,6 +96,7 @@ var whereYouAt = myPlayer.currentTime();
 
 ### currentTime(seconds) // Type: Integer or Float ###
 Seek to the supplied time (seconds). Returns the player object.
+
 ```js
 myPlayer.currentTime(120); // 2 minutes into the video
 ```
@@ -94,6 +104,7 @@ myPlayer.currentTime(120); // 2 minutes into the video
 
 ### duration() ###
 Returns the length in time of the video in seconds. NOTE: The video must have started loading before the duration can be known, and in the case of Flash, may not be known until the video starts playing.
+
 ```js
 var howLongIsThis = myPlayer.duration();
 ```
@@ -101,6 +112,7 @@ var howLongIsThis = myPlayer.duration();
 
 ### buffered() ###
 Returns a [TimeRange](glossary.md#timerange) object with sections of the video that have been downloaded. If you just want the percent of the video that's been downloaded, use bufferedPercent.
+
 ```js
 var bufferedTimeRange = myPlayer.buffered(),
 
@@ -120,6 +132,7 @@ firstRangeLength = firstRangeEnd - firstRangeStart;
 
 ### bufferedPercent() ###
 Returns the percent (as a decimal) of the video that's been downloaded. 0 means none, 1 means all.
+
 ```js
 var howMuchIsDownloaded = myPlayer.bufferedPercent();
 ```
@@ -127,6 +140,7 @@ var howMuchIsDownloaded = myPlayer.bufferedPercent();
 
 ### volume() ###
 Returns the current volume of the video as a percent in decimal form. 0 is off (muted), 1.0 is all the way up, 0.5 is half way.
+
 ```js
 var howLoudIsIt = myPlayer.volume();
 ```
@@ -134,6 +148,7 @@ var howLoudIsIt = myPlayer.volume();
 
 ### volume(percentAsDecimal) ###
 Set the volume to the supplied percent (as a decimal between 0 and 1).
+
 ```js
 myPlayer.volume(0.5); // Set volume to half
 ```
@@ -141,6 +156,7 @@ myPlayer.volume(0.5); // Set volume to half
 
 ### width() ###
 Returns the current width of the video in pixels.
+
 ```js
 var howWideIsIt = myPlayer.width();
 ```
@@ -148,6 +164,7 @@ var howWideIsIt = myPlayer.width();
 
 ### width(pixels) ###
 Change the width of the video to the supplied width in pixels. Returns the player object
+
 ```js
 myPlayer.width(640);
 ```
@@ -155,6 +172,7 @@ myPlayer.width(640);
 
 ### height() ###
 Returns the current height of the video in pixels.
+
 ```js
 var howTallIsIt = myPlayer.height();
 ```
@@ -162,6 +180,7 @@ var howTallIsIt = myPlayer.height();
 
 ### height(pixels) ###
 Change the height of the video to the supplied height in pixels. Returns the player object
+
 ```js
 myPlayer.height(480);
 ```
@@ -169,6 +188,7 @@ myPlayer.height(480);
 
 ### size(width, height) ###
 Changes the width and height of the video to the supplied width and height. This is more efficient if you're changing both width and height (only triggers the player's resize event once). Returns the player object.
+
 ```js
 myPlayer.size(640,480);
 ```
@@ -176,6 +196,7 @@ myPlayer.size(640,480);
 
 ### requestFullScreen() ###
 Increase the size of the video to full screen. In some browsers, full screen is not supported natively, so it enters full window mode, where the video fills the browser window. In browsers and devices that support native full screen, sometimes the browser's default controls will be shown, and not the Video.js custom skin. This includes most mobile devices (iOS, Android) and older versions of Safari. Returns the player object.
+
 ```js
 myPlayer.requestFullScreen();
 ```
@@ -183,6 +204,7 @@ myPlayer.requestFullScreen();
 
 ### cancelFullScreen() ###
 Return the video to its normal size after having been in full screen mode. Returns the player object.
+
 ```js
 myPlayer.cancelFullScreen();
 ```
@@ -201,6 +223,7 @@ myPlayer.addEvent("eventName", myFunc);
 ```
 
 You can also remove the listeners later.
+
 ```js
 myPlayer.removeEvent("eventName", myFunc);
 ```


### PR DESCRIPTION
I wanted to know if I could access the player api with a dom element rather than ID - though I couldn't find it in the documentation.

I figured this was an okay way to use the api, as it's used that way in [test.js](https://github.com/zencoder/video-js/blob/master/test/test.js#L49)

I've also added some whitespace so that the code blocks don't render inline locally.
