### PR TITLE
techOrder should be an array of strings

### DIFF
--- a/docs/tech.md
+++ b/docs/tech.md
@@ -42,11 +42,11 @@ Adding Playback Technology
 When adding additional Tech to a video player, make sure to add the supported tech to the video object.
 
 ### Tag Method: ###
-    <video data-setup='{"techOrder": ["html5", "flash", [other supported tech]]}'
+    <video data-setup='{"techOrder": ["html5", "flash", "other supported tech"]}'
 
 ### Object Method: ###
     _V_("videoID", {
-      techOrder: {"html5", "flash", [other supported tech]}
+      techOrder: ["html5", "flash", "other supported tech"]
     });
 
 Youtube Technology


### PR DESCRIPTION
- Correct the example where the value of techOrder is a hash when it should be an array.
- Make examples clearer that the elements of this array should be strings, not another array.
