### PR TITLE
Remove poster attribute instead of setting to null

### DIFF
--- a/tech/html5/html5.js
+++ b/tech/html5/html5.js
@@ -27,7 +27,7 @@ _V_.html5 = _V_.PlaybackTech.extend({
     // This fixes both issues. Need to wait for API, so it updates displays correctly
     player.ready(function(){
       if (this.options.autoplay && this.paused()) {
-        this.tag.poster = null; // Chrome Fix. Fixed in Chrome v16.
+        this.tag.removeAttribute("poster"); // Chrome Fix. Fixed in Chrome v16.
         this.play();
       }
     });


### PR DESCRIPTION
Setting the poster property to null is equivalent to settings the attribute value to "". Unlike most other browsers Firefox correctly interpretes "" as a valid relative URL and starts another request to the current page (or it's base URL). Firefox has adopted other browsers' behaviour and ignores empty <img> src attributes now (https://bugzilla.mozilla.org/show_bug.cgi?id=444931), but not yet so for empty poster attributes. This means that poster="" potentially breaks pages using, for example, CSRF protection and that the attribute has to be removed from the tag instead, which should have the same effect to the Safari/Chrome bugs mentioned.

Short example: http://jsfiddle.net/eCZFy/
