### PR TITLE
Allowing ARIA "role" attribute to be written to elements

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -55,7 +55,7 @@ _V_.extend({
         attrname;
     for (attrname in attributes){
       if (attributes.hasOwnProperty(attrname)) {
-        if (attrname.indexOf("-") !== -1) {
+        if (attrname.indexOf("-") !== -1 || attrname=="role") {
           el.setAttribute(attrname, attributes[attrname]);
         } else {
           el[attrname] = attributes[attrname];


### PR DESCRIPTION
In the current implementation, any time a "role" attribute is assigned to an element, it isn't actually getting written to the DOM. JavaScript seems to be doing some type of filtering to only allow valid attributes to be assigned to elements. Since ARIA attributes are not valid in the namespace for anything pre-HTML5, they are not getting written to the DOM. I took the existing workaround of looking for attributes with a "-" in it, presumably to look for attributes like "aria-valuenow", and just did a check to see if the "role" attribute is being added. In that case it uses the setAttribute function to add the role attribute. I believe "role" is the only ARIA associated attribute that is not prepend with "aria-".
