### PR TITLE
Fix null exception in iOS, when creating video tag.

### DIFF
--- a/src/js/media.html5.js
+++ b/src/js/media.html5.js
@@ -67,7 +67,7 @@ vjs.Html5.prototype.createEl = function(){
       player.el().removeChild(el);
     }
 
-    newEl = vjs.createElement('video', {
+    newEl = vjs.createEl('video', {
       id: el.id || player.id() + '_html5_api',
       className: el.className || 'vjs-tech'
     });


### PR DESCRIPTION
- Tested on iPad 3
- Exception is as follows:
  TypeError: 'undefined' is not a function (evaluating 'vjs.createElement('video', {
    id: el.id || player.id() + '_html5_api',
    className: el.className || 'vjs-tech'
  })')
