### PR TITLE
246 custom start time offset support

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -48,19 +48,11 @@ vjs.Player = function(tag, options, ready){
 
   this.on('ended', this.onEnded);
   this.on('play', this.onPlay);
+  this.on('firstplay', this.onFirstPlay);
   this.on('pause', this.onPause);
   this.on('progress', this.onProgress);
   this.on('durationchange', this.onDurationChange);
   this.on('error', this.onError);
-
-  //If the first starttime attribute is specified
-  //then we will start at the given offset in seconds
-
-  this.on('firstplay',function(){
-    if(this.options_['starttime']){
-      this.currentTime(this.options_['starttime']);
-    }
-  });
 
   // Make player easily findable by ID
   vjs.players[this.id_] = this;
@@ -357,6 +349,14 @@ vjs.Player.prototype.onEnded = function(){
 vjs.Player.prototype.onPlay = function(){
   vjs.removeClass(this.el_, 'vjs-paused');
   vjs.addClass(this.el_, 'vjs-playing');
+};
+
+vjs.Player.prototype.onFirstPlay = function(){
+    //If the first starttime attribute is specified
+    //then we will start at the given offset in seconds
+    if(this.options_['starttime']){
+      this.currentTime(this.options_['starttime']);
+    }
 };
 
 vjs.Player.prototype.onPause = function(){


### PR DESCRIPTION
This patch offers you to have a custom start time for a video.
See issue 246 for more details: https://github.com/zencoder/video-js/issues/246

Description:
By setting the value "starttime" in the data-setup array, any user can specify a custom start position for a video. Playback will start from that given offset.

Requirements:
Preload attribute in html5 video tag MUST be set to auto

Usage:
For example: {'start-time':80} 
This would start video playback from 00:01:20 -> HH:MM:SS
Not setting start-time will start playback from 0 like normal.

Compatibility:
Works with the latest build of VideoJS.

-Joseph Afework
