### PR TITLE
313 Save all video tag attributes while moving media element in DOM

### DIFF
--- a/src/js/media.html5.js
+++ b/src/js/media.html5.js
@@ -67,7 +67,7 @@ vjs.Html5.prototype.createEl = function(){
       player.el().removeChild(el);
       el = el.cloneNode(false);
     } else {
-      el = vjs.createElement('video', {
+      el = vjs.createEl('video', {
         id:player.id() + '_html5_api',
         className:'vjs-tech'
       });


### PR DESCRIPTION
Save all attributes, but not only 'id' and 'class'
