### PR TITLE
Fix volume handler initial position

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -786,6 +786,8 @@ vjs.VolumeControl.prototype.createEl = function(){
  */
 vjs.VolumeBar = function(player, options){
   goog.base(this, player, options);
+
+  setTimeout(vjs.bind(this, this.update), 0); // update when elements is in DOM
 };
 goog.inherits(vjs.VolumeBar, vjs.Slider);
 


### PR DESCRIPTION
Update volume handler position when element is in DOM already.
This is important if control bar is visible before playback is started.
