### PR TITLE
Add plugin event ordering test

### DIFF
--- a/test/unit/plugins.js
+++ b/test/unit/plugins.js
@@ -156,6 +156,7 @@ test('Plugins should not get events after stopImmediatePropagation is called', f
   player['testerPlugin']({});
 
   deepEqual(order, expectedOrder.slice(0, order.length), "plugins should receive events in order of initialization, until stopImmediatePropagation");
-  player.dispose();
 
-})
+  equal(order.length, 1, "only one event listener should have triggered");
+  player.dispose();
+});


### PR DESCRIPTION
I added a test that creates a few plugins that listen to a particular event and then another plugin that triggers that event.
The plugins are attached explicitly to a player via `player.pluginName({})`.
