### PR TITLE
Added support for building and testing in Windows to Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,10 @@ module.exports = function(grunt) {
       }
 
       if (results) {
+	var i = results.length; 
+	while (i--) {
+          results[i] = results[i].replace(/\\/g, '/');
+	}
         grunt.file.write('build/files/sourcelist.txt', results.join(','));
         grunt.file.write('build/files/sourcelist.js', 'var sourcelist = ["' + results.join('","') + '"]');
 


### PR DESCRIPTION
I incorporated Jim Wilson's suggestion of a while loop to step through the results Array, and globally replace all '\' characters with '/'.
Testing was on Windows (of course), but also on my mac, to ensure that grunt and grunt test ran successfully there as well.
