### PR TITLE
Added Support For Removing Components for iOS Devices

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -38,6 +38,7 @@ goog.inherits(vjs.ControlBar, vjs.Component);
 
 var isiOS = navigator.userAgent.match(/(iPhone|iPod|iPad)/);
 //Check to see if the useragent matches an iOS Device
+//isiOS returns a boolean value
 if(isiOS){
   //Exclude the audio controls and the mute button
   vjs.ControlBar.prototype.options_ = {


### PR DESCRIPTION
Fix for issue:#336

Currently iOS prevents users from controlling audio of the device from
the browser. To prevent user confusion, I have added support for
removing controls based of the user agent of the browser.

By default this removes the muteToggole and the volumeControl
components from iOS devices. All other devices still see all the
controls.

For future devices we can easily create custom control lists following
the same convention later.
