### PR TITLE
Poster image to stretch both horizontally and vertically while staying centered and maintaining aspect ratio.

### DIFF
--- a/src/css/video-js.css
+++ b/src/css/video-js.css
@@ -45,10 +45,22 @@ body.vjs-full-window {
 
 /* Poster Styles */
 .vjs-poster {
-  margin: 0 auto; padding: 0; cursor: pointer;
-
-  /* Scale with the size of the player div. Works when poster is vertically shorter, but stretches when it's less wide. */
-  position: relative; width: 100%; max-height: 100%;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+  background-size: contain;
+  cursor: pointer;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  width: 100%;
+}
+.vjs-poster img {
+  display: block;
+  margin: 0 auto;
+  max-height: 100%;
+  padding: 0;
+  width: 100%;
 }
 
 /* Text Track Styles */

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -969,17 +969,22 @@ vjs.PosterImage = function(player, options){
 goog.inherits(vjs.PosterImage, vjs.Button);
 
 vjs.PosterImage.prototype.createEl = function(){
-  var el = vjs.createEl('img', {
-    className: 'vjs-poster',
-
-    // Don't want poster to be tabbable.
-    tabIndex: -1
-  });
-
-  // src throws errors if no poster was defined.
-  if (this.player_.poster()) {
-    el.src = this.player_.poster();
+  var el = vjs.createEl('div', {
+        className: 'vjs-poster',
+        
+        // Don't want poster to be tabbable.
+        tabIndex: -1
+      }),
+      poster = this.player_.poster();
+  
+  if (poster) {
+    if ('backgroundSize' in el.style) {
+      el.style.backgroundImage = 'url("' + poster + '")';
+    } else {
+      el.appendChild(vjs.createEl('img', { src: poster }));
+    }
   }
+  
   return el;
 };
 


### PR DESCRIPTION
The existing poster implementation uses an <img> tag
stretched horizontally with capped max-height. This
works in some cases like pillar-boxing when the poster
is not as wide as the player. However it fails to
letter box when the player is taller than the poster.

This change uses a stretched div with background-image
and backround-size to create a vertically aligned
poster image which stretches in both directions to fit
while maintaining aspect ratio.

For browsers which do not support backgroundSize (IE8)
the original <img> based strategy is used as a fallback.
