### PR TITLE
Fix ability to add child after closure compiled

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -288,8 +288,8 @@ vjs.Component.prototype.addChild = function(child, options){
 
   // Add the UI object's element to the container div (box)
   // Having an element is not required
-  if (typeof component.el === 'function' && component.el()) {
-    this.el_.appendChild(component.el());
+  if (typeof component['el'] === 'function' && component['el']()) {
+    this.el_.appendChild(component['el']());
   }
 
   // Return so it can stored on parent object if desired.


### PR DESCRIPTION
After closure compiling the .el property on the input is renamed in the addChild method in component.js and needs to be changed to allow third party developers to add elements and such to existing components.
