### PR TITLE
Touchevents support for the control bar and seekbar

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -646,6 +646,8 @@ vjs.Slider.prototype.calculateDistance = function(event){
     boxW = boxW - handleW;
   }
 
+  // This is done because on Android, event.pageX is always 0 and the actual
+  // values live under the changedTouches array.
   if (pageX === 0 && event.changedTouches) {
     pageX = event.changedTouches[0].pageX;
   }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -172,11 +172,6 @@ vjs.fixEvent = function(event) {
       event[prop] = old[prop];
     }
 
-    if (event.changedTouches && event.pageX === 0 && event.pageY === 0) {
-      event.pageX = event.changedTouches[0].pageX;
-      event.pageY = event.changedTouches[0].pageY;
-    }
-
     // The event occurred on this element
     if (!event.target) {
       event.target = event.srcElement || document;


### PR DESCRIPTION
This adds touch-event support for iOS and Android.
This makes it so that tapping on the video will show and hide the controlbar like the plain video element in iOS works.
On Android, there is a play overlay that is always shown when paused, so, the BigPlayButton has been changed to show on pause. There is a new event `showBigPlayButton` that is emitted on pause which can be listened on the player and can be stopped via a `stopImmediatePropagation` call on the event object.

The way the controls are currently set up doesn't work that great with adding in touch-event support.
Also, Windows 8/RT touch works. Kind of. The seekbar won't seek via dragging, works via tapping, and the controlbar is always hidden unless you are actively touching the video element. Fixing both those issues is out of scope for this pull-request.

@BCjwhisenant will be working on verifying these changes.
