### PR TITLE
#376 Removing Helvetica from font-family declarations.

### DIFF
--- a/src/css/video-js.css
+++ b/src/css/video-js.css
@@ -65,7 +65,7 @@ body.vjs-full-window {
 
 /* Text Track Styles */
 /* Overall track holder for both captions and subtitles */
-.video-js .vjs-text-track-display { text-align: center; position: absolute; bottom: 4em; left: 1em; right: 1em; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
+.video-js .vjs-text-track-display { text-align: center; position: absolute; bottom: 4em; left: 1em; right: 1em; font-family: Arial, sans-serif; }
 /* Individual tracks */
 .video-js .vjs-text-track {
   display: none; color: #fff; font-size: 1.4em; text-align: center; margin-bottom: 0.1em;
@@ -304,7 +304,7 @@ so you can upgrade to newer versions easier. You can remove all these styles by 
   border-top: 1px solid #222;
   background-color: #333;
 
-  font-size: 1em; line-height: 1.0em; font-weight: normal; font-family: Helvetica, Arial, sans-serif;
+  font-size: 1em; line-height: 1.0em; font-weight: normal; font-family: Arial, sans-serif;
 
   background: #333;
   background: -moz-linear-gradient(top, #222, #333);
@@ -325,7 +325,7 @@ so you can upgrade to newer versions easier. You can remove all these styles by 
 
 .vjs-time-divider { display:none; }
 
-.vjs-default-skin .vjs-time-control { font-size: 1em; line-height: 1; font-weight: normal; font-family: Helvetica, Arial, sans-serif; }
+.vjs-default-skin .vjs-time-control { font-size: 1em; line-height: 1; font-weight: normal; font-family: Arial, sans-serif; }
 .vjs-default-skin .vjs-time-control span { line-height: 25px; /* Centering vertically */ }
 
 /* Fullscreen
@@ -483,7 +483,7 @@ div.vjs-loading-spinner .ball8 { opacity: 1.00; position:absolute; left: 6px; to
 
 /*.vjs-default-skin .vjs-menu-button:focus ul,*/ /* This is not needed because keyboard accessibility for the caption button is not handled with the focus any more. */
 .vjs-default-skin .vjs-menu-button:hover ul { display: block; list-style: none; }
-.vjs-default-skin .vjs-menu-button ul li { list-style: none; margin: 0; padding: 0.3em 0 0.3em 20px; line-height: 1.4em; font-size: 1.2em; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; text-align: left; }
+.vjs-default-skin .vjs-menu-button ul li { list-style: none; margin: 0; padding: 0.3em 0 0.3em 20px; line-height: 1.4em; font-size: 1.2em; font-family: Arial, sans-serif; text-align: left; }
 .vjs-default-skin .vjs-menu-button ul li.vjs-selected { text-decoration: underline; background: url('video-js.png') -125px -50px no-repeat; }
 .vjs-default-skin .vjs-menu-button ul li:focus,
 .vjs-default-skin .vjs-menu-button ul li:hover,


### PR DESCRIPTION
IE9 and IE10 can not properly render Type 1 fonts such as Helvetica. If
a user has such a font installed videojs stops functioning properly.

Hopefully I followed all the steps correctly. 
