### PR TITLE
Adding contribflow as grunt module/package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('contribflow');
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'build', 'minify', 'dist']);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "calcdeps": "~0.1.7",
     "grunt-contrib-clean": "~0.4.0a",
     "grunt-contrib-copy": "~0.3.2",
-    "mocha": "~1.8.1"
+    "mocha": "~1.8.1",
+    "contribflow": "~0.1.0"
   },
   "testling": {
     "browsers": [


### PR DESCRIPTION
Contrib was a set of grunt commands that were being built in the video.js repo, but they've now been moved to a node package
