### PR TITLE
Make the Duration Display not display the duration as a negative number

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -436,7 +436,7 @@ vjs.DurationDisplay.prototype.createEl = function(){
 
   this.content = vjs.createEl('div', {
     className: 'vjs-duration-display',
-    innerHTML: '<span class="vjs-control-text">Duration Time </span>' + '-0:00', // label the duration time for screen reader users
+    innerHTML: '<span class="vjs-control-text">Duration Time </span>' + '0:00', // label the duration time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
   });
 
@@ -446,7 +446,7 @@ vjs.DurationDisplay.prototype.createEl = function(){
 
 vjs.DurationDisplay.prototype.updateContent = function(){
   if (this.player_.duration()) {
-      this.content.innerHTML = '<span class="vjs-control-text">Duration Time </span>' + '-' + vjs.formatTime(this.player_.duration()); // label the duration time for screen reader users
+      this.content.innerHTML = '<span class="vjs-control-text">Duration Time </span>' + vjs.formatTime(this.player_.duration()); // label the duration time for screen reader users
   }
 };
 


### PR DESCRIPTION
The duration display, which isn't used by the default skin in video-js, displays a minus in front of the time. Because this is a duration display, this number should not be shown as a negative like the remaining time display.
