### PR TITLE
Move html tech feature detection earlier than superclass constructor. Fix #453

### DIFF
--- a/src/js/media.html5.js
+++ b/src/js/media.html5.js
@@ -12,15 +12,15 @@
 vjs.Html5 = vjs.MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
+    // volume cannot be changed from 1 on iOS
+    this.features.volumeControl = vjs.Html5.canControlVolume();
+
+    // In iOS, if you move a video element in the DOM, it breaks video playback.
+    this.features.movingMediaElementInDOM = !vjs.IS_IOS;
+
     vjs.MediaTechController.call(this, player, options, ready);
 
-  // volume cannot be changed from 1 on iOS
-  this.features.volumeControl = vjs.Html5.canControlVolume();
-
-  // In iOS, if you move a video element in the DOM, it breaks video playback.
-  this.features.movingMediaElementInDOM = !vjs.IS_IOS;
-
-  var source = options['source'];
+    var source = options['source'];
 
     // If the element source is already set, we may have missed the loadstart event, and want to trigger it.
     // We don't want to set the source again and interrupt playback.


### PR DESCRIPTION
The MediaTechController calls createEl during its initialization to construct the actual video element used for playback. On iOS, the video element must be recreated during this process so that it doesn't become unresponsive. Make sure that we determine whether recreating the video elemen is necessary before calling the superclass constructor.
