### PR TITLE
Add videojs to window directly. Fix #448

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -52,6 +52,7 @@ var vjs = function(id, options, ready){
 
 // Extended name, also available externally, window.videojs
 var videojs = vjs;
+window.videojs = window.vjs = vjs;
 
 // CDN Version. Used to target right flash swf.
 vjs.CDN_VERSION = 'GENERATED_CDN_VSN';


### PR DESCRIPTION
This is needed because otherwise, with videojs in an IIFE, we cannot access videojs directly.
