### PR TITLE
Fix calculateDistance on slider to work in iframes and all devices.

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -135,9 +135,7 @@ vjs.Slider.prototype.calculateDistance = function(event){
     boxW = boxW - handleW;
   }
 
-  // This is done because on Android, event.pageX is always 0 and the actual
-  // values live under the changedTouches array.
-  if (pageX === 0 && event.changedTouches) {
+  if (event.changedTouches) {
     pageX = event.changedTouches[0].pageX;
   }
 

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -75,3 +75,27 @@ test('should test and toggle volume control on `loadstart`', function(){
   ok(muteToggle.el().className.indexOf('vjs-hidden') < 0,
      'muteToggle does not show itself');
 });
+
+test('calculateDistance should use changedTouches, if available', function() {
+  var noop, player, slider, event;
+  noop = function(){};
+  player = {
+    id: noop,
+    on: noop,
+    ready: noop
+  };
+  slider = new vjs.Slider(player);
+  document.body.appendChild(slider.el_);
+  slider.el_.style.position = 'absolute';
+  slider.el_.style.width = '200px';
+  slider.el_.style.left = '0px';
+
+  event = {
+    pageX: 10,
+    changedTouches: [{
+      pageX: 100
+    }]
+  };
+
+  equal(slider.calculateDistance(event), 0.5, 'we should have touched exactly in the center, so, the ratio should be half');
+});


### PR DESCRIPTION
Make the slider use changedTouches, if available, for calculateDistance. `event.changedTouches` are only available when touch is available.
Add tests to make sure we get the correct ratio for calculateDistance
