### PR TITLE
Make preventDefault and stopPropagation call the corresponding methods on the actual event

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -189,6 +189,9 @@ vjs.fixEvent = function(event) {
 
     // Stop the default browser action
     event.preventDefault = function () {
+      if (old.preventDefault) {
+        old.preventDefault();
+      }
       event.returnValue = false;
       event.isDefaultPrevented = returnTrue;
     };
@@ -197,6 +200,9 @@ vjs.fixEvent = function(event) {
 
     // Stop the event from bubbling
     event.stopPropagation = function () {
+      if (old.stopPropagation) {
+        old.stopPropagation();
+      }
       event.cancelBubble = true;
       event.isPropagationStopped = returnTrue;
     };
@@ -205,6 +211,9 @@ vjs.fixEvent = function(event) {
 
     // Stop the event from bubbling and executing other handlers
     event.stopImmediatePropagation = function () {
+      if (old.stopImmediatePropagation) {
+        old.stopImmediatePropagation();
+      }
       event.isImmediatePropagationStopped = returnTrue;
       event.stopPropagation();
     };


### PR DESCRIPTION
Make preventDefault and stopPropagation call the corresponding methods on the actual event.
Most browsers accept the `event.returnValue` but newer versions of chrome for android do not respect this value.
