### PR TITLE
fixes fullscreen using html5 technology

### DIFF
--- a/src/js/media.html5.js
+++ b/src/js/media.html5.js
@@ -18,6 +18,8 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // In iOS, if you move a video element in the DOM, it breaks video playback.
     this.features.movingMediaElementInDOM = !vjs.IS_IOS;
 
+    this.features.fullscreenResize = true;
+
     vjs.MediaTechController.call(this, player, options, ready);
 
     var source = options['source'];


### PR DESCRIPTION
This PR fixes fullscreen functionality for HTML5 tech broken by 3a32f44 commit in `media.js`.

Issue is easily reproducible. Just try toggling fullscreen in Chrome. You'll get blackscreen, because tech was not reloaded back properly.
