### PR TITLE
Android browsers support video element fullscreen

### DIFF
--- a/src/js/media.html5.js
+++ b/src/js/media.html5.js
@@ -141,7 +141,7 @@ vjs.Html5.prototype.supportsFullScreen = function(){
   if (typeof this.el_.webkitEnterFullScreen == 'function') {
 
     // Seems to be broken in Chromium/Chrome && Safari in Leopard
-    if (!navigator.userAgent.match('Chrome') && !navigator.userAgent.match('Mac OS X 10.5')) {
+    if (/Android/.test(navigator.userAgent) || !/Chrome|Mac OS X 10.5/.test(navigator.userAgent)) {
       return true;
     }
   }


### PR DESCRIPTION
Modify the UA check in media.html5 for whether a video element supports enterFullScreen to return true for Android WebKit/Chrome browsers.
