### PR TITLE
Catch localStorage security exceptions. Fixes #351

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -543,16 +543,20 @@ vjs.get = function(url, onSuccess, onError){
 /* Local Storage
 ================================================================================ */
 vjs.setLocalStorage = function(key, value){
-  // IE was throwing errors referencing the var anywhere without this
-  var localStorage = window.localStorage || false;
-  if (!localStorage) { return; }
   try {
+    // IE was throwing errors referencing the var anywhere without this
+    var localStorage = window.localStorage || false;
+    if (!localStorage) { return; }
     localStorage[key] = value;
   } catch(e) {
     if (e.code == 22 || e.code == 1014) { // Webkit == 22 / Firefox == 1014
       vjs.log('LocalStorage Full (VideoJS)', e);
     } else {
-      vjs.log('LocalStorage Error (VideoJS)', e);
+      if (e.code == 18) {
+        vjs.log('LocalStorage not allowed (VideoJS)', e);
+      } else {
+        vjs.log('LocalStorage Error (VideoJS)', e);
+      }
     }
   }
 };


### PR DESCRIPTION
This traps DOM Security Exceptions when referencing localStorage. This happens in Chrome and Firefox (at least) when configured to not allow persistent data.

More information here: http://www.w3.org/TR/webstorage/#the-localstorage-attribute
