### PR TITLE
Dont enable onClick play state toggling on android via the MediaTechController

### DIFF
--- a/src/js/media.js
+++ b/src/js/media.js
@@ -41,7 +41,7 @@ vjs.MediaTechController.prototype.onClick = (function(){
           this.player_.pause();
         }
       }
-    }
+    };
   }
 })();
 


### PR DESCRIPTION
See discussion in #464.
In android, the state toggling in the media tech controller is interfering with hiding and showing the controls, so, I disabled that.
