### PR TITLE
Make Volume Menu Button default to vertical.

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -561,7 +561,11 @@ vjs.VolumeBar.prototype.onMouseMove = function(event) {
 };
 
 vjs.VolumeBar.prototype.getPercent = function(){
-  return this.player_.volume();
+  if (this.player_.muted()) {
+    return 0;
+  } else {
+    return this.player_.volume();
+  }
 };
 
 vjs.VolumeBar.prototype.stepForward = function(){


### PR DESCRIPTION
This can be configured by giving the volumeMenuButton, an option like
`{volumeBar: {vertical: false}}`. This can also be used to pass other
options to the volumeBar.

This needs some CSS changes to make the UI also vertical.
