### PR TITLE
createEl: dispose reference to cloned element

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -71,6 +71,8 @@ vjs.Html5.prototype.createEl = function(){
 
     // If the original tag is still there, remove it.
     if (el) {
+      el['player'] = null;
+      player.tag = null;
       player.el().removeChild(el);
       el = el.cloneNode(false);
     } else {


### PR DESCRIPTION
This allows future garbage collection to happen on the element which
is not longer used nor referenced by others.

Fixes #514
