### PR TITLE
Turn on tech method queuing

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -416,7 +416,7 @@ vjs.Player.prototype.getCache = function(){
 // Pass values to the playback tech
 vjs.Player.prototype.techCall = function(method, arg){
   // If it's not ready yet, call method when it is
-  if (this.tech && this.tech.isReady_) {
+  if (this.tech && !this.tech.isReady_) {
     this.tech.ready(function(){
       this[method](arg);
     });


### PR DESCRIPTION
There was a ready check that was missing and exclamation mark to check if the player was not ready.
