### PR TITLE
Localstorage namespace

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -540,27 +540,6 @@ vjs.get = function(url, onSuccess, onError){
   }
 };
 
-/* Local Storage
-================================================================================ */
-vjs.setLocalStorage = function(key, value){
-  try {
-    // IE was throwing errors referencing the var anywhere without this
-    var localStorage = window.localStorage || false;
-    if (!localStorage) { return; }
-    localStorage[key] = value;
-  } catch(e) {
-    if (e.code == 22 || e.code == 1014) { // Webkit == 22 / Firefox == 1014
-      vjs.log('LocalStorage Full (VideoJS)', e);
-    } else {
-      if (e.code == 18) {
-        vjs.log('LocalStorage not allowed (VideoJS)', e);
-      } else {
-        vjs.log('LocalStorage Error (VideoJS)', e);
-      }
-    }
-  }
-};
-
 /**
  * Get abosolute version of relative URL. Used to tell flash correct URL.
  * http://stackoverflow.com/questions/470832/getting-an-absolute-url-from-a-relative-one-ie6-issue

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -562,7 +562,7 @@ vjs.Player.prototype.volume = function(percentAsDecimal){
     vol = Math.max(0, Math.min(1, parseFloat(percentAsDecimal))); // Force value to between 0 and 1
     this.cache_.volume = vol;
     this.techCall('setVolume', vol);
-    vjs.setLocalStorage('volume', vol);
+    this.setLocalStorage('volume', vol);
     return this;
   }
 
@@ -851,6 +851,30 @@ vjs.Player.prototype.controls = function(controls){
 
 vjs.Player.prototype.error = function(){ return this.techGet('error'); };
 vjs.Player.prototype.ended = function(){ return this.techGet('ended'); };
+
+/* Local Storage
+================================================================================ */
+vjs.Player.prototype.setLocalStorage = function(key, value){
+  try {
+    // IE was throwing errors referencing the var anywhere without this
+    var localStorage = window.localStorage || false;
+    if (!localStorage) { return; }
+    if('localStorageNamespace' in this.options()){
+      key = this.options()['localStorageNamespace'] + '-' + key;
+    }
+    localStorage[key] = value;
+  } catch(e) {
+    if (e.code == 22 || e.code == 1014) { // Webkit == 22 / Firefox == 1014
+      vjs.log('LocalStorage Full (VideoJS)', e);
+    } else {
+      if (e.code == 18) {
+        vjs.log('LocalStorage not allowed (VideoJS)', e);
+      } else {
+        vjs.log('LocalStorage Error (VideoJS)', e);
+      }
+    }
+  }
+};
 
 // Methods to add support for
 // networkState: function(){ return this.techCall('networkState'); },

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -250,6 +250,21 @@ test('should set controls and trigger event', function() {
   player.dispose();
 });
 
+test('should set localStorage value', function(){
+  var player = PlayerTest.makePlayer();
+  window.localStorage.clear();
+  player.setLocalStorage('test', 'test');
+  ok(window.localStorage['test'] === 'test', 'localStorage updated');
+});
+
+test('should set localStorage value with namespace from options', function(){
+  var player = PlayerTest.makePlayer({'localStorageNamespace': 'test'});
+  window.localStorage.clear();
+  player.setLocalStorage('test', 'test');
+  ok(window.localStorage['test'] === undefined, 'un-namespaced key not set');
+  ok(window.localStorage['test-test'] === 'test', 'namespaced key set');
+});
+
 // Can't figure out how to test fullscreen events with tests
 // Browsers aren't triggering the events at least
 // asyncTest('should trigger the fullscreenchange event', function() {


### PR DESCRIPTION
New feature request: localStorage namespacing.

This will make setLocalStorage a method on a player instance. setLocalStorage will check for presence of a localStorageNamespace option, which, if present, will prepend to the localStorage key as `localStorageNamespace + '-' + key`

Requesting this feature because some pages can contain multiple player instances which should each have different localStorage namespaces.
