### PR TITLE
Fix IE making request for "null". fixes #583

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -41,7 +41,9 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // This fixes both issues. Need to wait for API, so it updates displays correctly
     player.ready(function(){
       if (this.options_['autoplay'] && this.paused()) {
-        this.tag.poster = null; // Chrome Fix. Fixed in Chrome v16.
+        if (/Chrome/.test(vjs.USER_AGENT)) {
+          this.tag.poster = null; // Chrome Fix. Fixed in Chrome v16.
+        }
         this.play();
       }
     });


### PR DESCRIPTION
A fix for old versions of Chrome causes IE to make requests for a file
called "null". We should not execute that code unless the user agent
contains "Chrome".
