### PR TITLE
When autoplay = true, delete tag.poster instead of setting to null

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -41,7 +41,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // This fixes both issues. Need to wait for API, so it updates displays correctly
     player.ready(function(){
       if (this.options_['autoplay'] && this.paused()) {
-        this.tag.poster = null; // Chrome Fix. Fixed in Chrome v16.
+        delete this.tag['poster']; // Chrome Fix. Fixed in Chrome v16.
         this.play();
       }
     });


### PR DESCRIPTION
Setting to null causes IE to try to update the image by making a request to 'null'
