### PR TITLE
Fix IE9 canPlayType error

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -215,7 +215,7 @@ vjs.Html5.canPlaySource = function(srcObj){
   // https://github.com/videojs/video.js/issues/519
   try {
     return !!vjs.TEST_VID.canPlayType(srcObj.type);
-  } catch() {
+  } catch(e) {
     return '';
   }
   // TODO: Check Type


### PR DESCRIPTION
IE9 throws an error on windows 7 when media player isn't installed. fixes #519
