### PR TITLE
Fix Player.buffered() to more correct behavior

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -544,12 +544,12 @@ vjs.Player.prototype.remainingTime = function(){
 vjs.Player.prototype.buffered = function(){
   var buffered = this.techGet('buffered'),
       start = 0,
-      buflen = buffered.length,
+      buflast = buffered.length - 1,
       // Default end to 0 and store in values
       end = this.cache_.bufferEnd = this.cache_.bufferEnd || 0;
 
-  if (buffered && buflen > 0 && buffered.end( buflen - 1) !== end) {
-    end = buffered.end( buflen - 1);
+  if (buffered && buflast >= 0 && buffered.end(buflast) !== end) {
+    end = buffered.end(buflast);
     // Storing values allows them be overridden by setBufferedFromProgress
     this.cache_.bufferEnd = end;
   }


### PR DESCRIPTION
The problem is that Player.buffered() always return the first time range. This means that while do seeking through the timeline, progress loader is not updated as far as browser sends new buffering info at the tail of buffered time-ranges, so, looks like it would be more correctly to grab this info from the last time-range object rather than from the first one.
