### PR TITLE
Added export for vjs.MenuButton

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -90,6 +90,7 @@ goog.exportSymbol('videojs.MuteToggle', vjs.MuteToggle);
 goog.exportSymbol('videojs.PosterImage', vjs.PosterImage);
 goog.exportSymbol('videojs.Menu', vjs.Menu);
 goog.exportSymbol('videojs.MenuItem', vjs.MenuItem);
+goog.exportSymbol('videojs.MenuButton', vjs.MenuButton);
 
 goog.exportSymbol('videojs.SubtitlesButton', vjs.SubtitlesButton);
 goog.exportSymbol('videojs.CaptionsButton', vjs.CaptionsButton);


### PR DESCRIPTION
Allows for plugins to create menu style buttons. See #647. I'm pretty new to Closure's variable export system, so please double check that I didn't overlook anything. Thanks.
