### PR TITLE
Fix wonky loading spinner when in center aligned element

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -4,11 +4,11 @@ Version GENERATED_AT_BUILD
 Create your own skin at http://designer.videojs.com
 */
 
-// To customize the player skin, change the values of the variables or edit the 
+// To customize the player skin, change the values of the variables or edit the
 // CSS below.
 // (This file uses LESS. Learn more at http://lesscss.org/)
 
-// The base font size controls the size of everything, not just text. All 
+// The base font size controls the size of everything, not just text. All
 // diminensions use em-based sizes so that the scale along with the font size.
 // Try increasing it to 20px and see what happens.
 @base-font-size: 10px;
@@ -16,8 +16,8 @@ Create your own skin at http://designer.videojs.com
 // The main font color controls the color of the text and the icons (font icons)
 @main-font-color: #CCCCCC; // e.g. rgb(255, 255, 255) or #ffffff
 
-// The default color of control backgrounds is mostly black but with a little 
-// bit of blue so it can still be seen on all black video frames, which are 
+// The default color of control backgrounds is mostly black but with a little
+// bit of blue so it can still be seen on all black video frames, which are
 // common.
 @control-bg-color: #07141E; // e.g. rgb(255, 255, 255) or #ffffff
 @control-bg-alpha: 0.7; // 1.0 = 100% opacity, 0.0 = 0% opacity
@@ -32,12 +32,12 @@ Create your own skin at http://designer.videojs.com
 @slider-background-color: #333333;
 @slider-background-alpha: 0.9; // 1.0 = 100% opacity, 0.0 = 0% opacity
 
-// The "Big Play Button" is the play button that shows before the video plays. 
-// To center it set the align values to center and middle. The typical location 
+// The "Big Play Button" is the play button that shows before the video plays.
+// To center it set the align values to center and middle. The typical location
 // of the button is the center, but there is trend towards moving it to a corner
 // where it gets out of the way of valuable content in the poster image.
 @big-play-align: left; // left, center, or right
-@big-play-vertical-align: top; // top, middle, or bottom 
+@big-play-vertical-align: top; // top, middle, or bottom
 // The button colors match the control colors by default but you can customize
 // them by replace the variables (@control-bg-color) with your own color values.
 @big-play-bg-color: @control-bg-color;
@@ -58,13 +58,16 @@ Create your own skin at http://designer.videojs.com
 
 /* SKIN
 ================================================================================
-The main class name for all skin-specific styles. To make your own skin, 
-replace all occurances of 'vjs-default-skin' with a new name. Then add your new 
-skin name to your video tag instead of the default skin. 
+The main class name for all skin-specific styles. To make your own skin,
+replace all occurances of 'vjs-default-skin' with a new name. Then add your new
+skin name to your video tag instead of the default skin.
 e.g. <video class="video-js my-skin-name">
 */
 .vjs-default-skin {
   color: @main-font-color;
+
+  // fixes wonky loading spinner when placed in center aligned element
+  text-align: left;
 }
 
 /* Custom Icon Font
@@ -98,7 +101,7 @@ The control icons are from a custom font. Each icon corresponds to a character
 @captions-icon: "\e008";
 
 /* Base UI Component Classes
--------------------------------------------------------------------------------- 
+--------------------------------------------------------------------------------
 */
 
 /* Slider - used for Volume bar and Seek bar */
@@ -141,13 +144,13 @@ The control icons are from a custom font. Each icon corresponds to a character
 
 /* Control Bar
 --------------------------------------------------------------------------------
-The default control bar that is a container for most of the controls. 
+The default control bar that is a container for most of the controls.
 */
 .vjs-default-skin .vjs-control-bar {
   /* Start hidden *///
   display: none;
   position: absolute;
-  /* Place control bar at the bottom of the player box/video. 
+  /* Place control bar at the bottom of the player box/video.
      If you want more margin below the control bar, add more height. *///
   bottom: 0;
   /* Use left/right to stretch to 100% width of player div *///
@@ -191,15 +194,15 @@ The default control bar that is a container for most of the controls.
   text-shadow: 0em 0em 1em rgba(255, 255, 255, 1);
 }
 
-.vjs-default-skin .vjs-control:focus { 
+.vjs-default-skin .vjs-control:focus {
   /*  outline: 0; *///
   /* keyboard-only users cannot see the focus on several of the UI elements when
   this is set to 0 */
 }
 
 /* Hide control text visually, but have it available for screenreaders */
-.vjs-default-skin .vjs-control-text { 
-  .hide-visually; 
+.vjs-default-skin .vjs-control-text {
+  .hide-visually;
 }
 
 /* Play/Pause
@@ -388,7 +391,7 @@ The default control bar that is a container for most of the controls.
 
 /* Big Play Button (play button at start)
 --------------------------------------------------------------------------------
-Positioning of the play button in the center or other corners can be done more 
+Positioning of the play button in the center or other corners can be done more
 easily in the skin designer. http://designer.videojs.com/
 */
 .vjs-default-skin .vjs-big-play-button {
@@ -609,18 +612,18 @@ REQUIRED STYLES (be careful overriding)
 ================================================================================
 When loading the player, the video tag is replaced with a DIV,
 that will hold the video tag or object tag for other playback methods.
-The div contains the video playback element (Flash or HTML5) and controls, 
+The div contains the video playback element (Flash or HTML5) and controls,
 and sets the width and height of the video.
 
-** If you want to add some kind of border/padding (e.g. a frame), or special 
-positioning, use another containing element. Otherwise you risk messing up 
+** If you want to add some kind of border/padding (e.g. a frame), or special
+positioning, use another containing element. Otherwise you risk messing up
 control positioning and full window mode. **
 */
 .video-js {
   background-color: #000;
   position: relative;
   padding: 0;
-  /* Start with 10px for base font size so other dimensions can be em based and 
+  /* Start with 10px for base font size so other dimensions can be em based and
      easily calculable. */
   font-size: @base-font-size;
   /* Allow poster to be vertially aligned. */
@@ -649,7 +652,7 @@ control positioning and full window mode. **
   height: 100%;
 }
 
-/* Fix for Firefox 9 fullscreen (only if it is enabled). Not needed when 
+/* Fix for Firefox 9 fullscreen (only if it is enabled). Not needed when
    checking fullScreenEnabled. */
 .video-js:-moz-full-screen { position: absolute; }
 
@@ -675,7 +678,7 @@ body.vjs-full-window {
   _position: absolute;
 }
 .video-js:-webkit-full-screen {
-  width: 100% !important; 
+  width: 100% !important;
   height: 100% !important;
 }
 
@@ -751,9 +754,9 @@ body.vjs-full-window {
   visibility: visible;
 }
 
-// MIXINS 
+// MIXINS
 // =============================================================================
-// Mixins are a LESS feature and are used to add vendor prefixes to CSS rules 
+// Mixins are a LESS feature and are used to add vendor prefixes to CSS rules
 // when needed.
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow
@@ -813,7 +816,7 @@ body.vjs-full-window {
 .user-select (@string: none) {
   /* user-select *///
   -webkit-user-select: @string;
-     -moz-user-select: @string;  
+     -moz-user-select: @string;
       -ms-user-select: @string;
           user-select: @string;
 }
@@ -822,14 +825,14 @@ body.vjs-full-window {
 // http://h5bp.com/v
 .hide-visually () {
   /* hide-visually *///
-  border: 0; 
-  clip: rect(0 0 0 0); 
-  height: 1px; 
-  margin: -1px; 
-  overflow: hidden; 
-  padding: 0; 
-  position: 
-  absolute; 
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position:
+  absolute;
   width: 1px;
 }
 
@@ -882,27 +885,27 @@ body.vjs-full-window {
 // * We want this file to continue to be accessible by people who don't know
 //   LESS but know CSS. This means finding the balance between using the most
 //   valuable LESS features (e.g. variables) and keeping it looking like CSS.
-//   So it's best to avoid advanced LESS features like conditional statements. 
-//   (we're using one for the big play button position because that's a hot 
+//   So it's best to avoid advanced LESS features like conditional statements.
+//   (we're using one for the big play button position because that's a hot
 //   topic)
-// 
+//
 // * We care about the readability of the CSS output of LESS, which means we
 //   have to be careful about what features of LESS we use. (if you're building
 //   your own skin this may not apply)
-//     1. Comments inside of rules (strangely) have an extra line added after 
-//        them in the CSS output. To avoid this we can add a LESS comment after 
+//     1. Comments inside of rules (strangely) have an extra line added after
+//        them in the CSS output. To avoid this we can add a LESS comment after
 //        the CSS comment.
 //          /* comment *///
-// 
+//
 //     2. In a rule with nested rules, any comments outside of a rule are moved
 //        to the top of the parent rule. i.e. it might look like:
 //          /* title of rule 1 */
 //          /* title of rule 2 */
 //          .rule1 {}
 //          .rule2 {}
-//        This is why we aren't using nested rules inside of the 
+//        This is why we aren't using nested rules inside of the
 //        vjs-default-skin class.
 
-/* ----------------------------------------------------------------------------- 
-The original source of this file lives at 
+/* -----------------------------------------------------------------------------
+The original source of this file lives at
 https://github.com/videojs/video.js/blob/master/src/css/video-js.less */


### PR DESCRIPTION
Big request here. Only actual changes are at lines 69 and 70.

```
// fixes wonky loading spinner when placed in center aligned element
text-align: left;
```
