### PR TITLE
Change setup doc URLs to respect current protocol

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,15 +12,15 @@ You can download the Video.js source and host it on your own servers, or use the
 
 ### CDN Version ###
 ```html
-<link href="http://vjs.zencdn.net/4.1/video-js.css" rel="stylesheet">
-<script src="http://vjs.zencdn.net/4.1/video.js"></script>
+<link href="//vjs.zencdn.net/4.1/video-js.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/4.1/video.js"></script>
 ```
 
 ### Self Hosted. ###
 With the self hosted option you'll also want to update the location of the video-js.swf file.
 ```html
-<link href="http://example.com/path/to/video-js.css" rel="stylesheet">
-<script src="http://example.com/path/to/video.js"></script>
+<link href="//example.com/path/to/video-js.css" rel="stylesheet">
+<script src="//example.com/path/to/video.js"></script>
 <script>
   videojs.options.flash.swf = "http://example.com/path/to/video-js.swf"
 </script>


### PR DESCRIPTION
Very small documentation change of `http://vjs...` to `//vjs...`

Thought it might be helpful for future users copypasting the instructions :)
