### PR TITLE
Use CSS to show and hide components. Use classList when supported.

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -526,7 +526,7 @@ vjs.Component.prototype.removeClass = function(classToRemove){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.show = function(){
-  this.el_.style.display = 'block';
+  this.removeClass('vjs-hidden');
   return this;
 };
 
@@ -535,7 +535,7 @@ vjs.Component.prototype.show = function(){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.hide = function(){
-  this.el_.style.display = 'none';
+  this.addClass('vjs-hidden');
   return this;
 };
 

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -256,34 +256,55 @@ vjs.isEmpty = function(obj) {
   return true;
 };
 
-/**
- * Add a CSS class name to an element
- * @param {Element} element    Element to add class name to
- * @param {String} classToAdd Classname to add
- */
-vjs.addClass = function(element, classToAdd){
-  if ((' '+element.className+' ').indexOf(' '+classToAdd+' ') == -1) {
-    element.className = element.className === '' ? classToAdd : element.className + ' ' + classToAdd;
-  }
-};
+(function(){
+  var addClass, removeClass;
 
-/**
- * Remove a CSS class name from an element
- * @param {Element} element    Element to remove from class name
- * @param {String} classToAdd Classname to remove
- */
-vjs.removeClass = function(element, classToRemove){
-  if (element.className.indexOf(classToRemove) == -1) { return; }
-  var classNames = element.className.split(' ');
-  // IE8 Does not support array.indexOf so using a for loop
-  for (var i = classNames.length - 1; i >= 0; i--) {
-    if (classNames[i] === classToRemove) {
-      classNames.splice(i,1);
-    }
+  if (document.createElement('div').classList) {
+
+    // use browser-native class manipulation
+    addClass = function(element, classToAdd){
+      element.classList.add(classToAdd);
+    };
+    removeClass = function(element, classToRemove){
+      element.classList.remove(classToRemove);
+    };
+
+  } else {
+
+    // parse the class property by hand
+    addClass = function(element, classToAdd){
+      if ((' '+element.className+' ').indexOf(' '+classToAdd+' ') == -1) {
+        element.className = element.className === '' ? classToAdd : element.className + ' ' + classToAdd;
+      }
+    };
+    removeClass = function(element, classToRemove){
+      if (element.className.indexOf(classToRemove) == -1) { return; }
+      var classNames = element.className.split(' ');
+      // IE8 Does not support array.indexOf so using a for loop
+      for (var i = classNames.length - 1; i >= 0; i--) {
+        if (classNames[i] === classToRemove) {
+          classNames.splice(i,1);
+        }
+      }
+      // classNames.splice(classNames.indexOf(classToRemove),1);
+      element.className = classNames.join(' ');
+    };
   }
-  // classNames.splice(classNames.indexOf(classToRemove),1);
-  element.className = classNames.join(' ');
-};
+
+  /**
+   * Add a CSS class name to an element
+   * @param {Element} element    Element to add class name to
+   * @param {String} classToAdd Classname to add
+   */
+  vjs.addClass = addClass;
+
+  /**
+   * Remove a CSS class name from an element
+   * @param {Element} element    Element to remove from class name
+   * @param {String} classToAdd Classname to remove
+   */
+  vjs.removeClass = removeClass;
+})();
 
 /**
  * Element for testing browser HTML5 video capabilities

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -162,9 +162,9 @@ test('should show and hide an element', function(){
   var comp = new vjs.Component(getFakePlayer(), {});
 
   comp.hide();
-  ok(comp.el().style.display === 'none');
+  ok(/vjs-hidden/.test(comp.el().className), 'the class is present when hidden');
   comp.show();
-  ok(comp.el().style.display === 'block');
+  ok(!/vjs-hidden/.test(comp.el().className), 'the class is absent when shown');
 });
 
 test('should change the width and height of a component', function(){


### PR DESCRIPTION
Instead of setting `display: none` directly on a component element to hide or show it, use vjs-hidden. This allows whether to show or hide elements to be overridden in custom skins or plugins. For example, a social plugin might want to show the loading spinner while it loads a login pop-up even though video.js would probably be hiding the spinner by default during that time. Added a load-time check for the classList property on elements so the implementation can avoid manually parsing the class property if it's present.
