### PR TITLE
Allow poster to be changed after init. Fixes #525

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -244,6 +244,9 @@ vjs.Flash.prototype.load = function(){
 vjs.Flash.prototype.poster = function(){
   this.el_.vjs_getProperty('poster');
 };
+vjs.Flash.prototype.setPoster = function(){
+  // poster images are not handled by the Flash tech so make this a no-op
+};
 
 vjs.Flash.prototype.buffered = function(){
   return vjs.createTimeRange(0, this.el_.vjs_getProperty('buffered'));

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -213,6 +213,9 @@ vjs.Html5.prototype.src = function(src){ this.el_.src = src; };
 vjs.Html5.prototype.load = function(){ this.el_.load(); };
 vjs.Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
 
+vjs.Html5.prototype.poster = function(){ return this.el_.poster; };
+vjs.Html5.prototype.setPoster = function(val){ this.el_.poster = val; };
+
 vjs.Html5.prototype.preload = function(){ return this.el_.preload; };
 vjs.Html5.prototype.setPreload = function(val){ this.el_.preload = val; };
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -842,10 +842,25 @@ vjs.Player.prototype.poster_;
  * @return {String}    Poster image source URL or null
  */
 vjs.Player.prototype.poster = function(src){
-  if (src !== undefined) {
-    this.poster_ = src;
+  var posterImage;
+  if (src === undefined) {
+    return this.poster_;
   }
-  return this.poster_;
+
+  // update the internal poster variable
+  this.poster_ = src;
+
+  // access the posterImage through the name index instead of directly off
+  // `this` because closure compiler erases the property even if it's being used...
+  posterImage = this.childNameIndex_['posterImage'];
+
+  // update the posterImage component
+  if (posterImage) {
+    posterImage.src(src);
+  }
+
+  // update the tech's poster
+  this.techCall('setPoster', src);
 };
 
 /**

--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -1,5 +1,20 @@
 /* Poster Image
 ================================================================================ */
+
+/**
+ * Helper function to set the poster source. To ensure the poster image resizes
+ * while maintaining its original aspect ratio, use a div with `background-size`
+ * when available. For browsers that do not support `background-size` (e.g.
+ * IE8), fall back on using a regular img element.
+ */
+var setSrc = function(el, src){
+  if ('backgroundSize' in el.style) {
+    el.style.backgroundImage = 'url("' + src + '")';
+  } else {
+    el.appendChild(vjs.createEl('img', { src: src }));
+  }
+};
+
 /**
  * Poster image. Shows before the video plays.
  * @param {vjs.Player|Object} player
@@ -29,14 +44,26 @@ vjs.PosterImage.prototype.createEl = function(){
       poster = this.player_.poster();
 
   if (poster) {
-    if ('backgroundSize' in el.style) {
-      el.style.backgroundImage = 'url("' + poster + '")';
-    } else {
-      el.appendChild(vjs.createEl('img', { src: poster }));
-    }
+    setSrc(el, poster);
   }
 
   return el;
+};
+
+vjs.PosterImage.prototype.src = function(url){
+  var el = this.el();
+
+  // getter
+  if (url === undefined) {
+    if ('backgroundSize' in el.style) {
+      return (/url\(['"]?(.*)['"]?\)/).exec(el.style.backgroundImage)[1];
+    } else {
+      return el.src;
+    }
+  }
+
+  // setter
+  setSrc(el, url);
 };
 
 vjs.PosterImage.prototype.onClick = function(){

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -30,6 +30,10 @@ vjs.MediaFaker.prototype.createEl = function(){
   return el;
 };
 
+// fake a poster attribute to mimic the video element
+vjs.MediaFaker.prototype.poster = function(){ return this.el().poster; };
+vjs.MediaFaker.prototype['setPoster'] = function(val){ this.el().poster = val; };
+
 vjs.MediaFaker.prototype.currentTime = function(){ return 0; };
 vjs.MediaFaker.prototype.volume = function(){ return 0; };
 vjs.MediaFaker.prototype.muted = function(){ return false; };

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -176,6 +176,28 @@ test('should transfer the poster attribute unmodified', function(){
   player.dispose();
 });
 
+test('should allow the poster to be changed after init', function() {
+  var tag, fixture, updatedPoster, player;
+  tag = PlayerTest.makeTag();
+  tag.setAttribute('poster', 'http://example.com/poster.jpg');
+  fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+  player = new vjs.Player(tag, {
+    'techOrder': ['mediaFaker']
+  });
+
+  updatedPoster = 'http://example.com/udpdated-poster.jpg';
+  player.poster(updatedPoster);
+  strictEqual(player.poster(), updatedPoster, 'the updated poster is returned');
+  strictEqual(player.tech.el().poster, updatedPoster, 'the poster attribute is updated');
+  strictEqual(fixture.querySelector('.vjs-poster').style.backgroundImage,
+              'url(' + updatedPoster + ')',
+              'the poster div background is updated');
+
+  player.dispose();
+});
+
 test('should load a media controller', function(){
   var player = PlayerTest.makePlayer({
     preload: 'none',


### PR DESCRIPTION
When poster() is called with a URL, set it to the PosterImage source and update the video element attribute.
