### PR TITLE
Fixed windowLoaded not setting on async script load

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -53,9 +53,13 @@ vjs.autoSetupTimeout = function(wait){
   setTimeout(vjs.autoSetup, wait);
 };
 
-vjs.one(window, 'load', function(){
+if (document.readyState === 'complete') {
   vjs.windowLoaded = true;
-});
+} else {
+  vjs.one(window, 'load', function(){
+    vjs.windowLoaded = true;
+  });
+}
 
 // Run Auto-load players
 // You have to wait at least once in case this script is loaded after your video in the DOM (weird behavior only with minified version)


### PR DESCRIPTION
vjs.one(window, "load") was never getting called back if video.js was loaded asynchronously. This caused a nasty infinite loop in autoSetup. Closes #727 
