### PR TITLE
Added appendNotSupportedMessage function.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -730,9 +730,18 @@ vjs.Player.prototype.selectSource = function(sources){
  * hosting website.
  */
 vjs.Player.prototype.appendNotSupportedMessage = function(){
-  this.el_.appendChild(vjs.createEl('p', {
-    innerHTML: this.options()['notSupportedMessage']
-  }));
+  var vjsError = document.getElementById("vjs-error");
+  //rewrite an existing error with a new message.
+  if(vjsError){
+    vjsError.innerHTML = this.options()['notSupportedMessage'];
+  }else{
+    //create a new error.
+    this.el_.appendChild(vjs.createEl('p', {
+      id: "vjs-error",
+      class: "vjs-error",
+      innerHTML: this.options()['notSupportedMessage']
+    }));
+  }
 };
 
 // src is a pretty powerful function


### PR DESCRIPTION
Can be called from parent website in case of external errors.

Website can change the notSupportedMessage then call this function to display a custom error. Messages will reuse existing error containers in case someone tries to throw an error message and the video throws a different error. A class of vjs-error is used for styling purposes. An id of vjs-error is used for selection purposes.
