### PR TITLE
Allow poster to be changed after init. Fixes #525

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -271,6 +271,9 @@ vjs.Flash.prototype.load = function(){
 vjs.Flash.prototype.poster = function(){
   this.el_.vjs_getProperty('poster');
 };
+vjs.Flash.prototype.setPoster = function(){
+  // poster images are not handled by the Flash tech so make this a no-op
+};
 
 vjs.Flash.prototype.buffered = function(){
   return vjs.createTimeRange(0, this.el_.vjs_getProperty('buffered'));

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -213,6 +213,9 @@ vjs.Html5.prototype.src = function(src){ this.el_.src = src; };
 vjs.Html5.prototype.load = function(){ this.el_.load(); };
 vjs.Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
 
+vjs.Html5.prototype.poster = function(){ return this.el_.poster; };
+vjs.Html5.prototype.setPoster = function(val){ this.el_.poster = val; };
+
 vjs.Html5.prototype.preload = function(){ return this.el_.preload; };
 vjs.Html5.prototype.setPreload = function(val){ this.el_.preload = val; };
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -837,10 +837,18 @@ vjs.Player.prototype.poster_;
  * @return {String}    Poster image source URL or null
  */
 vjs.Player.prototype.poster = function(src){
-  if (src !== undefined) {
-    this.poster_ = src;
+  if (src === undefined) {
+    return this.poster_;
   }
-  return this.poster_;
+
+  // update the internal poster variable
+  this.poster_ = src;
+
+  // alert components that the poster has been set
+  this.trigger('posterchange');
+
+  // update the tech's poster
+  this.techCall('setPoster', src);
 };
 
 /**

--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -11,9 +11,17 @@ vjs.PosterImage = vjs.Button.extend({
   init: function(player, options){
     vjs.Button.call(this, player, options);
 
+    if (player.poster()) {
+      this.src(player.poster());
+    }
+
     if (!player.poster() || !player.controls()) {
       this.hide();
     }
+
+    player.on('posterchange', vjs.bind(this, function(){
+      this.src(player.poster());
+    }));
 
     player.on('play', vjs.bind(this, this.hide));
   }
@@ -21,22 +29,43 @@ vjs.PosterImage = vjs.Button.extend({
 
 vjs.PosterImage.prototype.createEl = function(){
   var el = vjs.createEl('div', {
-        className: 'vjs-poster',
+    className: 'vjs-poster',
 
-        // Don't want poster to be tabbable.
-        tabIndex: -1
-      }),
-      poster = this.player_.poster();
-
-  if (poster) {
-    if ('backgroundSize' in el.style) {
-      el.style.backgroundImage = 'url("' + poster + '")';
-    } else {
-      el.appendChild(vjs.createEl('img', { src: poster }));
-    }
-  }
+    // Don't want poster to be tabbable.
+    tabIndex: -1
+  }),
+  poster = this.player_.poster();
 
   return el;
+};
+
+vjs.PosterImage.prototype.src = function(url){
+  var el = this.el();
+
+  // getter
+  if (url === undefined) {
+    if ('backgroundSize' in el.style) {
+      if (el.style.backgroundImage) {
+        // parse the poster url from the background-image value
+        return (/url\(['"]?(.*)['"]?\)/).exec(el.style.backgroundImage)[1];
+      }
+
+      // the poster is not specified
+      return '';
+    }
+    return el.querySelector('img').src;
+  }
+
+  // setter
+  // To ensure the poster image resizes while maintaining its original aspect
+  // ratio, use a div with `background-size` when available. For browsers that
+  // do not support `background-size` (e.g. IE8), fall back on using a regular
+  // img element.
+  if ('backgroundSize' in el.style) {
+    el.style.backgroundImage = 'url("' + url + '")';
+  } else {
+    el.appendChild(vjs.createEl('img', { src: url }));
+  }
 };
 
 vjs.PosterImage.prototype.onClick = function(){

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -100,3 +100,32 @@ test('calculateDistance should use changedTouches, if available', function() {
 
   equal(slider.calculateDistance(event), 0.5, 'we should have touched exactly in the center, so, the ratio should be half');
 });
+
+test('the poster getter should work correctly even when background-size is not available', function() {
+  var noop = function(){},
+      url = 'http://example.com/poster.jpg',
+      player = {
+        controls: noop,
+        id: noop,
+        on: noop,
+        ready: noop,
+        poster: function(){
+          return url;
+        }
+      },
+      poster = new vjs.PosterImage(player);
+
+  // mock out el() to return an element that behaves like IE8
+  poster.el = function(){
+    return {
+      style: {},
+      querySelector: function() {
+        return {
+          src: url
+        };
+      }
+    };
+  };
+
+  equal(url, poster.src(), 'the poster url is returned');
+});

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -30,6 +30,10 @@ vjs.MediaFaker.prototype.createEl = function(){
   return el;
 };
 
+// fake a poster attribute to mimic the video element
+vjs.MediaFaker.prototype.poster = function(){ return this.el().poster; };
+vjs.MediaFaker.prototype['setPoster'] = function(val){ this.el().poster = val; };
+
 vjs.MediaFaker.prototype.currentTime = function(){ return 0; };
 vjs.MediaFaker.prototype.seeking = function(){ return false; };
 vjs.MediaFaker.prototype.volume = function(){ return 0; };

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -176,6 +176,28 @@ test('should transfer the poster attribute unmodified', function(){
   player.dispose();
 });
 
+test('should allow the poster to be changed after init', function() {
+  var tag, fixture, updatedPoster, player;
+  tag = PlayerTest.makeTag();
+  tag.setAttribute('poster', 'http://example.com/poster.jpg');
+  fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+  player = new vjs.Player(tag, {
+    'techOrder': ['mediaFaker']
+  });
+
+  updatedPoster = 'http://example.com/udpdated-poster.jpg';
+  player.poster(updatedPoster);
+  strictEqual(player.poster(), updatedPoster, 'the updated poster is returned');
+  strictEqual(player.tech.el().poster, updatedPoster, 'the poster attribute is updated');
+  strictEqual(fixture.querySelector('.vjs-poster').style.backgroundImage,
+              'url(' + updatedPoster + ')',
+              'the poster div background is updated');
+
+  player.dispose();
+});
+
 test('should load a media controller', function(){
   var player = PlayerTest.makePlayer({
     preload: 'none',


### PR DESCRIPTION
When poster() is called with a URL, fire a `posterchange` event to update the PosterImage source and update the video element attribute.
