### PR TITLE
Expose deepMerge and copy utilities

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -32,6 +32,11 @@ goog.exportSymbol('videojs.options', vjs.options);
 goog.exportSymbol('videojs.players', vjs.players);
 goog.exportSymbol('videojs.TOUCH_ENABLED', vjs.TOUCH_ENABLED);
 
+// Allow plugins to use the same options-merging as components
+goog.exportSymbol('videojs.obj', vjs.obj);
+goog.exportProperty(vjs.obj, 'deepMerge', vjs.obj.deepMerge);
+goog.exportProperty(vjs.obj, 'copy', vjs.obj.copy);
+
 // Allow external components to use global cache
 goog.exportSymbol('videojs.cache', vjs.cache);
 

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -73,6 +73,12 @@ test('should export useful components to the public', function () {
   ok(videojs.MenuButton, 'MenuButton should be public');
 });
 
+test('should export object helpers for plugin authors', function(){
+  ok(videojs.obj, 'the obj namespace is public');
+  ok(videojs.obj.deepMerge, 'deepMerge is public');
+  ok(videojs.obj.copy, 'object copy is public');
+});
+
 test('should be able to initialize player twice on the same tag using string reference', function() {
   var videoTag = PlayerTest.makeTag();
   var id = videoTag.id;


### PR DESCRIPTION
Plugin authors will want to use the same logic to merge player options with defaults as video.js core and it doesn't make sense for every single plugin to have to re-implement that. Exposing these two utilities allows plugin authors to easily work with options the same way video.js itself does.
