### PR TITLE
Move player id generation

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -32,6 +32,9 @@ vjs.Player = vjs.Component.extend({
   init: function(tag, options, ready){
     this.tag = tag; // Store the original tag used to set options
 
+    // Make sure tag ID exists
+    tag.id = tag.id || 'vjs_video_' + vjs.guid++;
+
     // Set Options
     // The options argument overrides options set in the video tag
     // which overrides globally set options.
@@ -204,9 +207,6 @@ vjs.Player.prototype.createEl = function(){
       tag.removeChild(removeNodes[i]);
     }
   }
-
-  // Make sure tag ID exists
-  tag.id = tag.id || 'vjs_video_' + vjs.guid++;
 
   // Give video tag ID and class to player div
   // ID will now reference player box, not the video tag

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -350,3 +350,18 @@ test('should use custom message when encountering an unsupported video type',
 
   player.dispose();
 });
+
+test('should register players with generated ids', function(){
+  var fixture, video, player, id;
+  fixture = document.getElementById('qunit-fixture');
+
+  video = document.createElement('video');
+  video.className = 'vjs-default-skin video-js';
+  fixture.appendChild(video);
+
+  player = new vjs.Player(video);
+  id = player.el().id;
+
+  equal(player.el().id, player.id(), 'the player and element ids are equal');
+  ok(vjs.players[id], 'the generated id is registered');
+});


### PR DESCRIPTION
If the video element has a id attribute when video.js was created, it used that as the player id. If the video did not have an id, however, the player would get an auto-generated component id that started with "undefined_..." and the player element received a id like "vjs_video_...". This change modifies the player init order so that the video element is given an autogenerated id early in the process, which is then picked up by the player component when it gets around to initialization. This unifies the player component id and tag id and is more consistent with the structure created when a video element with a user-defined id is passed in.
