### PR TITLE
Add a vjs.Player externs file for fullscreen functionality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,12 +52,12 @@ module.exports = function(grunt) {
     minify: {
       source:{
         src: ['build/files/combined.video.js', 'build/compiler/goog.base.js', 'src/js/exports.js'],
-        externs: ['src/js/media/flash.externs.js'],
+        externs: ['src/js/player.externs.js', 'src/js/media/flash.externs.js'],
         dest: 'build/files/minified.video.js'
       },
       tests: {
         src: ['build/files/combined.video.js', 'build/compiler/goog.base.js', 'src/js/exports.js', 'test/unit/*.js', '!test/unit/api.js'],
-        externs: ['src/js/media/flash.externs.js', 'test/qunit/qunit-externs.js'],
+        externs: ['src/js/player.externs.js', 'src/js/media/flash.externs.js', 'test/qunit/qunit-externs.js'],
         dest: 'build/files/test.minified.video.js'
       }
     },

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -23,11 +23,11 @@ vjs.FullscreenToggle.prototype.buildCSSClass = function(){
 };
 
 vjs.FullscreenToggle.prototype.onClick = function(){
-  if (!this.player_['isFullScreen']) {
-    this.player_['requestFullScreen']();
+  if (!this.player_.isFullScreen) {
+    this.player_.requestFullScreen();
     this.el_.children[0].children[0].innerHTML = 'Non-Fullscreen'; // change the button text to "Non-Fullscreen"
   } else {
-    this.player_['cancelFullScreen']();
+    this.player_.cancelFullScreen();
     this.el_.children[0].children[0].innerHTML = 'Fullscreen'; // change the button to "Fullscreen"
   }
 };

--- a/src/js/player.externs.js
+++ b/src/js/player.externs.js
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Externs for videojs.Player. Externs are functions that the
+ * compiler shouldn't obfuscate.
+ */
+
+/**
+ * Fullscreen functionality
+ */
+videojs.Player.prototype.isFullScreen = undefined;
+videojs.Player.prototype.requestFullScreen = function(){};
+videojs.Player.prototype.cancelFullScreen = function(){};


### PR DESCRIPTION
Use an externs file for fullscreen-related functionality on the player object. Otherwise, closure compiler replaces them with minified method names and makes it impossible to supply a simpler "player" object with customized fullscreen logic for the fullscreenToggle to interact with.
