### PR TITLE
Bug/callstack gh 860

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -686,7 +686,7 @@ vjs.Player.prototype.duration = function(seconds){
     this.onDurationChange();
   }
 
-  return this.cache_.duration;
+  return this.cache_.duration || 0;
 };
 
 // Calculates how much time is left. Not in spec, but useful.


### PR DESCRIPTION
This addresses bug #860.
First, we check to make sure that we got a duration from the `techGet` call, which may return nothing if the tech isn't ready yet, and then we call to update the duration if a duration exists. Otherwise, we don't.
If we don't have a cached value for duration, we should default to returning zero.
