### PR TITLE
Make textTracks an extern

### DIFF
--- a/src/js/player.externs.js
+++ b/src/js/player.externs.js
@@ -9,3 +9,8 @@
 videojs.Player.prototype.isFullScreen = undefined;
 videojs.Player.prototype.requestFullScreen = function(){};
 videojs.Player.prototype.cancelFullScreen = function(){};
+
+/**
+ * Text tracks
+ */
+videojs.Player.prototype.textTracks = function(){};


### PR DESCRIPTION
TextTracks are queried during player initialization whether they're present or not so the method must be present on Player objects. Make sure the method name isn't minified so it's possible to create a Player object without having to extend videojs.Player directly.
