### PR TITLE
Fix capability detection for poster image

### DIFF
--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -29,7 +29,7 @@ vjs.PosterImage = vjs.Button.extend({
 });
 
 // use the test el to check for backgroundSize style support
-var _backgroundSizeSupported = 'backgroundSize' in vjs.TEST_VID;
+var _backgroundSizeSupported = 'backgroundSize' in vjs.TEST_VID.style;
 
 vjs.PosterImage.prototype.createEl = function(){
   var el = vjs.createEl('div', {


### PR DESCRIPTION
We were checking if `backgroundSize` was present on the video element, not the style property of the video element. That meant the IE fallback was being used on all platforms and breaks aspect-ratio preserving poster scaling for those browsers that support it.
