### PR TITLE
Fix to reuse HTML5 tech

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -48,6 +48,10 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // In Chrome (15), if you have autoplay + a poster + no controls, the video gets hidden (but audio plays)
     // This fixes both issues. Need to wait for API, so it updates displays correctly
     player.ready(function(){
+      // Update the duration and volume in case the player has been used before
+      this.trigger('durationchange');
+      this.trigger('volumechange');
+      
       if (this.tag && this.options_['autoplay'] && this.paused()) {
         delete this.tag['poster']; // Chrome Fix. Fixed in Chrome v16.
         this.play();


### PR DESCRIPTION
Two bugs were existing for Video.js when you were trying to change the tech back to HTML5. 
1. The <video> element wasn't adding himself back to the DOM.
2. The duration / volume of the player were not updated when we switch back to the HTML5 tech.

See http://jsbin.com/ocOrogAT/4 (http://jsbin.com/ocOrogAT/4/edit)
1. The first Html5 video is playing correctly. 
2. The first Youtube video is playing correctly.
3. The second Html5 video is playing outside the DOM
4. The second Html5 video has the wrong duration (hasn't been updated)

If you know a smarter way to fix it, let me know. The way to fix the duration/volume looks pretty hackish to me.

(related to https://github.com/eXon/videojs-youtube/issues/45)
