### PR TITLE
Remove added userActivity_ to global

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1286,7 +1286,7 @@ vjs.Player.prototype.listenForUserActivity = function(){
   var onMouseActivity, onMouseDown, mouseInProgress, onMouseUp,
       activityCheck, inactivityTimeout;
 
-  onMouseActivity = this.reportUserActivity;
+  onMouseActivity = vjs.bind(this, this.reportUserActivity);
 
   onMouseDown = function() {
     onMouseActivity();
@@ -1297,7 +1297,7 @@ vjs.Player.prototype.listenForUserActivity = function(){
     // Setting userActivity=true now and setting the interval to the same time
     // as the activityCheck interval (250) should ensure we never miss the
     // next activityCheck
-    mouseInProgress = setInterval(vjs.bind(this, onMouseActivity), 250);
+    mouseInProgress = setInterval(this, onMouseActivity, 250);
   };
 
   onMouseUp = function(event) {


### PR DESCRIPTION
I browsed this html.

``` html
<!DOCTYPE html>
<html>
  <head>
    <script src="video.js/dist/video-js/video.dev.js"></script>
  </head>
  <body>
    <div id="test"></div>
    <div id="video"></div>
    <script>
      videojs.options.techOrder = ['flash'];
      videojs.options.flash.swf = 'video.js/dist/video-js/video-js.swf';
      videojs('video');

      var el = document.getElementById('test');
      el.style.cssText = 'border: 1px solid red; background-color: #fee; font-weight: bold;';
      setInterval(function() {
        el.textContent = 'window.userActivity_ is "' + window.userActivity_ + '"';
      }, 500);
    </script>
  </body>
</html>
```

`window.userAcitvity_` is undefined at first. But it is now true If I click on the video.
Because `onMouseActivity();` is not specified thisValue, thisValue in the `reportUserActivity` is window.
