### PR TITLE
Support dist target on Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,6 +147,16 @@ module.exports = function(grunt) {
           baseURL: 'https://github.com/videojs/video.js/blob/master/'
         }
       }
+    },
+    zip: {
+      dist: {
+        router: function (filepath) {
+          var path = require('path');
+          return path.relative('dist', filepath);
+        },
+        src: ['dist/video-js/**/*'],
+        dest: 'dist/video-js-' + version.full + '.zip'
+      }
     }
   });
 
@@ -161,6 +171,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('contribflow');
   grunt.loadNpmTasks('grunt-karma');
   grunt.loadNpmTasks('videojs-doc-generator');
+  grunt.loadNpmTasks('grunt-zip');
 
   // grunt.loadTasks('./docs/tasks/');
   // grunt.loadTasks('../videojs-doc-generator/tasks/');
@@ -265,9 +276,7 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('dist', 'Creating distribution', function(){
-    var exec = require('child_process').exec;
-    var done = this.async();
+  grunt.registerTask('dist-copy', 'Assembling distribution', function(){
     var css, jsmin, jsdev, cdnjs;
 
     // Manually copy each source file
@@ -305,21 +314,8 @@ module.exports = function(grunt) {
     // GA Tracking Pixel (manually building the pixel URL)
     cdnjs = uglify.minify('src/js/cdn.js').code.replace('v0.0.0', 'v'+version.full);
     grunt.file.write('dist/cdn/video.js', jsmin + cdnjs);
-
-    // Zip up into video-js-VERSION.zip
-    exec('cd dist && zip -r video-js-'+version.full+'.zip video-js && cd ..', { maxBuffer: 500*1024 }, function(err, stdout, stderr){
-
-      if (err) {
-        grunt.warn(err);
-        done(false);
-      }
-
-      if (stdout) {
-        grunt.log.writeln(stdout);
-      }
-
-      done();
-    });
   });
+
+  grunt.registerTask('dist', 'Creating distribution', ['dist-copy', 'zip:dist']);
 
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-karma": "~0.4.4",
     "karma-qunit": "~0.0.2",
     "videojs-doc-generator": "0.0.1",
-    "qunitjs": "~1.12.0"
+    "qunitjs": "~1.12.0",
+    "grunt-zip": "0.10.2"
   },
   "testling": {
     "browsers": [


### PR DESCRIPTION
The dist target tries to use the Unix/Mac 'zip' utility, which isn't present on Windows. Without this fix, the 'grunt:dist' target (and, by extension, the default 'grunt' target) does not succeed.
