### PR TITLE
Karma example is missing util

### DIFF
--- a/test/karma.conf.js.example
+++ b/test/karma.conf.js.example
@@ -64,6 +64,7 @@ files = [
   '../src/js/json.js',
   '../src/js/setup.js',
   '../src/js/plugins.js',
+  '../src/js/util.js',
   '../test/unit/*.js'
 ];
 


### PR DESCRIPTION
Karma tests fail using the example karma.conf, because the util file is not included.
