### PR TITLE
Store last seek time in the Flash tech

### DIFF
--- a/src/js/control-bar/progress-control.js
+++ b/src/js/control-bar/progress-control.js
@@ -68,25 +68,7 @@ vjs.SeekBar.prototype.updateARIAAttributes = function(){
 };
 
 vjs.SeekBar.prototype.getPercent = function(){
-  var currentTime;
-  // Flash RTMP provider will not report the correct time
-  // immediately after a seek. This isn't noticeable if you're
-  // seeking while the video is playing, but it is if you seek
-  // while the video is paused.
-  if (this.player_.techName === 'Flash' && this.player_.seeking()) {
-    var cache = this.player_.getCache();
-    if (cache.lastSetCurrentTime) {
-      currentTime = cache.lastSetCurrentTime;
-    }
-    else {
-      currentTime = this.player_.currentTime();
-    }
-  }
-  else {
-    currentTime = this.player_.currentTime();
-  }
-
-  return currentTime / this.player_.duration();
+  return this.player_.currentTime() / this.player_.duration();
 };
 
 vjs.SeekBar.prototype.onMouseDown = function(event){

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -60,7 +60,9 @@ vjs.Flash = vjs.MediaTechController.extend({
           'id': objId,
           'name': objId, // Both ID and Name needed or swf to identifty itself
           'class': 'vjs-tech'
-        }, options['attributes'])
+        }, options['attributes']),
+
+        lastSeekTarget
     ;
 
     // If source was supplied pass as a flash var.
@@ -74,6 +76,17 @@ vjs.Flash = vjs.MediaTechController.extend({
         flashVars['src'] = encodeURIComponent(vjs.getAbsoluteURL(source.src));
       }
     }
+
+    this['setCurrentTime'] = function(time){
+      lastSeekTarget = time;
+      this.el_.vjs_setProperty('currentTime', time);
+    };
+    this['currentTime'] = function(time){
+      if (this.seeking()) {
+        return lastSeekTarget;
+      }
+      return this.el_.vjs_getProperty('currentTime');
+    };
 
     // Add placeholder to player div
     vjs.insertFirst(placeHolder, parentEl);
@@ -302,9 +315,9 @@ vjs.Flash.prototype.enterFullScreen = function(){
 
 // Create setters and getters for attributes
 var api = vjs.Flash.prototype,
-    readWrite = 'rtmpConnection,rtmpStream,preload,currentTime,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(','),
+    readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(','),
     readOnly = 'error,currentSrc,networkState,readyState,seeking,initialTime,duration,startOffsetTime,paused,played,seekable,ended,videoTracks,audioTracks,videoWidth,videoHeight,textTracks'.split(',');
-    // Overridden: buffered
+    // Overridden: buffered, currentTime
 
 /**
  * @this {*}

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -646,9 +646,6 @@ vjs.Player.prototype.paused = function(){
 vjs.Player.prototype.currentTime = function(seconds){
   if (seconds !== undefined) {
 
-    // cache the last set value for smoother scrubbing
-    this.cache_.lastSetCurrentTime = seconds;
-
     this.techCall('setCurrentTime', seconds);
 
     // improve the accuracy of manual timeupdates

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -62,3 +62,37 @@ test('test canPlaySource', function() {
   ok(!canPlaySource({ type: 'video/webm; codecs="vp8, vorbis"' }));
   ok(!canPlaySource({ type: 'video/webm' }));
 });
+
+test('currentTime is the seek target during seeking', function() {
+  var noop = function() {},
+      seeking = false,
+      parentEl = document.createElement('div'),
+      tech = new vjs.Flash({
+        id: noop,
+        on: noop,
+        options_: {}
+      }, {
+        'parentEl': parentEl
+      }),
+      currentTime;
+
+  tech.el().vjs_setProperty = function(property, value) {
+    if (property === 'currentTime') {
+      currentTime = value;
+    }
+  };
+  tech.el().vjs_getProperty = function(name) {
+    if (name === 'currentTime') {
+      return currentTime;
+    } else if (name === 'seeking') {
+      return seeking;
+    }
+  };
+
+  currentTime = 3;
+  strictEqual(3, tech.currentTime(), 'currentTime is retreived from the SWF');
+
+  tech['setCurrentTime'](7);
+  seeking = true;
+  strictEqual(7, tech.currentTime(), 'during seeks the target time is returned');
+});


### PR DESCRIPTION
Instead of caching the last seek time at the player level, cache it in the Flash tech. The only place this value was used was in the progress controls when Flash was loaded, so this simplifies the logic in that component and pushes the hack down into a single location.

I tested seeking on an RTMP stream while paused and noticed that 1 in 5 times, the progress bar incorrectly reports the currentTime. I logged both branches of the currentTime getter in the Flash tech, however, and it appears the incorrect return value is because the SWF is reporting that it is no longer seeking. That says to me that this issue would still exist in 4.3, so things should be no worse than they were before.
