### PR TITLE
Fix touch detection test on non-touch devices

### DIFF
--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -72,7 +72,7 @@ test('should export ready api call to public', function() {
 });
 
 test('should export useful components to the public', function () {
-  ok(videojs.TOUCH_ENABLED, 'Touch detection should be public');
+  ok(videojs.TOUCH_ENABLED !== undefined, 'Touch detection should be public');
   ok(videojs.ControlBar, 'ControlBar should be public');
   ok(videojs.Button, 'Button should be public');
   ok(videojs.PlayToggle, 'PlayToggle should be public');


### PR DESCRIPTION
TOUCH_ENABLED is false on non-touch devices which causes our minified API test to fail when opened in a browser on a traditional destktop machine. It worked fine through the command line because apparanetly phantomjs supports touch events (ha!). Check to make sure the property is not undefined instead.
