### PR TITLE
Quiet down deprecation warnings

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -179,7 +179,8 @@ vjs.fixEvent = function(event) {
     // TODO: Probably best to create a whitelist of event props
     for (var key in old) {
       // Safari 6.0.3 warns you if you try to copy deprecated layerX/Y
-      if (key !== 'layerX' && key !== 'layerY') {
+      // Chrome warns you if you try to copy deprecated keyboardEvent.keyLocation
+      if (key !== 'layerX' && key !== 'layerY' && key !== 'keyboardEvent.keyLocation') {
         // Chrome 32+ warns if you try to copy deprecated returnValue, but
         // we still want to if preventDefault isn't supported (IE8).
         if (!(key == 'returnValue' && old.preventDefault)) {


### PR DESCRIPTION
Deprecation warnings were getting chatty, so this removes deprecated `keyboardEvent.keyLocation` (not in use anyway) and only copies `returnValue` if `preventDefault` is not available. 
