### PR TITLE
Inserts Fullscreen events .fixes #688

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -128,6 +128,8 @@ goog.exportProperty(vjs.Html5.prototype, 'setMuted', vjs.Html5.prototype.setMute
 goog.exportProperty(vjs.Html5.prototype, 'setPreload', vjs.Html5.prototype.setPreload);
 goog.exportProperty(vjs.Html5.prototype, 'setAutoplay', vjs.Html5.prototype.setAutoplay);
 goog.exportProperty(vjs.Html5.prototype, 'setLoop', vjs.Html5.prototype.setLoop);
+goog.exportProperty(vjs.Html5.prototype, 'enterFullScreen', vjs.Html5.prototype.enterFullScreen);
+goog.exportProperty(vjs.Html5.prototype, 'exitFullScreen', vjs.Html5.prototype.exitFullScreen);
 
 goog.exportSymbol('videojs.Flash', vjs.Flash);
 goog.exportProperty(vjs.Flash, 'isSupported', vjs.Flash.isSupported);


### PR DESCRIPTION
This commit includes "enterfullscreen" and "exitfullscreen" method which currently is not available on the playback technology's API
Testing: ('fullscreen icon now works on safari')

Issue: 688
