### PR TITLE
Stopped component's dispose event from bubbling up

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -72,7 +72,7 @@ vjs.Component = vjs.CoreObject.extend({
  * Dispose of the component and all child components
  */
 vjs.Component.prototype.dispose = function(){
-  this.trigger('dispose');
+  this.trigger({ type: 'dispose', 'bubbles': false });
 
   // Dispose all children.
   if (this.children_) {

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -83,11 +83,16 @@ test('should dispose of component and children', function(){
   var id = comp.el()[vjs.expando];
 
   var hasDisposed = false;
-  comp.on('dispose', function(){ hasDisposed = true; });
+  var bubbles = null;
+  comp.on('dispose', function(event){
+    hasDisposed = true;
+    bubbles = event.bubbles;
+  });
 
   comp.dispose();
 
   ok(hasDisposed, 'component fired dispose event');
+  ok(bubbles === false, 'dispose event does not bubble');
   ok(!comp.children(), 'component children were deleted');
   ok(!comp.el(), 'component element was deleted');
   ok(!child.children(), 'child children were deleted');


### PR DESCRIPTION
In IRC bkelley was running into an issue where after changing techs, user activity listeners would stop. The issue was that the dispose event was bubbling up from the tech when it's exposed and being triggered on the player. That shouldn't happen.
