### PR TITLE
Adding AMD wrapper and removing global references

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -194,10 +194,18 @@ module.exports = function(grunt) {
     }
 
     // Create a combined sources file. https://github.com/zencoder/video-js/issues/287
-    var combined = '';
+    var combined = '(function(window) {\n';
     sourceFiles.forEach(function(result){
       combined += grunt.file.read(result);
     });
+    combined += [
+      'if (typeof define === "function" && define.amd) {',
+      '  define([], function() {',
+      '    return vjs;',
+      '  });',
+      '}',
+      '})(window);'
+    ].join('\n');
     // Replace CDN version ref in js. Use major/minor version.
     combined = combined.replace(/GENERATED_CDN_VSN/g, version.majorMinor);
     grunt.file.write('build/files/combined.video.js', combined);

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -361,7 +361,7 @@ vjs.Component.prototype.addChild = function(child, options){
     // If there's no .player_, this is a player
     // Closure Compiler throws an 'incomplete alias' warning if we use the vjs variable directly.
     // Every class should be exported, so this should never be a problem here.
-    component = new window['videojs'][componentClass](this.player_ || this, options);
+    component = new videojs[componentClass](this.player_ || this, options);
 
   // child is a component instance
   } else {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -61,7 +61,6 @@ var vjs = function(id, options, ready){
 
 // Extended name, also available externally, window.videojs
 var videojs = vjs;
-window.videojs = window.vjs = vjs;
 
 // CDN Version. Used to target right flash swf.
 vjs.CDN_VERSION = 'GENERATED_CDN_VSN';

--- a/src/js/media/loader.js
+++ b/src/js/media/loader.js
@@ -14,7 +14,7 @@ vjs.MediaLoader = vjs.Component.extend({
     if (!player.options_['sources'] || player.options_['sources'].length === 0) {
       for (var i=0,j=player.options_['techOrder']; i<j.length; i++) {
         var techName = vjs.capitalize(j[i]),
-            tech = window['videojs'][techName];
+            tech = videojs[techName];
 
         // Check if the browser supports this technology
         if (tech && tech.isSupported()) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -286,7 +286,7 @@ vjs.Player.prototype.loadTech = function(techName, source){
   }
 
   // Initialize tech instance
-  this.tech = new window['videojs'][techName](this, techOptions);
+  this.tech = new videojs[techName](this, techOptions);
 
   this.tech.ready(techReady);
 };
@@ -966,7 +966,7 @@ vjs.Player.prototype.selectSource = function(sources){
   // Loop through each playback technology in the options order
   for (var i=0,j=this.options_['techOrder'];i<j.length;i++) {
     var techName = vjs.capitalize(j[i]),
-        tech = window['videojs'][techName];
+        tech = videojs[techName];
 
     // Check if the browser supports this technology
     if (tech.isSupported()) {
@@ -1043,7 +1043,7 @@ vjs.Player.prototype.src = function(source){
   // Case: Source object { src: '', type: '' ... }
   } else if (source instanceof Object) {
 
-    if (window['videojs'][this.techName]['canPlaySource'](source)) {
+    if (videojs[this.techName]['canPlaySource'](source)) {
       this.src(source.src);
     } else {
       // Send through tech loop to check for a compatible technology.

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -50,7 +50,7 @@ vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
   var Kind = vjs.capitalize(kind || 'subtitles');
 
   // Create correct texttrack class. CaptionsTrack, etc.
-  var track = new window['videojs'][Kind + 'Track'](this, options);
+  var track = new videojs[Kind + 'Track'](this, options);
 
   tracks.push(track);
 
@@ -679,7 +679,7 @@ vjs.TextTrack.prototype.reset = function(){
 vjs.CaptionsTrack = vjs.TextTrack.extend();
 vjs.CaptionsTrack.prototype.kind_ = 'captions';
 // Exporting here because Track creation requires the track kind
-// to be available on global object. e.g. new window['videojs'][Kind + 'Track']
+// to be available on global object. e.g. new videojs[Kind + 'Track']
 
 /**
  * The track component for managing the hiding and showing of subtitles


### PR DESCRIPTION
Removed the global references to `window.videojs` replacing it with
a bare reference to the variable

@eleith
