### PR TITLE
Enable building videojs with browserify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,19 @@
     "karma-qunit": "~0.0.2",
     "videojs-doc-generator": "0.0.1",
     "qunitjs": "~1.12.0",
-    "grunt-zip": "0.10.2"
+    "grunt-zip": "0.10.2",
+    "browserify-shim": "~3.2.2"
+  },
+  "main": "./dist/video-js/video.dev.js",
+  "browser": {
+    "videojs": "./dist/video-js/video.js"
+  },
+  "browserify-shim": {
+    "videojs": "window.videojs"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
   }
 }


### PR DESCRIPTION
This uses browserify-shim to get browserify to recognize videojs.
It uses dist/video-js/video.js for the main file of the module.
To build using browserify, you just run browserify on the module and
use --standalone (or -s) to make it produce a UMD file.
This seems to work just fine in the browser (and requirejs looks like
it'll work, though, I haven't tested it) but it won't work in node right
now because videojs is doing a lot of stuff with 'document' directly and
its causing problems in node.
