### PR TITLE
Sometimes, the current time is not the same as duration time when streaming was finished

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -489,6 +489,8 @@ vjs.Player.prototype.onProgress = function(){
  * @event ended
  */
 vjs.Player.prototype.onEnded = function(){
+  this.trigger('timeupdate');
+
   if (this.options_['loop']) {
     this.currentTime(0);
     this.play();


### PR DESCRIPTION
Although not always, I confirmed this phenomenon on flash with RTMP streaming. It seems that this happens depend on timing and/or by specific files.
### Description:

Happens on Windows 7 and Ubuntu 12.04LTS.
Seen with IE8, IE9, Firefox 26 Ubuntu, Chrome32 Ubuntu, Flash 11.2.
1. play streaming with RTMP
2. do play or pause/resume or seek repeatedly
3. sometimes, it looks stopping before the end point.

I think updating current time is better on ended event.
### Expected:

The current time should be the same as duration time on ended.
### Acutual:

Sometimes, the current time is not updated when streaming was finished, like this.

![stop_time_on_ended1](https://f.cloud.github.com/assets/96569/2118020/0c29623a-90ef-11e3-95ec-230bebb50fde.png)
