### PR TITLE
Create 'track' element in the HTML5 shiv sample

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -14,7 +14,7 @@ You can download the Video.js source and host it on your own servers, or use the
 
 > ```html
 <script type="text/javascript">
-  document.createElement('video');document.createElement('audio');
+  document.createElement('video');document.createElement('audio');document.createElement('track');
 </script>
 ```
 


### PR DESCRIPTION
Matches the shiv to the one at [the start of `src/js/core.js`](https://github.com/videojs/video.js/blob/master/src/js/core.js#L8).

Right now it's missing `<track>`.
