### PR TITLE
Set default flash movie scale in JS

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -51,6 +51,7 @@ vjs.Flash = vjs.MediaTechController.extend({
 
         // Merge default parames with ones passed in
         params = vjs.obj.merge({
+          'scale': 'noscale', // Default movie scaling
           'wmode': 'opaque', // Opaque is needed to overlay controls, but can affect playback performance
           'bgcolor': '#000000' // Using bgcolor prevents a white flash when the object is loading
         }, options['params']),


### PR DESCRIPTION
Currently hard coded in AS. See video-swf-js pull request 
https://github.com/videojs/video-js-swf/pull/81

Setting scale value via JS allows it to be overriden e.g.

``` js
videojs(‘video-player’, flash: { params: {scale: 'noborder’}}
```
