### PR TITLE
Add component(1) support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "video.js",
   "description": "An HTML5 and Flash video player with a common API and skin for both.",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "keywords": [
     "videojs",
     "html5",


### PR DESCRIPTION
I have to reference `video.dev.js` over the minified version because the minifier seems to munge the `module.exports` property. This isn't a problem as minification is an app-level concern, but I wanted to bring it to your attention. I will file a separate bug for it ;)
