### PR TITLE
Move captions down when controls are inactive

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -770,8 +770,12 @@ body.vjs-full-window {
   left: 1em;
   right: 1em;
 }
+
 /* Move captions down when controls aren't being shown */
-.video-js.vjs-user-inactive .vjs-text-track-display { bottom: 1em; }
+.video-js.vjs-user-inactive .vjs-text-track-display { 
+  bottom: 1em; 
+}
+
 /* Individual tracks */
 .video-js .vjs-text-track {
   display: none;


### PR DESCRIPTION
Pull request based on https://github.com/videojs/video.js/issues/1049 - moving captions towards bottom of video when controls are inactive.
