### PR TITLE
Reduce number of files in dist package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
-# .npmignore needed so dist dir won't be ignored
-# https://npmjs.org/doc/developers.html#Keeping-files-out-of-your-package
+# Exclude everything but the contents of the dist directory.
+**/*
+!dist/**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -314,6 +314,8 @@ module.exports = function(grunt) {
     grunt.file.copy('node_modules/videojs-swf/dist/video-js.swf', 'dist/video-js/video-js.swf');
     grunt.file.copy('build/demo-files/demo.html', 'dist/video-js/demo.html');
     grunt.file.copy('build/demo-files/demo.captions.vtt', 'dist/video-js/demo.captions.vtt');
+    grunt.file.copy('src/css/video-js.less', 'dist/video-js/video-js.less');
+
 
     // Copy over font files
     grunt.file.recurse('build/files/font', function(absdir, rootdir, subdir, filename) {


### PR DESCRIPTION
Use .npmignore to package a smaller subset of videojs for distribution (just the dist directory). Make sure to include the video-js.less file in the dist for the designer to use.
