### PR TITLE
Loading Spinner Fixes

### DIFF
--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -15,8 +15,6 @@ vjs.LoadingSpinner = vjs.Component.extend({
     player.on('canplay', vjs.bind(this, this.hide));
     player.on('canplaythrough', vjs.bind(this, this.hide));
     player.on('playing', vjs.bind(this, this.hide));
-    player.on('seeked', vjs.bind(this, this.hide));
-
     player.on('seeking', vjs.bind(this, this.show));
 
     // in some browsers seeking does not trigger the 'playing' event,
@@ -25,6 +23,7 @@ vjs.LoadingSpinner = vjs.Component.extend({
     player.on('seeked', vjs.bind(this, this.hide));
 
     player.on('error', vjs.bind(this, this.show));
+    player.on('ended', vjs.bind(this, this.hide));
 
     // Not showing spinner on stalled any more. Browsers may stall and then not trigger any events that would remove the spinner.
     // Checked in Chrome 16 and Safari 5.1.2. http://help.videojs.com/discussions/problems/883-why-is-the-download-progress-showing


### PR DESCRIPTION
- Bind hide on ended event to resolve issue #1058.
- Remove duplicate seeked event line.
