### PR TITLE
Don't force sliders to get evaluated on load

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -368,6 +368,8 @@ fonts to show/hide properly.
   height: 100%;
   margin: 0;
   padding: 0;
+  /* updated by javascript during playback */
+  width: 0;
   /* Needed for IE6 *///
   left: 0;
   top: 0;

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -16,8 +16,6 @@ vjs.Slider = vjs.Component.extend({
     this.bar = this.getChild(this.options_['barName']);
     this.handle = this.getChild(this.options_['handleName']);
 
-    player.on(this.playerEvent, vjs.bind(this, this.update));
-
     this.on('mousedown', this.onMouseDown);
     this.on('touchstart', this.onMouseDown);
     this.on('focus', this.onFocus);
@@ -26,10 +24,7 @@ vjs.Slider = vjs.Component.extend({
 
     this.player_.on('controlsvisible', vjs.bind(this, this.update));
 
-    // This is actually to fix the volume handle position. http://twitter.com/#!/gerritvanaaken/status/159046254519787520
-    // this.player_.one('timeupdate', vjs.bind(this, this.update));
-
-    player.ready(vjs.bind(this, this.update));
+    player.on(this.playerEvent, vjs.bind(this, this.update));
 
     this.boundEvents = {};
   }


### PR DESCRIPTION
Since the load and play progress sliders are guaranteed to start from zero, set that through CSS. Calling Slider.prototype.update forces a re-flow because element dimensions are queried and style rules changed. That reflow consistently took around 60ms on my laptop which would mean dropped frames and "jerkiness" on initialization.

Here's a timeline from an iPad mini before this change:
![screen shot 2014-03-12 at 3 40 34 pm](https://f.cloud.github.com/assets/56667/2403234/525add50-aa2c-11e3-843f-62d6e189ffbf.png)

and after:
![screen shot 2014-03-12 at 5 23 47 pm](https://f.cloud.github.com/assets/56667/2403263/a124fa6a-aa2c-11e3-8d8f-b0b0aa582349.png)
