### PR TITLE
Monkeypatch canPlayType on Android 4.0+ for HLS

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -304,11 +304,9 @@ vjs.Html5.canControlVolume = function(){
 
   vjs.Html5.unpatchCanPlayType = function() {
     var r = vjs.TEST_VID.constructor.prototype.canPlayType;
-    if (canPlayType) {
-      vjs.TEST_VID.constructor.prototype.canPlayType = canPlayType;
-      canPlayType = null;
-      return r;
-    }
+    vjs.TEST_VID.constructor.prototype.canPlayType = canPlayType;
+    canPlayType = null;
+    return r;
   };
 
   // by default, patch the video element

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -59,10 +59,8 @@ test('patchCanPlayType patches canplaytype with our function, conditionally', fu
   patchedCanPlayType = video.canPlayType;
   unpatchedCanPlayType = vjs.Html5.unpatchCanPlayType();
 
-  if (canPlayType) {
-    strictEqual(canPlayType, vjs.TEST_VID.constructor.prototype.canPlayType, 'original canPlayType and unpatched canPlayType should be equal');
-    strictEqual(patchedCanPlayType, unpatchedCanPlayType, 'patched canPlayType and function returned from unpatch are equal');
-  }
+  strictEqual(canPlayType, vjs.TEST_VID.constructor.prototype.canPlayType, 'original canPlayType and unpatched canPlayType should be equal');
+  strictEqual(patchedCanPlayType, unpatchedCanPlayType, 'patched canPlayType and function returned from unpatch are equal');
 
   vjs.ANDROID_VERSION = oldAV;
   vjs.Html5.unpatchCanPlayType();


### PR DESCRIPTION
Android devices starting with 4.0 can play HLS natively to some extent.
However, they do not say so in the canPlayType method. This commit
monkey patches canPlayType to respond with "maybe" for
"application/x-mpegURL" and "application/vnd.apple.mpegURL". Otherwise,
it'll fallback to the original canPlayType method.

Caveat, HLS on android is somewhat broken. In my test streams, it doesn't have a duration so you can't seek.

This fixes videojs/videojs-contrib-hls#29
