### PR TITLE
Fix code in examples.

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -89,13 +89,13 @@ The third argument is a 'ready' callback. Once Video.js has initialized it will 
 Instead of using an element ID, you can also pass a reference to the element itself.
 
 ```js
-videojs(document.getElementsById('example_video_1')), {}, function()) {
+videojs(document.getElementsById('example_video_1'), {}, function() {
   // This is functionally the same as the previous example.
 });
 ```
 
 ```js
-videojs(document.getElementsByClassName('awesome_video_class')[0], {}, function()) {
+videojs(document.getElementsByClassName('awesome_video_class')[0], {}, function() {
   // You can grab an element by class if you'd like, just make sure
   // if it's an array that you pick one (here we chose the first).
 });


### PR DESCRIPTION
The examples are broken with extra parentheses. Fixed.
