### PR TITLE
Fix currentSrc when Flash returns null

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -284,8 +284,8 @@ vjs.Flash.prototype.currentSrc = function(){
   var src = this.el_.vjs_getProperty('currentSrc');
   // no src, check and see if RTMP
   if (src == null) {
-    var connection = this.rtmpConnection(),
-        stream = this.rtmpStream();
+    var connection = this['rtmpConnection'](),
+        stream = this['rtmpStream']();
 
     if (connection && stream) {
       src = vjs.Flash.streamFromParts(connection, stream);


### PR DESCRIPTION
It looks like GCC was mangling `rtmpConnection` and `rtmpStream` before invoking them. Unfortunately, we define those methods as string literals so they do not have mangled equivalents. Invoke them using string literals so GCC never mangles the method names.
