### PR TITLE
startOffsetTime reading is added.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -771,6 +771,15 @@ vjs.Player.prototype.bufferedPercent = function(){
 };
 
 /**
+ * Get time from which the beginning is reproduced video
+ *
+ * @return {Number}
+ */
+vjs.Player.prototype.startOffsetTime = function(){
+  return this.techGet('startOffsetTime') || 0;
+};
+
+/**
  * Get or set the current volume of the media
  *
  *     // get


### PR DESCRIPTION
startOffsetTime reading is added.
Parameter for: https://github.com/videojs/video-js-swf/pull/88

It is necessary for display of the real moment from where video in case of pseudo-streaming is reproduced.
