### PR TITLE
Adding styling and implementation fixes for vertical volume menu

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -294,10 +294,6 @@ fonts to show/hide properly.
   margin: 1.1em auto 0;
 }
 
-.vjs-default-skin .vjs-volume-menu-button .vjs-menu-content {
-  height: 2.9em;
-}
-
 .vjs-default-skin .vjs-volume-level {
   position: absolute;
   top: 0;
@@ -328,9 +324,38 @@ fonts to show/hide properly.
   height: 1em;
 }
 
-.vjs-default-skin .vjs-volume-menu-button .vjs-menu .vjs-menu-content {
-  width: 6em;
-  left: -4em;
+.vjs-default-skin .vjs-volume-menu-button .vjs-menu {
+  left: 0.5em;
+  border-left: 1.5em solid transparent;
+  border-right: 1.5em solid transparent;
+}
+
+.vjs-default-skin .vjs-volume-menu-button.vjs-menu-button .vjs-menu .vjs-menu-content {
+  width: 2.9em;
+  left: -1.5em;
+  height: 10em;
+}
+
+.vjs-default-skin .vjs-volume-menu-button .vjs-volume-bar {
+  width: 0.6em;
+  height: 8em;
+}
+
+.vjs-default-skin .vjs-volume-menu-button .vjs-volume-bar .vjs-volume-level {
+  width: 100%;
+  top: auto;
+  bottom: 0;
+  /* assuming volume starts at 1.0 */
+  height: 100%;
+}
+
+.vjs-default-skin .vjs-volume-menu-button .vjs-volume-bar .vjs-volume-handle:before {
+  top: -0.3em;
+  left: -0.1em;
+}
+
+.vjs-default-skin .vjs-volume-menu-button .vjs-volume-bar .vjs-volume-handle {
+  left: auto;
 }
 
 /* Progress

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -94,13 +94,13 @@ vjs.Slider.prototype.update = function(){
   if (handle) {
 
     var box = this.el_,
-        boxWidth = box.offsetWidth,
+        boxSize = this.options_.vertical ? box.offsetHeight : box.offsetWidth,
 
         handleWidth = handle.el().offsetWidth,
 
         // The width of the handle in percent of the containing box
         // In IE, widths may not be ready yet causing NaN
-        handlePercent = (handleWidth) ? handleWidth / boxWidth : 0,
+        handlePercent = (handleWidth) ? handleWidth / boxSize : 0,
 
         // Get the adjusted size of the box, considering that the handle's center never touches the left or right side.
         // There is a margin of half the handle's width on both sides.
@@ -112,12 +112,21 @@ vjs.Slider.prototype.update = function(){
     // The bar does reach the left side, so we need to account for this in the bar's width
     barProgress = adjustedProgress + (handlePercent / 2);
 
-    // Move the handle from the left based on the adjected progress
-    handle.el().style.left = vjs.round(adjustedProgress * 100, 2) + '%';
+    if (this.options_.vertical) {
+
+      // Move the handle from the top based on the adjusted progress
+      handle.el().style.top = vjs.round((1 - barProgress) * 100, 2) + '%';
+
+    } else {
+
+      // Move the handle from the left based on the adjusted progress
+      handle.el().style.left = vjs.round(adjustedProgress * 100, 2) + '%';
+
+    }
   }
 
   // Set the new bar width
-  bar.el().style.width = vjs.round(barProgress * 100, 2) + '%';
+  bar.el().style[this.options_.vertical ? 'height' : 'width'] = vjs.round(barProgress * 100, 2) + '%';
 };
 
 vjs.Slider.prototype.calculateDistance = function(event){
@@ -125,7 +134,8 @@ vjs.Slider.prototype.calculateDistance = function(event){
 
   el = this.el_;
   box = vjs.findPosition(el);
-  boxW = boxH = el.offsetWidth;
+  boxW = el.offsetWidth;
+  boxH = el.offsetHeight;
   handle = this.handle;
 
   if (this.options_.vertical) {
@@ -139,13 +149,15 @@ vjs.Slider.prototype.calculateDistance = function(event){
 
     if (handle) {
       var handleH = handle.el().offsetHeight;
-      // Adjusted X and Width, so handle doesn't go outside the bar
+      // Adjusted Y and Height, so handle doesn't go outside the bar
       boxY = boxY + (handleH / 2);
       boxH = boxH - handleH;
     }
 
     // Percent that the click is through the adjusted area
-    return Math.max(0, Math.min(1, ((boxY - pageY) + boxH) / boxH));
+    // Since we're measuring from the top, we reverse the percentages to have
+    // the bottom be 0%.
+    return Math.max(0, Math.min(1, 1 - ((pageY - boxY) / boxH)));
 
   } else {
     boxX = box.left;


### PR DESCRIPTION
Previous implementation wasn't completely correct; styling was
out-of-date. Addresses #942

example to play with here: http://codepen.io/jnwng/pen/peDhl

![screen shot 2014-04-23 at 11 50 11 am](https://cloud.githubusercontent.com/assets/1118534/2781800/205f5e86-cb18-11e3-921a-fb2759006760.png)
![screen shot 2014-04-23 at 11 50 06 am](https://cloud.githubusercontent.com/assets/1118534/2781801/205f6142-cb18-11e3-84a8-2a04ac3f762f.png)
![screen shot 2014-04-23 at 11 49 58 am](https://cloud.githubusercontent.com/assets/1118534/2781802/205f801e-cb18-11e3-91e3-9a3734825113.png)
