### PR TITLE
Prevent js error in IE 8 on XP

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1000,7 +1000,7 @@ vjs.Player.prototype.selectSource = function(sources){
         tech = window['videojs'][techName];
 
     // Check if the browser supports this technology
-    if (tech.isSupported()) {
+    if (tech && tech.isSupported()) {
       // Loop through each source object
       for (var a=0,b=sources;a<b.length;a++) {
         var source = b[a];


### PR DESCRIPTION
A minor tweak to prevent IE 8 from throwing a js error. In my testing on a IE8 virtual machine, I get an error here (sometimes). Adding the check if `tech` is defined seems to clear it up.
