### PR TITLE
Invoke the loadstart handler manually if the tech already triggered the ...

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -77,6 +77,11 @@ vjs.Player = vjs.Component.extend({
     //   this.addClass('vjs-touch-enabled');
     // }
 
+    // if loadstart has already fired, invoke the handler now
+    if (this.currentSrc()) {
+      this.onLoadStart();
+    }
+
     this.on('loadstart', this.onLoadStart);
     this.on('ended', this.onEnded);
     this.on('play', this.onPlay);


### PR DESCRIPTION
...event. Fixes #1207.

Check if the player already has a currentSrc on load and call the loadstart handler explicitly. This ensures that the first play listener is properly registered before playback begins.

@heff, @seniorflexdeveloper: This deserves some tests but I wanted to open the PR to get some feedback.
