### PR TITLE
Localsauce karma

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -385,8 +385,10 @@ module.exports = function(grunt) {
             return done();
           }
 
-          stdout.pipe(process.stdout);
-          stderr.pipe(process.stderr);
+          grunt.verbose.error(stderr.toString());
+          grunt.verbose.writeln(stdout.toString());
+          grunt.task.run(['karma:saucelabs']);
+          done();
       });
     } else {
       grunt.task.run(['karma:saucelabs']);


### PR DESCRIPTION
This adds an _untested_ local ability to run tests on saucelabs.
You run it in one of two ways:

``` sh
# assuming you already have a connection to saucelabs
grunt saucelabs

# if you want grunt to run sauce_connect for you and then run the task
grunt saucelabs:connect
```
