### PR TITLE
Fix for Bug #877 Extended cue breakage in vtt files

### DIFF
--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -482,7 +482,7 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
       };
 
       // Timing line
-      time = line.split(' ');
+      time = line.split(/[\t ]+/);
       cue.startTime = this.parseCueTime(time[0]);
       cue.endTime = this.parseCueTime(time[2]);
 

--- a/test/unit/tracks.js
+++ b/test/unit/tracks.js
@@ -39,10 +39,15 @@ test('cue parsing', function() {
   equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
   equal(mockTrack.cues_[0].text, 'Text line 1', 'Cue text');
 
-  // Uncomment to test a fix for #183
-  // mockTrack.reset(); // reset mock track
-  // var timeWithTabs = vttHead + '00:00.700\t-->\t00:04.110\nText line 1';
-  // mockTrack.parseCues(timeWithTabs);
-  // equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
-  // equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
+  mockTrack.reset(); // reset mock track
+  var timeWithTabs = vttHead + '00:00.700\t-->\t00:04.110\nText line 1';
+  mockTrack.parseCues(timeWithTabs);
+  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
+  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
+
+  mockTrack.reset(); // reset mock track
+  var timeWithMixedWhiteSpace = vttHead + '00:00.700  -->\t 00:04.110\nText line 1';
+  mockTrack.parseCues(timeWithMixedWhiteSpace);
+  equal(mockTrack.cues_[0].startTime, 0.7, 'Cue start time w/ spaces');
+  equal(mockTrack.cues_[0].endTime, 4.11, 'Cue end time w/ spaces');
 });


### PR DESCRIPTION
Only send actual time components to parseCueTime (no extended info). I also some commented out tests since they no longer apply. 
