### PR TITLE
Make sure the cursor disappear in fullscreen

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -854,6 +854,11 @@ body.vjs-full-window {
 }
 .video-js.vjs-fullscreen.vjs-user-inactive {
   cursor: none;
+  
+  .vjs-tech {
+    /* make sure the cursor disappear in fullscreen */
+    pointer-events: none;
+  }
 }
 
 /* Poster Styles */


### PR DESCRIPTION
This will make sure that the video, object or iframe tag is not overriding our attempt to hide the cursor in fullscreen.

Should fix every tech including html5, flash and iframe-based (like YouTube, see https://github.com/eXon/videojs-youtube/issues/122)
