### PR TITLE
Adjusting autoplay to properly wait for loadstart event.

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -56,7 +56,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
     player.ready(function(){
       if (this.tag && this.options_['autoplay'] && this.paused()) {
         delete this.tag['poster']; // Chrome Fix. Fixed in Chrome v16.
-        this.play();
+        this.one('loadstart', vjs.bind(this, this.play));
       }
     });
 


### PR DESCRIPTION
Since moving the loadstart into the `player.ready` function [here](https://github.com/videojs/video.js/commit/bad5130c8ff76c96494f0918399a1976dc1a2278), there
exists a race condition whereby the player emits a `play` event
before the `loadstart` event, but since `onLoadStart` was waiting
for that `play` event, the play button never goes away.

alternatively, we could adjust https://github.com/videojs/video.js/blob/master/src/js/player.js#L412-L413 to instead wait for the `playing` event instead of the `play` event, since we know that the `playing` event will always be after the `loadstart`, whereas `play` is not guaranteed to be so.
