### PR TITLE
Count stageclick events from the SWF as user activity

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -858,7 +858,7 @@ vjs.Component.prototype.onResize;
  *
  * This is used to support toggling the controls through a tap on the video.
  *
- * We're requireing them to be enabled because otherwise every component would
+ * We're requiring them to be enabled because otherwise every component would
  * have this extra overhead unnecessarily, on mobile devices where extra
  * overhead is especially bad.
  * @private

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1461,6 +1461,10 @@ vjs.Player.prototype.listenForUserActivity = function(){
   this.on('keydown', onActivity);
   this.on('keyup', onActivity);
 
+  // native click events on the SWF aren't triggered on IE11, Win8.1RT
+  // use stageclick events triggered from inside the SWF instead
+  this.on('stageclick', onActivity);
+
   // Run an interval every 250 milliseconds instead of stuffing everything into
   // the mousemove/touchmove function itself, to prevent performance degradation.
   // `this.reportUserActivity` simply sets this.userActivity_ to true, which


### PR DESCRIPTION
IE11 on Win8.1 RT does not report click events on the SWF object. The SWF already triggers `stageclick` events whenever a click/touch is detected however, so we can use those to keep the control bar from hiding forever.
