### PR TITLE
Count stageclick events from the SWF as user activity

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -114,6 +114,10 @@ vjs.Flash = vjs.MediaTechController.extend({
       });
     }
 
+    // native click events on the SWF aren't triggered on IE11, Win8.1RT
+    // use stageclick events triggered from inside the SWF instead
+    player.on('stageclick', player.reportUserActivity);
+
     // Flash iFrame Mode
     // In web browsers there are multiple instances where changing the parent element or visibility of a plugin causes the plugin to reload.
     // - Firefox just about always. https://bugzilla.mozilla.org/show_bug.cgi?id=90268 (might be fixed by version 13)


### PR DESCRIPTION
IE11 on Win8.1 RT does not report click events on the SWF object. The SWF already triggers stageclick events whenever a click/touch is detected however, so we can use those to keep the control bar from hiding forever.
