### PR TITLE
Fixed vertical slider check when obfuscated

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -128,7 +128,7 @@ vjs.Slider.prototype.calculateDistance = function(event){
   boxW = boxH = el.offsetWidth;
   handle = this.handle;
 
-  if (this.options().vertical) {
+  if (this.options()['vertical']) {
     boxY = box.top;
 
     if (event.changedTouches) {


### PR DESCRIPTION
In #477, support for vertical slider computation was added.
The config check breaks when obfuscated, it ends up being something like `if(a.j.Wd)`

I've just started to familiarize myself with the code-base, but I believe `this.options().vertical` is the correct way to check an option. This should solve the obfuscation issue.
