### PR TITLE
dispose tech after turning event bindings off

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -290,12 +290,13 @@ vjs.Player.prototype.loadTech = function(techName, source){
 
 vjs.Player.prototype.unloadTech = function(){
   this.isReady_ = false;
-  this.tech.dispose();
 
   // Turn off any manual progress or timeupdate tracking
   if (this.manualProgress) { this.manualProgressOff(); }
 
   if (this.manualTimeUpdates) { this.manualTimeUpdatesOff(); }
+
+  this.tech.dispose();
 
   this.tech = false;
 };


### PR DESCRIPTION
Switching the disposal order so that event bindings are turned off before tech.dispose() is called. Previously, bindings to timeupdate that touched the tech element would error out, as the element was destroyed before a timeupdate event was triggered in [player.js:403](https://github.com/videojs/video.js/blob/8a05aa11a13eeccffaff39d5579214c908b8aa13/src/js/player.js#L403)
