### PR TITLE
exporting techName and loadTech

### DIFF
--- a/src/js/player.externs.js
+++ b/src/js/player.externs.js
@@ -81,3 +81,9 @@ videojs.Player.prototype.userActive = function(){};
  * Native controls
  */
 videojs.Player.prototype.usingNativeControls = function(){};
+
+/**
+ * Tech
+ */
+videojs.Player.prototype.techName = function(){};
+videojs.Player.prototype.loadTech = function(){};


### PR DESCRIPTION
Exporting techName and loadTech. The use case is to allow videojs-contrib-ads to snapshot and restore the current loaded tech. 

Switching tech would be better done by video.js transparently based on the source object passed to .src(), but the player does not retain source type information for later retrieval, only the source url, and modifying that would be a breaking change.

In videojs-contrib-ads, the tech needs to be snapshotted and restored when the ad relies on a different tech to the content video, as the videojs player does not check for compatibility when passing a string to .src()
https://github.com/guardian/videojs-contrib-ads/commit/e7c14b34781742dc6a7ed41234ea1e7f9fa18c9e
