### PR TITLE
bower: ignore dot files, build and tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,13 @@
     "flash",
     "video",
     "player"
-  ]
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "build"
+  ],
 }


### PR DESCRIPTION
Add 'ignore' directive to bower.json.

This ignores all dot files, test directories and build directories. Fixes #1105.
