### PR TITLE
Track the object element during init and remove it if the tech is dispos...

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -244,19 +244,12 @@ vjs.Flash = vjs.MediaTechController.extend({
 
     // If not using iFrame mode, embed as normal object
     } else {
-      this.obj = vjs.Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
+      this.el_ = vjs.Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
     }
   }
 });
 
 vjs.Flash.prototype.dispose = function(){
-  // the tech is being disposed before onReady has been triggered
-  // removing the object from the DOM prevents that from firing
-  // and overwriting the state of the replacement tech
-  if (this.obj) {
-    this.obj.parentNode.removeChild(this.obj);
-    this.obj = null;
-  }
   vjs.MediaTechController.prototype.dispose.call(this);
 };
 
@@ -407,14 +400,6 @@ vjs.Flash['onReady'] = function(currSwf){
 
   // Reference player on tech element
   el['player'] = player;
-
-  // Update reference to playback technology element
-  tech.el_ = el;
-
-  // Remove the initialization reference to the tech element
-  if (tech.obj) {
-    tech.obj = null;
-  }
 
   vjs.Flash.checkReady(tech);
 };

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -112,27 +112,3 @@ test('dispose removes the object element even before ready fires', function() {
   strictEqual(tech.el(), null, 'tech el is null');
   strictEqual(parentEl.children.length, 0, 'parent el is empty');
 });
-
-test('dispose removes the object element after ready fires', function() {
-  var noop = function() {},
-      parentEl = document.createElement('div'),
-      player = {
-        id: noop,
-        on: noop,
-        options_: {}
-      },
-      tech = new vjs.Flash(player, {
-        'parentEl': parentEl
-      });
-
-  player.tech = tech;
-
-  document.getElementById('qunit-fixture').appendChild(parentEl);
-  tech.obj['player'] = player;
-
-  vjs.Flash['onReady'](parentEl.children[0].id);
-  strictEqual(tech.obj, null, 'nulled initialization reference');
-  tech.dispose();
-  strictEqual(tech.el(), null, 'tech el is null');
-  strictEqual(parentEl.children.length, 0, 'parent el is empty');
-});


### PR DESCRIPTION
...ed before onReady. For #1339.

If dispose() was called before the SWF triggered onReady(), the placeholder div would be cleaned up but the actual object element would be left behind to mess things up in the future. Keep track of the object element during initialization and make sure it is removed if flash is unloaded early.
