### PR TITLE
Fix Flash methods that were hidden from overriding

### DIFF
--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -92,7 +92,7 @@ test('currentTime is the seek target during seeking', function() {
   currentTime = 3;
   strictEqual(3, tech.currentTime(), 'currentTime is retreived from the SWF');
 
-  tech.setCurrentTime(7);
+  tech['setCurrentTime'](7);
   seeking = true;
   strictEqual(7, tech.currentTime(), 'during seeks the target time is returned');
 });


### PR DESCRIPTION
In #961 we moved the currentTime and setCurrentTime methods of the Flash tech to be created in the init method, but this blocks them from being overridden by techs that subclass Flash (e.g. HLS). This PR fixes that.
