### PR TITLE
WIP: Working browserify. Not backwards compatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,19 @@
   "homepage": "http://videojs.com",
   "author": "Steve Heffernan",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "build": "browserify -d --standalone 'videojs' . -o bundle.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/videojs/video.js.git"
   },
-  "main": "./dist/video-js/video.js",
+  "main": "./src/js/video.js",
   "dependencies": {
     "videojs-swf": "4.4.2"
   },
   "devDependencies": {
+    "browserify": "^4.2.1",
     "calcdeps": "~0.1.7",
     "chg": "~0.1.8",
     "contribflow": "~0.2.0",

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -1,5 +1,6 @@
-var vjs = {};
-var Button = require('./button.js');
+var BigPlayButton, Button;
+
+Button = require('./button.js');
 
 /* Big Play Button
 ================================================================================ */
@@ -11,9 +12,9 @@ var Button = require('./button.js');
  * @class
  * @constructor
  */
-vjs.BigPlayButton = Button.extend();
+BigPlayButton = Button.extend();
 
-vjs.BigPlayButton.prototype.createEl = function(){
+BigPlayButton.prototype.createEl = function(){
   return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-big-play-button',
     innerHTML: '<span aria-hidden="true"></span>',
@@ -21,8 +22,8 @@ vjs.BigPlayButton.prototype.createEl = function(){
   });
 };
 
-vjs.BigPlayButton.prototype.onClick = function(){
+BigPlayButton.prototype.onClick = function(){
   this.player_.play();
 };
 
-module.exports = vjs.BigPlayButton;
+module.exports = BigPlayButton;

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -1,3 +1,6 @@
+var vjs = {};
+var Button = require('./button.js');
+
 /* Big Play Button
 ================================================================================ */
 /**
@@ -8,10 +11,10 @@
  * @class
  * @constructor
  */
-vjs.BigPlayButton = vjs.Button.extend();
+vjs.BigPlayButton = Button.extend();
 
 vjs.BigPlayButton.prototype.createEl = function(){
-  return vjs.Button.prototype.createEl.call(this, 'div', {
+  return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-big-play-button',
     innerHTML: '<span aria-hidden="true"></span>',
     'aria-label': 'play video'
@@ -21,3 +24,5 @@ vjs.BigPlayButton.prototype.createEl = function(){
 vjs.BigPlayButton.prototype.onClick = function(){
   this.player_.play();
 };
+
+module.exports = vjs.BigPlayButton;

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var Component = require('./component.js');
+var vjslib = require('./lib.js');
+var vjsevents = require('./events.js');
+
 /* Button - Base class for all buttons
 ================================================================================ */
 /**
@@ -7,13 +12,13 @@
  * @class
  * @constructor
  */
-vjs.Button = vjs.Component.extend({
+vjs.Button = Component.extend({
   /**
    * @constructor
    * @inheritDoc
    */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     this.emitTapEvents();
 
@@ -28,22 +33,22 @@ vjs.Button.prototype.createEl = function(type, props){
   var el;
 
   // Add standard Aria and Tabindex info
-  props = vjs.obj.merge({
+  props = vjslib.obj.merge({
     className: this.buildCSSClass(),
     'role': 'button',
     'aria-live': 'polite', // let the screen reader user know that the text of the button may change
     tabIndex: 0
   }, props);
 
-  el = vjs.Component.prototype.createEl.call(this, type, props);
+  el = Component.prototype.createEl.call(this, type, props);
 
   // if innerHTML hasn't been overridden (bigPlayButton), add content elements
   if (!props.innerHTML) {
-    this.contentEl_ = vjs.createEl('div', {
+    this.contentEl_ = vjslib.createEl('div', {
       className: 'vjs-control-content'
     });
 
-    this.controlText_ = vjs.createEl('span', {
+    this.controlText_ = vjslib.createEl('span', {
       className: 'vjs-control-text',
       innerHTML: this.buttonText || 'Need Text'
     });
@@ -57,7 +62,7 @@ vjs.Button.prototype.createEl = function(type, props){
 
 vjs.Button.prototype.buildCSSClass = function(){
   // TODO: Change vjs-control to vjs-button?
-  return 'vjs-control ' + vjs.Component.prototype.buildCSSClass.call(this);
+  return 'vjs-control ' + Component.prototype.buildCSSClass.call(this);
 };
 
   // Click - Override with specific functionality for button
@@ -65,7 +70,7 @@ vjs.Button.prototype.onClick = function(){};
 
   // Focus - Add keyboard functionality to element
 vjs.Button.prototype.onFocus = function(){
-  vjs.on(document, 'keyup', vjs.bind(this, this.onKeyPress));
+  vjsevents.on(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
   // KeyPress (document level) - Trigger click when keys are pressed
@@ -79,5 +84,7 @@ vjs.Button.prototype.onKeyPress = function(event){
 
 // Blur - Remove keyboard triggers
 vjs.Button.prototype.onBlur = function(){
-  vjs.off(document, 'keyup', vjs.bind(this, this.onKeyPress));
+  vjsevents.off(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
+
+module.exports = vjs.Button;

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var Component = require('./component.js');
-var vjslib = require('./lib.js');
-var vjsevents = require('./events.js');
+var Button, Component, vjslib, vjsevents;
+
+Component = require('./component.js');
+vjslib = require('./lib.js');
+vjsevents = require('./events.js');
 
 /* Button - Base class for all buttons
 ================================================================================ */
@@ -12,7 +13,7 @@ var vjsevents = require('./events.js');
  * @class
  * @constructor
  */
-vjs.Button = Component.extend({
+Button = Component.extend({
   /**
    * @constructor
    * @inheritDoc
@@ -29,7 +30,7 @@ vjs.Button = Component.extend({
   }
 });
 
-vjs.Button.prototype.createEl = function(type, props){
+Button.prototype.createEl = function(type, props){
   var el;
 
   // Add standard Aria and Tabindex info
@@ -60,21 +61,21 @@ vjs.Button.prototype.createEl = function(type, props){
   return el;
 };
 
-vjs.Button.prototype.buildCSSClass = function(){
+Button.prototype.buildCSSClass = function(){
   // TODO: Change vjs-control to vjs-button?
   return 'vjs-control ' + Component.prototype.buildCSSClass.call(this);
 };
 
   // Click - Override with specific functionality for button
-vjs.Button.prototype.onClick = function(){};
+Button.prototype.onClick = function(){};
 
   // Focus - Add keyboard functionality to element
-vjs.Button.prototype.onFocus = function(){
+Button.prototype.onFocus = function(){
   vjsevents.on(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
   // KeyPress (document level) - Trigger click when keys are pressed
-vjs.Button.prototype.onKeyPress = function(event){
+Button.prototype.onKeyPress = function(event){
   // Check for space bar (32) or enter (13) keys
   if (event.which == 32 || event.which == 13) {
     event.preventDefault();
@@ -83,8 +84,8 @@ vjs.Button.prototype.onKeyPress = function(event){
 };
 
 // Blur - Remove keyboard triggers
-vjs.Button.prototype.onBlur = function(){
+Button.prototype.onBlur = function(){
   vjsevents.off(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
-module.exports = vjs.Button;
+module.exports = Button;

--- a/src/js/cdn.js
+++ b/src/js/cdn.js
@@ -1,3 +1,5 @@
+module.exports = function sendGAEvent() {
+
 /**
  * Google Analytics tracking pixel for the freely hosted version of Video.js
  * at vjs.zencdn.net. We'll use this data to develop a support matrix of
@@ -54,3 +56,5 @@
     +'&utme=8(vjsv)9(v0.0.0)'
   ;
 })(new Image(),window,navigator,encodeURIComponent);
+
+}

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1,3 +1,9 @@
+var vjs = {};
+var CoreObject = require('./core-object.js');
+var vjslib = require('./lib.js');
+var vjsutil = require('./util.js')
+var vjsevents = require('./events.js');
+
 /**
  * @fileoverview Player Component - Base class for all UI objects
  *
@@ -32,7 +38,7 @@
  * @constructor
  * @extends vjs.CoreObject
  */
-vjs.Component = vjs.CoreObject.extend({
+vjs.Component = CoreObject.extend({
   /**
    * the constructor function for the class
    *
@@ -42,13 +48,13 @@ vjs.Component = vjs.CoreObject.extend({
     this.player_ = player;
 
     // Make a copy of prototype.options_ to protect against overriding global defaults
-    this.options_ = vjs.obj.copy(this.options_);
+    this.options_ = vjslib.obj.copy(this.options_);
 
     // Updated options with supplied options
     options = this.options(options);
 
     // Get ID from options, element, or create using player ID and unique ID
-    this.id_ = options['id'] || ((options['el'] && options['el']['id']) ? options['el']['id'] : player.id() + '_component_' + vjs.guid++ );
+    this.id_ = options['id'] || ((options['el'] && options['el']['id']) ? options['el']['id'] : player.id() + '_component_' + vjslib.guid++ );
 
     this.name_ = options['name'] || null;
 
@@ -100,7 +106,7 @@ vjs.Component.prototype.dispose = function(){
     this.el_.parentNode.removeChild(this.el_);
   }
 
-  vjs.removeData(this.el_);
+  vjslib.removeData(this.el_);
   this.el_ = null;
 };
 
@@ -173,7 +179,7 @@ vjs.Component.prototype.options_;
 vjs.Component.prototype.options = function(obj){
   if (obj === undefined) return this.options_;
 
-  return this.options_ = vjs.util.mergeOptions(this.options_, obj);
+  return this.options_ = vjsutil.mergeOptions(this.options_, obj);
 };
 
 /**
@@ -192,7 +198,7 @@ vjs.Component.prototype.el_;
  * @return {Element}
  */
 vjs.Component.prototype.createEl = function(tagName, attributes){
-  return vjs.createEl(tagName, attributes);
+  return vjslib.createEl(tagName, attributes);
 };
 
 /**
@@ -347,6 +353,8 @@ vjs.Component.prototype.getChild = function(name){
 vjs.Component.prototype.addChild = function(child, options){
   var component, componentClass, componentName, componentId;
 
+  components = require('./components.js');
+
   // If string, create new component with options
   if (typeof child === 'string') {
 
@@ -356,7 +364,7 @@ vjs.Component.prototype.addChild = function(child, options){
     options = options || {};
 
     // Assume name of set is a lowercased name of the UI Class (PlayButton, etc.)
-    componentClass = options['componentClass'] || vjs.capitalize(componentName);
+    componentClass = options['componentClass'] || vjslib.capitalize(componentName);
 
     // Set name through options
     options['name'] = componentName;
@@ -365,7 +373,7 @@ vjs.Component.prototype.addChild = function(child, options){
     // If there's no .player_, this is a player
     // Closure Compiler throws an 'incomplete alias' warning if we use the vjs variable directly.
     // Every class should be exported, so this should never be a problem here.
-    component = new window['videojs'][componentClass](this.player_ || this, options);
+    component = new components[componentClass](this.player_ || this, options);
 
   // child is a component instance
   } else {
@@ -471,7 +479,7 @@ vjs.Component.prototype.initChildren = function(){
 
   if (children) {
     // Allow for an array of children details to passed in the options
-    if (vjs.obj.isArray(children)) {
+    if (vjslib.obj.isArray(children)) {
       for (var i = 0; i < children.length; i++) {
         child = children[i];
 
@@ -486,7 +494,7 @@ vjs.Component.prototype.initChildren = function(){
         parent[name] = parent.addChild(name, opts);
       }
     } else {
-      vjs.obj.each(children, function(name, opts){
+      vjslib.obj.each(children, function(name, opts){
         // Allow for disabling default components
         // e.g. vjs.options['children']['posterImage'] = false
         if (opts === false) return;
@@ -529,7 +537,7 @@ vjs.Component.prototype.buildCSSClass = function(){
  * @return {vjs.Component} self
  */
 vjs.Component.prototype.on = function(type, fn){
-  vjs.on(this.el_, type, vjs.bind(this, fn));
+  vjsevents.on(this.el_, type, vjslib.bind(this, fn));
   return this;
 };
 
@@ -543,7 +551,7 @@ vjs.Component.prototype.on = function(type, fn){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.off = function(type, fn){
-  vjs.off(this.el_, type, fn);
+  vjsevents.off(this.el_, type, fn);
   return this;
 };
 
@@ -555,7 +563,7 @@ vjs.Component.prototype.off = function(type, fn){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.one = function(type, fn) {
-  vjs.one(this.el_, type, vjs.bind(this, fn));
+  vjsevents.one(this.el_, type, vjslib.bind(this, fn));
   return this;
 };
 
@@ -569,7 +577,7 @@ vjs.Component.prototype.one = function(type, fn) {
  * @return {vjs.Component}      self
  */
 vjs.Component.prototype.trigger = function(type, event){
-  vjs.trigger(this.el_, type, event);
+  vjsevents.trigger(this.el_, type, event);
   return this;
 };
 
@@ -661,7 +669,7 @@ vjs.Component.prototype.triggerReady = function(){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.addClass = function(classToAdd){
-  vjs.addClass(this.el_, classToAdd);
+  vjslib.addClass(this.el_, classToAdd);
   return this;
 };
 
@@ -672,7 +680,7 @@ vjs.Component.prototype.addClass = function(classToAdd){
  * @return {vjs.Component}
  */
 vjs.Component.prototype.removeClass = function(classToRemove){
-  vjs.removeClass(this.el_, classToRemove);
+  vjslib.removeClass(this.el_, classToRemove);
   return this;
 };
 
@@ -830,7 +838,7 @@ vjs.Component.prototype.dimension = function(widthOrHeight, num, skipListeners){
   // TODO: handle display:none and no dimension style using px
   } else {
 
-    return parseInt(this.el_['offset'+vjs.capitalize(widthOrHeight)], 10);
+    return parseInt(this.el_['offset'+vjslib.capitalize(widthOrHeight)], 10);
 
     // ComputedStyle version.
     // Only difference is if the element is hidden it will return
@@ -955,7 +963,7 @@ vjs.Component.prototype.enableTouchActivity = function() {
   var report, touchHolding, touchEnd;
 
   // listener for reporting that the user is active
-  report = vjs.bind(this.player(), this.player().reportUserActivity);
+  report = vjslib.bind(this.player(), this.player().reportUserActivity);
 
   this.on('touchstart', function() {
     report();
@@ -978,3 +986,4 @@ vjs.Component.prototype.enableTouchActivity = function() {
   this.on('touchcancel', touchEnd);
 };
 
+module.exports = vjs.Component;

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1,8 +1,9 @@
-var vjs = {};
-var CoreObject = require('./core-object.js');
-var vjslib = require('./lib.js');
-var vjsutil = require('./util.js')
-var vjsevents = require('./events.js');
+var Component, CoreObject, vjslib, vjsutil, vjsevents;
+
+CoreObject = require('./core-object.js');
+vjslib = require('./lib.js');
+vjsutil = require('./util.js')
+vjsevents = require('./events.js');
 
 /**
  * @fileoverview Player Component - Base class for all UI objects
@@ -38,7 +39,7 @@ var vjsevents = require('./events.js');
  * @constructor
  * @extends vjs.CoreObject
  */
-vjs.Component = CoreObject.extend({
+Component = CoreObject.extend({
   /**
    * the constructor function for the class
    *
@@ -81,7 +82,7 @@ vjs.Component = CoreObject.extend({
 /**
  * Dispose of the component and all child components
  */
-vjs.Component.prototype.dispose = function(){
+Component.prototype.dispose = function(){
   this.trigger({ type: 'dispose', 'bubbles': false });
 
   // Dispose all children.
@@ -116,14 +117,14 @@ vjs.Component.prototype.dispose = function(){
  * @type {vjs.Player}
  * @private
  */
-vjs.Component.prototype.player_ = true;
+Component.prototype.player_ = true;
 
 /**
  * Return the component's player
  *
  * @return {vjs.Player}
  */
-vjs.Component.prototype.player = function(){
+Component.prototype.player = function(){
   return this.player_;
 };
 
@@ -133,7 +134,7 @@ vjs.Component.prototype.player = function(){
  * @type {Object}
  * @private
  */
-vjs.Component.prototype.options_;
+Component.prototype.options_;
 
 /**
  * Deep merge of options objects
@@ -176,7 +177,7 @@ vjs.Component.prototype.options_;
  * @param  {Object} obj Object of new option values
  * @return {Object}     A NEW object of this.options_ and obj merged
  */
-vjs.Component.prototype.options = function(obj){
+Component.prototype.options = function(obj){
   if (obj === undefined) return this.options_;
 
   return this.options_ = vjsutil.mergeOptions(this.options_, obj);
@@ -188,7 +189,7 @@ vjs.Component.prototype.options = function(obj){
  * @type {Element}
  * @private
  */
-vjs.Component.prototype.el_;
+Component.prototype.el_;
 
 /**
  * Create the component's DOM element
@@ -197,7 +198,7 @@ vjs.Component.prototype.el_;
  * @param  {Object=} attributes An object of element attributes that should be set on the element
  * @return {Element}
  */
-vjs.Component.prototype.createEl = function(tagName, attributes){
+Component.prototype.createEl = function(tagName, attributes){
   return vjslib.createEl(tagName, attributes);
 };
 
@@ -208,7 +209,7 @@ vjs.Component.prototype.createEl = function(tagName, attributes){
  *
  * @return {Element}
  */
-vjs.Component.prototype.el = function(){
+Component.prototype.el = function(){
   return this.el_;
 };
 
@@ -219,7 +220,7 @@ vjs.Component.prototype.el = function(){
  * @type {Element}
  * @private
  */
-vjs.Component.prototype.contentEl_;
+Component.prototype.contentEl_;
 
 /**
  * Return the component's DOM element for embedding content.
@@ -227,7 +228,7 @@ vjs.Component.prototype.contentEl_;
  *
  * @return {Element}
  */
-vjs.Component.prototype.contentEl = function(){
+Component.prototype.contentEl = function(){
   return this.contentEl_ || this.el_;
 };
 
@@ -237,7 +238,7 @@ vjs.Component.prototype.contentEl = function(){
  * @type {String}
  * @private
  */
-vjs.Component.prototype.id_;
+Component.prototype.id_;
 
 /**
  * Get the component's ID
@@ -246,7 +247,7 @@ vjs.Component.prototype.id_;
  *
  * @return {String}
  */
-vjs.Component.prototype.id = function(){
+Component.prototype.id = function(){
   return this.id_;
 };
 
@@ -256,7 +257,7 @@ vjs.Component.prototype.id = function(){
  * @type {String}
  * @private
  */
-vjs.Component.prototype.name_;
+Component.prototype.name_;
 
 /**
  * Get the component's name. The name is often used to reference the component.
@@ -265,7 +266,7 @@ vjs.Component.prototype.name_;
  *
  * @return {String}
  */
-vjs.Component.prototype.name = function(){
+Component.prototype.name = function(){
   return this.name_;
 };
 
@@ -275,7 +276,7 @@ vjs.Component.prototype.name = function(){
  * @type {Array}
  * @private
  */
-vjs.Component.prototype.children_;
+Component.prototype.children_;
 
 /**
  * Get an array of all child components
@@ -284,7 +285,7 @@ vjs.Component.prototype.children_;
  *
  * @return {Array} The children
  */
-vjs.Component.prototype.children = function(){
+Component.prototype.children = function(){
   return this.children_;
 };
 
@@ -294,14 +295,14 @@ vjs.Component.prototype.children = function(){
  * @type {Object}
  * @private
  */
-vjs.Component.prototype.childIndex_;
+Component.prototype.childIndex_;
 
 /**
  * Returns a child component with the provided ID
  *
  * @return {vjs.Component}
  */
-vjs.Component.prototype.getChildById = function(id){
+Component.prototype.getChildById = function(id){
   return this.childIndex_[id];
 };
 
@@ -311,14 +312,14 @@ vjs.Component.prototype.getChildById = function(id){
  * @type {Object}
  * @private
  */
-vjs.Component.prototype.childNameIndex_;
+Component.prototype.childNameIndex_;
 
 /**
  * Returns a child component with the provided name
  *
  * @return {vjs.Component}
  */
-vjs.Component.prototype.getChild = function(name){
+Component.prototype.getChild = function(name){
   return this.childNameIndex_[name];
 };
 
@@ -350,8 +351,8 @@ vjs.Component.prototype.getChild = function(name){
  * @return {vjs.Component} The child component (created by this process if a string was used)
  * @suppress {accessControls|checkRegExp|checkTypes|checkVars|const|constantProperty|deprecated|duplicate|es5Strict|fileoverviewTags|globalThis|invalidCasts|missingProperties|nonStandardJsDocs|strictModuleDepCheck|undefinedNames|undefinedVars|unknownDefines|uselessCode|visibility}
  */
-vjs.Component.prototype.addChild = function(child, options){
-  var component, componentClass, componentName, componentId;
+Component.prototype.addChild = function(child, options){
+  var component, componentClass, componentName, componentId, components;
 
   components = require('./components.js');
 
@@ -410,7 +411,7 @@ vjs.Component.prototype.addChild = function(child, options){
  *
  * @param  {vjs.Component} component Component to remove
  */
-vjs.Component.prototype.removeChild = function(component){
+Component.prototype.removeChild = function(component){
   if (typeof component === 'string') {
     component = this.getChild(component);
   }
@@ -471,7 +472,7 @@ vjs.Component.prototype.removeChild = function(component){
  *     });
  *
  */
-vjs.Component.prototype.initChildren = function(){
+Component.prototype.initChildren = function(){
   var parent, children, child, name, opts;
 
   parent = this;
@@ -511,7 +512,7 @@ vjs.Component.prototype.initChildren = function(){
  *
  * @return {String} The constructed class name
  */
-vjs.Component.prototype.buildCSSClass = function(){
+Component.prototype.buildCSSClass = function(){
     // Child classes can include a function that does:
     // return 'CLASS NAME' + this._super();
     return '';
@@ -536,7 +537,7 @@ vjs.Component.prototype.buildCSSClass = function(){
  * @param  {Function} fn   The event listener
  * @return {vjs.Component} self
  */
-vjs.Component.prototype.on = function(type, fn){
+Component.prototype.on = function(type, fn){
   vjsevents.on(this.el_, type, vjslib.bind(this, fn));
   return this;
 };
@@ -550,7 +551,7 @@ vjs.Component.prototype.on = function(type, fn){
  * @param  {Function=} fn   Event listener. Without fn it will remove all listeners for a type.
  * @return {vjs.Component}
  */
-vjs.Component.prototype.off = function(type, fn){
+Component.prototype.off = function(type, fn){
   vjsevents.off(this.el_, type, fn);
   return this;
 };
@@ -562,7 +563,7 @@ vjs.Component.prototype.off = function(type, fn){
  * @param  {Function} fn   Event listener
  * @return {vjs.Component}
  */
-vjs.Component.prototype.one = function(type, fn) {
+Component.prototype.one = function(type, fn) {
   vjsevents.one(this.el_, type, vjslib.bind(this, fn));
   return this;
 };
@@ -576,7 +577,7 @@ vjs.Component.prototype.one = function(type, fn) {
  * @param  {Event|Object} event The event object to be passed to the listener
  * @return {vjs.Component}      self
  */
-vjs.Component.prototype.trigger = function(type, event){
+Component.prototype.trigger = function(type, event){
   vjsevents.trigger(this.el_, type, event);
   return this;
 };
@@ -590,7 +591,7 @@ vjs.Component.prototype.trigger = function(type, event){
  * @private
  * @type {Boolean}
  */
-vjs.Component.prototype.isReady_;
+Component.prototype.isReady_;
 
 /**
  * Trigger ready as soon as initialization is finished
@@ -602,7 +603,7 @@ vjs.Component.prototype.isReady_;
  * @type {Boolean}
  * @private
  */
-vjs.Component.prototype.isReadyOnInitFinish_ = true;
+Component.prototype.isReadyOnInitFinish_ = true;
 
 /**
  * List of ready listeners
@@ -610,7 +611,7 @@ vjs.Component.prototype.isReadyOnInitFinish_ = true;
  * @type {Array}
  * @private
  */
-vjs.Component.prototype.readyQueue_;
+Component.prototype.readyQueue_;
 
 /**
  * Bind a listener to the component's ready state
@@ -621,7 +622,7 @@ vjs.Component.prototype.readyQueue_;
  * @param  {Function} fn Ready listener
  * @return {vjs.Component}
  */
-vjs.Component.prototype.ready = function(fn){
+Component.prototype.ready = function(fn){
   if (fn) {
     if (this.isReady_) {
       fn.call(this);
@@ -640,7 +641,7 @@ vjs.Component.prototype.ready = function(fn){
  *
  * @return {vjs.Component}
  */
-vjs.Component.prototype.triggerReady = function(){
+Component.prototype.triggerReady = function(){
   this.isReady_ = true;
 
   var readyQueue = this.readyQueue_;
@@ -668,7 +669,7 @@ vjs.Component.prototype.triggerReady = function(){
  * @param {String} classToAdd Classname to add
  * @return {vjs.Component}
  */
-vjs.Component.prototype.addClass = function(classToAdd){
+Component.prototype.addClass = function(classToAdd){
   vjslib.addClass(this.el_, classToAdd);
   return this;
 };
@@ -679,7 +680,7 @@ vjs.Component.prototype.addClass = function(classToAdd){
  * @param {String} classToRemove Classname to remove
  * @return {vjs.Component}
  */
-vjs.Component.prototype.removeClass = function(classToRemove){
+Component.prototype.removeClass = function(classToRemove){
   vjslib.removeClass(this.el_, classToRemove);
   return this;
 };
@@ -689,7 +690,7 @@ vjs.Component.prototype.removeClass = function(classToRemove){
  *
  * @return {vjs.Component}
  */
-vjs.Component.prototype.show = function(){
+Component.prototype.show = function(){
   this.el_.style.display = 'block';
   return this;
 };
@@ -699,7 +700,7 @@ vjs.Component.prototype.show = function(){
  *
  * @return {vjs.Component}
  */
-vjs.Component.prototype.hide = function(){
+Component.prototype.hide = function(){
   this.el_.style.display = 'none';
   return this;
 };
@@ -711,7 +712,7 @@ vjs.Component.prototype.hide = function(){
  * @return {vjs.Component}
  * @private
  */
-vjs.Component.prototype.lockShowing = function(){
+Component.prototype.lockShowing = function(){
   this.addClass('vjs-lock-showing');
   return this;
 };
@@ -723,7 +724,7 @@ vjs.Component.prototype.lockShowing = function(){
  * @return {vjs.Component}
  * @private
  */
-vjs.Component.prototype.unlockShowing = function(){
+Component.prototype.unlockShowing = function(){
   this.removeClass('vjs-lock-showing');
   return this;
 };
@@ -734,7 +735,7 @@ vjs.Component.prototype.unlockShowing = function(){
  * Currently private because we're movign towards more css-based states.
  * @private
  */
-vjs.Component.prototype.disable = function(){
+Component.prototype.disable = function(){
   this.hide();
   this.show = function(){};
 };
@@ -752,7 +753,7 @@ vjs.Component.prototype.disable = function(){
  * @return {vjs.Component} This component, when setting the width
  * @return {Number|String} The width, when getting
  */
-vjs.Component.prototype.width = function(num, skipListeners){
+Component.prototype.width = function(num, skipListeners){
   return this.dimension('width', num, skipListeners);
 };
 
@@ -769,7 +770,7 @@ vjs.Component.prototype.width = function(num, skipListeners){
  * @return {vjs.Component} This component, when setting the height
  * @return {Number|String} The height, when getting
  */
-vjs.Component.prototype.height = function(num, skipListeners){
+Component.prototype.height = function(num, skipListeners){
   return this.dimension('height', num, skipListeners);
 };
 
@@ -780,7 +781,7 @@ vjs.Component.prototype.height = function(num, skipListeners){
  * @param  {Number|String} height
  * @return {vjs.Component} The component
  */
-vjs.Component.prototype.dimensions = function(width, height){
+Component.prototype.dimensions = function(width, height){
   // Skip resize listeners on width for optimization
   return this.width(width, true).height(height);
 };
@@ -803,7 +804,7 @@ vjs.Component.prototype.dimensions = function(width, height){
  * @return {Number|String} The dimension if nothing was set
  * @private
  */
-vjs.Component.prototype.dimension = function(widthOrHeight, num, skipListeners){
+Component.prototype.dimension = function(widthOrHeight, num, skipListeners){
   if (num !== undefined) {
 
     // Check if using css width/height (% or px) and adjust
@@ -859,7 +860,7 @@ vjs.Component.prototype.dimension = function(widthOrHeight, num, skipListeners){
  * Fired when the width and/or height of the component changes
  * @event resize
  */
-vjs.Component.prototype.onResize;
+Component.prototype.onResize;
 
 /**
  * Emit 'tap' events when touch events are supported
@@ -871,7 +872,7 @@ vjs.Component.prototype.onResize;
  * overhead is especially bad.
  * @private
  */
-vjs.Component.prototype.emitTapEvents = function(){
+Component.prototype.emitTapEvents = function(){
   var touchStart, firstTouch, touchTime, couldBeTap, noTap,
       xdiff, ydiff, touchDistance, tapMovementThreshold;
 
@@ -959,7 +960,7 @@ vjs.Component.prototype.emitTapEvents = function(){
  * whenever touch events happen, and this can be turned off by components that
  * want touch events to act differently.
  */
-vjs.Component.prototype.enableTouchActivity = function() {
+Component.prototype.enableTouchActivity = function() {
   var report, touchHolding, touchEnd;
 
   // listener for reporting that the user is active
@@ -986,4 +987,4 @@ vjs.Component.prototype.enableTouchActivity = function() {
   this.on('touchcancel', touchEnd);
 };
 
-module.exports = vjs.Component;
+module.exports = Component;

--- a/src/js/components.js
+++ b/src/js/components.js
@@ -8,12 +8,14 @@ timedisplay = require('./control-bar/time-display.js');
 volume = require('./control-bar/volume-control.js');
 
 module.exports = {
+  Component: require('./component.js'),
+  Button: require('./button.js'),
+
   Html5: require('./media/html5.js'),
   Flash: require('./media/flash.js'),
   MediaLoader: require('./media/loader.js'),
   MediaTechController: require('./media/media.js'),
 
-  Button: require('./button.js'),
   BigPlayButton: require('./big-play-button.js'),
 
   ErrorDisplay: require('./error-display.js'),

--- a/src/js/components.js
+++ b/src/js/components.js
@@ -1,0 +1,72 @@
+var vjs = {};
+
+vjs.Html5 = require('./media/html5.js');
+vjs.Flash = require('./media/flash.js');
+vjs.MediaLoader = require('./media/loader.js');
+vjs.MediaTechController = require('./media/media.js');
+
+vjs.BigPlayButton = require('./big-play-button.js');
+vjs.Button = require('./button.js');
+
+vjs.ErrorDisplay = require('./error-display.js');
+
+vjs.LoadingSpinner = require('./loading-spinner.js');
+
+var menu = require('./menu.js');
+vjs.Menu = menu.Menu;
+vjs.MenuItem = menu.MenuItem;
+vjs.MenuButton = menu.MenuButton;
+
+vjs.PosterImage = require('./poster.js')
+
+var slider = require('./slider.js');
+vjs.Slider = slider.Slider;
+vjs.SliderHandle = slider.SliderHandle;
+
+var tracks = require('./tracks.js');
+vjs.TextTrack = tracks.TextTrack;
+vjs.CaptionsTrack = tracks.CaptionsTrack;
+vjs.SubtitlesTrack = tracks.SubtitlesTrack;
+vjs.ChaptersTrack = tracks.ChaptersTrack;
+
+vjs.TextTrackDisplay = tracks.TextTrackDisplay;
+vjs.TextTrackMenuItem = tracks.TextTrackMenuItem;
+vjs.OffTextTrackMenuItem = tracks.OffTextTrackMenuItem;
+vjs.TextTrackButton = tracks.TextTrackButton;
+
+vjs.CaptionsButton = tracks.CaptionsButton;
+vjs.SubtitlesButton = tracks.SubtitlesButton;
+vjs.ChaptersButton = tracks.ChaptersButton;
+
+vjs.ChaptersTrackMenuItem = tracks.ChaptersTrackMenuItem;
+
+// CONTROL BAR ITEMS
+vjs.ControlBar = require('./control-bar/control-bar.js');
+vjs.FullscreenToggle = require('./control-bar/fullscreen-toggle.js');
+vjs.LiveDisplay = require('./control-bar/live-display.js');
+vjs.MuteToggle = require('./control-bar/mute-toggle.js');
+vjs.PlayToggle = require('./control-bar/play-toggle.js');
+vjs.PlaybackRateMenuButton = require('./control-bar/playback-rate-menu-button.js');
+
+var progress = require('./control-bar/progress-control.js');
+vjs.ProgressControl = progress.ProgressControl;
+vjs.SeekBar = progress.SeekBar;
+vjs.LoadProgressBar = progress.LoadProgressBar;
+vjs.PlayProgressBar = progress.PlayProgressBar;
+vjs.SeekHandle = progress.SeekHandle;
+
+var timedisplay = require('./control-bar/time-display.js');
+vjs.CurrentTimeDisplay = timedisplay.CurrentTimeDisplay;
+vjs.DurationDisplay = timedisplay.DurationDisplay;
+vjs.TimeDivider = timedisplay.TimeDivider;
+vjs.RemainingTimeDisplay = timedisplay.RemainingTimeDisplay;
+
+var volume = require('./control-bar/volume-control.js');
+vjs.VolumeControl = volume.VolumeControl;
+vjs.VolumeBar = volume.VolumeBar;
+vjs.VolumeLevel = volume.VolumeLevel;
+vjs.VolumeHandle = volume.VolumeHandle;
+vjs.VolumeMenuButton = require('./control-bar/volume-menu-button.js');
+
+
+module.exports = vjs;

--- a/src/js/components.js
+++ b/src/js/components.js
@@ -1,72 +1,72 @@
-var vjs = {};
+var menu, slider, tracks, progress, timedisplay, volume;
 
-vjs.Html5 = require('./media/html5.js');
-vjs.Flash = require('./media/flash.js');
-vjs.MediaLoader = require('./media/loader.js');
-vjs.MediaTechController = require('./media/media.js');
+menu = require('./menu.js');
+slider = require('./slider.js');
+tracks = require('./tracks.js');
+progress = require('./control-bar/progress-control.js');
+timedisplay = require('./control-bar/time-display.js');
+volume = require('./control-bar/volume-control.js');
 
-vjs.BigPlayButton = require('./big-play-button.js');
-vjs.Button = require('./button.js');
+module.exports = {
+  Html5: require('./media/html5.js'),
+  Flash: require('./media/flash.js'),
+  MediaLoader: require('./media/loader.js'),
+  MediaTechController: require('./media/media.js'),
 
-vjs.ErrorDisplay = require('./error-display.js');
+  Button: require('./button.js'),
+  BigPlayButton: require('./big-play-button.js'),
 
-vjs.LoadingSpinner = require('./loading-spinner.js');
+  ErrorDisplay: require('./error-display.js'),
+  MediaError: require('./media-error.js'),
 
-var menu = require('./menu.js');
-vjs.Menu = menu.Menu;
-vjs.MenuItem = menu.MenuItem;
-vjs.MenuButton = menu.MenuButton;
+  LoadingSpinner: require('./loading-spinner.js'),
 
-vjs.PosterImage = require('./poster.js')
+  Menu: menu.Menu,
+  MenuItem: menu.MenuItem,
+  MenuButton: menu.MenuButton,
 
-var slider = require('./slider.js');
-vjs.Slider = slider.Slider;
-vjs.SliderHandle = slider.SliderHandle;
+  PosterImage: require('./poster.js'),
 
-var tracks = require('./tracks.js');
-vjs.TextTrack = tracks.TextTrack;
-vjs.CaptionsTrack = tracks.CaptionsTrack;
-vjs.SubtitlesTrack = tracks.SubtitlesTrack;
-vjs.ChaptersTrack = tracks.ChaptersTrack;
+  Slider: slider.Slider,
+  SliderHandle: slider.SliderHandle,
 
-vjs.TextTrackDisplay = tracks.TextTrackDisplay;
-vjs.TextTrackMenuItem = tracks.TextTrackMenuItem;
-vjs.OffTextTrackMenuItem = tracks.OffTextTrackMenuItem;
-vjs.TextTrackButton = tracks.TextTrackButton;
+  TextTrack: tracks.TextTrack,
+  CaptionsTrack: tracks.CaptionsTrack,
+  SubtitlesTrack: tracks.SubtitlesTrack,
+  ChaptersTrack: tracks.ChaptersTrack,
 
-vjs.CaptionsButton = tracks.CaptionsButton;
-vjs.SubtitlesButton = tracks.SubtitlesButton;
-vjs.ChaptersButton = tracks.ChaptersButton;
+  TextTrackDisplay: tracks.TextTrackDisplay,
+  TextTrackMenuItem: tracks.TextTrackMenuItem,
+  OffTextTrackMenuItem: tracks.OffTextTrackMenuItem,
+  ChaptersTrackMenuItem: tracks.ChaptersTrackMenuItem,
 
-vjs.ChaptersTrackMenuItem = tracks.ChaptersTrackMenuItem;
+  TextTrackButton: tracks.TextTrackButton,
+  CaptionsButton: tracks.CaptionsButton,
+  SubtitlesButton: tracks.SubtitlesButton,
+  ChaptersButton: tracks.ChaptersButton,
 
-// CONTROL BAR ITEMS
-vjs.ControlBar = require('./control-bar/control-bar.js');
-vjs.FullscreenToggle = require('./control-bar/fullscreen-toggle.js');
-vjs.LiveDisplay = require('./control-bar/live-display.js');
-vjs.MuteToggle = require('./control-bar/mute-toggle.js');
-vjs.PlayToggle = require('./control-bar/play-toggle.js');
-vjs.PlaybackRateMenuButton = require('./control-bar/playback-rate-menu-button.js');
+  // CONTROL BAR ITEMS
+  ControlBar: require('./control-bar/control-bar.js'),
+  FullscreenToggle: require('./control-bar/fullscreen-toggle.js'),
+  LiveDisplay: require('./control-bar/live-display.js'),
+  MuteToggle: require('./control-bar/mute-toggle.js'),
+  PlayToggle: require('./control-bar/play-toggle.js'),
+  PlaybackRateMenuButton: require('./control-bar/playback-rate-menu-button.js'),
 
-var progress = require('./control-bar/progress-control.js');
-vjs.ProgressControl = progress.ProgressControl;
-vjs.SeekBar = progress.SeekBar;
-vjs.LoadProgressBar = progress.LoadProgressBar;
-vjs.PlayProgressBar = progress.PlayProgressBar;
-vjs.SeekHandle = progress.SeekHandle;
+  ProgressControl: progress.ProgressControl,
+  SeekBar: progress.SeekBar,
+  LoadProgressBar: progress.LoadProgressBar,
+  PlayProgressBar: progress.PlayProgressBar,
+  SeekHandle: progress.SeekHandle,
 
-var timedisplay = require('./control-bar/time-display.js');
-vjs.CurrentTimeDisplay = timedisplay.CurrentTimeDisplay;
-vjs.DurationDisplay = timedisplay.DurationDisplay;
-vjs.TimeDivider = timedisplay.TimeDivider;
-vjs.RemainingTimeDisplay = timedisplay.RemainingTimeDisplay;
+  CurrentTimeDisplay: timedisplay.CurrentTimeDisplay,
+  DurationDisplay: timedisplay.DurationDisplay,
+  TimeDivider: timedisplay.TimeDivider,
+  RemainingTimeDisplay: timedisplay.RemainingTimeDisplay,
 
-var volume = require('./control-bar/volume-control.js');
-vjs.VolumeControl = volume.VolumeControl;
-vjs.VolumeBar = volume.VolumeBar;
-vjs.VolumeLevel = volume.VolumeLevel;
-vjs.VolumeHandle = volume.VolumeHandle;
-vjs.VolumeMenuButton = require('./control-bar/volume-menu-button.js');
-
-
-module.exports = vjs;
+  VolumeControl: volume.VolumeControl,
+  VolumeBar: volume.VolumeBar,
+  VolumeLevel: volume.VolumeLevel,
+  VolumeHandle: volume.VolumeHandle,
+  VolumeMenuButton: require('./control-bar/volume-menu-button.js')
+}

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+
 /**
  * Container of main controls
  * @param {vjs.Player|Object} player
@@ -6,7 +10,7 @@
  * @constructor
  * @extends vjs.Component
  */
-vjs.ControlBar = vjs.Component.extend();
+vjs.ControlBar = Component.extend();
 
 vjs.ControlBar.prototype.options_ = {
   loadEvent: 'play',
@@ -27,7 +31,9 @@ vjs.ControlBar.prototype.options_ = {
 };
 
 vjs.ControlBar.prototype.createEl = function(){
-  return vjs.createEl('div', {
+  return vjslib.createEl('div', {
     className: 'vjs-control-bar'
   });
 };
+
+module.exports = vjs.ControlBar;

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
+var ControlBar, Component, vjslib;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
 
 /**
  * Container of main controls
@@ -10,9 +11,9 @@ var vjslib = require('../lib.js');
  * @constructor
  * @extends vjs.Component
  */
-vjs.ControlBar = Component.extend();
+ControlBar = Component.extend();
 
-vjs.ControlBar.prototype.options_ = {
+ControlBar.prototype.options_ = {
   loadEvent: 'play',
   children: {
     'playToggle': {},
@@ -30,10 +31,10 @@ vjs.ControlBar.prototype.options_ = {
   }
 };
 
-vjs.ControlBar.prototype.createEl = function(){
+ControlBar.prototype.createEl = function(){
   return vjslib.createEl('div', {
     className: 'vjs-control-bar'
   });
 };
 
-module.exports = vjs.ControlBar;
+module.exports = ControlBar;

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -1,3 +1,6 @@
+var vjs = {};
+var Button = require('../button.js');
+
 /**
  * Toggle fullscreen video
  * @param {vjs.Player|Object} player
@@ -5,21 +8,21 @@
  * @class
  * @extends vjs.Button
  */
-vjs.FullscreenToggle = vjs.Button.extend({
+vjs.FullscreenToggle = Button.extend({
   /**
    * @constructor
    * @memberof vjs.FullscreenToggle
    * @instance
    */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
   }
 });
 
 vjs.FullscreenToggle.prototype.buttonText = 'Fullscreen';
 
 vjs.FullscreenToggle.prototype.buildCSSClass = function(){
-  return 'vjs-fullscreen-control ' + vjs.Button.prototype.buildCSSClass.call(this);
+  return 'vjs-fullscreen-control ' + Button.prototype.buildCSSClass.call(this);
 };
 
 vjs.FullscreenToggle.prototype.onClick = function(){
@@ -31,3 +34,5 @@ vjs.FullscreenToggle.prototype.onClick = function(){
     this.controlText_.innerHTML = 'Fullscreen';
   }
 };
+
+module.exports = vjs.FullscreenToggle;

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -1,5 +1,6 @@
-var vjs = {};
-var Button = require('../button.js');
+var FullscreenToggle, Button;
+
+Button = require('../button.js');
 
 /**
  * Toggle fullscreen video
@@ -8,7 +9,7 @@ var Button = require('../button.js');
  * @class
  * @extends vjs.Button
  */
-vjs.FullscreenToggle = Button.extend({
+FullscreenToggle = Button.extend({
   /**
    * @constructor
    * @memberof vjs.FullscreenToggle
@@ -19,13 +20,13 @@ vjs.FullscreenToggle = Button.extend({
   }
 });
 
-vjs.FullscreenToggle.prototype.buttonText = 'Fullscreen';
+FullscreenToggle.prototype.buttonText = 'Fullscreen';
 
-vjs.FullscreenToggle.prototype.buildCSSClass = function(){
+FullscreenToggle.prototype.buildCSSClass = function(){
   return 'vjs-fullscreen-control ' + Button.prototype.buildCSSClass.call(this);
 };
 
-vjs.FullscreenToggle.prototype.onClick = function(){
+FullscreenToggle.prototype.onClick = function(){
   if (!this.player_.isFullscreen()) {
     this.player_.requestFullscreen();
     this.controlText_.innerHTML = 'Non-Fullscreen';
@@ -35,4 +36,4 @@ vjs.FullscreenToggle.prototype.onClick = function(){
   }
 };
 
-module.exports = vjs.FullscreenToggle;
+module.exports = FullscreenToggle;

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
+var LiveDisplay, Component, vjslib;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
 
 /**
  * Displays the live indicator
@@ -9,13 +10,13 @@ var vjslib = require('../lib.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.LiveDisplay = Component.extend({
+LiveDisplay = Component.extend({
   init: function(player, options){
     Component.call(this, player, options);
   }
 });
 
-vjs.LiveDisplay.prototype.createEl = function(){
+LiveDisplay.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-live-controls vjs-control'
   });
@@ -31,4 +32,4 @@ vjs.LiveDisplay.prototype.createEl = function(){
   return el;
 };
 
-module.exports = vjs.LiveDisplay;
+module.exports = LiveDisplay;

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+
 /**
  * Displays the live indicator
  * TODO - Future make it click to snap to live
@@ -5,18 +9,18 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.LiveDisplay = vjs.Component.extend({
+vjs.LiveDisplay = Component.extend({
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
   }
 });
 
 vjs.LiveDisplay.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-live-controls vjs-control'
   });
 
-  this.contentEl_ = vjs.createEl('div', {
+  this.contentEl_ = vjslib.createEl('div', {
     className: 'vjs-live-display',
     innerHTML: '<span class="vjs-control-text">Stream Type </span>LIVE',
     'aria-live': 'off'
@@ -26,3 +30,5 @@ vjs.LiveDisplay.prototype.createEl = function(){
 
   return el;
 };
+
+module.exports = vjs.LiveDisplay;

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Button = require('../button.js');
-var vjslib = require('../lib.js');
+var MuteToggle, Button, vjslib;
+
+Button = require('../button.js');
+vjslib = require('../lib.js');
 
 /**
  * A button component for muting the audio
@@ -9,7 +10,7 @@ var vjslib = require('../lib.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.MuteToggle = Button.extend({
+MuteToggle = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -30,18 +31,18 @@ vjs.MuteToggle = Button.extend({
   }
 });
 
-vjs.MuteToggle.prototype.createEl = function(){
+MuteToggle.prototype.createEl = function(){
   return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-mute-control vjs-control',
     innerHTML: '<div><span class="vjs-control-text">Mute</span></div>'
   });
 };
 
-vjs.MuteToggle.prototype.onClick = function(){
+MuteToggle.prototype.onClick = function(){
   this.player_.muted( this.player_.muted() ? false : true );
 };
 
-vjs.MuteToggle.prototype.update = function(){
+MuteToggle.prototype.update = function(){
   var vol = this.player_.volume(),
       level = 3;
 
@@ -73,4 +74,4 @@ vjs.MuteToggle.prototype.update = function(){
   vjslib.addClass(this.el_, 'vjs-vol-'+level);
 };
 
-module.exports = vjs.MuteToggle;
+module.exports = MuteToggle;

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Button = require('../button.js');
+var vjslib = require('../lib.js');
+
 /**
  * A button component for muting the audio
  *
@@ -5,18 +9,18 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.MuteToggle = vjs.Button.extend({
+vjs.MuteToggle = Button.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
 
-    player.on('volumechange', vjs.bind(this, this.update));
+    player.on('volumechange', vjslib.bind(this, this.update));
 
     // hide mute toggle if the current tech doesn't support volume control
     if (player.tech && player.tech.features && player.tech.features['volumeControl'] === false) {
       this.addClass('vjs-hidden');
     }
-    player.on('loadstart', vjs.bind(this, function(){
+    player.on('loadstart', vjslib.bind(this, function(){
       if (player.tech.features && player.tech.features['volumeControl'] === false) {
         this.addClass('vjs-hidden');
       } else {
@@ -27,7 +31,7 @@ vjs.MuteToggle = vjs.Button.extend({
 });
 
 vjs.MuteToggle.prototype.createEl = function(){
-  return vjs.Button.prototype.createEl.call(this, 'div', {
+  return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-mute-control vjs-control',
     innerHTML: '<div><span class="vjs-control-text">Mute</span></div>'
   });
@@ -64,7 +68,9 @@ vjs.MuteToggle.prototype.update = function(){
 
   /* TODO improve muted icon classes */
   for (var i = 0; i < 4; i++) {
-    vjs.removeClass(this.el_, 'vjs-vol-'+i);
+    vjslib.removeClass(this.el_, 'vjs-vol-'+i);
   }
-  vjs.addClass(this.el_, 'vjs-vol-'+level);
+  vjslib.addClass(this.el_, 'vjs-vol-'+level);
 };
+
+module.exports = vjs.MuteToggle;

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Button = require('../button.js');
-var vjslib = require('../lib.js');
+var PlayToggle, Button, vjslib;
+
+Button = require('../button.js');
+vjslib = require('../lib.js');
 
 /**
  * Button to toggle between play and pause
@@ -9,7 +10,7 @@ var vjslib = require('../lib.js');
  * @class
  * @constructor
  */
-vjs.PlayToggle = Button.extend({
+PlayToggle = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -19,14 +20,14 @@ vjs.PlayToggle = Button.extend({
   }
 });
 
-vjs.PlayToggle.prototype.buttonText = 'Play';
+PlayToggle.prototype.buttonText = 'Play';
 
-vjs.PlayToggle.prototype.buildCSSClass = function(){
+PlayToggle.prototype.buildCSSClass = function(){
   return 'vjs-play-control ' + Button.prototype.buildCSSClass.call(this);
 };
 
 // OnClick - Toggle between play and pause
-vjs.PlayToggle.prototype.onClick = function(){
+PlayToggle.prototype.onClick = function(){
   if (this.player_.paused()) {
     this.player_.play();
   } else {
@@ -35,17 +36,17 @@ vjs.PlayToggle.prototype.onClick = function(){
 };
 
   // OnPlay - Add the vjs-playing class to the element so it can change appearance
-vjs.PlayToggle.prototype.onPlay = function(){
+PlayToggle.prototype.onPlay = function(){
   vjslib.removeClass(this.el_, 'vjs-paused');
   vjslib.addClass(this.el_, 'vjs-playing');
   this.el_.children[0].children[0].innerHTML = 'Pause'; // change the button text to "Pause"
 };
 
   // OnPause - Add the vjs-paused class to the element so it can change appearance
-vjs.PlayToggle.prototype.onPause = function(){
+PlayToggle.prototype.onPause = function(){
   vjslib.removeClass(this.el_, 'vjs-playing');
   vjslib.addClass(this.el_, 'vjs-paused');
   this.el_.children[0].children[0].innerHTML = 'Play'; // change the button text to "Play"
 };
 
-module.exports = vjs.PlayToggle;
+module.exports = PlayToggle;

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Button = require('../button.js');
+var vjslib = require('../lib.js');
+
 /**
  * Button to toggle between play and pause
  * @param {vjs.Player|Object} player
@@ -5,20 +9,20 @@
  * @class
  * @constructor
  */
-vjs.PlayToggle = vjs.Button.extend({
+vjs.PlayToggle = Button.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
 
-    player.on('play', vjs.bind(this, this.onPlay));
-    player.on('pause', vjs.bind(this, this.onPause));
+    player.on('play', vjslib.bind(this, this.onPlay));
+    player.on('pause', vjslib.bind(this, this.onPause));
   }
 });
 
 vjs.PlayToggle.prototype.buttonText = 'Play';
 
 vjs.PlayToggle.prototype.buildCSSClass = function(){
-  return 'vjs-play-control ' + vjs.Button.prototype.buildCSSClass.call(this);
+  return 'vjs-play-control ' + Button.prototype.buildCSSClass.call(this);
 };
 
 // OnClick - Toggle between play and pause
@@ -32,14 +36,16 @@ vjs.PlayToggle.prototype.onClick = function(){
 
   // OnPlay - Add the vjs-playing class to the element so it can change appearance
 vjs.PlayToggle.prototype.onPlay = function(){
-  vjs.removeClass(this.el_, 'vjs-paused');
-  vjs.addClass(this.el_, 'vjs-playing');
+  vjslib.removeClass(this.el_, 'vjs-paused');
+  vjslib.addClass(this.el_, 'vjs-playing');
   this.el_.children[0].children[0].innerHTML = 'Pause'; // change the button text to "Pause"
 };
 
   // OnPause - Add the vjs-paused class to the element so it can change appearance
 vjs.PlayToggle.prototype.onPause = function(){
-  vjs.removeClass(this.el_, 'vjs-playing');
-  vjs.addClass(this.el_, 'vjs-paused');
+  vjslib.removeClass(this.el_, 'vjs-playing');
+  vjslib.addClass(this.el_, 'vjs-paused');
   this.el_.children[0].children[0].innerHTML = 'Play'; // change the button text to "Play"
 };
+
+module.exports = vjs.PlayToggle;

--- a/src/js/control-bar/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu-button.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var vjsmenu = require('../menu.js');
-var vjslib = require('../lib.js');
-var Component = require('../component.js');
+var PlaybackRateMenuButton, Component, vjsmenu, vjslib;
+
+vjsmenu = require('../menu.js');
+vjslib = require('../lib.js');
+Component = require('../component.js');
 
 /**
  * The component for controlling the playback rate
@@ -10,7 +11,7 @@ var Component = require('../component.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.PlaybackRateMenuButton = vjsmenu.MenuButton.extend({
+PlaybackRateMenuButton = vjsmenu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
     vjsmenu.MenuButton.call(this, player, options);
@@ -23,7 +24,7 @@ vjs.PlaybackRateMenuButton = vjsmenu.MenuButton.extend({
   }
 });
 
-vjs.PlaybackRateMenuButton.prototype.createEl = function(){
+PlaybackRateMenuButton.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-playback-rate vjs-menu-button vjs-control',
     innerHTML: '<div class="vjs-control-content"><span class="vjs-control-text">Playback Rate</span></div>'
@@ -40,14 +41,14 @@ vjs.PlaybackRateMenuButton.prototype.createEl = function(){
 };
 
 // Menu creation
-vjs.PlaybackRateMenuButton.prototype.createMenu = function(){
+PlaybackRateMenuButton.prototype.createMenu = function(){
   var menu = new vjsmenu.Menu(this.player());
   var rates = this.player().options()['playbackRates'];
 
   if (rates) {
     for (var i = rates.length - 1; i >= 0; i--) {
       menu.addChild(
-        new vjs.PlaybackRateMenuItem(this.player(), { 'rate': rates[i] + 'x'})
+        new PlaybackRateMenuItem(this.player(), { 'rate': rates[i] + 'x'})
         );
     };
   }
@@ -55,12 +56,12 @@ vjs.PlaybackRateMenuButton.prototype.createMenu = function(){
   return menu;
 };
 
-vjs.PlaybackRateMenuButton.prototype.updateARIAAttributes = function(){
+PlaybackRateMenuButton.prototype.updateARIAAttributes = function(){
   // Current playback rate
   this.el().setAttribute('aria-valuenow', this.player().playbackRate());
 };
 
-vjs.PlaybackRateMenuButton.prototype.onClick = function(){
+PlaybackRateMenuButton.prototype.onClick = function(){
   // select next rate option
   var currentRate = this.player().playbackRate();
   var rates = this.player().options()['playbackRates'];
@@ -75,7 +76,7 @@ vjs.PlaybackRateMenuButton.prototype.onClick = function(){
   this.player().playbackRate(newRate);
 };
 
-vjs.PlaybackRateMenuButton.prototype.playbackRateSupported = function(){
+PlaybackRateMenuButton.prototype.playbackRateSupported = function(){
   return this.player().tech
     && this.player().tech.features['playbackRate']
     && this.player().options()['playbackRates']
@@ -86,7 +87,7 @@ vjs.PlaybackRateMenuButton.prototype.playbackRateSupported = function(){
 /**
  * Hide playback rate controls when they're no playback rate options to select
  */
-vjs.PlaybackRateMenuButton.prototype.updateVisibility = function(){
+PlaybackRateMenuButton.prototype.updateVisibility = function(){
   if (this.playbackRateSupported()) {
     this.removeClass('vjs-hidden');
   } else {
@@ -97,7 +98,7 @@ vjs.PlaybackRateMenuButton.prototype.updateVisibility = function(){
 /**
  * Update button label when rate changed
  */
-vjs.PlaybackRateMenuButton.prototype.updateLabel = function(){
+PlaybackRateMenuButton.prototype.updateLabel = function(){
   if (this.playbackRateSupported()) {
     this.labelEl_.innerHTML = this.player().playbackRate() + 'x';
   }
@@ -108,7 +109,7 @@ vjs.PlaybackRateMenuButton.prototype.updateLabel = function(){
  *
  * @constructor
  */
-vjs.PlaybackRateMenuItem = vjsmenu.MenuItem.extend({
+PlaybackRateMenuItem = vjsmenu.MenuItem.extend({
   contentElType: 'button',
   /** @constructor */
   init: function(player, options){
@@ -124,13 +125,13 @@ vjs.PlaybackRateMenuItem = vjsmenu.MenuItem.extend({
   }
 });
 
-vjs.PlaybackRateMenuItem.prototype.onClick = function(){
+PlaybackRateMenuItem.prototype.onClick = function(){
   vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player().playbackRate(this.rate);
 };
 
-vjs.PlaybackRateMenuItem.prototype.update = function(){
+PlaybackRateMenuItem.prototype.update = function(){
   this.selected(this.player().playbackRate() == this.rate);
 };
 
-module.exports = vjs.PlaybackRateMenuButton;
+module.exports = PlaybackRateMenuButton;

--- a/src/js/control-bar/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu-button.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var vjsmenu = require('../menu.js');
+var vjslib = require('../lib.js');
+var Component = require('../component.js');
+
 /**
  * The component for controlling the playback rate
  *
@@ -5,26 +10,26 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.PlaybackRateMenuButton = vjs.MenuButton.extend({
+vjs.PlaybackRateMenuButton = vjsmenu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.MenuButton.call(this, player, options);
+    vjsmenu.MenuButton.call(this, player, options);
 
     this.updateVisibility();
     this.updateLabel();
 
-    player.on('loadstart', vjs.bind(this, this.updateVisibility));
-    player.on('ratechange', vjs.bind(this, this.updateLabel));
+    player.on('loadstart', vjslib.bind(this, this.updateVisibility));
+    player.on('ratechange', vjslib.bind(this, this.updateLabel));
   }
 });
 
 vjs.PlaybackRateMenuButton.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-playback-rate vjs-menu-button vjs-control',
     innerHTML: '<div class="vjs-control-content"><span class="vjs-control-text">Playback Rate</span></div>'
   });
 
-  this.labelEl_ = vjs.createEl('div', {
+  this.labelEl_ = vjslib.createEl('div', {
     className: 'vjs-playback-rate-value',
     innerHTML: 1.0
   });
@@ -36,7 +41,7 @@ vjs.PlaybackRateMenuButton.prototype.createEl = function(){
 
 // Menu creation
 vjs.PlaybackRateMenuButton.prototype.createMenu = function(){
-  var menu = new vjs.Menu(this.player());
+  var menu = new vjsmenu.Menu(this.player());
   var rates = this.player().options()['playbackRates'];
 
   if (rates) {
@@ -103,7 +108,7 @@ vjs.PlaybackRateMenuButton.prototype.updateLabel = function(){
  *
  * @constructor
  */
-vjs.PlaybackRateMenuItem = vjs.MenuItem.extend({
+vjs.PlaybackRateMenuItem = vjsmenu.MenuItem.extend({
   contentElType: 'button',
   /** @constructor */
   init: function(player, options){
@@ -113,17 +118,19 @@ vjs.PlaybackRateMenuItem = vjs.MenuItem.extend({
     // Modify options for parent MenuItem class's init.
     options['label'] = label;
     options['selected'] = rate === 1;
-    vjs.MenuItem.call(this, player, options);
+    vjsmenu.MenuItem.call(this, player, options);
 
-    this.player().on('ratechange', vjs.bind(this, this.update));
+    this.player().on('ratechange', vjslib.bind(this, this.update));
   }
 });
 
 vjs.PlaybackRateMenuItem.prototype.onClick = function(){
-  vjs.MenuItem.prototype.onClick.call(this);
+  vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player().playbackRate(this.rate);
 };
 
 vjs.PlaybackRateMenuItem.prototype.update = function(){
   this.selected(this.player().playbackRate() == this.rate);
 };
+
+module.exports = vjs.PlaybackRateMenuButton;

--- a/src/js/control-bar/progress-control.js
+++ b/src/js/control-bar/progress-control.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+var slider = require('../slider.js');
+
 /**
  * The Progress Control component contains the seek bar, load progress,
  * and play progress
@@ -6,10 +11,10 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.ProgressControl = vjs.Component.extend({
+vjs.ProgressControl = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
   }
 });
 
@@ -20,7 +25,7 @@ vjs.ProgressControl.prototype.options_ = {
 };
 
 vjs.ProgressControl.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-progress-control vjs-control'
   });
 };
@@ -32,12 +37,12 @@ vjs.ProgressControl.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.SeekBar = vjs.Slider.extend({
+vjs.SeekBar = slider.Slider.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Slider.call(this, player, options);
-    player.on('timeupdate', vjs.bind(this, this.updateARIAAttributes));
-    player.ready(vjs.bind(this, this.updateARIAAttributes));
+    slider.Slider.call(this, player, options);
+    player.on('timeupdate', vjslib.bind(this, this.updateARIAAttributes));
+    player.ready(vjslib.bind(this, this.updateARIAAttributes));
   }
 });
 
@@ -54,7 +59,7 @@ vjs.SeekBar.prototype.options_ = {
 vjs.SeekBar.prototype.playerEvent = 'timeupdate';
 
 vjs.SeekBar.prototype.createEl = function(){
-  return vjs.Slider.prototype.createEl.call(this, 'div', {
+  return slider.Slider.prototype.createEl.call(this, 'div', {
     className: 'vjs-progress-holder',
     'aria-label': 'video progress bar'
   });
@@ -63,8 +68,8 @@ vjs.SeekBar.prototype.createEl = function(){
 vjs.SeekBar.prototype.updateARIAAttributes = function(){
     // Allows for smooth scrubbing, when player can't keep up.
     var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-    this.el_.setAttribute('aria-valuenow',vjs.round(this.getPercent()*100, 2)); // machine readable value of progress bar (percentage complete)
-    this.el_.setAttribute('aria-valuetext',vjs.formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
+    this.el_.setAttribute('aria-valuenow',vjslib.round(this.getPercent()*100, 2)); // machine readable value of progress bar (percentage complete)
+    this.el_.setAttribute('aria-valuetext',vjslib.formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
 };
 
 vjs.SeekBar.prototype.getPercent = function(){
@@ -72,7 +77,7 @@ vjs.SeekBar.prototype.getPercent = function(){
 };
 
 vjs.SeekBar.prototype.onMouseDown = function(event){
-  vjs.Slider.prototype.onMouseDown.call(this, event);
+  slider.Slider.prototype.onMouseDown.call(this, event);
 
   this.player_.scrubbing = true;
 
@@ -91,7 +96,7 @@ vjs.SeekBar.prototype.onMouseMove = function(event){
 };
 
 vjs.SeekBar.prototype.onMouseUp = function(event){
-  vjs.Slider.prototype.onMouseUp.call(this, event);
+  slider.Slider.prototype.onMouseUp.call(this, event);
 
   this.player_.scrubbing = false;
   if (this.videoWasPlaying) {
@@ -115,23 +120,23 @@ vjs.SeekBar.prototype.stepBack = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.LoadProgressBar = vjs.Component.extend({
+vjs.LoadProgressBar = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
-    player.on('progress', vjs.bind(this, this.update));
+    Component.call(this, player, options);
+    player.on('progress', vjslib.bind(this, this.update));
   }
 });
 
 vjs.LoadProgressBar.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-load-progress',
     innerHTML: '<span class="vjs-control-text">Loaded: 0%</span>'
   });
 };
 
 vjs.LoadProgressBar.prototype.update = function(){
-  if (this.el_.style) { this.el_.style.width = vjs.round(this.player_.bufferedPercent() * 100, 2) + '%'; }
+  if (this.el_.style) { this.el_.style.width = vjslib.round(this.player_.bufferedPercent() * 100, 2) + '%'; }
 };
 
 
@@ -142,15 +147,15 @@ vjs.LoadProgressBar.prototype.update = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.PlayProgressBar = vjs.Component.extend({
+vjs.PlayProgressBar = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
   }
 });
 
 vjs.PlayProgressBar.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-play-progress',
     innerHTML: '<span class="vjs-control-text">Progress: 0%</span>'
   });
@@ -164,10 +169,10 @@ vjs.PlayProgressBar.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.SeekHandle = vjs.SliderHandle.extend({
+vjs.SeekHandle = slider.SliderHandle.extend({
   init: function(player, options) {
-    vjs.SliderHandle.call(this, player, options);
-    player.on('timeupdate', vjs.bind(this, this.updateContent));
+    slider.SliderHandle.call(this, player, options);
+    player.on('timeupdate', vjslib.bind(this, this.updateContent));
   }
 });
 
@@ -181,7 +186,7 @@ vjs.SeekHandle.prototype.defaultValue = '00:00';
 
 /** @inheritDoc */
 vjs.SeekHandle.prototype.createEl = function() {
-  return vjs.SliderHandle.prototype.createEl.call(this, 'div', {
+  return slider.SliderHandle.prototype.createEl.call(this, 'div', {
     className: 'vjs-seek-handle',
     'aria-live': 'off'
   });
@@ -189,5 +194,7 @@ vjs.SeekHandle.prototype.createEl = function() {
 
 vjs.SeekHandle.prototype.updateContent = function() {
   var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-  this.el_.innerHTML = '<span class="vjs-control-text">' + vjs.formatTime(time, this.player_.duration()) + '</span>';
+  this.el_.innerHTML = '<span class="vjs-control-text">' + vjslib.formatTime(time, this.player_.duration()) + '</span>';
 };
+
+module.exports = vjs;

--- a/src/js/control-bar/progress-control.js
+++ b/src/js/control-bar/progress-control.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
-var slider = require('../slider.js');
+var ProgressControl, SeekBar, LoadProgressBar, PlayProgressBar, SeekHandle, Component, vjslib, slider;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
+slider = require('../slider.js');
 
 /**
  * The Progress Control component contains the seek bar, load progress,
@@ -11,20 +12,20 @@ var slider = require('../slider.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.ProgressControl = Component.extend({
+ProgressControl = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
   }
 });
 
-vjs.ProgressControl.prototype.options_ = {
+ProgressControl.prototype.options_ = {
   children: {
     'seekBar': {}
   }
 };
 
-vjs.ProgressControl.prototype.createEl = function(){
+ProgressControl.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-progress-control vjs-control'
   });
@@ -37,7 +38,7 @@ vjs.ProgressControl.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.SeekBar = slider.Slider.extend({
+SeekBar = slider.Slider.extend({
   /** @constructor */
   init: function(player, options){
     slider.Slider.call(this, player, options);
@@ -46,7 +47,7 @@ vjs.SeekBar = slider.Slider.extend({
   }
 });
 
-vjs.SeekBar.prototype.options_ = {
+SeekBar.prototype.options_ = {
   children: {
     'loadProgressBar': {},
     'playProgressBar': {},
@@ -56,27 +57,27 @@ vjs.SeekBar.prototype.options_ = {
   'handleName': 'seekHandle'
 };
 
-vjs.SeekBar.prototype.playerEvent = 'timeupdate';
+SeekBar.prototype.playerEvent = 'timeupdate';
 
-vjs.SeekBar.prototype.createEl = function(){
+SeekBar.prototype.createEl = function(){
   return slider.Slider.prototype.createEl.call(this, 'div', {
     className: 'vjs-progress-holder',
     'aria-label': 'video progress bar'
   });
 };
 
-vjs.SeekBar.prototype.updateARIAAttributes = function(){
+SeekBar.prototype.updateARIAAttributes = function(){
     // Allows for smooth scrubbing, when player can't keep up.
     var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
     this.el_.setAttribute('aria-valuenow',vjslib.round(this.getPercent()*100, 2)); // machine readable value of progress bar (percentage complete)
     this.el_.setAttribute('aria-valuetext',vjslib.formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
 };
 
-vjs.SeekBar.prototype.getPercent = function(){
+SeekBar.prototype.getPercent = function(){
   return this.player_.currentTime() / this.player_.duration();
 };
 
-vjs.SeekBar.prototype.onMouseDown = function(event){
+SeekBar.prototype.onMouseDown = function(event){
   slider.Slider.prototype.onMouseDown.call(this, event);
 
   this.player_.scrubbing = true;
@@ -85,7 +86,7 @@ vjs.SeekBar.prototype.onMouseDown = function(event){
   this.player_.pause();
 };
 
-vjs.SeekBar.prototype.onMouseMove = function(event){
+SeekBar.prototype.onMouseMove = function(event){
   var newTime = this.calculateDistance(event) * this.player_.duration();
 
   // Don't let video end while scrubbing.
@@ -95,7 +96,7 @@ vjs.SeekBar.prototype.onMouseMove = function(event){
   this.player_.currentTime(newTime);
 };
 
-vjs.SeekBar.prototype.onMouseUp = function(event){
+SeekBar.prototype.onMouseUp = function(event){
   slider.Slider.prototype.onMouseUp.call(this, event);
 
   this.player_.scrubbing = false;
@@ -104,11 +105,11 @@ vjs.SeekBar.prototype.onMouseUp = function(event){
   }
 };
 
-vjs.SeekBar.prototype.stepForward = function(){
+SeekBar.prototype.stepForward = function(){
   this.player_.currentTime(this.player_.currentTime() + 5); // more quickly fast forward for keyboard-only users
 };
 
-vjs.SeekBar.prototype.stepBack = function(){
+SeekBar.prototype.stepBack = function(){
   this.player_.currentTime(this.player_.currentTime() - 5); // more quickly rewind for keyboard-only users
 };
 
@@ -120,7 +121,7 @@ vjs.SeekBar.prototype.stepBack = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.LoadProgressBar = Component.extend({
+LoadProgressBar = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -128,14 +129,14 @@ vjs.LoadProgressBar = Component.extend({
   }
 });
 
-vjs.LoadProgressBar.prototype.createEl = function(){
+LoadProgressBar.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-load-progress',
     innerHTML: '<span class="vjs-control-text">Loaded: 0%</span>'
   });
 };
 
-vjs.LoadProgressBar.prototype.update = function(){
+LoadProgressBar.prototype.update = function(){
   if (this.el_.style) { this.el_.style.width = vjslib.round(this.player_.bufferedPercent() * 100, 2) + '%'; }
 };
 
@@ -147,14 +148,14 @@ vjs.LoadProgressBar.prototype.update = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.PlayProgressBar = Component.extend({
+PlayProgressBar = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
   }
 });
 
-vjs.PlayProgressBar.prototype.createEl = function(){
+PlayProgressBar.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-play-progress',
     innerHTML: '<span class="vjs-control-text">Progress: 0%</span>'
@@ -169,7 +170,7 @@ vjs.PlayProgressBar.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.SeekHandle = slider.SliderHandle.extend({
+SeekHandle = slider.SliderHandle.extend({
   init: function(player, options) {
     slider.SliderHandle.call(this, player, options);
     player.on('timeupdate', vjslib.bind(this, this.updateContent));
@@ -182,19 +183,26 @@ vjs.SeekHandle = slider.SliderHandle.extend({
  * @type {String}
  * @private
  */
-vjs.SeekHandle.prototype.defaultValue = '00:00';
+SeekHandle.prototype.defaultValue = '00:00';
 
 /** @inheritDoc */
-vjs.SeekHandle.prototype.createEl = function() {
+SeekHandle.prototype.createEl = function() {
   return slider.SliderHandle.prototype.createEl.call(this, 'div', {
     className: 'vjs-seek-handle',
     'aria-live': 'off'
   });
 };
 
-vjs.SeekHandle.prototype.updateContent = function() {
+SeekHandle.prototype.updateContent = function() {
   var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
   this.el_.innerHTML = '<span class="vjs-control-text">' + vjslib.formatTime(time, this.player_.duration()) + '</span>';
 };
 
-module.exports = vjs;
+module.exports = {
+  ProgressControl: ProgressControl,
+  LoadProgressBar: LoadProgressBar,
+  PlayProgressBar: PlayProgressBar,
+  SeekBar: SeekBar,
+  SeekHandle: SeekHandle
+};
+

--- a/src/js/control-bar/time-display.js
+++ b/src/js/control-bar/time-display.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
+var CurrentTimeDisplay, DurationDisplay, TimeDivider, RemainingTimeDisplay, Component, vjslib;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
 
 /**
  * Displays the current time
@@ -8,7 +9,7 @@ var vjslib = require('../lib.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.CurrentTimeDisplay = Component.extend({
+CurrentTimeDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -17,7 +18,7 @@ vjs.CurrentTimeDisplay = Component.extend({
   }
 });
 
-vjs.CurrentTimeDisplay.prototype.createEl = function(){
+CurrentTimeDisplay.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-current-time vjs-time-controls vjs-control'
   });
@@ -32,7 +33,7 @@ vjs.CurrentTimeDisplay.prototype.createEl = function(){
   return el;
 };
 
-vjs.CurrentTimeDisplay.prototype.updateContent = function(){
+CurrentTimeDisplay.prototype.updateContent = function(){
   // Allows for smooth scrubbing, when player can't keep up.
   var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
   this.contentEl_.innerHTML = '<span class="vjs-control-text">Current Time </span>' + vjslib.formatTime(time, this.player_.duration());
@@ -44,7 +45,7 @@ vjs.CurrentTimeDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.DurationDisplay = Component.extend({
+DurationDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -58,7 +59,7 @@ vjs.DurationDisplay = Component.extend({
   }
 });
 
-vjs.DurationDisplay.prototype.createEl = function(){
+DurationDisplay.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-duration vjs-time-controls vjs-control'
   });
@@ -73,7 +74,7 @@ vjs.DurationDisplay.prototype.createEl = function(){
   return el;
 };
 
-vjs.DurationDisplay.prototype.updateContent = function(){
+DurationDisplay.prototype.updateContent = function(){
   var duration = this.player_.duration();
   if (duration) {
       this.contentEl_.innerHTML = '<span class="vjs-control-text">Duration Time </span>' + vjslib.formatTime(duration); // label the duration time for screen reader users
@@ -89,14 +90,14 @@ vjs.DurationDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.TimeDivider = Component.extend({
+TimeDivider = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
   }
 });
 
-vjs.TimeDivider.prototype.createEl = function(){
+TimeDivider.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-time-divider',
     innerHTML: '<div><span>/</span></div>'
@@ -109,7 +110,7 @@ vjs.TimeDivider.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.RemainingTimeDisplay = Component.extend({
+RemainingTimeDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -118,7 +119,7 @@ vjs.RemainingTimeDisplay = Component.extend({
   }
 });
 
-vjs.RemainingTimeDisplay.prototype.createEl = function(){
+RemainingTimeDisplay.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-remaining-time vjs-time-controls vjs-control'
   });
@@ -133,7 +134,7 @@ vjs.RemainingTimeDisplay.prototype.createEl = function(){
   return el;
 };
 
-vjs.RemainingTimeDisplay.prototype.updateContent = function(){
+RemainingTimeDisplay.prototype.updateContent = function(){
   if (this.player_.duration()) {
     this.contentEl_.innerHTML = '<span class="vjs-control-text">Remaining Time </span>' + '-'+ vjslib.formatTime(this.player_.remainingTime());
   }
@@ -143,4 +144,9 @@ vjs.RemainingTimeDisplay.prototype.updateContent = function(){
   // this.contentEl_.innerHTML = vjs.formatTime(time, this.player_.duration());
 };
 
-module.exports = vjs;
+module.exports = {
+  CurrentTimeDisplay: CurrentTimeDisplay,
+  DurationDisplay: DurationDisplay,
+  TimeDivider: TimeDivider,
+  RemainingTimeDisplay: RemainingTimeDisplay
+};

--- a/src/js/control-bar/time-display.js
+++ b/src/js/control-bar/time-display.js
@@ -1,24 +1,28 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+
 /**
  * Displays the current time
  * @param {vjs.Player|Object} player
  * @param {Object=} options
  * @constructor
  */
-vjs.CurrentTimeDisplay = vjs.Component.extend({
+vjs.CurrentTimeDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
-    player.on('timeupdate', vjs.bind(this, this.updateContent));
+    player.on('timeupdate', vjslib.bind(this, this.updateContent));
   }
 });
 
 vjs.CurrentTimeDisplay.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-current-time vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = vjs.createEl('div', {
+  this.contentEl_ = vjslib.createEl('div', {
     className: 'vjs-current-time-display',
     innerHTML: '<span class="vjs-control-text">Current Time </span>' + '0:00', // label the current time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -31,7 +35,7 @@ vjs.CurrentTimeDisplay.prototype.createEl = function(){
 vjs.CurrentTimeDisplay.prototype.updateContent = function(){
   // Allows for smooth scrubbing, when player can't keep up.
   var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
-  this.contentEl_.innerHTML = '<span class="vjs-control-text">Current Time </span>' + vjs.formatTime(time, this.player_.duration());
+  this.contentEl_.innerHTML = '<span class="vjs-control-text">Current Time </span>' + vjslib.formatTime(time, this.player_.duration());
 };
 
 /**
@@ -40,26 +44,26 @@ vjs.CurrentTimeDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.DurationDisplay = vjs.Component.extend({
+vjs.DurationDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     // this might need to be changed to 'durationchange' instead of 'timeupdate' eventually,
     // however the durationchange event fires before this.player_.duration() is set,
     // so the value cannot be written out using this method.
     // Once the order of durationchange and this.player_.duration() being set is figured out,
     // this can be updated.
-    player.on('timeupdate', vjs.bind(this, this.updateContent));
+    player.on('timeupdate', vjslib.bind(this, this.updateContent));
   }
 });
 
 vjs.DurationDisplay.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-duration vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = vjs.createEl('div', {
+  this.contentEl_ = vjslib.createEl('div', {
     className: 'vjs-duration-display',
     innerHTML: '<span class="vjs-control-text">Duration Time </span>' + '0:00', // label the duration time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -72,7 +76,7 @@ vjs.DurationDisplay.prototype.createEl = function(){
 vjs.DurationDisplay.prototype.updateContent = function(){
   var duration = this.player_.duration();
   if (duration) {
-      this.contentEl_.innerHTML = '<span class="vjs-control-text">Duration Time </span>' + vjs.formatTime(duration); // label the duration time for screen reader users
+      this.contentEl_.innerHTML = '<span class="vjs-control-text">Duration Time </span>' + vjslib.formatTime(duration); // label the duration time for screen reader users
   }
 };
 
@@ -85,15 +89,15 @@ vjs.DurationDisplay.prototype.updateContent = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.TimeDivider = vjs.Component.extend({
+vjs.TimeDivider = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
   }
 });
 
 vjs.TimeDivider.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-time-divider',
     innerHTML: '<div><span>/</span></div>'
   });
@@ -105,21 +109,21 @@ vjs.TimeDivider.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.RemainingTimeDisplay = vjs.Component.extend({
+vjs.RemainingTimeDisplay = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
-    player.on('timeupdate', vjs.bind(this, this.updateContent));
+    player.on('timeupdate', vjslib.bind(this, this.updateContent));
   }
 });
 
 vjs.RemainingTimeDisplay.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-remaining-time vjs-time-controls vjs-control'
   });
 
-  this.contentEl_ = vjs.createEl('div', {
+  this.contentEl_ = vjslib.createEl('div', {
     className: 'vjs-remaining-time-display',
     innerHTML: '<span class="vjs-control-text">Remaining Time </span>' + '-0:00', // label the remaining time for screen reader users
     'aria-live': 'off' // tell screen readers not to automatically read the time as it changes
@@ -131,10 +135,12 @@ vjs.RemainingTimeDisplay.prototype.createEl = function(){
 
 vjs.RemainingTimeDisplay.prototype.updateContent = function(){
   if (this.player_.duration()) {
-    this.contentEl_.innerHTML = '<span class="vjs-control-text">Remaining Time </span>' + '-'+ vjs.formatTime(this.player_.remainingTime());
+    this.contentEl_.innerHTML = '<span class="vjs-control-text">Remaining Time </span>' + '-'+ vjslib.formatTime(this.player_.remainingTime());
   }
 
   // Allows for smooth scrubbing, when player can't keep up.
   // var time = (this.player_.scrubbing) ? this.player_.getCache().currentTime : this.player_.currentTime();
   // this.contentEl_.innerHTML = vjs.formatTime(time, this.player_.duration());
 };
+
+module.exports = vjs;

--- a/src/js/control-bar/volume-control.js
+++ b/src/js/control-bar/volume-control.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
-var slider = require('../slider.js');
+var VolumeControl, VolumeBar, VolumeLevel, VolumeLevel, VolumeHandle, Component, vjslib, slider;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
+slider = require('../slider.js');
 
 /**
  * The component for controlling the volume level
@@ -10,7 +11,7 @@ var slider = require('../slider.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeControl = Component.extend({
+VolumeControl = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -29,13 +30,13 @@ vjs.VolumeControl = Component.extend({
   }
 });
 
-vjs.VolumeControl.prototype.options_ = {
+VolumeControl.prototype.options_ = {
   children: {
     'volumeBar': {}
   }
 };
 
-vjs.VolumeControl.prototype.createEl = function(){
+VolumeControl.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-control vjs-control'
   });
@@ -48,7 +49,7 @@ vjs.VolumeControl.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeBar = slider.Slider.extend({
+VolumeBar = slider.Slider.extend({
   /** @constructor */
   init: function(player, options){
     slider.Slider.call(this, player, options);
@@ -57,13 +58,13 @@ vjs.VolumeBar = slider.Slider.extend({
   }
 });
 
-vjs.VolumeBar.prototype.updateARIAAttributes = function(){
+VolumeBar.prototype.updateARIAAttributes = function(){
   // Current value of volume bar as a percentage
   this.el_.setAttribute('aria-valuenow',vjslib.round(this.player_.volume()*100, 2));
   this.el_.setAttribute('aria-valuetext',vjslib.round(this.player_.volume()*100, 2)+'%');
 };
 
-vjs.VolumeBar.prototype.options_ = {
+VolumeBar.prototype.options_ = {
   children: {
     'volumeLevel': {},
     'volumeHandle': {}
@@ -72,16 +73,16 @@ vjs.VolumeBar.prototype.options_ = {
   'handleName': 'volumeHandle'
 };
 
-vjs.VolumeBar.prototype.playerEvent = 'volumechange';
+VolumeBar.prototype.playerEvent = 'volumechange';
 
-vjs.VolumeBar.prototype.createEl = function(){
+VolumeBar.prototype.createEl = function(){
   return slider.Slider.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-bar',
     'aria-label': 'volume level'
   });
 };
 
-vjs.VolumeBar.prototype.onMouseMove = function(event) {
+VolumeBar.prototype.onMouseMove = function(event) {
   if (this.player_.muted()) {
     this.player_.muted(false);
   }
@@ -89,7 +90,7 @@ vjs.VolumeBar.prototype.onMouseMove = function(event) {
   this.player_.volume(this.calculateDistance(event));
 };
 
-vjs.VolumeBar.prototype.getPercent = function(){
+VolumeBar.prototype.getPercent = function(){
   if (this.player_.muted()) {
     return 0;
   } else {
@@ -97,11 +98,11 @@ vjs.VolumeBar.prototype.getPercent = function(){
   }
 };
 
-vjs.VolumeBar.prototype.stepForward = function(){
+VolumeBar.prototype.stepForward = function(){
   this.player_.volume(this.player_.volume() + 0.1);
 };
 
-vjs.VolumeBar.prototype.stepBack = function(){
+VolumeBar.prototype.stepBack = function(){
   this.player_.volume(this.player_.volume() - 0.1);
 };
 
@@ -112,14 +113,14 @@ vjs.VolumeBar.prototype.stepBack = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeLevel = Component.extend({
+VolumeLevel = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
   }
 });
 
-vjs.VolumeLevel.prototype.createEl = function(){
+VolumeLevel.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-level',
     innerHTML: '<span class="vjs-control-text"></span>'
@@ -133,15 +134,20 @@ vjs.VolumeLevel.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
- vjs.VolumeHandle = slider.SliderHandle.extend();
+ VolumeHandle = slider.SliderHandle.extend();
 
- vjs.VolumeHandle.prototype.defaultValue = '00:00';
+ VolumeHandle.prototype.defaultValue = '00:00';
 
  /** @inheritDoc */
- vjs.VolumeHandle.prototype.createEl = function(){
+ VolumeHandle.prototype.createEl = function(){
    return slider.SliderHandle.prototype.createEl.call(this, 'div', {
      className: 'vjs-volume-handle'
    });
  };
 
-module.exports = vjs;
+module.exports = {
+  VolumeControl: VolumeControl,
+  VolumeBar: VolumeBar,
+  VolumeLevel: VolumeLevel,
+  VolumeHandle: VolumeHandle
+};

--- a/src/js/control-bar/volume-control.js
+++ b/src/js/control-bar/volume-control.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+var slider = require('../slider.js');
+
 /**
  * The component for controlling the volume level
  *
@@ -5,16 +10,16 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeControl = vjs.Component.extend({
+vjs.VolumeControl = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     // hide volume controls when they're not supported by the current tech
     if (player.tech && player.tech.features && player.tech.features['volumeControl'] === false) {
       this.addClass('vjs-hidden');
     }
-    player.on('loadstart', vjs.bind(this, function(){
+    player.on('loadstart', vjslib.bind(this, function(){
       if (player.tech.features && player.tech.features['volumeControl'] === false) {
         this.addClass('vjs-hidden');
       } else {
@@ -31,7 +36,7 @@ vjs.VolumeControl.prototype.options_ = {
 };
 
 vjs.VolumeControl.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-control vjs-control'
   });
 };
@@ -43,19 +48,19 @@ vjs.VolumeControl.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeBar = vjs.Slider.extend({
+vjs.VolumeBar = slider.Slider.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Slider.call(this, player, options);
-    player.on('volumechange', vjs.bind(this, this.updateARIAAttributes));
-    player.ready(vjs.bind(this, this.updateARIAAttributes));
+    slider.Slider.call(this, player, options);
+    player.on('volumechange', vjslib.bind(this, this.updateARIAAttributes));
+    player.ready(vjslib.bind(this, this.updateARIAAttributes));
   }
 });
 
 vjs.VolumeBar.prototype.updateARIAAttributes = function(){
   // Current value of volume bar as a percentage
-  this.el_.setAttribute('aria-valuenow',vjs.round(this.player_.volume()*100, 2));
-  this.el_.setAttribute('aria-valuetext',vjs.round(this.player_.volume()*100, 2)+'%');
+  this.el_.setAttribute('aria-valuenow',vjslib.round(this.player_.volume()*100, 2));
+  this.el_.setAttribute('aria-valuetext',vjslib.round(this.player_.volume()*100, 2)+'%');
 };
 
 vjs.VolumeBar.prototype.options_ = {
@@ -70,7 +75,7 @@ vjs.VolumeBar.prototype.options_ = {
 vjs.VolumeBar.prototype.playerEvent = 'volumechange';
 
 vjs.VolumeBar.prototype.createEl = function(){
-  return vjs.Slider.prototype.createEl.call(this, 'div', {
+  return slider.Slider.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-bar',
     'aria-label': 'volume level'
   });
@@ -107,15 +112,15 @@ vjs.VolumeBar.prototype.stepBack = function(){
  * @param {Object=} options
  * @constructor
  */
-vjs.VolumeLevel = vjs.Component.extend({
+vjs.VolumeLevel = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
   }
 });
 
 vjs.VolumeLevel.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-level',
     innerHTML: '<span class="vjs-control-text"></span>'
   });
@@ -128,13 +133,15 @@ vjs.VolumeLevel.prototype.createEl = function(){
  * @param {Object=} options
  * @constructor
  */
- vjs.VolumeHandle = vjs.SliderHandle.extend();
+ vjs.VolumeHandle = slider.SliderHandle.extend();
 
  vjs.VolumeHandle.prototype.defaultValue = '00:00';
 
  /** @inheritDoc */
  vjs.VolumeHandle.prototype.createEl = function(){
-   return vjs.SliderHandle.prototype.createEl.call(this, 'div', {
+   return slider.SliderHandle.prototype.createEl.call(this, 'div', {
      className: 'vjs-volume-handle'
    });
  };
+
+module.exports = vjs;

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -1,15 +1,16 @@
-var vjs = {};
-var menu = require('../menu.js');
-var volume = require('./volume-control.js');
-var vjslib = require('../lib.js');
-var MuteToggle = require('./mute-toggle.js');
-var Button = require('../button.js');
+var VolumeMenuButton, Button, MuteToggle, menu, volume, vjslib;
+
+Button = require('../button.js');
+MuteToggle = require('./mute-toggle.js');
+menu = require('../menu.js');
+volume = require('./volume-control.js');
+vjslib = require('../lib.js');
 
 /**
  * Menu button with a popup for showing the volume slider.
  * @constructor
  */
-vjs.VolumeMenuButton = menu.MenuButton.extend({
+VolumeMenuButton = menu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
     menu.MenuButton.call(this, player, options);
@@ -32,7 +33,7 @@ vjs.VolumeMenuButton = menu.MenuButton.extend({
   }
 });
 
-vjs.VolumeMenuButton.prototype.createMenu = function(){
+VolumeMenuButton.prototype.createMenu = function(){
   var menu = new menu.Menu(this.player_, {
     contentElType: 'div'
   });
@@ -41,17 +42,18 @@ vjs.VolumeMenuButton.prototype.createMenu = function(){
   return menu;
 };
 
-vjs.VolumeMenuButton.prototype.onClick = function(){
+VolumeMenuButton.prototype.onClick = function(){
   MuteToggle.prototype.onClick.call(this);
   menu.MenuButton.prototype.onClick.call(this);
 };
 
-vjs.VolumeMenuButton.prototype.createEl = function(){
+VolumeMenuButton.prototype.createEl = function(){
   return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-menu-button vjs-menu-button vjs-control',
     innerHTML: '<div><span class="vjs-control-text">Mute</span></div>'
   });
 };
-vjs.VolumeMenuButton.prototype.update = MuteToggle.prototype.update;
 
-module.exports = vjs.VolumeMenuButton;
+VolumeMenuButton.prototype.update = MuteToggle.prototype.update;
+
+module.exports = VolumeMenuButton;

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -1,20 +1,27 @@
+var vjs = {};
+var menu = require('../menu.js');
+var volume = require('./volume-control.js');
+var vjslib = require('../lib.js');
+var MuteToggle = require('./mute-toggle.js');
+var Button = require('../button.js');
+
 /**
  * Menu button with a popup for showing the volume slider.
  * @constructor
  */
-vjs.VolumeMenuButton = vjs.MenuButton.extend({
+vjs.VolumeMenuButton = menu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.MenuButton.call(this, player, options);
+    menu.MenuButton.call(this, player, options);
 
     // Same listeners as MuteToggle
-    player.on('volumechange', vjs.bind(this, this.update));
+    player.on('volumechange', vjslib.bind(this, this.update));
 
     // hide mute toggle if the current tech doesn't support volume control
     if (player.tech && player.tech.features && player.tech.features.volumeControl === false) {
       this.addClass('vjs-hidden');
     }
-    player.on('loadstart', vjs.bind(this, function(){
+    player.on('loadstart', vjslib.bind(this, function(){
       if (player.tech.features && player.tech.features.volumeControl === false) {
         this.addClass('vjs-hidden');
       } else {
@@ -26,23 +33,25 @@ vjs.VolumeMenuButton = vjs.MenuButton.extend({
 });
 
 vjs.VolumeMenuButton.prototype.createMenu = function(){
-  var menu = new vjs.Menu(this.player_, {
+  var menu = new menu.Menu(this.player_, {
     contentElType: 'div'
   });
-  var vc = new vjs.VolumeBar(this.player_, vjs.obj.merge({vertical: true}, this.options_.volumeBar));
+  var vc = new volume.VolumeBar(this.player_, vjslib.obj.merge({vertical: true}, this.options_.volumeBar));
   menu.addChild(vc);
   return menu;
 };
 
 vjs.VolumeMenuButton.prototype.onClick = function(){
-  vjs.MuteToggle.prototype.onClick.call(this);
-  vjs.MenuButton.prototype.onClick.call(this);
+  MuteToggle.prototype.onClick.call(this);
+  menu.MenuButton.prototype.onClick.call(this);
 };
 
 vjs.VolumeMenuButton.prototype.createEl = function(){
-  return vjs.Button.prototype.createEl.call(this, 'div', {
+  return Button.prototype.createEl.call(this, 'div', {
     className: 'vjs-volume-menu-button vjs-menu-button vjs-control',
     innerHTML: '<div><span class="vjs-control-text">Mute</span></div>'
   });
 };
-vjs.VolumeMenuButton.prototype.update = vjs.MuteToggle.prototype.update;
+vjs.VolumeMenuButton.prototype.update = MuteToggle.prototype.update;
+
+module.exports = vjs.VolumeMenuButton;

--- a/src/js/core-object.js
+++ b/src/js/core-object.js
@@ -1,5 +1,6 @@
-var vjs = {};
-var vjslib = require('./lib.js');
+var CoreObject, vjslib;
+
+vjslib = require('./lib.js');
 
 /**
  * Core Object/Class for objects that use inheritance + contstructors
@@ -52,7 +53,7 @@ var vjslib = require('./lib.js');
  * @class
  * @constructor
  */
-vjs.CoreObject = vjs['CoreObject'] = function(){};
+CoreObject = function(){};
 // Manually exporting vjs['CoreObject'] here for Closure Compiler
 // because of the use of the extend/create class methods
 // If we didn't do this, those functions would get flattend to something like
@@ -70,7 +71,7 @@ vjs.CoreObject = vjs['CoreObject'] = function(){};
  * @return {vjs.CoreObject} An object that inherits from CoreObject
  * @this {*}
  */
-vjs.CoreObject.extend = function(props){
+CoreObject.extend = function(props){
   var init, subObj;
 
   props = props || {};
@@ -98,9 +99,9 @@ vjs.CoreObject.extend = function(props){
   subObj.prototype.constructor = subObj;
 
   // Make the class extendable
-  subObj.extend = vjs.CoreObject.extend;
+  subObj.extend = CoreObject.extend;
   // Make a function for creating instances
-  subObj.create = vjs.CoreObject.create;
+  subObj.create = CoreObject.create;
 
   // Extend subObj's prototype with functions and other properties from props
   for (var name in props) {
@@ -120,7 +121,7 @@ vjs.CoreObject.extend = function(props){
  * @return {vjs.CoreObject} An instance of a CoreObject subclass
  * @this {*}
  */
-vjs.CoreObject.create = function(){
+CoreObject.create = function(){
   // Create a new object that inherits from this object's prototype
   var inst = vjslib.obj.create(this.prototype);
 
@@ -131,4 +132,4 @@ vjs.CoreObject.create = function(){
   return inst;
 };
 
-module.exports = vjs.CoreObject;
+module.exports = CoreObject;

--- a/src/js/core-object.js
+++ b/src/js/core-object.js
@@ -1,3 +1,6 @@
+var vjs = {};
+var vjslib = require('./lib.js');
+
 /**
  * Core Object/Class for objects that use inheritance + contstructors
  *
@@ -89,7 +92,7 @@ vjs.CoreObject.extend = function(props){
   };
 
   // Inherit from this object's prototype
-  subObj.prototype = vjs.obj.create(this.prototype);
+  subObj.prototype = vjslib.obj.create(this.prototype);
   // Reset the constructor property for subObj otherwise
   // instances of subObj would have the constructor of the parent Object
   subObj.prototype.constructor = subObj;
@@ -119,7 +122,7 @@ vjs.CoreObject.extend = function(props){
  */
 vjs.CoreObject.create = function(){
   // Create a new object that inherits from this object's prototype
-  var inst = vjs.obj.create(this.prototype);
+  var inst = vjslib.obj.create(this.prototype);
 
   // Apply this constructor function to the new object
   this.apply(inst, arguments);
@@ -127,3 +130,5 @@ vjs.CoreObject.create = function(){
   // Return the new object
   return inst;
 };
+
+module.exports = vjs.CoreObject;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1,6 +1,7 @@
-var vjs, Player, CoreObject, options, vjslib;
+var vjs, Player, CoreObject, options, vjslib, plugins;
 
 Player = require('./player.js');
+plugins = require('./plugins.js');
 options = require('./options.js');
 vjslib = require('./lib.js');
 CoreObject = require('./core-object.js');
@@ -69,6 +70,7 @@ vjs = function(id, options, ready){
 };
 
 vjs.options = options;
+vjs.plugins = plugins;
 
 // Extended name, also available externally, window.videojs
 //var videojs = vjs;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1,7 +1,9 @@
-var Player = require('./player.js');
-var options = require('./options.js');
-var vjslib = require('./lib.js');
-var CoreObject = require('./core-object.js');
+var vjs, Player, CoreObject, options, vjslib;
+
+Player = require('./player.js');
+options = require('./options.js');
+vjslib = require('./lib.js');
+CoreObject = require('./core-object.js');
 
 /**
  * @fileoverview Main function src.
@@ -30,7 +32,7 @@ var elementShiv = function() {
  * @return {vjs.Player}             A player instance
  * @namespace
  */
-var vjs = function(id, options, ready){
+vjs = function(id, options, ready){
   var tag; // Element of ID
 
   // Allow for element or ID to be passed in
@@ -43,8 +45,8 @@ var vjs = function(id, options, ready){
     }
 
     // If a player instance has already been created for this ID return it.
-    if (vjs.players[id]) {
-      return vjs.players[id];
+    if (Player.players[id]) {
+      return Player.players[id];
 
     // Otherwise get element for ID
     } else {
@@ -63,12 +65,10 @@ var vjs = function(id, options, ready){
 
   // Element may have a player attr referring to an already created player instance.
   // If not, set up a new player and return the instance.
-  return tag['player'] || new vjs.Player(tag, options, ready);
+  return tag['player'] || new Player(tag, options, ready);
 };
 
 vjs.options = options;
-vjs.Player = Player;
-vjs.players = Player.players;
 
 // Extended name, also available externally, window.videojs
 //var videojs = vjs;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -71,6 +71,7 @@ vjs = function(id, options, ready){
 
 vjs.options = options;
 vjs.plugins = plugins;
+vjs.Player = Player;
 
 // Extended name, also available externally, window.videojs
 //var videojs = vjs;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -1,11 +1,18 @@
+var Player = require('./player.js');
+var options = require('./options.js');
+var vjslib = require('./lib.js');
+var CoreObject = require('./core-object.js');
+
 /**
  * @fileoverview Main function src.
  */
 
-// HTML5 Shiv. Must be in <head> to support older browsers.
-document.createElement('video');
-document.createElement('audio');
-document.createElement('track');
+var elementShiv = function() {
+  // HTML5 Shiv. Must be in <head> to support older browsers.
+  document.createElement('video');
+  document.createElement('audio');
+  document.createElement('track');
+}
 
 /**
  * Doubles as the main function for users to create a player instance and also
@@ -41,7 +48,7 @@ var vjs = function(id, options, ready){
 
     // Otherwise get element for ID
     } else {
-      tag = vjs.el(id);
+      tag = vjslib.el(id);
     }
 
   // ID is a media element
@@ -59,78 +66,23 @@ var vjs = function(id, options, ready){
   return tag['player'] || new vjs.Player(tag, options, ready);
 };
 
+vjs.options = options;
+vjs.Player = Player;
+vjs.players = Player.players;
+
 // Extended name, also available externally, window.videojs
-var videojs = vjs;
-window.videojs = window.vjs = vjs;
+//var videojs = vjs;
+//window.videojs = window.vjs = vjs;
 
 // CDN Version. Used to target right flash swf.
 vjs.CDN_VERSION = 'GENERATED_CDN_VSN';
 vjs.ACCESS_PROTOCOL = ('https:' == document.location.protocol ? 'https://' : 'http://');
 
-/**
- * Global Player instance options, surfaced from vjs.Player.prototype.options_
- * vjs.options = vjs.Player.prototype.options_
- * All options should use string keys so they avoid
- * renaming by closure compiler
- * @type {Object}
- */
-vjs.options = {
-  // Default order of fallback technology
-  'techOrder': ['html5','flash'],
-  // techOrder: ['flash','html5'],
-
-  'html5': {},
-  'flash': {},
-
-  // Default of web browser is 300x150. Should rely on source width/height.
-  'width': 300,
-  'height': 150,
-  // defaultVolume: 0.85,
-  'defaultVolume': 0.00, // The freakin seaguls are driving me crazy!
-
-  // default playback rates
-  'playbackRates': [],
-  // Add playback rate selection by adding rates
-  // 'playbackRates': [0.5, 1, 1.5, 2],
-
-  // Included control sets
-  'children': {
-    'mediaLoader': {},
-    'posterImage': {},
-    'textTrackDisplay': {},
-    'loadingSpinner': {},
-    'bigPlayButton': {},
-    'controlBar': {},
-    'errorDisplay': {}
-  },
-
-  // Default message to show when a video cannot be played.
-  'notSupportedMessage': 'No compatible source was found for this video.'
-};
-
 // Set CDN Version of swf
 // The added (+) blocks the replace from changing this GENERATED_CDN_VSN string
 if (vjs.CDN_VERSION !== 'GENERATED'+'_CDN_VSN') {
-  videojs.options['flash']['swf'] = vjs.ACCESS_PROTOCOL + 'vjs.zencdn.net/'+vjs.CDN_VERSION+'/video-js.swf';
+  options['flash']['swf'] = vjs.ACCESS_PROTOCOL + 'vjs.zencdn.net/'+vjs.CDN_VERSION+'/video-js.swf';
 }
 
-/**
- * Global player list
- * @type {Object}
- */
-vjs.players = {};
-
-/*!
- * Custom Universal Module Definition (UMD)
- *
- * Video.js will never be a non-browser lib so we can simplify UMD a bunch and
- * still support requirejs and browserify. This also needs to be closure
- * compiler compatible, so string keys are used.
- */
-if (typeof define === 'function' && define['amd']) {
-  define([], function(){ return videojs; });
-
-// checking that module is an object too because of umdjs/umd#35
-} else if (typeof exports === 'object' && typeof module === 'object') {
-  module['exports'] = videojs;
-}
+module.exports = vjs;
+module.exports.elementShiv = elementShiv;

--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('./component.js');
-var vjslib = require('./lib.js');
+var ErrorDisplay, Component, vjslib;
+
+Component = require('./component.js');
+vjslib = require('./lib.js');
 
 /**
  * Display that an error has occurred making the video unplayable
@@ -8,7 +9,7 @@ var vjslib = require('./lib.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.ErrorDisplay = Component.extend({
+ErrorDisplay = Component.extend({
   init: function(player, options){
     Component.call(this, player, options);
 
@@ -17,7 +18,7 @@ vjs.ErrorDisplay = Component.extend({
   }
 });
 
-vjs.ErrorDisplay.prototype.createEl = function(){
+ErrorDisplay.prototype.createEl = function(){
   var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-error-display'
   });
@@ -28,10 +29,10 @@ vjs.ErrorDisplay.prototype.createEl = function(){
   return el;
 };
 
-vjs.ErrorDisplay.prototype.update = function(){
+ErrorDisplay.prototype.update = function(){
   if (this.player().error()) {
     this.contentEl_.innerHTML = this.player().error().message;
   }
 };
 
-module.exports = vjs.ErrorDisplay;
+module.exports = ErrorDisplay;

--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -1,24 +1,28 @@
+var vjs = {};
+var Component = require('./component.js');
+var vjslib = require('./lib.js');
+
 /**
  * Display that an error has occurred making the video unplayable
  * @param {vjs.Player|Object} player
  * @param {Object=} options
  * @constructor
  */
-vjs.ErrorDisplay = vjs.Component.extend({
+vjs.ErrorDisplay = Component.extend({
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     this.update();
-    player.on('error', vjs.bind(this, this.update));
+    player.on('error', vjslib.bind(this, this.update));
   }
 });
 
 vjs.ErrorDisplay.prototype.createEl = function(){
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-error-display'
   });
 
-  this.contentEl_ = vjs.createEl('div');
+  this.contentEl_ = vjslib.createEl('div');
   el.appendChild(this.contentEl_);
 
   return el;
@@ -29,3 +33,5 @@ vjs.ErrorDisplay.prototype.update = function(){
     this.contentEl_.innerHTML = this.player().error().message;
   }
 };
+
+module.exports = vjs.ErrorDisplay;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -1,3 +1,6 @@
+var vjs = {};
+var vjslib = require('./lib.js');
+
 /**
  * @fileoverview Event System (John Resig - Secrets of a JS Ninja http://jsninja.com/)
  * (Original book version wasn't completely usable, so fixed some things and made Closure Compiler compatible)
@@ -16,18 +19,18 @@
  * @private
  */
 vjs.on = function(elem, type, fn){
-  if (vjs.obj.isArray(type)) {
+  if (vjslib.obj.isArray(type)) {
     return _handleMultipleEvents(vjs.on, elem, type, fn);
   }
 
-  var data = vjs.getData(elem);
+  var data = vjslib.getData(elem);
 
   // We need a place to store all our handler data
   if (!data.handlers) data.handlers = {};
 
   if (!data.handlers[type]) data.handlers[type] = [];
 
-  if (!fn.guid) fn.guid = vjs.guid++;
+  if (!fn.guid) fn.guid = vjslib.guid++;
 
   data.handlers[type].push(fn);
 
@@ -74,14 +77,14 @@ vjs.on = function(elem, type, fn){
  */
 vjs.off = function(elem, type, fn) {
   // Don't want to add a cache object through getData if not needed
-  if (!vjs.hasData(elem)) return;
+  if (!vjslib.hasData(elem)) return;
 
-  var data = vjs.getData(elem);
+  var data = vjslib.getData(elem);
 
   // If no events exist, nothing to unbind
   if (!data.handlers) { return; }
 
-  if (vjs.obj.isArray(type)) {
+  if (vjslib.obj.isArray(type)) {
     return _handleMultipleEvents(vjs.off, elem, type, fn);
   }
 
@@ -127,7 +130,7 @@ vjs.off = function(elem, type, fn) {
  * @private
  */
 vjs.cleanUpEvents = function(elem, type) {
-  var data = vjs.getData(elem);
+  var data = vjslib.getData(elem);
 
   // Remove the events of a particular type if there are none left
   if (data.handlers[type].length === 0) {
@@ -144,7 +147,7 @@ vjs.cleanUpEvents = function(elem, type) {
   }
 
   // Remove the events object if there are no types left
-  if (vjs.isEmpty(data.handlers)) {
+  if (vjslib.isEmpty(data.handlers)) {
     delete data.handlers;
     delete data.dispatcher;
     delete data.disabled;
@@ -155,8 +158,8 @@ vjs.cleanUpEvents = function(elem, type) {
   }
 
   // Finally remove the expando if there is no data left
-  if (vjs.isEmpty(data)) {
-    vjs.removeData(elem);
+  if (vjslib.isEmpty(data)) {
+    vjslib.removeData(elem);
   }
 };
 
@@ -280,7 +283,7 @@ vjs.trigger = function(elem, event) {
   // Fetches element data and a reference to the parent (for bubbling).
   // Don't want to add a data object to cache for every parent,
   // so checking hasData first.
-  var elemData = (vjs.hasData(elem)) ? vjs.getData(elem) : {};
+  var elemData = (vjslib.hasData(elem)) ? vjslib.getData(elem) : {};
   var parent = elem.parentNode || elem.ownerDocument;
       // type = event.type || event,
       // handler;
@@ -304,7 +307,7 @@ vjs.trigger = function(elem, event) {
 
   // If at the top of the DOM, triggers the default action unless disabled.
   } else if (!parent && !event.defaultPrevented) {
-    var targetData = vjs.getData(event.target);
+    var targetData = vjslib.getData(event.target);
 
     // Checks if the target has a default action for this event.
     if (event.target[event.type]) {
@@ -350,7 +353,7 @@ vjs.trigger = function(elem, event) {
  * @private
  */
 vjs.one = function(elem, type, fn) {
-  if (vjs.obj.isArray(type)) {
+  if (vjslib.obj.isArray(type)) {
     return _handleMultipleEvents(vjs.one, elem, type, fn);
   }
   var func = function(){
@@ -358,7 +361,7 @@ vjs.one = function(elem, type, fn) {
     fn.apply(this, arguments);
   };
   // copy the guid to the new function so it can removed using the original function's ID
-  func.guid = fn.guid = fn.guid || vjs.guid++;
+  func.guid = fn.guid = fn.guid || vjslib.guid++;
   vjs.on(elem, type, func);
 };
 
@@ -371,7 +374,9 @@ vjs.one = function(elem, type, fn) {
  * @private
  */
 function _handleMultipleEvents(fn, elem, type, callback) {
-  vjs.arr.forEach(type, function(type) {
+  vjslib.arr.forEach(type, function(type) {
     fn(elem, type, callback); //Call the event method for each one of the types
   });
 }
+
+module.exports = vjs;

--- a/src/js/fullscreen-api.js
+++ b/src/js/fullscreen-api.js
@@ -1,15 +1,11 @@
-var vjs = {
-  browser: {}
-};
-
-var apiMap, specApi, browserApi, i;
+var fullscreenAPI, apiMap, specApi, browserApi, i;
 
 /**
  * Store the browser-specifc methods for the fullscreen API
  * @type {Object|undefined}
  * @private
  */
-vjs.browser.fullscreenAPI;
+//vjs.browser.fullscreenAPI;
 
 // browser API methods
 // map approach from Screenful.js - https://github.com/sindresorhus/screenfull.js
@@ -75,12 +71,11 @@ for (i=0; i<apiMap.length; i++) {
 // map the browser API names to the spec API names
 // or leave vjs.browser.fullscreenAPI undefined
 if (browserApi) {
-  vjs.browser.fullscreenAPI = {};
+  fullscreenAPI = {};
 
   for (i=0; i<browserApi.length; i++) {
-    vjs.browser.fullscreenAPI[specApi[i]] = browserApi[i];
+    fullscreenAPI[specApi[i]] = browserApi[i];
   }
 }
 
-
-module.exports = vjs.browser.fullscreenAPI;
+module.exports = fullscreenAPI;

--- a/src/js/fullscreen-api.js
+++ b/src/js/fullscreen-api.js
@@ -1,82 +1,86 @@
-(function(){
-  var apiMap, specApi, browserApi, i;
+var vjs = {
+  browser: {}
+};
 
-  /**
-   * Store the browser-specifc methods for the fullscreen API
-   * @type {Object|undefined}
-   * @private
-   */
-  vjs.browser.fullscreenAPI;
+var apiMap, specApi, browserApi, i;
 
-  // browser API methods
-  // map approach from Screenful.js - https://github.com/sindresorhus/screenfull.js
-  apiMap = [
-    // Spec: https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html
-    [
-      'requestFullscreen',
-      'exitFullscreen',
-      'fullscreenElement',
-      'fullscreenEnabled',
-      'fullscreenchange',
-      'fullscreenerror'
-    ],
-    // WebKit
-    [
-      'webkitRequestFullscreen',
-      'webkitExitFullscreen',
-      'webkitFullscreenElement',
-      'webkitFullscreenEnabled',
-      'webkitfullscreenchange',
-      'webkitfullscreenerror'
-    ],
-    // Old WebKit (Safari 5.1)
-    [
-      'webkitRequestFullScreen',
-      'webkitCancelFullScreen',
-      'webkitCurrentFullScreenElement',
-      'webkitCancelFullScreen',
-      'webkitfullscreenchange',
-      'webkitfullscreenerror'
-    ],
-    // Mozilla
-    [
-      'mozRequestFullScreen',
-      'mozCancelFullScreen',
-      'mozFullScreenElement',
-      'mozFullScreenEnabled',
-      'mozfullscreenchange',
-      'mozfullscreenerror'
-    ],
-    // Microsoft
-    [
-      'msRequestFullscreen',
-      'msExitFullscreen',
-      'msFullscreenElement',
-      'msFullscreenEnabled',
-      'MSFullscreenChange',
-      'MSFullscreenError'
-    ]
-  ];
+/**
+ * Store the browser-specifc methods for the fullscreen API
+ * @type {Object|undefined}
+ * @private
+ */
+vjs.browser.fullscreenAPI;
 
-  specApi = apiMap[0];
+// browser API methods
+// map approach from Screenful.js - https://github.com/sindresorhus/screenfull.js
+apiMap = [
+  // Spec: https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html
+  [
+    'requestFullscreen',
+    'exitFullscreen',
+    'fullscreenElement',
+    'fullscreenEnabled',
+    'fullscreenchange',
+    'fullscreenerror'
+  ],
+  // WebKit
+  [
+    'webkitRequestFullscreen',
+    'webkitExitFullscreen',
+    'webkitFullscreenElement',
+    'webkitFullscreenEnabled',
+    'webkitfullscreenchange',
+    'webkitfullscreenerror'
+  ],
+  // Old WebKit (Safari 5.1)
+  [
+    'webkitRequestFullScreen',
+    'webkitCancelFullScreen',
+    'webkitCurrentFullScreenElement',
+    'webkitCancelFullScreen',
+    'webkitfullscreenchange',
+    'webkitfullscreenerror'
+  ],
+  // Mozilla
+  [
+    'mozRequestFullScreen',
+    'mozCancelFullScreen',
+    'mozFullScreenElement',
+    'mozFullScreenEnabled',
+    'mozfullscreenchange',
+    'mozfullscreenerror'
+  ],
+  // Microsoft
+  [
+    'msRequestFullscreen',
+    'msExitFullscreen',
+    'msFullscreenElement',
+    'msFullscreenEnabled',
+    'MSFullscreenChange',
+    'MSFullscreenError'
+  ]
+];
 
-  // determine the supported set of functions
-  for (i=0; i<apiMap.length; i++) {
-    // check for exitFullscreen function
-    if (apiMap[i][1] in document) {
-      browserApi = apiMap[i];
-      break;
-    }
+specApi = apiMap[0];
+
+// determine the supported set of functions
+for (i=0; i<apiMap.length; i++) {
+  // check for exitFullscreen function
+  if (apiMap[i][1] in document) {
+    browserApi = apiMap[i];
+    break;
   }
+}
 
-  // map the browser API names to the spec API names
-  // or leave vjs.browser.fullscreenAPI undefined
-  if (browserApi) {
-    vjs.browser.fullscreenAPI = {};
+// map the browser API names to the spec API names
+// or leave vjs.browser.fullscreenAPI undefined
+if (browserApi) {
+  vjs.browser.fullscreenAPI = {};
 
-    for (i=0; i<browserApi.length; i++) {
-      vjs.browser.fullscreenAPI[specApi[i]] = browserApi[i];
-    }
+  for (i=0; i<browserApi.length; i++) {
+    vjs.browser.fullscreenAPI[specApi[i]] = browserApi[i];
   }
+}
 
-})();
+
+module.exports = vjs.browser.fullscreenAPI;

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -1,3 +1,5 @@
+var vjs = {};
+
 /**
  * @fileoverview Add JSON support
  * @suppress {undefinedVars}
@@ -73,3 +75,5 @@ if (typeof window.JSON !== 'undefined' && window.JSON.parse === 'function') {
       throw new SyntaxError('JSON.parse(): invalid or malformed JSON data');
   };
 }
+
+module.exports = vjs.JSON;

--- a/src/js/json.js
+++ b/src/js/json.js
@@ -1,4 +1,4 @@
-var vjs = {};
+var vjsJSON;
 
 /**
  * @fileoverview Add JSON support
@@ -15,13 +15,13 @@ var vjs = {};
  * @namespace
  * @private
  */
-vjs.JSON;
+vjsJSON;
 
 if (typeof window.JSON !== 'undefined' && window.JSON.parse === 'function') {
-  vjs.JSON = window.JSON;
+  vjsJSON = window.JSON;
 
 } else {
-  vjs.JSON = {};
+  vjsJSON = {};
 
   var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g;
 
@@ -33,7 +33,7 @@ if (typeof window.JSON !== 'undefined' && window.JSON.parse === 'function') {
    * @param {Function=} [reviver] Optional function that can transform the results
    * @return {Object|Array} The parsed JSON
    */
-  vjs.JSON.parse = function (text, reviver) {
+  vjsJSON.parse = function (text, reviver) {
       var j;
 
       function walk(holder, key) {
@@ -76,4 +76,4 @@ if (typeof window.JSON !== 'undefined' && window.JSON.parse === 'function') {
   };
 }
 
-module.exports = vjs.JSON;
+module.exports = vjsJSON;

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -1,3 +1,4 @@
+var vjs = {};
 var hasOwnProp = Object.prototype.hasOwnProperty;
 
 /**
@@ -342,7 +343,7 @@ vjs.TEST_VID = vjs.createEl('video');
  * @constant
  * @private
  */
-vjs.USER_AGENT = navigator.userAgent;
+vjs.USER_AGENT = navigator.userAgent || '';
 
 /**
  * Device is an iPhone
@@ -868,3 +869,5 @@ vjs.arr.forEach = function(array, callback, thisArg) {
 
   return array;
 };
+
+module.exports = vjs;

--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Component = require('./component.js');
+var vjslib = require('./lib.js');
+
 /* Loading Spinner
 ================================================================================ */
 /**
@@ -7,33 +11,35 @@
  * @class
  * @constructor
  */
-vjs.LoadingSpinner = vjs.Component.extend({
+vjs.LoadingSpinner = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
-    player.on('canplay', vjs.bind(this, this.hide));
-    player.on('canplaythrough', vjs.bind(this, this.hide));
-    player.on('playing', vjs.bind(this, this.hide));
-    player.on('seeking', vjs.bind(this, this.show));
+    player.on('canplay', vjslib.bind(this, this.hide));
+    player.on('canplaythrough', vjslib.bind(this, this.hide));
+    player.on('playing', vjslib.bind(this, this.hide));
+    player.on('seeking', vjslib.bind(this, this.show));
 
     // in some browsers seeking does not trigger the 'playing' event,
     // so we also need to trap 'seeked' if we are going to set a
     // 'seeking' event
-    player.on('seeked', vjs.bind(this, this.hide));
+    player.on('seeked', vjslib.bind(this, this.hide));
 
-    player.on('ended', vjs.bind(this, this.hide));
+    player.on('ended', vjslib.bind(this, this.hide));
 
     // Not showing spinner on stalled any more. Browsers may stall and then not trigger any events that would remove the spinner.
     // Checked in Chrome 16 and Safari 5.1.2. http://help.videojs.com/discussions/problems/883-why-is-the-download-progress-showing
     // player.on('stalled', vjs.bind(this, this.show));
 
-    player.on('waiting', vjs.bind(this, this.show));
+    player.on('waiting', vjslib.bind(this, this.show));
   }
 });
 
 vjs.LoadingSpinner.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-loading-spinner'
   });
 };
+
+module.exports = vjs.LoadingSpinner;

--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('./component.js');
-var vjslib = require('./lib.js');
+var LoadingSpinner, Component, vjslib;
+
+Component = require('./component.js');
+vjslib = require('./lib.js');
 
 /* Loading Spinner
 ================================================================================ */
@@ -11,7 +12,7 @@ var vjslib = require('./lib.js');
  * @class
  * @constructor
  */
-vjs.LoadingSpinner = Component.extend({
+LoadingSpinner = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -36,10 +37,10 @@ vjs.LoadingSpinner = Component.extend({
   }
 });
 
-vjs.LoadingSpinner.prototype.createEl = function(){
+LoadingSpinner.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-loading-spinner'
   });
 };
 
-module.exports = vjs.LoadingSpinner;
+module.exports = LoadingSpinner;

--- a/src/js/media-error.js
+++ b/src/js/media-error.js
@@ -1,3 +1,5 @@
+var vjs = {};
+
 /**
  * Custom MediaError to mimic the HTML5 MediaError
  * @param {Number} code The media error code
@@ -67,3 +69,5 @@ for (var errNum = 0; errNum < vjs.MediaError.errorTypes.length; errNum++) {
   // values should be accessible on both the class and instance
   vjs.MediaError.prototype[vjs.MediaError.errorTypes[errNum]] = errNum;
 }
+
+module.exports = vjs.MediaError;

--- a/src/js/media-error.js
+++ b/src/js/media-error.js
@@ -1,21 +1,24 @@
-var vjs = {};
+var MediaError, vjslib;
+
+vjslib = require('./lib.js');
+
 
 /**
  * Custom MediaError to mimic the HTML5 MediaError
  * @param {Number} code The media error code
  */
-vjs.MediaError = function(code){
+MediaError = function(code){
   if (typeof code === 'number') {
     this.code = code;
   } else if (typeof code === 'string') {
     // default code is zero, so this is a custom error
     this.message = code;
   } else if (typeof code === 'object') { // object
-    vjs.obj.merge(this, code);
+    vjslib.obj.merge(this, code);
   }
 
   if (!this.message) {
-    this.message = vjs.MediaError.defaultMessages[this.code] || '';
+    this.message = MediaError.defaultMessages[this.code] || '';
   }
 };
 
@@ -24,7 +27,7 @@ vjs.MediaError = function(code){
  * MediaError types
  * @type {Number}
  */
-vjs.MediaError.prototype.code = 0;
+MediaError.prototype.code = 0;
 
 /**
  * An optional message to be shown with the error.
@@ -32,7 +35,7 @@ vjs.MediaError.prototype.code = 0;
  * but allows for more informative custom errors.
  * @type {String}
  */
-vjs.MediaError.prototype.message = '';
+MediaError.prototype.message = '';
 
 /**
  * An optional status code that can be set by plugins
@@ -43,9 +46,9 @@ vjs.MediaError.prototype.message = '';
  * to display more information.
  * @type {[type]}
  */
-vjs.MediaError.prototype.status = null;
+MediaError.prototype.status = null;
 
-vjs.MediaError.errorTypes = [
+MediaError.errorTypes = [
   'MEDIA_ERR_CUSTOM',            // = 0
   'MEDIA_ERR_ABORTED',           // = 1
   'MEDIA_ERR_NETWORK',           // = 2
@@ -54,7 +57,7 @@ vjs.MediaError.errorTypes = [
   'MEDIA_ERR_ENCRYPTED'          // = 5
 ];
 
-vjs.MediaError.defaultMessages = {
+MediaError.defaultMessages = {
   1: 'You aborted the video playback',
   2: 'A network error caused the video download to fail part-way.',
   3: 'The video playback was aborted due to a corruption problem or because the video used features your browser did not support.',
@@ -64,10 +67,10 @@ vjs.MediaError.defaultMessages = {
 
 // Add types as properties on MediaError
 // e.g. MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
-for (var errNum = 0; errNum < vjs.MediaError.errorTypes.length; errNum++) {
-  vjs.MediaError[vjs.MediaError.errorTypes[errNum]] = errNum;
+for (var errNum = 0; errNum < MediaError.errorTypes.length; errNum++) {
+  MediaError[MediaError.errorTypes[errNum]] = errNum;
   // values should be accessible on both the class and instance
-  vjs.MediaError.prototype[vjs.MediaError.errorTypes[errNum]] = errNum;
+  MediaError.prototype[MediaError.errorTypes[errNum]] = errNum;
 }
 
-module.exports = vjs.MediaError;
+module.exports = MediaError;

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var MediaTechController = require('./media.js');
+var vjslib = require('../lib.js');
+var vjsevents = require('../events.js');
+
 /**
  * @fileoverview VideoJS-SWF - Custom Flash Player with HTML5-ish API
  * https://github.com/zencoder/video-js-swf
@@ -12,10 +17,10 @@
  * @param {Function=} ready
  * @constructor
  */
-vjs.Flash = vjs.MediaTechController.extend({
+vjs.Flash = MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.MediaTechController.call(this, player, options, ready);
+    MediaTechController.call(this, player, options, ready);
 
     var source = options['source'],
 
@@ -23,7 +28,7 @@ vjs.Flash = vjs.MediaTechController.extend({
         parentEl = options['parentEl'],
 
         // Create a temporary element to be replaced by swf object
-        placeHolder = this.el_ = vjs.createEl('div', { id: player.id() + '_temp_flash' }),
+        placeHolder = this.el_ = vjslib.createEl('div', { id: player.id() + '_temp_flash' }),
 
         // Generate ID for swf object
         objId = player.id()+'_flash_api',
@@ -34,7 +39,7 @@ vjs.Flash = vjs.MediaTechController.extend({
         playerOptions = player.options_,
 
         // Merge default flashvars with ones passed in to init
-        flashVars = vjs.obj.merge({
+        flashVars = vjslib.obj.merge({
 
           // SWF Callback Functions
           'readyFunction': 'videojs.Flash.onReady',
@@ -50,13 +55,13 @@ vjs.Flash = vjs.MediaTechController.extend({
         }, options['flashVars']),
 
         // Merge default parames with ones passed in
-        params = vjs.obj.merge({
+        params = vjslib.obj.merge({
           'wmode': 'opaque', // Opaque is needed to overlay controls, but can affect playback performance
           'bgcolor': '#000000' // Using bgcolor prevents a white flash when the object is loading
         }, options['params']),
 
         // Merge default attributes with ones passed in
-        attributes = vjs.obj.merge({
+        attributes = vjslib.obj.merge({
           'id': objId,
           'name': objId, // Both ID and Name needed or swf to identifty itself
           'class': 'vjs-tech'
@@ -73,7 +78,7 @@ vjs.Flash = vjs.MediaTechController.extend({
         flashVars['rtmpStream'] = encodeURIComponent(parts.stream);
       }
       else {
-        flashVars['src'] = encodeURIComponent(vjs.getAbsoluteURL(source.src));
+        flashVars['src'] = encodeURIComponent(vjslib.getAbsoluteURL(source.src));
       }
     }
 
@@ -91,7 +96,7 @@ vjs.Flash = vjs.MediaTechController.extend({
     };
 
     // Add placeholder to player div
-    vjs.insertFirst(placeHolder, parentEl);
+    vjslib.insertFirst(placeHolder, parentEl);
 
     // Having issues with Flash reloading on certain page actions (hide/resize/fullscreen) in certain browsers
     // This allows resetting the playhead when we catch the reload
@@ -105,9 +110,9 @@ vjs.Flash = vjs.MediaTechController.extend({
 
     // firefox doesn't bubble mousemove events to parent. videojs/video-js-swf#37
     // bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=836786
-    if (vjs.IS_FIREFOX) {
+    if (vjslib.IS_FIREFOX) {
       this.ready(function(){
-        vjs.on(this.el(), 'mousemove', vjs.bind(this, function(){
+        vjsevents.on(this.el(), 'mousemove', vjslib.bind(this, function(){
           // since it's a custom event, don't bubble higher than the player
           this.player().trigger({ 'type':'mousemove', 'bubbles': false });
         }));
@@ -138,10 +143,10 @@ vjs.Flash = vjs.MediaTechController.extend({
     //    Not sure why that even works, but it causes the browser to look like it's continuously trying to load the page.
     // Firefox 3.6 keeps calling the iframe onload function anytime I write to it, causing an endless loop.
 
-    if (options['iFrameMode'] === true && !vjs.IS_FIREFOX) {
+    if (options['iFrameMode'] === true && !vjslib.IS_FIREFOX) {
 
       // Create iFrame with vjs-tech class so it's 100% width/height
-      var iFrm = vjs.createEl('iframe', {
+      var iFrm = vjslib.createEl('iframe', {
         'id': objId + '_iframe',
         'name': objId + '_iframe',
         'className': 'vjs-tech',
@@ -174,7 +179,7 @@ vjs.Flash = vjs.MediaTechController.extend({
       // iFrm.src = "iframe.html";
 
       // Wait until iFrame has loaded to write into it.
-      vjs.on(iFrm, 'load', vjs.bind(this, function(){
+      vjsevents.on(iFrm, 'load', vjslib.bind(this, function(){
 
         var iDoc,
             iWin = iFrm.contentWindow;
@@ -212,7 +217,7 @@ vjs.Flash = vjs.MediaTechController.extend({
         iWin['player'] = this.player_;
 
         // Create swf ready function for iFrame window
-        iWin['ready'] = vjs.bind(this.player_, function(currSwf){
+        iWin['ready'] = vjslib.bind(this.player_, function(currSwf){
           var el = iDoc.getElementById(currSwf),
               player = this,
               tech = player.tech;
@@ -225,7 +230,7 @@ vjs.Flash = vjs.MediaTechController.extend({
         });
 
         // Create event listener for all swf events
-        iWin['events'] = vjs.bind(this.player_, function(swfID, eventName){
+        iWin['events'] = vjslib.bind(this.player_, function(swfID, eventName){
           var player = this;
           if (player && player.techName === 'flash') {
             player.trigger(eventName);
@@ -233,8 +238,8 @@ vjs.Flash = vjs.MediaTechController.extend({
         });
 
         // Create error listener for all swf errors
-        iWin['errors'] = vjs.bind(this.player_, function(swfID, eventName){
-          vjs.log('Flash Error', eventName);
+        iWin['errors'] = vjslib.bind(this.player_, function(swfID, eventName){
+          vjslib.log('Flash Error', eventName);
         });
 
       }));
@@ -250,7 +255,7 @@ vjs.Flash = vjs.MediaTechController.extend({
 });
 
 vjs.Flash.prototype.dispose = function(){
-  vjs.MediaTechController.prototype.dispose.call(this);
+  MediaTechController.prototype.dispose.call(this);
 };
 
 vjs.Flash.prototype.play = function(){
@@ -272,7 +277,7 @@ vjs.Flash.prototype.src = function(src){
     this.setRtmpStream(src.stream);
   } else {
     // Make sure source URL is abosolute.
-    src = vjs.getAbsoluteURL(src);
+    src = vjslib.getAbsoluteURL(src);
     this.el_.vjs_src(src);
   }
 
@@ -310,7 +315,7 @@ vjs.Flash.prototype.setPoster = function(){
 };
 
 vjs.Flash.prototype.buffered = function(){
-  return vjs.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
+  return vjslib.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
 };
 
 vjs.Flash.prototype.supportsFullScreen = function(){
@@ -391,7 +396,7 @@ vjs.Flash.streamingFormats = {
 };
 
 vjs.Flash['onReady'] = function(currSwf){
-  var el = vjs.el(currSwf);
+  var el = vjslib.el(currSwf);
 
   // Get player from box
   // On firefox reloads, el might already have a player
@@ -429,13 +434,13 @@ vjs.Flash.checkReady = function(tech){
 
 // Trigger events from the swf on the player
 vjs.Flash['onEvent'] = function(swfID, eventName){
-  var player = vjs.el(swfID)['player'];
+  var player = vjslib.el(swfID)['player'];
   player.trigger(eventName);
 };
 
 // Log errors from the swf
 vjs.Flash['onError'] = function(swfID, err){
-  var player = vjs.el(swfID)['player'];
+  var player = vjslib.el(swfID)['player'];
   var msg = 'FLASH: '+err;
 
   if (err == 'srcnotfound') {
@@ -471,7 +476,7 @@ vjs.Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
   var code = vjs.Flash.getEmbedCode(swf, flashVars, params, attributes),
 
       // Get element by embedding code and retrieving created element
-      obj = vjs.createEl('div', { innerHTML: code }).childNodes[0],
+      obj = vjslib.createEl('div', { innerHTML: code }).childNodes[0],
 
       par = placeHolder.parentNode
   ;
@@ -498,13 +503,13 @@ vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
 
   // Convert flash vars to string
   if (flashVars) {
-    vjs.obj.each(flashVars, function(key, val){
+    vjslib.obj.each(flashVars, function(key, val){
       flashVarsString += (key + '=' + val + '&amp;');
     });
   }
 
   // Add swf, flashVars, and other default params
-  params = vjs.obj.merge({
+  params = vjslib.obj.merge({
     'movie': swf,
     'flashvars': flashVarsString,
     'allowScriptAccess': 'always', // Required to talk to swf
@@ -512,11 +517,11 @@ vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
   }, params);
 
   // Create param tags string
-  vjs.obj.each(params, function(key, val){
+  vjslib.obj.each(params, function(key, val){
     paramsString += '<param name="'+key+'" value="'+val+'" />';
   });
 
-  attributes = vjs.obj.merge({
+  attributes = vjslib.obj.merge({
     // Add swf to attributes (need both for IE and Others to work)
     'data': swf,
 
@@ -527,7 +532,7 @@ vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
   }, attributes);
 
   // Create Attributes string
-  vjs.obj.each(attributes, function(key, val){
+  vjslib.obj.each(attributes, function(key, val){
     attrsString += (key + '="' + val + '" ');
   });
 
@@ -581,3 +586,5 @@ vjs.Flash.RTMP_RE = /^rtmp[set]?:\/\//i;
 vjs.Flash.isStreamingSrc = function(src) {
   return vjs.Flash.RTMP_RE.test(src);
 };
+
+module.exports = vjs.Flash;

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var MediaTechController = require('./media.js');
-var vjslib = require('../lib.js');
-var vjsevents = require('../events.js');
+var Flash, MediaTechController, vjslib, vjsevents;
+
+MediaTechController = require('./media.js');
+vjslib = require('../lib.js');
+vjsevents = require('../events.js');
 
 /**
  * @fileoverview VideoJS-SWF - Custom Flash Player with HTML5-ish API
@@ -17,7 +18,7 @@ var vjsevents = require('../events.js');
  * @param {Function=} ready
  * @constructor
  */
-vjs.Flash = MediaTechController.extend({
+Flash = MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
     MediaTechController.call(this, player, options, ready);
@@ -72,8 +73,8 @@ vjs.Flash = MediaTechController.extend({
 
     // If source was supplied pass as a flash var.
     if (source) {
-      if (source.type && vjs.Flash.isStreamingType(source.type)) {
-        var parts = vjs.Flash.streamToParts(source.src);
+      if (source.type && Flash.isStreamingType(source.type)) {
+        var parts = Flash.streamToParts(source.src);
         flashVars['rtmpConnection'] = encodeURIComponent(parts.connection);
         flashVars['rtmpStream'] = encodeURIComponent(parts.stream);
       }
@@ -165,14 +166,14 @@ vjs.Flash = MediaTechController.extend({
 
       // Tried embedding the flash object in the page first, and then adding a place holder to the iframe, then replacing the placeholder with the page object.
       // The goal here was to try to load the swf URL in the parent page first and hope that got around the firefox security error
-      // var newObj = vjs.Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
+      // var newObj = Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
       // (in onload)
       //  var temp = vjs.createEl('a', { id:'asdf', innerHTML: 'asdf' } );
       //  iDoc.body.appendChild(temp);
 
       // Tried embedding the flash object through javascript in the iframe source.
       // This works in webkit but still triggers the firefox security error
-      // iFrm.src = 'javascript: document.write('"+vjs.Flash.getEmbedCode(options['swf'], flashVars, params, attributes)+"');";
+      // iFrm.src = 'javascript: document.write('"+Flash.getEmbedCode(options['swf'], flashVars, params, attributes)+"');";
 
       // Tried an actual local iframe just to make sure that works, but it kills the easiness of the CDN version if you require the user to host an iframe
       // We should add an option to host the iframe locally though, because it could help a lot of issues.
@@ -210,7 +211,7 @@ vjs.Flash = MediaTechController.extend({
         // Using document.write actually got around the security error that browsers were throwing.
         // Again, it's a dynamically generated (same domain) iframe, loading an external Flash swf.
         // Not sure why that's a security issue, but apparently it is.
-        iDoc.write(vjs.Flash.getEmbedCode(options['swf'], flashVars, params, attributes));
+        iDoc.write(Flash.getEmbedCode(options['swf'], flashVars, params, attributes));
 
         // Setting variables on the window needs to come after the doc write because otherwise they can get reset in some browsers
         // So far no issues with swf ready event being called before it's set on the window.
@@ -226,7 +227,7 @@ vjs.Flash = MediaTechController.extend({
           tech.el_ = el;
 
           // Make sure swf is actually ready. Sometimes the API isn't actually yet.
-          vjs.Flash.checkReady(tech);
+          Flash.checkReady(tech);
         });
 
         // Create event listener for all swf events
@@ -249,30 +250,30 @@ vjs.Flash = MediaTechController.extend({
 
     // If not using iFrame mode, embed as normal object
     } else {
-      vjs.Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
+      Flash.embed(options['swf'], placeHolder, flashVars, params, attributes);
     }
   }
 });
 
-vjs.Flash.prototype.dispose = function(){
+Flash.prototype.dispose = function(){
   MediaTechController.prototype.dispose.call(this);
 };
 
-vjs.Flash.prototype.play = function(){
+Flash.prototype.play = function(){
   this.el_.vjs_play();
 };
 
-vjs.Flash.prototype.pause = function(){
+Flash.prototype.pause = function(){
   this.el_.vjs_pause();
 };
 
-vjs.Flash.prototype.src = function(src){
+Flash.prototype.src = function(src){
   if (src === undefined) {
     return this.currentSrc();
   }
 
-  if (vjs.Flash.isStreamingSrc(src)) {
-    src = vjs.Flash.streamToParts(src);
+  if (Flash.isStreamingSrc(src)) {
+    src = Flash.streamToParts(src);
     this.setRtmpConnection(src.connection);
     this.setRtmpStream(src.stream);
   } else {
@@ -289,7 +290,7 @@ vjs.Flash.prototype.src = function(src){
   }
 };
 
-vjs.Flash.prototype.currentSrc = function(){
+Flash.prototype.currentSrc = function(){
   var src = this.el_.vjs_getProperty('currentSrc');
   // no src, check and see if RTMP
   if (src == null) {
@@ -297,37 +298,37 @@ vjs.Flash.prototype.currentSrc = function(){
         stream = this['rtmpStream']();
 
     if (connection && stream) {
-      src = vjs.Flash.streamFromParts(connection, stream);
+      src = Flash.streamFromParts(connection, stream);
     }
   }
   return src;
 };
 
-vjs.Flash.prototype.load = function(){
+Flash.prototype.load = function(){
   this.el_.vjs_load();
 };
 
-vjs.Flash.prototype.poster = function(){
+Flash.prototype.poster = function(){
   this.el_.vjs_getProperty('poster');
 };
-vjs.Flash.prototype.setPoster = function(){
+Flash.prototype.setPoster = function(){
   // poster images are not handled by the Flash tech so make this a no-op
 };
 
-vjs.Flash.prototype.buffered = function(){
+Flash.prototype.buffered = function(){
   return vjslib.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
 };
 
-vjs.Flash.prototype.supportsFullScreen = function(){
+Flash.prototype.supportsFullScreen = function(){
   return false; // Flash does not allow fullscreen through javascript
 };
 
-vjs.Flash.prototype.enterFullScreen = function(){
+Flash.prototype.enterFullScreen = function(){
   return false;
 };
 
 // Create setters and getters for attributes
-var api = vjs.Flash.prototype,
+var api = Flash.prototype,
     readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(','),
     readOnly = 'error,networkState,readyState,seeking,initialTime,duration,startOffsetTime,paused,played,seekable,ended,videoTracks,audioTracks,videoWidth,videoHeight,textTracks'.split(',');
     // Overridden: buffered, currentTime, currentSrc
@@ -365,12 +366,12 @@ var createGetter = function(attr){
 
 /* Flash Support Testing -------------------------------------------------------- */
 
-vjs.Flash.isSupported = function(){
-  return vjs.Flash.version()[0] >= 10;
+Flash.isSupported = function(){
+  return Flash.version()[0] >= 10;
   // return swfobject.hasFlashPlayerVersion('10');
 };
 
-vjs.Flash.canPlaySource = function(srcObj){
+Flash.canPlaySource = function(srcObj){
   var type;
 
   if (!srcObj.type) {
@@ -378,24 +379,24 @@ vjs.Flash.canPlaySource = function(srcObj){
   }
 
   type = srcObj.type.replace(/;.*/,'').toLowerCase();
-  if (type in vjs.Flash.formats || type in vjs.Flash.streamingFormats) {
+  if (type in Flash.formats || type in Flash.streamingFormats) {
     return 'maybe';
   }
 };
 
-vjs.Flash.formats = {
+Flash.formats = {
   'video/flv': 'FLV',
   'video/x-flv': 'FLV',
   'video/mp4': 'MP4',
   'video/m4v': 'MP4'
 };
 
-vjs.Flash.streamingFormats = {
+Flash.streamingFormats = {
   'rtmp/mp4': 'MP4',
   'rtmp/flv': 'FLV'
 };
 
-vjs.Flash['onReady'] = function(currSwf){
+Flash['onReady'] = function(currSwf){
   var el = vjslib.el(currSwf);
 
   // Get player from box
@@ -409,12 +410,12 @@ vjs.Flash['onReady'] = function(currSwf){
   // Update reference to playback technology element
   tech.el_ = el;
 
-  vjs.Flash.checkReady(tech);
+  Flash.checkReady(tech);
 };
 
 // The SWF isn't alwasy ready when it says it is. Sometimes the API functions still need to be added to the object.
 // If it's not ready, we set a timeout to check again shortly.
-vjs.Flash.checkReady = function(tech){
+Flash.checkReady = function(tech){
 
   // Check if API property exists
   if (tech.el().vjs_getProperty) {
@@ -426,20 +427,20 @@ vjs.Flash.checkReady = function(tech){
   } else {
 
     setTimeout(function(){
-      vjs.Flash.checkReady(tech);
+      Flash.checkReady(tech);
     }, 50);
 
   }
 };
 
 // Trigger events from the swf on the player
-vjs.Flash['onEvent'] = function(swfID, eventName){
+Flash['onEvent'] = function(swfID, eventName){
   var player = vjslib.el(swfID)['player'];
   player.trigger(eventName);
 };
 
 // Log errors from the swf
-vjs.Flash['onError'] = function(swfID, err){
+Flash['onError'] = function(swfID, err){
   var player = vjslib.el(swfID)['player'];
   var msg = 'FLASH: '+err;
 
@@ -453,7 +454,7 @@ vjs.Flash['onError'] = function(swfID, err){
 };
 
 // Flash Version Check
-vjs.Flash.version = function(){
+Flash.version = function(){
   var version = '0,0,0';
 
   // IE
@@ -472,8 +473,8 @@ vjs.Flash.version = function(){
 };
 
 // Flash embedding method. Only used in non-iframe mode
-vjs.Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
-  var code = vjs.Flash.getEmbedCode(swf, flashVars, params, attributes),
+Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
+  var code = Flash.getEmbedCode(swf, flashVars, params, attributes),
 
       // Get element by embedding code and retrieving created element
       obj = vjslib.createEl('div', { innerHTML: code }).childNodes[0],
@@ -494,7 +495,7 @@ vjs.Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
 
 };
 
-vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
+Flash.getEmbedCode = function(swf, flashVars, params, attributes){
 
   var objTag = '<object type="application/x-shockwave-flash"',
       flashVarsString = '',
@@ -539,11 +540,11 @@ vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
   return objTag + attrsString + '>' + paramsString + '</object>';
 };
 
-vjs.Flash.streamFromParts = function(connection, stream) {
+Flash.streamFromParts = function(connection, stream) {
   return connection + '&' + stream;
 };
 
-vjs.Flash.streamToParts = function(src) {
+Flash.streamToParts = function(src) {
   var parts = {
     connection: '',
     stream: ''
@@ -575,16 +576,16 @@ vjs.Flash.streamToParts = function(src) {
   return parts;
 };
 
-vjs.Flash.isStreamingType = function(srcType) {
-  return srcType in vjs.Flash.streamingFormats;
+Flash.isStreamingType = function(srcType) {
+  return srcType in Flash.streamingFormats;
 };
 
 // RTMP has four variations, any string starting
 // with one of these protocols should be valid
-vjs.Flash.RTMP_RE = /^rtmp[set]?:\/\//i;
+Flash.RTMP_RE = /^rtmp[set]?:\/\//i;
 
-vjs.Flash.isStreamingSrc = function(src) {
-  return vjs.Flash.RTMP_RE.test(src);
+Flash.isStreamingSrc = function(src) {
+  return Flash.RTMP_RE.test(src);
 };
 
-module.exports = vjs.Flash;
+module.exports = Flash;

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var MediaTechController = require('./media.js');
+var vjslib = require('../lib.js');
+var vjsevents = require('../events.js');
+
 /**
  * @fileoverview HTML5 Media Controller - Wrapper for HTML5 Media API
  */
@@ -9,7 +14,7 @@
  * @param {Function=} ready
  * @constructor
  */
-vjs.Html5 = vjs.MediaTechController.extend({
+vjs.Html5 = MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
     // volume cannot be changed from 1 on iOS
@@ -19,12 +24,12 @@ vjs.Html5 = vjs.MediaTechController.extend({
     this.features['playbackRate'] = vjs.Html5.canControlPlaybackRate();
 
     // In iOS, if you move a video element in the DOM, it breaks video playback.
-    this.features['movingMediaElementInDOM'] = !vjs.IS_IOS;
+    this.features['movingMediaElementInDOM'] = !vjslib.IS_IOS;
 
     // HTML video is able to automatically resize when going to fullscreen
     this.features['fullscreenResize'] = true;
 
-    vjs.MediaTechController.call(this, player, options, ready);
+    MediaTechController.call(this, player, options, ready);
     this.setupTriggers();
 
     var source = options['source'];
@@ -38,7 +43,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if (vjs.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] !== false) {
+    if (vjslib.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] !== false) {
       this.useNativeControls();
     }
 
@@ -58,7 +63,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
 });
 
 vjs.Html5.prototype.dispose = function(){
-  vjs.MediaTechController.prototype.dispose.call(this);
+  MediaTechController.prototype.dispose.call(this);
 };
 
 vjs.Html5.prototype.createEl = function(){
@@ -80,7 +85,7 @@ vjs.Html5.prototype.createEl = function(){
       el = clone;
       player.tag = null;
     } else {
-      el = vjs.createEl('video', {
+      el = vjslib.createEl('video', {
         id:player.id() + '_html5_api',
         className:'vjs-tech'
       });
@@ -88,7 +93,7 @@ vjs.Html5.prototype.createEl = function(){
     // associate the player with the new tag
     el['player'] = player;
 
-    vjs.insertFirst(el, player.el());
+    vjslib.insertFirst(el, player.el());
   }
 
   // Update specific tag settings, in case they were overridden
@@ -109,7 +114,7 @@ vjs.Html5.prototype.createEl = function(){
 // Triggers removed using this.off when disposed
 vjs.Html5.prototype.setupTriggers = function(){
   for (var i = vjs.Html5.Events.length - 1; i >= 0; i--) {
-    vjs.on(this.el_, vjs.Html5.Events[i], vjs.bind(this, this.eventHandler));
+    vjsevents.on(this.el_, vjs.Html5.Events[i], vjslib.bind(this, this.eventHandler));
   }
 };
 
@@ -169,7 +174,7 @@ vjs.Html5.prototype.setCurrentTime = function(seconds){
   try {
     this.el_.currentTime = seconds;
   } catch(e) {
-    vjs.log(e, 'Video is not ready. (Video.js)');
+    vjslib.log(e, 'Video is not ready. (Video.js)');
     // this.warning(VideoJS.warnings.videoNotReady);
   }
 };
@@ -189,7 +194,7 @@ vjs.Html5.prototype.supportsFullScreen = function(){
   if (typeof this.el_.webkitEnterFullScreen == 'function') {
 
     // Seems to be broken in Chromium/Chrome && Safari in Leopard
-    if (/Android/.test(vjs.USER_AGENT) || !/Chrome|Mac OS X 10.5/.test(vjs.USER_AGENT)) {
+    if (/Android/.test(vjslib.USER_AGENT) || !/Chrome|Mac OS X 10.5/.test(vjslib.USER_AGENT)) {
       return true;
     }
   }
@@ -250,19 +255,19 @@ vjs.Html5.prototype.networkState = function(){ return this.el_.networkState; };
 vjs.Html5.isSupported = function(){
   // ie9 with no Media Player is a LIAR! (#984)
   try {
-    vjs.TEST_VID['volume'] = 0.5;
+    vjslib.TEST_VID['volume'] = 0.5;
   } catch (e) {
     return false;
   }
 
-  return !!vjs.TEST_VID.canPlayType;
+  return !!vjslib.TEST_VID.canPlayType;
 };
 
 vjs.Html5.canPlaySource = function(srcObj){
   // IE9 on Windows 7 without MediaPlayer throws an error here
   // https://github.com/videojs/video.js/issues/519
   try {
-    return !!vjs.TEST_VID.canPlayType(srcObj.type);
+    return !!vjslib.TEST_VID.canPlayType(srcObj.type);
   } catch(e) {
     return '';
   }
@@ -272,15 +277,15 @@ vjs.Html5.canPlaySource = function(srcObj){
 };
 
 vjs.Html5.canControlVolume = function(){
-  var volume =  vjs.TEST_VID.volume;
-  vjs.TEST_VID.volume = (volume / 2) + 0.1;
-  return volume !== vjs.TEST_VID.volume;
+  var volume =  vjslib.TEST_VID.volume;
+  vjslib.TEST_VID.volume = (volume / 2) + 0.1;
+  return volume !== vjslib.TEST_VID.volume;
 };
 
 vjs.Html5.canControlPlaybackRate = function(){
-  var playbackRate =  vjs.TEST_VID.playbackRate;
-  vjs.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
-  return playbackRate !== vjs.TEST_VID.playbackRate;
+  var playbackRate =  vjslib.TEST_VID.playbackRate;
+  vjslib.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
+  return playbackRate !== vjslib.TEST_VID.playbackRate;
 };
 
 // HTML5 Feature detection and Device Fixes --------------------------------- //
@@ -291,12 +296,12 @@ vjs.Html5.canControlPlaybackRate = function(){
 
   vjs.Html5.patchCanPlayType = function() {
     // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
-    if (vjs.ANDROID_VERSION >= 4.0) {
+    if (vjslib.ANDROID_VERSION >= 4.0) {
       if (!canPlayType) {
-        canPlayType = vjs.TEST_VID.constructor.prototype.canPlayType;
+        canPlayType = vjslib.TEST_VID.constructor.prototype.canPlayType;
       }
 
-      vjs.TEST_VID.constructor.prototype.canPlayType = function(type) {
+      vjslib.TEST_VID.constructor.prototype.canPlayType = function(type) {
         if (type && mpegurlRE.test(type)) {
           return 'maybe';
         }
@@ -305,12 +310,12 @@ vjs.Html5.canControlPlaybackRate = function(){
     }
 
     // Override Android 2.2 and less canPlayType method which is broken
-    if (vjs.IS_OLD_ANDROID) {
+    if (vjslib.IS_OLD_ANDROID) {
       if (!canPlayType) {
-        canPlayType = vjs.TEST_VID.constructor.prototype.canPlayType;
+        canPlayType = vjslib.TEST_VID.constructor.prototype.canPlayType;
       }
 
-      vjs.TEST_VID.constructor.prototype.canPlayType = function(type){
+      vjslib.TEST_VID.constructor.prototype.canPlayType = function(type){
         if (type && mp4RE.test(type)) {
           return 'maybe';
         }
@@ -320,8 +325,8 @@ vjs.Html5.canControlPlaybackRate = function(){
   };
 
   vjs.Html5.unpatchCanPlayType = function() {
-    var r = vjs.TEST_VID.constructor.prototype.canPlayType;
-    vjs.TEST_VID.constructor.prototype.canPlayType = canPlayType;
+    var r = vjslib.TEST_VID.constructor.prototype.canPlayType;
+    vjslib.TEST_VID.constructor.prototype.canPlayType = canPlayType;
     canPlayType = null;
     return r;
   };
@@ -364,3 +369,5 @@ vjs.Html5.disposeMediaElement = function(el){
     })();
   }
 };
+
+module.exports = vjs.Html5;

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var MediaTechController = require('./media.js');
-var vjslib = require('../lib.js');
-var vjsevents = require('../events.js');
+var Html5, MediaTechController, vjslib, vjsevents;
+
+MediaTechController = require('./media.js');
+vjslib = require('../lib.js');
+vjsevents = require('../events.js');
 
 /**
  * @fileoverview HTML5 Media Controller - Wrapper for HTML5 Media API
@@ -14,14 +15,14 @@ var vjsevents = require('../events.js');
  * @param {Function=} ready
  * @constructor
  */
-vjs.Html5 = MediaTechController.extend({
+Html5 = MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
     // volume cannot be changed from 1 on iOS
-    this.features['volumeControl'] = vjs.Html5.canControlVolume();
+    this.features['volumeControl'] = Html5.canControlVolume();
 
     // just in case; or is it excessively...
-    this.features['playbackRate'] = vjs.Html5.canControlPlaybackRate();
+    this.features['playbackRate'] = Html5.canControlPlaybackRate();
 
     // In iOS, if you move a video element in the DOM, it breaks video playback.
     this.features['movingMediaElementInDOM'] = !vjslib.IS_IOS;
@@ -62,11 +63,11 @@ vjs.Html5 = MediaTechController.extend({
   }
 });
 
-vjs.Html5.prototype.dispose = function(){
+Html5.prototype.dispose = function(){
   MediaTechController.prototype.dispose.call(this);
 };
 
-vjs.Html5.prototype.createEl = function(){
+Html5.prototype.createEl = function(){
   var player = this.player_,
       // If possible, reuse original tag for HTML5 playback technology element
       el = player.tag,
@@ -81,7 +82,7 @@ vjs.Html5.prototype.createEl = function(){
     // If the original tag is still there, clone and remove it.
     if (el) {
       clone = el.cloneNode(false);
-      vjs.Html5.disposeMediaElement(el);
+      Html5.disposeMediaElement(el);
       el = clone;
       player.tag = null;
     } else {
@@ -112,13 +113,13 @@ vjs.Html5.prototype.createEl = function(){
 // Make video events trigger player events
 // May seem verbose here, but makes other APIs possible.
 // Triggers removed using this.off when disposed
-vjs.Html5.prototype.setupTriggers = function(){
-  for (var i = vjs.Html5.Events.length - 1; i >= 0; i--) {
-    vjsevents.on(this.el_, vjs.Html5.Events[i], vjslib.bind(this, this.eventHandler));
+Html5.prototype.setupTriggers = function(){
+  for (var i = Html5.Events.length - 1; i >= 0; i--) {
+    vjsevents.on(this.el_, Html5.Events[i], vjslib.bind(this, this.eventHandler));
   }
 };
 
-vjs.Html5.prototype.eventHandler = function(evt){
+Html5.prototype.eventHandler = function(evt){
   // In the case of an error, set the error prop on the player
   // and let the player handle triggering the event.
   if (evt.type == 'error') {
@@ -133,7 +134,7 @@ vjs.Html5.prototype.eventHandler = function(evt){
   }
 };
 
-vjs.Html5.prototype.useNativeControls = function(){
+Html5.prototype.useNativeControls = function(){
   var tech, player, controlsOn, controlsOff, cleanUp;
 
   tech = this;
@@ -165,12 +166,12 @@ vjs.Html5.prototype.useNativeControls = function(){
 };
 
 
-vjs.Html5.prototype.play = function(){ this.el_.play(); };
-vjs.Html5.prototype.pause = function(){ this.el_.pause(); };
-vjs.Html5.prototype.paused = function(){ return this.el_.paused; };
+Html5.prototype.play = function(){ this.el_.play(); };
+Html5.prototype.pause = function(){ this.el_.pause(); };
+Html5.prototype.paused = function(){ return this.el_.paused; };
 
-vjs.Html5.prototype.currentTime = function(){ return this.el_.currentTime; };
-vjs.Html5.prototype.setCurrentTime = function(seconds){
+Html5.prototype.currentTime = function(){ return this.el_.currentTime; };
+Html5.prototype.setCurrentTime = function(seconds){
   try {
     this.el_.currentTime = seconds;
   } catch(e) {
@@ -179,18 +180,18 @@ vjs.Html5.prototype.setCurrentTime = function(seconds){
   }
 };
 
-vjs.Html5.prototype.duration = function(){ return this.el_.duration || 0; };
-vjs.Html5.prototype.buffered = function(){ return this.el_.buffered; };
+Html5.prototype.duration = function(){ return this.el_.duration || 0; };
+Html5.prototype.buffered = function(){ return this.el_.buffered; };
 
-vjs.Html5.prototype.volume = function(){ return this.el_.volume; };
-vjs.Html5.prototype.setVolume = function(percentAsDecimal){ this.el_.volume = percentAsDecimal; };
-vjs.Html5.prototype.muted = function(){ return this.el_.muted; };
-vjs.Html5.prototype.setMuted = function(muted){ this.el_.muted = muted; };
+Html5.prototype.volume = function(){ return this.el_.volume; };
+Html5.prototype.setVolume = function(percentAsDecimal){ this.el_.volume = percentAsDecimal; };
+Html5.prototype.muted = function(){ return this.el_.muted; };
+Html5.prototype.setMuted = function(muted){ this.el_.muted = muted; };
 
-vjs.Html5.prototype.width = function(){ return this.el_.offsetWidth; };
-vjs.Html5.prototype.height = function(){ return this.el_.offsetHeight; };
+Html5.prototype.width = function(){ return this.el_.offsetWidth; };
+Html5.prototype.height = function(){ return this.el_.offsetHeight; };
 
-vjs.Html5.prototype.supportsFullScreen = function(){
+Html5.prototype.supportsFullScreen = function(){
   if (typeof this.el_.webkitEnterFullScreen == 'function') {
 
     // Seems to be broken in Chromium/Chrome && Safari in Leopard
@@ -201,7 +202,7 @@ vjs.Html5.prototype.supportsFullScreen = function(){
   return false;
 };
 
-vjs.Html5.prototype.enterFullScreen = function(){
+Html5.prototype.enterFullScreen = function(){
   var video = this.el_;
   if (video.paused && video.networkState <= video.HAVE_METADATA) {
     // attempt to prime the video element for programmatic access
@@ -218,41 +219,41 @@ vjs.Html5.prototype.enterFullScreen = function(){
     video.webkitEnterFullScreen();
   }
 };
-vjs.Html5.prototype.exitFullScreen = function(){
+Html5.prototype.exitFullScreen = function(){
   this.el_.webkitExitFullScreen();
 };
-vjs.Html5.prototype.src = function(src){ this.el_.src = src; };
-vjs.Html5.prototype.load = function(){ this.el_.load(); };
-vjs.Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
+Html5.prototype.src = function(src){ this.el_.src = src; };
+Html5.prototype.load = function(){ this.el_.load(); };
+Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
 
-vjs.Html5.prototype.poster = function(){ return this.el_.poster; };
-vjs.Html5.prototype.setPoster = function(val){ this.el_.poster = val; };
+Html5.prototype.poster = function(){ return this.el_.poster; };
+Html5.prototype.setPoster = function(val){ this.el_.poster = val; };
 
-vjs.Html5.prototype.preload = function(){ return this.el_.preload; };
-vjs.Html5.prototype.setPreload = function(val){ this.el_.preload = val; };
+Html5.prototype.preload = function(){ return this.el_.preload; };
+Html5.prototype.setPreload = function(val){ this.el_.preload = val; };
 
-vjs.Html5.prototype.autoplay = function(){ return this.el_.autoplay; };
-vjs.Html5.prototype.setAutoplay = function(val){ this.el_.autoplay = val; };
+Html5.prototype.autoplay = function(){ return this.el_.autoplay; };
+Html5.prototype.setAutoplay = function(val){ this.el_.autoplay = val; };
 
-vjs.Html5.prototype.controls = function(){ return this.el_.controls; };
-vjs.Html5.prototype.setControls = function(val){ this.el_.controls = !!val; };
+Html5.prototype.controls = function(){ return this.el_.controls; };
+Html5.prototype.setControls = function(val){ this.el_.controls = !!val; };
 
-vjs.Html5.prototype.loop = function(){ return this.el_.loop; };
-vjs.Html5.prototype.setLoop = function(val){ this.el_.loop = val; };
+Html5.prototype.loop = function(){ return this.el_.loop; };
+Html5.prototype.setLoop = function(val){ this.el_.loop = val; };
 
-vjs.Html5.prototype.error = function(){ return this.el_.error; };
-vjs.Html5.prototype.seeking = function(){ return this.el_.seeking; };
-vjs.Html5.prototype.ended = function(){ return this.el_.ended; };
-vjs.Html5.prototype.defaultMuted = function(){ return this.el_.defaultMuted; };
+Html5.prototype.error = function(){ return this.el_.error; };
+Html5.prototype.seeking = function(){ return this.el_.seeking; };
+Html5.prototype.ended = function(){ return this.el_.ended; };
+Html5.prototype.defaultMuted = function(){ return this.el_.defaultMuted; };
 
-vjs.Html5.prototype.playbackRate = function(){ return this.el_.playbackRate; };
-vjs.Html5.prototype.setPlaybackRate = function(val){ this.el_.playbackRate = val; };
+Html5.prototype.playbackRate = function(){ return this.el_.playbackRate; };
+Html5.prototype.setPlaybackRate = function(val){ this.el_.playbackRate = val; };
 
-vjs.Html5.prototype.networkState = function(){ return this.el_.networkState; };
+Html5.prototype.networkState = function(){ return this.el_.networkState; };
 
 /* HTML5 Support Testing ---------------------------------------------------- */
 
-vjs.Html5.isSupported = function(){
+Html5.isSupported = function(){
   // ie9 with no Media Player is a LIAR! (#984)
   try {
     vjslib.TEST_VID['volume'] = 0.5;
@@ -263,7 +264,7 @@ vjs.Html5.isSupported = function(){
   return !!vjslib.TEST_VID.canPlayType;
 };
 
-vjs.Html5.canPlaySource = function(srcObj){
+Html5.canPlaySource = function(srcObj){
   // IE9 on Windows 7 without MediaPlayer throws an error here
   // https://github.com/videojs/video.js/issues/519
   try {
@@ -276,13 +277,13 @@ vjs.Html5.canPlaySource = function(srcObj){
   // Check Media Type
 };
 
-vjs.Html5.canControlVolume = function(){
+Html5.canControlVolume = function(){
   var volume =  vjslib.TEST_VID.volume;
   vjslib.TEST_VID.volume = (volume / 2) + 0.1;
   return volume !== vjslib.TEST_VID.volume;
 };
 
-vjs.Html5.canControlPlaybackRate = function(){
+Html5.canControlPlaybackRate = function(){
   var playbackRate =  vjslib.TEST_VID.playbackRate;
   vjslib.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
   return playbackRate !== vjslib.TEST_VID.playbackRate;
@@ -294,7 +295,7 @@ vjs.Html5.canControlPlaybackRate = function(){
       mpegurlRE = /^application\/(?:x-|vnd\.apple\.)mpegurl/i,
       mp4RE = /^video\/mp4/i;
 
-  vjs.Html5.patchCanPlayType = function() {
+  Html5.patchCanPlayType = function() {
     // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
     if (vjslib.ANDROID_VERSION >= 4.0) {
       if (!canPlayType) {
@@ -324,7 +325,7 @@ vjs.Html5.canControlPlaybackRate = function(){
     }
   };
 
-  vjs.Html5.unpatchCanPlayType = function() {
+  Html5.unpatchCanPlayType = function() {
     var r = vjslib.TEST_VID.constructor.prototype.canPlayType;
     vjslib.TEST_VID.constructor.prototype.canPlayType = canPlayType;
     canPlayType = null;
@@ -332,13 +333,13 @@ vjs.Html5.canControlPlaybackRate = function(){
   };
 
   // by default, patch the video element
-  vjs.Html5.patchCanPlayType();
+  Html5.patchCanPlayType();
 })();
 
 // List of all HTML5 events (various uses).
-vjs.Html5.Events = 'loadstart,suspend,abort,error,emptied,stalled,loadedmetadata,loadeddata,canplay,canplaythrough,playing,waiting,seeking,seeked,ended,durationchange,timeupdate,progress,play,pause,ratechange,volumechange'.split(',');
+Html5.Events = 'loadstart,suspend,abort,error,emptied,stalled,loadedmetadata,loadeddata,canplay,canplaythrough,playing,waiting,seeking,seeked,ended,durationchange,timeupdate,progress,play,pause,ratechange,volumechange'.split(',');
 
-vjs.Html5.disposeMediaElement = function(el){
+Html5.disposeMediaElement = function(el){
   if (!el) { return; }
 
   el['player'] = null;
@@ -370,4 +371,4 @@ vjs.Html5.disposeMediaElement = function(el){
   }
 };
 
-module.exports = vjs.Html5;
+module.exports = Html5;

--- a/src/js/media/loader.js
+++ b/src/js/media/loader.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
+var MediaLoader, Component, vjslib;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
 
 /**
  * The Media Loader is the component that decides which playback technology to load
@@ -8,7 +9,7 @@ var vjslib = require('../lib.js');
  *
  * @constructor
  */
-vjs.MediaLoader = Component.extend({
+MediaLoader = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     var components = require('../components.js');
@@ -38,4 +39,4 @@ vjs.MediaLoader = Component.extend({
   }
 });
 
-module.exports = vjs.MediaLoader;
+module.exports = MediaLoader;

--- a/src/js/media/loader.js
+++ b/src/js/media/loader.js
@@ -1,20 +1,26 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+
 /**
  * The Media Loader is the component that decides which playback technology to load
  * when the player is initialized.
  *
  * @constructor
  */
-vjs.MediaLoader = vjs.Component.extend({
+vjs.MediaLoader = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.Component.call(this, player, options, ready);
+    var components = require('../components.js');
+
+    Component.call(this, player, options, ready);
 
     // If there are no sources when the player is initialized,
     // load the first supported playback technology.
     if (!player.options_['sources'] || player.options_['sources'].length === 0) {
       for (var i=0,j=player.options_['techOrder']; i<j.length; i++) {
-        var techName = vjs.capitalize(j[i]),
-            tech = window['videojs'][techName];
+        var techName = vjslib.capitalize(j[i]),
+            tech = components[techName];
 
         // Check if the browser supports this technology
         if (tech && tech.isSupported()) {
@@ -31,3 +37,5 @@ vjs.MediaLoader = vjs.Component.extend({
     }
   }
 });
+
+module.exports = vjs.MediaLoader;

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var Component = require('../component.js');
-var vjslib = require('../lib.js');
+var MediaTechController, Component, vjslib;
+
+Component = require('../component.js');
+vjslib = require('../lib.js');
 
 /**
  * @fileoverview Media Technology Controller - Base class for media playback
@@ -13,7 +14,7 @@ var vjslib = require('../lib.js');
  * @param {Object=} options Options object
  * @constructor
  */
-vjs.MediaTechController = Component.extend({
+MediaTechController = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     options = options || {};
@@ -46,7 +47,7 @@ vjs.MediaTechController = Component.extend({
  * keep the controls showing, but that shouldn't be an issue. A touch and hold on
  * any controls will still keep the user active
  */
-vjs.MediaTechController.prototype.initControlsListeners = function(){
+MediaTechController.prototype.initControlsListeners = function(){
   var player, tech, activateControls, deactivateControls;
 
   tech = this;
@@ -78,7 +79,7 @@ vjs.MediaTechController.prototype.initControlsListeners = function(){
   });
 };
 
-vjs.MediaTechController.prototype.addControlsListeners = function(){
+MediaTechController.prototype.addControlsListeners = function(){
   var userWasActive;
 
   // Some browsers (Chrome & IE) don't trigger a click on a flash swf, but do
@@ -114,7 +115,7 @@ vjs.MediaTechController.prototype.addControlsListeners = function(){
  * Remove the listeners used for click and tap controls. This is needed for
  * toggling to controls disabled, where a tap/touch should do nothing.
  */
-vjs.MediaTechController.prototype.removeControlsListeners = function(){
+MediaTechController.prototype.removeControlsListeners = function(){
   // We don't want to just use `this.off()` because there might be other needed
   // listeners added by techs that extend this.
   this.off('tap');
@@ -130,7 +131,7 @@ vjs.MediaTechController.prototype.removeControlsListeners = function(){
 /**
  * Handle a click on the media element. By default will play/pause the media.
  */
-vjs.MediaTechController.prototype.onClick = function(event){
+MediaTechController.prototype.onClick = function(event){
   // We're using mousedown to detect clicks thanks to Flash, but mousedown
   // will also be triggered with right-clicks, so we need to prevent that
   if (event.button !== 0) return;
@@ -150,7 +151,7 @@ vjs.MediaTechController.prototype.onClick = function(event){
  * Handle a tap on the media element. By default it will toggle the user
  * activity state, which hides and shows the controls.
  */
-vjs.MediaTechController.prototype.onTap = function(){
+MediaTechController.prototype.onTap = function(){
   this.player().userActive(!this.player().userActive());
 };
 
@@ -160,9 +161,9 @@ vjs.MediaTechController.prototype.onTap = function(){
  * Poster support for techs should be optional, so we don't want techs to
  * break if they don't have a way to set a poster.
  */
-vjs.MediaTechController.prototype.setPoster = function(){};
+MediaTechController.prototype.setPoster = function(){};
 
-vjs.MediaTechController.prototype.features = {
+MediaTechController.prototype.features = {
   'volumeControl': true,
 
   // Resizing plugins using request fullscreen reloads the plugin
@@ -175,6 +176,4 @@ vjs.MediaTechController.prototype.features = {
   'timeupdateEvents': false
 };
 
-vjs.media = {};
-
-module.exports = vjs.MediaTechController;
+module.exports = MediaTechController;

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var Component = require('../component.js');
+var vjslib = require('../lib.js');
+
 /**
  * @fileoverview Media Technology Controller - Base class for media playback
  * technology controllers like Flash and HTML5
@@ -9,14 +13,14 @@
  * @param {Object=} options Options object
  * @constructor
  */
-vjs.MediaTechController = vjs.Component.extend({
+vjs.MediaTechController = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     options = options || {};
     // we don't want the tech to report user activity automatically.
     // This is done manually in addControlsListeners
     options.reportTouchActivity = false;
-    vjs.Component.call(this, player, options, ready);
+    Component.call(this, player, options, ready);
 
     this.initControlsListeners();
   }
@@ -54,7 +58,7 @@ vjs.MediaTechController.prototype.initControlsListeners = function(){
     }
   };
 
-  deactivateControls = vjs.bind(tech, tech.removeControlsListeners);
+  deactivateControls = vjslib.bind(tech, tech.removeControlsListeners);
 
   // Set up event listeners once the tech is ready and has an element to apply
   // listeners to
@@ -172,3 +176,5 @@ vjs.MediaTechController.prototype.features = {
 };
 
 vjs.media = {};
+
+module.exports = vjs.MediaTechController;

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -1,8 +1,9 @@
-var vjs = {};
-var Component = require('./component.js');
-var vjslib = require('./lib.js');
-var vjsevents = require('./events.js');
-var Button = require('./button.js');
+var Menu, MenuItem, MenuButton, Component, Button, vjslib, vjsevents;
+
+Component = require('./component.js');
+Button = require('./button.js');
+vjslib = require('./lib.js');
+vjsevents = require('./events.js');
 
 /* Menu
 ================================================================================ */
@@ -15,13 +16,13 @@ var Button = require('./button.js');
  * @class
  * @constructor
  */
-vjs.Menu = Component.extend();
+Menu = Component.extend();
 
 /**
  * Add a menu item to the menu
  * @param {Object|String} component Component or component type to add
  */
-vjs.Menu.prototype.addItem = function(component){
+Menu.prototype.addItem = function(component){
   this.addChild(component);
   component.on('click', vjslib.bind(this, function(){
     this.unlockShowing();
@@ -29,7 +30,7 @@ vjs.Menu.prototype.addItem = function(component){
 };
 
 /** @inheritDoc */
-vjs.Menu.prototype.createEl = function(){
+Menu.prototype.createEl = function(){
   var contentElType = this.options().contentElType || 'ul';
   this.contentEl_ = vjslib.createEl(contentElType, {
     className: 'vjs-menu-content'
@@ -58,7 +59,7 @@ vjs.Menu.prototype.createEl = function(){
  * @class
  * @constructor
  */
-vjs.MenuItem = Button.extend({
+MenuItem = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -67,7 +68,7 @@ vjs.MenuItem = Button.extend({
 });
 
 /** @inheritDoc */
-vjs.MenuItem.prototype.createEl = function(type, props){
+MenuItem.prototype.createEl = function(type, props){
   return Button.prototype.createEl.call(this, 'li', vjslib.obj.merge({
     className: 'vjs-menu-item',
     innerHTML: this.options_['label']
@@ -77,7 +78,7 @@ vjs.MenuItem.prototype.createEl = function(type, props){
 /**
  * Handle a click on the menu item, and set it to selected
  */
-vjs.MenuItem.prototype.onClick = function(){
+MenuItem.prototype.onClick = function(){
   this.selected(true);
 };
 
@@ -85,7 +86,7 @@ vjs.MenuItem.prototype.onClick = function(){
  * Set this menu item as selected or not
  * @param  {Boolean} selected
  */
-vjs.MenuItem.prototype.selected = function(selected){
+MenuItem.prototype.selected = function(selected){
   if (selected) {
     this.addClass('vjs-selected');
     this.el_.setAttribute('aria-selected',true);
@@ -102,7 +103,7 @@ vjs.MenuItem.prototype.selected = function(selected){
  * @param {Object=} options
  * @constructor
  */
-vjs.MenuButton = Button.extend({
+MenuButton = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -128,10 +129,10 @@ vjs.MenuButton = Button.extend({
  * @type {Boolean}
  * @private
  */
-vjs.MenuButton.prototype.buttonPressed_ = false;
+MenuButton.prototype.buttonPressed_ = false;
 
-vjs.MenuButton.prototype.createMenu = function(){
-  var menu = new vjs.Menu(this.player_);
+MenuButton.prototype.createMenu = function(){
+  var menu = new Menu(this.player_);
 
   // Add a title list item to the top
   if (this.options().title) {
@@ -157,10 +158,10 @@ vjs.MenuButton.prototype.createMenu = function(){
 /**
  * Create the list of menu items. Specific to each subclass.
  */
-vjs.MenuButton.prototype.createItems = function(){};
+MenuButton.prototype.createItems = function(){};
 
 /** @inheritDoc */
-vjs.MenuButton.prototype.buildCSSClass = function(){
+MenuButton.prototype.buildCSSClass = function(){
   return this.className + ' vjs-menu-button ' + Button.prototype.buildCSSClass.call(this);
 };
 
@@ -168,11 +169,11 @@ vjs.MenuButton.prototype.buildCSSClass = function(){
 // This function is not needed anymore. Instead, the keyboard functionality is handled by
 // treating the button as triggering a submenu. When the button is pressed, the submenu
 // appears. Pressing the button again makes the submenu disappear.
-vjs.MenuButton.prototype.onFocus = function(){};
+MenuButton.prototype.onFocus = function(){};
 // Can't turn off list display that we turned on with focus, because list would go away.
-vjs.MenuButton.prototype.onBlur = function(){};
+MenuButton.prototype.onBlur = function(){};
 
-vjs.MenuButton.prototype.onClick = function(){
+MenuButton.prototype.onClick = function(){
   // When you click the button it adds focus, which will show the menu indefinitely.
   // So we'll remove focus when the mouse leaves the button.
   // Focus is needed for tab navigation.
@@ -187,7 +188,7 @@ vjs.MenuButton.prototype.onClick = function(){
   }
 };
 
-vjs.MenuButton.prototype.onKeyPress = function(event){
+MenuButton.prototype.onKeyPress = function(event){
   event.preventDefault();
 
   // Check for space bar (32) or enter (13) keys
@@ -205,7 +206,7 @@ vjs.MenuButton.prototype.onKeyPress = function(event){
   }
 };
 
-vjs.MenuButton.prototype.pressButton = function(){
+MenuButton.prototype.pressButton = function(){
   this.buttonPressed_ = true;
   this.menu.lockShowing();
   this.el_.setAttribute('aria-pressed', true);
@@ -214,10 +215,14 @@ vjs.MenuButton.prototype.pressButton = function(){
   }
 };
 
-vjs.MenuButton.prototype.unpressButton = function(){
+MenuButton.prototype.unpressButton = function(){
   this.buttonPressed_ = false;
   this.menu.unlockShowing();
   this.el_.setAttribute('aria-pressed', false);
 };
 
-module.exports = vjs;
+module.exports = {
+  Menu: Menu,
+  MenuItem: MenuItem,
+  MenuButton: MenuButton
+};

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -1,3 +1,9 @@
+var vjs = {};
+var Component = require('./component.js');
+var vjslib = require('./lib.js');
+var vjsevents = require('./events.js');
+var Button = require('./button.js');
+
 /* Menu
 ================================================================================ */
 /**
@@ -9,7 +15,7 @@
  * @class
  * @constructor
  */
-vjs.Menu = vjs.Component.extend();
+vjs.Menu = Component.extend();
 
 /**
  * Add a menu item to the menu
@@ -17,7 +23,7 @@ vjs.Menu = vjs.Component.extend();
  */
 vjs.Menu.prototype.addItem = function(component){
   this.addChild(component);
-  component.on('click', vjs.bind(this, function(){
+  component.on('click', vjslib.bind(this, function(){
     this.unlockShowing();
   }));
 };
@@ -25,10 +31,10 @@ vjs.Menu.prototype.addItem = function(component){
 /** @inheritDoc */
 vjs.Menu.prototype.createEl = function(){
   var contentElType = this.options().contentElType || 'ul';
-  this.contentEl_ = vjs.createEl(contentElType, {
+  this.contentEl_ = vjslib.createEl(contentElType, {
     className: 'vjs-menu-content'
   });
-  var el = vjs.Component.prototype.createEl.call(this, 'div', {
+  var el = Component.prototype.createEl.call(this, 'div', {
     append: this.contentEl_,
     className: 'vjs-menu'
   });
@@ -36,7 +42,7 @@ vjs.Menu.prototype.createEl = function(){
 
   // Prevent clicks from bubbling up. Needed for Menu Buttons,
   // where a click on the parent is significant
-  vjs.on(el, 'click', function(event){
+  vjsevents.on(el, 'click', function(event){
     event.preventDefault();
     event.stopImmediatePropagation();
   });
@@ -52,17 +58,17 @@ vjs.Menu.prototype.createEl = function(){
  * @class
  * @constructor
  */
-vjs.MenuItem = vjs.Button.extend({
+vjs.MenuItem = Button.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
     this.selected(options['selected']);
   }
 });
 
 /** @inheritDoc */
 vjs.MenuItem.prototype.createEl = function(type, props){
-  return vjs.Button.prototype.createEl.call(this, 'li', vjs.obj.merge({
+  return Button.prototype.createEl.call(this, 'li', vjslib.obj.merge({
     className: 'vjs-menu-item',
     innerHTML: this.options_['label']
   }, props));
@@ -96,10 +102,10 @@ vjs.MenuItem.prototype.selected = function(selected){
  * @param {Object=} options
  * @constructor
  */
-vjs.MenuButton = vjs.Button.extend({
+vjs.MenuButton = Button.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
 
     this.menu = this.createMenu();
 
@@ -129,9 +135,9 @@ vjs.MenuButton.prototype.createMenu = function(){
 
   // Add a title list item to the top
   if (this.options().title) {
-    menu.contentEl().appendChild(vjs.createEl('li', {
+    menu.contentEl().appendChild(vjslib.createEl('li', {
       className: 'vjs-menu-title',
-      innerHTML: vjs.capitalize(this.options().title),
+      innerHTML: vjslib.capitalize(this.options().title),
       tabindex: -1
     }));
   }
@@ -155,7 +161,7 @@ vjs.MenuButton.prototype.createItems = function(){};
 
 /** @inheritDoc */
 vjs.MenuButton.prototype.buildCSSClass = function(){
-  return this.className + ' vjs-menu-button ' + vjs.Button.prototype.buildCSSClass.call(this);
+  return this.className + ' vjs-menu-button ' + Button.prototype.buildCSSClass.call(this);
 };
 
 // Focus - Add keyboard functionality to element
@@ -170,7 +176,7 @@ vjs.MenuButton.prototype.onClick = function(){
   // When you click the button it adds focus, which will show the menu indefinitely.
   // So we'll remove focus when the mouse leaves the button.
   // Focus is needed for tab navigation.
-  this.one('mouseout', vjs.bind(this, function(){
+  this.one('mouseout', vjslib.bind(this, function(){
     this.menu.unlockShowing();
     this.el_.blur();
   }));
@@ -214,3 +220,4 @@ vjs.MenuButton.prototype.unpressButton = function(){
   this.el_.setAttribute('aria-pressed', false);
 };
 
+module.exports = vjs;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,0 +1,44 @@
+var vjs = {};
+
+/**
+ * Global Player instance options, surfaced from vjs.Player.prototype.options_
+ * vjs.options = vjs.Player.prototype.options_
+ * All options should use string keys so they avoid
+ * renaming by closure compiler
+ * @type {Object}
+ */
+vjs.options = {
+  // Default order of fallback technology
+  'techOrder': ['html5','flash'],
+  // techOrder: ['flash','html5'],
+
+  'html5': {},
+  'flash': {},
+
+  // Default of web browser is 300x150. Should rely on source width/height.
+  'width': 300,
+  'height': 150,
+  // defaultVolume: 0.85,
+  'defaultVolume': 0.00, // The freakin seaguls are driving me crazy!
+
+  // default playback rates
+  'playbackRates': [],
+  // Add playback rate selection by adding rates
+  // 'playbackRates': [0.5, 1, 1.5, 2],
+
+  // Included control sets
+  'children': {
+    'mediaLoader': {},
+    'posterImage': {},
+    'textTrackDisplay': {},
+    'loadingSpinner': {},
+    'bigPlayButton': {},
+    'controlBar': {},
+    'errorDisplay': {}
+  },
+
+  // Default message to show when a video cannot be played.
+  'notSupportedMessage': 'No compatible source was found for this video.'
+};
+
+module.exports = vjs.options;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,5 +1,3 @@
-var vjs = {};
-
 /**
  * Global Player instance options, surfaced from vjs.Player.prototype.options_
  * vjs.options = vjs.Player.prototype.options_
@@ -7,7 +5,7 @@ var vjs = {};
  * renaming by closure compiler
  * @type {Object}
  */
-vjs.options = {
+module.exports = {
   // Default order of fallback technology
   'techOrder': ['html5','flash'],
   // techOrder: ['flash','html5'],
@@ -41,4 +39,3 @@ vjs.options = {
   'notSupportedMessage': 'No compatible source was found for this video.'
 };
 
-module.exports = vjs.options;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,16 +1,17 @@
-var vjs = {};
-var Component = require('./component.js');
-var MediaError = require('./media-error.js');
-var vjslib = require('./lib.js');
-var vjsevents = require('./events.js');
-var fullscreenApi = require('./fullscreen-api.js');
-var vjsoptions = require('./options.js');
+var Player, players, Component, MediaError, vjslib, vjsevents, fullscreenApi, vjsoptions;
+
+Component = require('./component.js');
+MediaError = require('./media-error.js');
+vjslib = require('./lib.js');
+vjsevents = require('./events.js');
+fullscreenApi = require('./fullscreen-api.js');
+vjsoptions = require('./options.js');
 
 /**
  * Global player list
  * @type {Object}
  */
-vjs.players = {};
+players = {};
 
 /**
  * An instance of the `vjs.Player` class is created when any of the Video.js setup methods are used to initialize a video.
@@ -32,7 +33,7 @@ vjs.players = {};
  * @class
  * @extends vjs.Component
  */
-vjs.Player = Component.extend({
+Player = Component.extend({
 
   /**
    * player's constructor function
@@ -92,7 +93,7 @@ vjs.Player = Component.extend({
     // }
 
     // Make player easily findable by ID
-    vjs.players[this.id_] = this;
+    players[this.id_] = this;
 
     if (options['plugins']) {
       vjslib.obj.each(options['plugins'], function(key, val){
@@ -113,7 +114,7 @@ vjs.Player = Component.extend({
  * @type {Object}
  * @private
  */
-vjs.Player.prototype.options_ = vjsoptions;
+Player.prototype.options_ = vjsoptions;
 
 /**
  * Destroys the video player and does any necessary cleanup
@@ -123,13 +124,13 @@ vjs.Player.prototype.options_ = vjsoptions;
  * This is especially helpful if you are dynamically adding and removing videos
  * to/from the DOM.
  */
-vjs.Player.prototype.dispose = function(){
+Player.prototype.dispose = function(){
   this.trigger('dispose');
   // prevent dispose from being called twice
   this.off('dispose');
 
   // Kill reference to this player
-  vjs.players[this.id_] = null;
+  players[this.id_] = null;
   if (this.tag && this.tag['player']) { this.tag['player'] = null; }
   if (this.el_ && this.el_['player']) { this.el_['player'] = null; }
 
@@ -143,7 +144,7 @@ vjs.Player.prototype.dispose = function(){
   Component.prototype.dispose.call(this);
 };
 
-vjs.Player.prototype.getTagSettings = function(tag){
+Player.prototype.getTagSettings = function(tag){
   var options = {
     'sources': [],
     'tracks': []
@@ -172,7 +173,7 @@ vjs.Player.prototype.getTagSettings = function(tag){
   return options;
 };
 
-vjs.Player.prototype.createEl = function(){
+Player.prototype.createEl = function(){
   var el = this.el_ = Component.prototype.createEl.call(this, 'div');
   var tag = this.tag;
 
@@ -253,7 +254,7 @@ vjs.Player.prototype.createEl = function(){
 // ================================================================================ */
 // Load/Create an instance of playback technlogy including element and API methods
 // And append playback element in player div.
-vjs.Player.prototype.loadTech = function(techName, source){
+Player.prototype.loadTech = function(techName, source){
   var components = require('./components.js');
 
   // Pause and remove current playback technology
@@ -303,7 +304,7 @@ vjs.Player.prototype.loadTech = function(techName, source){
   this.tech.ready(techReady);
 };
 
-vjs.Player.prototype.unloadTech = function(){
+Player.prototype.unloadTech = function(){
   this.isReady_ = false;
 
   // Turn off any manual progress or timeupdate tracking
@@ -334,7 +335,7 @@ vjs.Player.prototype.unloadTech = function(){
 ================================================================================ */
 // Manually trigger progress events based on changes to the buffered amount
 // Many flash players and older HTML5 browsers don't send progress or progress-like events
-vjs.Player.prototype.manualProgressOn = function(){
+Player.prototype.manualProgressOn = function(){
   this.manualProgress = true;
 
   // Trigger progress watching when a source begins loading
@@ -356,12 +357,12 @@ vjs.Player.prototype.manualProgressOn = function(){
   }
 };
 
-vjs.Player.prototype.manualProgressOff = function(){
+Player.prototype.manualProgressOff = function(){
   this.manualProgress = false;
   this.stopTrackingProgress();
 };
 
-vjs.Player.prototype.trackProgress = function(){
+Player.prototype.trackProgress = function(){
 
   this.progressInterval = setInterval(vjslib.bind(this, function(){
     // Don't trigger unless buffered amount is greater than last time
@@ -375,10 +376,10 @@ vjs.Player.prototype.trackProgress = function(){
     }
   }), 500);
 };
-vjs.Player.prototype.stopTrackingProgress = function(){ clearInterval(this.progressInterval); };
+Player.prototype.stopTrackingProgress = function(){ clearInterval(this.progressInterval); };
 
 /*! Time Tracking -------------------------------------------------------------- */
-vjs.Player.prototype.manualTimeUpdatesOn = function(){
+Player.prototype.manualTimeUpdatesOn = function(){
   this.manualTimeUpdates = true;
 
   this.on('play', this.trackCurrentTime);
@@ -396,14 +397,14 @@ vjs.Player.prototype.manualTimeUpdatesOn = function(){
   }
 };
 
-vjs.Player.prototype.manualTimeUpdatesOff = function(){
+Player.prototype.manualTimeUpdatesOff = function(){
   this.manualTimeUpdates = false;
   this.stopTrackingCurrentTime();
   this.off('play', this.trackCurrentTime);
   this.off('pause', this.stopTrackingCurrentTime);
 };
 
-vjs.Player.prototype.trackCurrentTime = function(){
+Player.prototype.trackCurrentTime = function(){
   if (this.currentTimeInterval) { this.stopTrackingCurrentTime(); }
   this.currentTimeInterval = setInterval(vjslib.bind(this, function(){
     this.trigger('timeupdate');
@@ -411,7 +412,7 @@ vjs.Player.prototype.trackCurrentTime = function(){
 };
 
 // Turn off play progress tracking (when paused or dragging)
-vjs.Player.prototype.stopTrackingCurrentTime = function(){
+Player.prototype.stopTrackingCurrentTime = function(){
   clearInterval(this.currentTimeInterval);
 
   // #1002 - if the video ends right before the next timeupdate would happen,
@@ -425,7 +426,7 @@ vjs.Player.prototype.stopTrackingCurrentTime = function(){
  * Fired when the user agent begins looking for media data
  * @event loadstart
  */
-vjs.Player.prototype.onLoadStart = function() {
+Player.prototype.onLoadStart = function() {
   // TODO: Update to use `emptied` event instead. See #1277.
 
   // reset the error state
@@ -445,9 +446,9 @@ vjs.Player.prototype.onLoadStart = function() {
   }
 };
 
-vjs.Player.prototype.hasStarted_ = false;
+Player.prototype.hasStarted_ = false;
 
-vjs.Player.prototype.hasStarted = function(hasStarted){
+Player.prototype.hasStarted = function(hasStarted){
   if (hasStarted !== undefined) {
     // only update if this is a new value
     if (this.hasStarted_ !== hasStarted) {
@@ -469,25 +470,25 @@ vjs.Player.prototype.hasStarted = function(hasStarted){
  * Fired when the player has initial duration and dimension information
  * @event loadedmetadata
  */
-vjs.Player.prototype.onLoadedMetaData;
+Player.prototype.onLoadedMetaData;
 
 /**
  * Fired when the player has downloaded data at the current playback position
  * @event loadeddata
  */
-vjs.Player.prototype.onLoadedData;
+Player.prototype.onLoadedData;
 
 /**
  * Fired when the player has finished downloading the source data
  * @event loadedalldata
  */
-vjs.Player.prototype.onLoadedAllData;
+Player.prototype.onLoadedAllData;
 
 /**
  * Fired whenever the media begins or resumes playback
  * @event play
  */
-vjs.Player.prototype.onPlay = function(){
+Player.prototype.onPlay = function(){
   vjslib.removeClass(this.el_, 'vjs-paused');
   vjslib.addClass(this.el_, 'vjs-playing');
 };
@@ -501,7 +502,7 @@ vjs.Player.prototype.onPlay = function(){
  *
  * @event firstplay
  */
-vjs.Player.prototype.onFirstPlay = function(){
+Player.prototype.onFirstPlay = function(){
     //If the first starttime attribute is specified
     //then we will start at the given offset in seconds
     if(this.options_['starttime']){
@@ -515,7 +516,7 @@ vjs.Player.prototype.onFirstPlay = function(){
  * Fired whenever the media has been paused
  * @event pause
  */
-vjs.Player.prototype.onPause = function(){
+Player.prototype.onPause = function(){
   vjslib.removeClass(this.el_, 'vjs-playing');
   vjslib.addClass(this.el_, 'vjs-paused');
 };
@@ -527,13 +528,13 @@ vjs.Player.prototype.onPause = function(){
  * playback technology in use.
  * @event timeupdate
  */
-vjs.Player.prototype.onTimeUpdate;
+Player.prototype.onTimeUpdate;
 
 /**
  * Fired while the user agent is downloading media data
  * @event progress
  */
-vjs.Player.prototype.onProgress = function(){
+Player.prototype.onProgress = function(){
   // Add custom event for when source is finished downloading.
   if (this.bufferedPercent() == 1) {
     this.trigger('loadedalldata');
@@ -544,7 +545,7 @@ vjs.Player.prototype.onProgress = function(){
  * Fired when the end of the media resource is reached (currentTime == duration)
  * @event ended
  */
-vjs.Player.prototype.onEnded = function(){
+Player.prototype.onEnded = function(){
   if (this.options_['loop']) {
     this.currentTime(0);
     this.play();
@@ -555,7 +556,7 @@ vjs.Player.prototype.onEnded = function(){
  * Fired when the duration of the media resource is first known or changed
  * @event durationchange
  */
-vjs.Player.prototype.onDurationChange = function(){
+Player.prototype.onDurationChange = function(){
   // Allows for cacheing value instead of asking player each time.
   // We need to get the techGet response and check for a value so we don't
   // accidentally cause the stack to blow up.
@@ -578,13 +579,13 @@ vjs.Player.prototype.onDurationChange = function(){
  * Fired when the volume changes
  * @event volumechange
  */
-vjs.Player.prototype.onVolumeChange;
+Player.prototype.onVolumeChange;
 
 /**
  * Fired when the player switches in or out of fullscreen mode
  * @event fullscreenchange
  */
-vjs.Player.prototype.onFullscreenChange = function() {
+Player.prototype.onFullscreenChange = function() {
   if (this.isFullscreen()) {
     this.addClass('vjs-fullscreen');
   } else {
@@ -599,14 +600,14 @@ vjs.Player.prototype.onFullscreenChange = function() {
  * Object for cached values.
  * @private
  */
-vjs.Player.prototype.cache_;
+Player.prototype.cache_;
 
-vjs.Player.prototype.getCache = function(){
+Player.prototype.getCache = function(){
   return this.cache_;
 };
 
 // Pass values to the playback tech
-vjs.Player.prototype.techCall = function(method, arg){
+Player.prototype.techCall = function(method, arg){
   // If it's not ready yet, call method when it is
   if (this.tech && !this.tech.isReady_) {
     this.tech.ready(function(){
@@ -625,7 +626,7 @@ vjs.Player.prototype.techCall = function(method, arg){
 };
 
 // Get calls can't wait for the tech, and sometimes don't need to.
-vjs.Player.prototype.techGet = function(method){
+Player.prototype.techGet = function(method){
   if (this.tech && this.tech.isReady_) {
 
     // Flash likes to die and reload when you hide or reposition it.
@@ -660,7 +661,7 @@ vjs.Player.prototype.techGet = function(method){
  *
  * @return {vjs.Player} self
  */
-vjs.Player.prototype.play = function(){
+Player.prototype.play = function(){
   this.techCall('play');
   return this;
 };
@@ -672,7 +673,7 @@ vjs.Player.prototype.play = function(){
  *
  * @return {vjs.Player} self
  */
-vjs.Player.prototype.pause = function(){
+Player.prototype.pause = function(){
   this.techCall('pause');
   return this;
 };
@@ -685,7 +686,7 @@ vjs.Player.prototype.pause = function(){
  *
  * @return {Boolean} false if the media is currently playing, or true otherwise
  */
-vjs.Player.prototype.paused = function(){
+Player.prototype.paused = function(){
   // The initial state of paused should be true (in Safari it's actually false)
   return (this.techGet('paused') === false) ? false : true;
 };
@@ -703,7 +704,7 @@ vjs.Player.prototype.paused = function(){
  * @return {Number}        The time in seconds, when not setting
  * @return {vjs.Player}    self, when the current time is set
  */
-vjs.Player.prototype.currentTime = function(seconds){
+Player.prototype.currentTime = function(seconds){
   if (seconds !== undefined) {
 
     this.techCall('setCurrentTime', seconds);
@@ -734,7 +735,7 @@ vjs.Player.prototype.currentTime = function(seconds){
  *
  * @return {Number} The duration of the video in seconds
  */
-vjs.Player.prototype.duration = function(seconds){
+Player.prototype.duration = function(seconds){
   if (seconds !== undefined) {
 
     // cache the last set value for optimiized scrubbing (esp. Flash)
@@ -751,7 +752,7 @@ vjs.Player.prototype.duration = function(seconds){
 };
 
 // Calculates how much time is left. Not in spec, but useful.
-vjs.Player.prototype.remainingTime = function(){
+Player.prototype.remainingTime = function(){
   return this.duration() - this.currentTime();
 };
 
@@ -780,7 +781,7 @@ vjs.Player.prototype.remainingTime = function(){
  *
  * @return {Object} A mock TimeRange object (following HTML spec)
  */
-vjs.Player.prototype.buffered = function(){
+Player.prototype.buffered = function(){
   var buffered = this.techGet('buffered'),
       start = 0,
       buflast = buffered.length - 1,
@@ -806,7 +807,7 @@ vjs.Player.prototype.buffered = function(){
  *
  * @return {Number} A decimal between 0 and 1 representing the percent
  */
-vjs.Player.prototype.bufferedPercent = function(){
+Player.prototype.bufferedPercent = function(){
   return (this.duration()) ? this.buffered().end(0) / this.duration() : 0;
 };
 
@@ -825,7 +826,7 @@ vjs.Player.prototype.bufferedPercent = function(){
  * @return {Number}                  The current volume, when getting
  * @return {vjs.Player}              self, when setting
  */
-vjs.Player.prototype.volume = function(percentAsDecimal){
+Player.prototype.volume = function(percentAsDecimal){
   var vol;
 
   if (percentAsDecimal !== undefined) {
@@ -855,7 +856,7 @@ vjs.Player.prototype.volume = function(percentAsDecimal){
  * @return {Boolean} True if mute is on, false if not, when getting
  * @return {vjs.Player} self, when setting mute
  */
-vjs.Player.prototype.muted = function(muted){
+Player.prototype.muted = function(muted){
   if (muted !== undefined) {
     this.techCall('setMuted', muted);
     return this;
@@ -865,7 +866,7 @@ vjs.Player.prototype.muted = function(muted){
 
 // Check if current tech can support native fullscreen
 // (e.g. with built in controls lik iOS, so not our flash swf)
-vjs.Player.prototype.supportsFullScreen = function(){
+Player.prototype.supportsFullScreen = function(){
   return this.techGet('supportsFullScreen') || false;
 };
 
@@ -874,7 +875,7 @@ vjs.Player.prototype.supportsFullScreen = function(){
  * @type {Boolean}
  * @private
  */
-vjs.Player.prototype.isFullscreen_ = false;
+Player.prototype.isFullscreen_ = false;
 
 /**
  * Check if the player is in fullscreen mode
@@ -893,7 +894,7 @@ vjs.Player.prototype.isFullscreen_ = false;
  * @return {Boolean} true if fullscreen, false if not
  * @return {vjs.Player} self, when setting
  */
-vjs.Player.prototype.isFullscreen = function(isFS){
+Player.prototype.isFullscreen = function(isFS){
   if (isFS !== undefined) {
     this.isFullscreen_ = !!isFS;
     return this;
@@ -905,7 +906,7 @@ vjs.Player.prototype.isFullscreen = function(isFS){
  * Old naming for isFullscreen()
  * @deprecated for lowercase 's' version
  */
-vjs.Player.prototype.isFullScreen = function(isFS){
+Player.prototype.isFullScreen = function(isFS){
   vjslib.log.warn('player.isFullScreen() has been deprecated, use player.isFullscreen() with a lowercase "s")');
   return this.isFullscreen(isFS);
 };
@@ -924,7 +925,7 @@ vjs.Player.prototype.isFullScreen = function(isFS){
  *
  * @return {vjs.Player} self
  */
-vjs.Player.prototype.requestFullscreen = function(){
+Player.prototype.requestFullscreen = function(){
   var fsApi = fullscreenApi;
 
   this.isFullscreen(true);
@@ -969,7 +970,7 @@ vjs.Player.prototype.requestFullscreen = function(){
  * Old naming for requestFullscreen
  * @deprecated for lower case 's' version
  */
-vjs.Player.prototype.requestFullScreen = function(){
+Player.prototype.requestFullScreen = function(){
   vjslib.log.warn('player.requestFullScreen() has been deprecated, use player.requestFullscreen() with a lowercase "s")');
   return this.requestFullscreen();
 };
@@ -982,7 +983,7 @@ vjs.Player.prototype.requestFullScreen = function(){
  *
  * @return {vjs.Player} self
  */
-vjs.Player.prototype.exitFullscreen = function(){
+Player.prototype.exitFullscreen = function(){
   var fsApi = fullscreenApi;
   this.isFullscreen(false);
 
@@ -1003,13 +1004,13 @@ vjs.Player.prototype.exitFullscreen = function(){
  * Old naming for exitFullscreen
  * @deprecated for exitFullscreen
  */
-vjs.Player.prototype.cancelFullScreen = function(){
+Player.prototype.cancelFullScreen = function(){
   vjslib.log.warn('player.cancelFullScreen() has been deprecated, use player.exitFullscreen()');
   return this.exitFullscreen();
 };
 
 // When fullscreen isn't supported we can stretch the video container to as wide as the browser will let us.
-vjs.Player.prototype.enterFullWindow = function(){
+Player.prototype.enterFullWindow = function(){
   this.isFullWindow = true;
 
   // Storing original doc overflow value to return to when fullscreen is off
@@ -1026,7 +1027,7 @@ vjs.Player.prototype.enterFullWindow = function(){
 
   this.trigger('enterFullWindow');
 };
-vjs.Player.prototype.fullWindowOnEscKey = function(event){
+Player.prototype.fullWindowOnEscKey = function(event){
   if (event.keyCode === 27) {
     if (this.isFullscreen() === true) {
       this.exitFullscreen();
@@ -1036,7 +1037,7 @@ vjs.Player.prototype.fullWindowOnEscKey = function(event){
   }
 };
 
-vjs.Player.prototype.exitFullWindow = function(){
+Player.prototype.exitFullWindow = function(){
   this.isFullWindow = false;
   vjsevents.off(document, 'keydown', this.fullWindowOnEscKey);
 
@@ -1051,7 +1052,7 @@ vjs.Player.prototype.exitFullWindow = function(){
   this.trigger('exitFullWindow');
 };
 
-vjs.Player.prototype.selectSource = function(sources){
+Player.prototype.selectSource = function(sources){
 
   // Loop through each playback technology in the options order
   for (var i=0,j=this.options_['techOrder'];i<j.length;i++) {
@@ -1113,7 +1114,7 @@ vjs.Player.prototype.selectSource = function(sources){
  * @return {String} The current video source when getting
  * @return {String} The player when setting
  */
-vjs.Player.prototype.src = function(source){
+Player.prototype.src = function(source){
   if (source === undefined) {
     return this.techGet('src');
   }
@@ -1178,18 +1179,18 @@ vjs.Player.prototype.src = function(source){
 
 // Begin loading the src data
 // http://dev.w3.org/html5/spec/video.html#dom-media-load
-vjs.Player.prototype.load = function(){
+Player.prototype.load = function(){
   this.techCall('load');
   return this;
 };
 
 // http://dev.w3.org/html5/spec/video.html#dom-media-currentsrc
-vjs.Player.prototype.currentSrc = function(){
+Player.prototype.currentSrc = function(){
   return this.techGet('currentSrc') || this.cache_.src || '';
 };
 
 // Attributes/Options
-vjs.Player.prototype.preload = function(value){
+Player.prototype.preload = function(value){
   if (value !== undefined) {
     this.techCall('setPreload', value);
     this.options_['preload'] = value;
@@ -1197,7 +1198,7 @@ vjs.Player.prototype.preload = function(value){
   }
   return this.techGet('preload');
 };
-vjs.Player.prototype.autoplay = function(value){
+Player.prototype.autoplay = function(value){
   if (value !== undefined) {
     this.techCall('setAutoplay', value);
     this.options_['autoplay'] = value;
@@ -1205,7 +1206,7 @@ vjs.Player.prototype.autoplay = function(value){
   }
   return this.techGet('autoplay', value);
 };
-vjs.Player.prototype.loop = function(value){
+Player.prototype.loop = function(value){
   if (value !== undefined) {
     this.techCall('setLoop', value);
     this.options_['loop'] = value;
@@ -1219,7 +1220,7 @@ vjs.Player.prototype.loop = function(value){
  * @type {String}
  * @private
  */
-vjs.Player.prototype.poster_;
+Player.prototype.poster_;
 
 /**
  * get or set the poster image source url
@@ -1236,7 +1237,7 @@ vjs.Player.prototype.poster_;
  * @return {String} poster URL when getting
  * @return {vjs.Player} self when setting
  */
-vjs.Player.prototype.poster = function(src){
+Player.prototype.poster = function(src){
   if (src === undefined) {
     return this.poster_;
   }
@@ -1256,14 +1257,14 @@ vjs.Player.prototype.poster = function(src){
  * @type {Boolean}
  * @private
  */
-vjs.Player.prototype.controls_;
+Player.prototype.controls_;
 
 /**
  * Get or set whether or not the controls are showing.
  * @param  {Boolean} controls Set controls to showing or not
  * @return {Boolean}    Controls are showing
  */
-vjs.Player.prototype.controls = function(bool){
+Player.prototype.controls = function(bool){
   if (bool !== undefined) {
     bool = !!bool; // force boolean
     // Don't trigger a change event unless it actually changed
@@ -1284,7 +1285,7 @@ vjs.Player.prototype.controls = function(bool){
   return this.controls_;
 };
 
-vjs.Player.prototype.usingNativeControls_;
+Player.prototype.usingNativeControls_;
 
 /**
  * Toggle native controls on/off. Native controls are the controls built into
@@ -1298,7 +1299,7 @@ vjs.Player.prototype.usingNativeControls_;
  * @return {vjs.Player}      Returns the player
  * @private
  */
-vjs.Player.prototype.usingNativeControls = function(bool){
+Player.prototype.usingNativeControls = function(bool){
   if (bool !== undefined) {
     bool = !!bool; // force boolean
     // Don't trigger a change event unless it actually changed
@@ -1340,7 +1341,7 @@ vjs.Player.prototype.usingNativeControls = function(bool){
  * @type {Object}
  * @private
  */
-vjs.Player.prototype.error_ = null;
+Player.prototype.error_ = null;
 
 /**
  * Set or get the current MediaError
@@ -1348,7 +1349,7 @@ vjs.Player.prototype.error_ = null;
  * @return {vjs.MediaError|null}     when getting
  * @return {vjs.Player}              when setting
  */
-vjs.Player.prototype.error = function(err){
+Player.prototype.error = function(err){
   if (err === undefined) {
     return this.error_;
   }
@@ -1380,18 +1381,18 @@ vjs.Player.prototype.error = function(err){
   return this;
 };
 
-vjs.Player.prototype.ended = function(){ return this.techGet('ended'); };
-vjs.Player.prototype.seeking = function(){ return this.techGet('seeking'); };
+Player.prototype.ended = function(){ return this.techGet('ended'); };
+Player.prototype.seeking = function(){ return this.techGet('seeking'); };
 
 // When the player is first initialized, trigger activity so components
 // like the control bar show themselves if needed
-vjs.Player.prototype.userActivity_ = true;
-vjs.Player.prototype.reportUserActivity = function(event){
+Player.prototype.userActivity_ = true;
+Player.prototype.reportUserActivity = function(event){
   this.userActivity_ = true;
 };
 
-vjs.Player.prototype.userActive_ = true;
-vjs.Player.prototype.userActive = function(bool){
+Player.prototype.userActive_ = true;
+Player.prototype.userActive = function(bool){
   if (bool !== undefined) {
     bool = !!bool;
     if (bool !== this.userActive_) {
@@ -1433,7 +1434,7 @@ vjs.Player.prototype.userActive = function(bool){
   return this.userActive_;
 };
 
-vjs.Player.prototype.listenForUserActivity = function(){
+Player.prototype.listenForUserActivity = function(){
   var onActivity, onMouseMove, onMouseDown, mouseInProgress, onMouseUp,
       activityCheck, inactivityTimeout, lastMoveX, lastMoveY;
 
@@ -1514,7 +1515,7 @@ vjs.Player.prototype.listenForUserActivity = function(){
   });
 };
 
-vjs.Player.prototype.playbackRate = function(rate) {
+Player.prototype.playbackRate = function(rate) {
   if (rate !== undefined) {
     this.techCall('setPlaybackRate', rate);
     return this;
@@ -1548,5 +1549,5 @@ vjs.Player.prototype.playbackRate = function(rate) {
 // currentSrcList: the array of sources including other formats and bitrates
 // playList: array of source lists in order of playback
 
-module.exports = vjs.Player;
-module.exports.players = vjs.players;
+module.exports = Player;
+module.exports.players = players;

--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -1,13 +1,11 @@
-var vjs = {};
-vjs.Player = require('./player.js');
+var Player = require('./player.js');
+
 /**
  * the method for registering a video.js plugin
  *
  * @param  {String} name The name of the plugin
  * @param  {Function} init The function that is run when the player inits
  */
-vjs.plugin = function(name, init){
-  vjs.Player.prototype[name] = init;
+module.exports = function plugin(name, init){
+  Player.prototype[name] = init;
 };
-
-module.exports = vjs.plugin;

--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -1,3 +1,5 @@
+var vjs = {};
+vjs.Player = require('./player.js');
 /**
  * the method for registering a video.js plugin
  *
@@ -7,3 +9,5 @@
 vjs.plugin = function(name, init){
   vjs.Player.prototype[name] = init;
 };
+
+module.exports = vjs.plugin;

--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var vjslib = require('./lib.js');
-var Button = require('./button.js');
+var PosterImage, Button, vjslib;
+
+Button = require('./button.js');
+vjslib = require('./lib.js');
 
 /* Poster Image
 ================================================================================ */
@@ -11,7 +12,7 @@ var Button = require('./button.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.PosterImage = Button.extend({
+PosterImage = Button.extend({
   /** @constructor */
   init: function(player, options){
     Button.call(this, player, options);
@@ -35,7 +36,7 @@ vjs.PosterImage = Button.extend({
 // use the test el to check for backgroundSize style support
 var _backgroundSizeSupported = 'backgroundSize' in vjslib.TEST_VID.style;
 
-vjs.PosterImage.prototype.createEl = function(){
+PosterImage.prototype.createEl = function(){
   var el = vjslib.createEl('div', {
     className: 'vjs-poster',
 
@@ -51,7 +52,7 @@ vjs.PosterImage.prototype.createEl = function(){
   return el;
 };
 
-vjs.PosterImage.prototype.src = function(url){
+PosterImage.prototype.src = function(url){
   var el = this.el();
 
   // getter
@@ -74,11 +75,11 @@ vjs.PosterImage.prototype.src = function(url){
   }
 };
 
-vjs.PosterImage.prototype.onClick = function(){
+PosterImage.prototype.onClick = function(){
   // Only accept clicks when controls are enabled
   if (this.player().controls()) {
     this.player_.play();
   }
 };
 
-module.exports = vjs.PosterImage;
+module.exports = PosterImage;

--- a/src/js/poster.js
+++ b/src/js/poster.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var vjslib = require('./lib.js');
+var Button = require('./button.js');
+
 /* Poster Image
 ================================================================================ */
 /**
@@ -7,10 +11,10 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.PosterImage = vjs.Button.extend({
+vjs.PosterImage = Button.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Button.call(this, player, options);
+    Button.call(this, player, options);
 
     if (player.poster()) {
       this.src(player.poster());
@@ -20,19 +24,19 @@ vjs.PosterImage = vjs.Button.extend({
       this.hide();
     }
 
-    player.on('posterchange', vjs.bind(this, function(){
+    player.on('posterchange', vjslib.bind(this, function(){
       this.src(player.poster());
     }));
 
-    player.on('play', vjs.bind(this, this.hide));
+    player.on('play', vjslib.bind(this, this.hide));
   }
 });
 
 // use the test el to check for backgroundSize style support
-var _backgroundSizeSupported = 'backgroundSize' in vjs.TEST_VID.style;
+var _backgroundSizeSupported = 'backgroundSize' in vjslib.TEST_VID.style;
 
 vjs.PosterImage.prototype.createEl = function(){
-  var el = vjs.createEl('div', {
+  var el = vjslib.createEl('div', {
     className: 'vjs-poster',
 
     // Don't want poster to be tabbable.
@@ -41,7 +45,7 @@ vjs.PosterImage.prototype.createEl = function(){
 
   if (!_backgroundSizeSupported) {
     // setup an img element as a fallback for IE8
-    el.appendChild(vjs.createEl('img'));
+    el.appendChild(vjslib.createEl('img'));
   }
 
   return el;
@@ -76,3 +80,5 @@ vjs.PosterImage.prototype.onClick = function(){
     this.player_.play();
   }
 };
+
+module.exports = vjs.PosterImage;

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -1,3 +1,7 @@
+var vjs = {};
+var vjsJSON = require('./json.js');
+var vjsevents = require('./events.js');
+
 /**
  * @fileoverview Functions for automatically setting up a player
  * based on the data-setup attribute of the video tag
@@ -28,7 +32,7 @@ vjs.autoSetup = function(){
 
             // Parse options JSON
             // If empty string, make it a parsable json object.
-            options = vjs.JSON.parse(options || '{}');
+            options = vjsJSON.parse(options || '{}');
 
             // Create new video.js instance.
             player = videojs(vid, options);
@@ -56,11 +60,9 @@ vjs.autoSetupTimeout = function(wait){
 if (document.readyState === 'complete') {
   vjs.windowLoaded = true;
 } else {
-  vjs.one(window, 'load', function(){
+  vjsevents.one(window, 'load', function(){
     vjs.windowLoaded = true;
   });
 }
 
-// Run Auto-load players
-// You have to wait at least once in case this script is loaded after your video in the DOM (weird behavior only with minified version)
-vjs.autoSetupTimeout(1);
+module.exports = vjs;

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -1,6 +1,7 @@
-var vjs = {};
-var vjsJSON = require('./json.js');
-var vjsevents = require('./events.js');
+var autoSetup, autoSetupTimeout, hasLoaded, windowLoaded, vjsJSON, vjsevents;
+
+vjsJSON = require('./json.js');
+vjsevents = require('./events.js');
 
 /**
  * @fileoverview Functions for automatically setting up a player
@@ -8,7 +9,7 @@ var vjsevents = require('./events.js');
  */
 
 // Automatically set up any tags that have a data-setup attribute
-vjs.autoSetup = function(){
+autoSetup = function(){
   var options, vid, player,
       vids = document.getElementsByTagName('video');
 
@@ -41,28 +42,37 @@ vjs.autoSetup = function(){
 
       // If getAttribute isn't defined, we need to wait for the DOM.
       } else {
-        vjs.autoSetupTimeout(1);
+        autoSetupTimeout(1);
         break;
       }
     }
 
   // No videos were found, so keep looping unless page is finisehd loading.
-  } else if (!vjs.windowLoaded) {
-    vjs.autoSetupTimeout(1);
+  } else if (!windowLoaded) {
+    autoSetupTimeout(1);
   }
 };
 
 // Pause to let the DOM keep processing
-vjs.autoSetupTimeout = function(wait){
-  setTimeout(vjs.autoSetup, wait);
+autoSetupTimeout = function(wait){
+  setTimeout(autoSetup, wait);
 };
 
+// return whether window has loaded
+hasLoaded = function() {
+  return windowLoaded;
+}
+
 if (document.readyState === 'complete') {
-  vjs.windowLoaded = true;
+  windowLoaded = true;
 } else {
   vjsevents.one(window, 'load', function(){
-    vjs.windowLoaded = true;
+    windowLoaded = true;
   });
 }
 
-module.exports = vjs;
+module.exports = {
+  autoSetup: autoSetup,
+  autoSetupTimeout: autoSetupTimeout,
+  hasLoaded: hasLoaded
+};

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -1,3 +1,8 @@
+var vjs = {};
+var Component = require('./component.js');
+var vjslib = require('./lib.js');
+var vjsevents = require('./events.js');
+
 /* Slider
 ================================================================================ */
 /**
@@ -7,10 +12,10 @@
  * @param {Object=} options
  * @constructor
  */
-vjs.Slider = vjs.Component.extend({
+vjs.Slider = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     // Set property names to bar and handle to match with the child Slider class is looking for
     this.bar = this.getChild(this.options_['barName']);
@@ -22,9 +27,9 @@ vjs.Slider = vjs.Component.extend({
     this.on('blur', this.onBlur);
     this.on('click', this.onClick);
 
-    this.player_.on('controlsvisible', vjs.bind(this, this.update));
+    this.player_.on('controlsvisible', vjslib.bind(this, this.update));
 
-    player.on(this.playerEvent, vjs.bind(this, this.update));
+    player.on(this.playerEvent, vjslib.bind(this, this.update));
 
     this.boundEvents = {};
   }
@@ -34,7 +39,7 @@ vjs.Slider.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider';
-  props = vjs.obj.merge({
+  props = vjslib.obj.merge({
     'role': 'slider',
     'aria-valuenow': 0,
     'aria-valuemin': 0,
@@ -42,30 +47,30 @@ vjs.Slider.prototype.createEl = function(type, props) {
     tabIndex: 0
   }, props);
 
-  return vjs.Component.prototype.createEl.call(this, type, props);
+  return Component.prototype.createEl.call(this, type, props);
 };
 
 vjs.Slider.prototype.onMouseDown = function(event){
   event.preventDefault();
-  vjs.blockTextSelection();
+  vjslib.blockTextSelection();
 
-  this.boundEvents.move = vjs.bind(this, this.onMouseMove);
-  this.boundEvents.end = vjs.bind(this, this.onMouseUp);
+  this.boundEvents.move = vjslib.bind(this, this.onMouseMove);
+  this.boundEvents.end = vjslib.bind(this, this.onMouseUp);
 
-  vjs.on(document, 'mousemove', this.boundEvents.move);
-  vjs.on(document, 'mouseup', this.boundEvents.end);
-  vjs.on(document, 'touchmove', this.boundEvents.move);
-  vjs.on(document, 'touchend', this.boundEvents.end);
+  vjsevents.on(document, 'mousemove', this.boundEvents.move);
+  vjsevents.on(document, 'mouseup', this.boundEvents.end);
+  vjsevents.on(document, 'touchmove', this.boundEvents.move);
+  vjsevents.on(document, 'touchend', this.boundEvents.end);
 
   this.onMouseMove(event);
 };
 
 vjs.Slider.prototype.onMouseUp = function() {
-  vjs.unblockTextSelection();
-  vjs.off(document, 'mousemove', this.boundEvents.move, false);
-  vjs.off(document, 'mouseup', this.boundEvents.end, false);
-  vjs.off(document, 'touchmove', this.boundEvents.move, false);
-  vjs.off(document, 'touchend', this.boundEvents.end, false);
+  vjslib.unblockTextSelection();
+  vjsevents.off(document, 'mousemove', this.boundEvents.move, false);
+  vjsevents.off(document, 'mouseup', this.boundEvents.end, false);
+  vjsevents.off(document, 'touchmove', this.boundEvents.move, false);
+  vjsevents.off(document, 'touchend', this.boundEvents.end, false);
 
   this.update();
 };
@@ -113,18 +118,18 @@ vjs.Slider.prototype.update = function(){
     barProgress = adjustedProgress + (handlePercent / 2);
 
     // Move the handle from the left based on the adjected progress
-    handle.el().style.left = vjs.round(adjustedProgress * 100, 2) + '%';
+    handle.el().style.left = vjslib.round(adjustedProgress * 100, 2) + '%';
   }
 
   // Set the new bar width
-  bar.el().style.width = vjs.round(barProgress * 100, 2) + '%';
+  bar.el().style.width = vjslib.round(barProgress * 100, 2) + '%';
 };
 
 vjs.Slider.prototype.calculateDistance = function(event){
   var el, box, boxX, boxY, boxW, boxH, handle, pageX, pageY;
 
   el = this.el_;
-  box = vjs.findPosition(el);
+  box = vjslib.findPosition(el);
   boxW = boxH = el.offsetWidth;
   handle = this.handle;
 
@@ -170,7 +175,7 @@ vjs.Slider.prototype.calculateDistance = function(event){
 };
 
 vjs.Slider.prototype.onFocus = function(){
-  vjs.on(document, 'keyup', vjs.bind(this, this.onKeyPress));
+  vjsevents.on(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
 vjs.Slider.prototype.onKeyPress = function(event){
@@ -184,7 +189,7 @@ vjs.Slider.prototype.onKeyPress = function(event){
 };
 
 vjs.Slider.prototype.onBlur = function(){
-  vjs.off(document, 'keyup', vjs.bind(this, this.onKeyPress));
+  vjsevents.off(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
 /**
@@ -204,7 +209,7 @@ vjs.Slider.prototype.onClick = function(event){
  * @param {Object=} options
  * @constructor
  */
-vjs.SliderHandle = vjs.Component.extend();
+vjs.SliderHandle = Component.extend();
 
 /**
  * Default value of the slider
@@ -219,9 +224,11 @@ vjs.SliderHandle.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider-handle';
-  props = vjs.obj.merge({
+  props = vjslib.obj.merge({
     innerHTML: '<span class="vjs-control-text">'+this.defaultValue+'</span>'
   }, props);
 
-  return vjs.Component.prototype.createEl.call(this, 'div', props);
+  return Component.prototype.createEl.call(this, 'div', props);
 };
+
+module.exports = vjs;

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -1,7 +1,8 @@
-var vjs = {};
-var Component = require('./component.js');
-var vjslib = require('./lib.js');
-var vjsevents = require('./events.js');
+var Slider, SliderHandle, Component, vjslib, vjsevents;
+
+Component = require('./component.js');
+vjslib = require('./lib.js');
+vjsevents = require('./events.js');
 
 /* Slider
 ================================================================================ */
@@ -12,7 +13,7 @@ var vjsevents = require('./events.js');
  * @param {Object=} options
  * @constructor
  */
-vjs.Slider = Component.extend({
+Slider = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -35,7 +36,7 @@ vjs.Slider = Component.extend({
   }
 });
 
-vjs.Slider.prototype.createEl = function(type, props) {
+Slider.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider';
@@ -50,7 +51,7 @@ vjs.Slider.prototype.createEl = function(type, props) {
   return Component.prototype.createEl.call(this, type, props);
 };
 
-vjs.Slider.prototype.onMouseDown = function(event){
+Slider.prototype.onMouseDown = function(event){
   event.preventDefault();
   vjslib.blockTextSelection();
 
@@ -65,7 +66,7 @@ vjs.Slider.prototype.onMouseDown = function(event){
   this.onMouseMove(event);
 };
 
-vjs.Slider.prototype.onMouseUp = function() {
+Slider.prototype.onMouseUp = function() {
   vjslib.unblockTextSelection();
   vjsevents.off(document, 'mousemove', this.boundEvents.move, false);
   vjsevents.off(document, 'mouseup', this.boundEvents.end, false);
@@ -75,7 +76,7 @@ vjs.Slider.prototype.onMouseUp = function() {
   this.update();
 };
 
-vjs.Slider.prototype.update = function(){
+Slider.prototype.update = function(){
   // In VolumeBar init we have a setTimeout for update that pops and update to the end of the
   // execution stack. The player is destroyed before then update will cause an error
   if (!this.el_) return;
@@ -125,7 +126,7 @@ vjs.Slider.prototype.update = function(){
   bar.el().style.width = vjslib.round(barProgress * 100, 2) + '%';
 };
 
-vjs.Slider.prototype.calculateDistance = function(event){
+Slider.prototype.calculateDistance = function(event){
   var el, box, boxX, boxY, boxW, boxH, handle, pageX, pageY;
 
   el = this.el_;
@@ -174,11 +175,11 @@ vjs.Slider.prototype.calculateDistance = function(event){
   }
 };
 
-vjs.Slider.prototype.onFocus = function(){
+Slider.prototype.onFocus = function(){
   vjsevents.on(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
-vjs.Slider.prototype.onKeyPress = function(event){
+Slider.prototype.onKeyPress = function(event){
   if (event.which == 37) { // Left Arrow
     event.preventDefault();
     this.stepBack();
@@ -188,7 +189,7 @@ vjs.Slider.prototype.onKeyPress = function(event){
   }
 };
 
-vjs.Slider.prototype.onBlur = function(){
+Slider.prototype.onBlur = function(){
   vjsevents.off(document, 'keyup', vjslib.bind(this, this.onKeyPress));
 };
 
@@ -197,7 +198,7 @@ vjs.Slider.prototype.onBlur = function(){
  *   from bubbling up to parent elements like button menus.
  * @param  {Object} event Event object
  */
-vjs.Slider.prototype.onClick = function(event){
+Slider.prototype.onClick = function(event){
   event.stopImmediatePropagation();
   event.preventDefault();
 };
@@ -209,7 +210,7 @@ vjs.Slider.prototype.onClick = function(event){
  * @param {Object=} options
  * @constructor
  */
-vjs.SliderHandle = Component.extend();
+SliderHandle = Component.extend();
 
 /**
  * Default value of the slider
@@ -217,10 +218,10 @@ vjs.SliderHandle = Component.extend();
  * @type {Number}
  * @private
  */
-vjs.SliderHandle.prototype.defaultValue = 0;
+SliderHandle.prototype.defaultValue = 0;
 
 /** @inheritDoc */
-vjs.SliderHandle.prototype.createEl = function(type, props) {
+SliderHandle.prototype.createEl = function(type, props) {
   props = props || {};
   // Add the slider element class to all sub classes
   props.className = props.className + ' vjs-slider-handle';
@@ -231,4 +232,7 @@ vjs.SliderHandle.prototype.createEl = function(type, props) {
   return Component.prototype.createEl.call(this, 'div', props);
 };
 
-module.exports = vjs;
+module.exports = {
+  Slider: Slider,
+  SliderHandle: SliderHandle
+};

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -1,8 +1,12 @@
-var vjs = {};
-var vjslib = require('./lib.js');
-var Component = require('./component.js');
-var vjsmenu = require('./menu.js');
-vjs.Player = require('./player.js');
+var Player, Component, vjsmenu, vjslib,
+    TextTrack, CaptionsTrack, SubtitlesTrack, ChaptersTrack,
+    TextTrackDisplay, TextTrackMenuItem, OffTextTrackMenuItem, ChaptersTrackMenuItem,
+    TextTrackButton, CaptionsButton, SubtitlesButton, ChaptersButton;
+
+Component = require('./component.js');
+vjsmenu = require('./menu.js');
+vjslib = require('./lib.js');
+Player = require('./player.js');
 
 /**
  * @fileoverview Text Tracks
@@ -20,7 +24,7 @@ vjs.Player = require('./player.js');
  * @type {Array}
  * @private
  */
-vjs.Player.prototype.textTracks_;
+Player.prototype.textTracks_;
 
 /**
  * Get an array of associated text tracks. captions, subtitles, chapters, descriptions
@@ -28,7 +32,7 @@ vjs.Player.prototype.textTracks_;
  * @return {Array}           Array of track objects
  * @private
  */
-vjs.Player.prototype.textTracks = function(){
+Player.prototype.textTracks = function(){
   this.textTracks_ = this.textTracks_ || [];
   return this.textTracks_;
 };
@@ -43,8 +47,12 @@ vjs.Player.prototype.textTracks = function(){
  * @param {Object=} options     Additional track options, like src
  * @private
  */
-vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
-  var tracks = this.textTracks_ = this.textTracks_ || [];
+Player.prototype.addTextTrack = function(kind, label, language, options){
+  var tracks, components;
+  components = require('./components.js');
+
+  tracks = this.textTracks_ = this.textTracks_ || [];
+
   options = options || {};
 
   options['kind'] = kind;
@@ -56,7 +64,7 @@ vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
   var Kind = vjslib.capitalize(kind || 'subtitles');
 
   // Create correct texttrack class. CaptionsTrack, etc.
-  var track = new vjs[Kind + 'Track'](this, options);
+  var track = new components[Kind + 'Track'](this, options);
 
   tracks.push(track);
 
@@ -83,7 +91,7 @@ vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
  * @param {Array} trackList Array of track elements or objects (fake track elements)
  * @private
  */
-vjs.Player.prototype.addTextTracks = function(trackList){
+Player.prototype.addTextTracks = function(trackList){
   var trackObj;
 
   for (var i = 0; i < trackList.length; i++) {
@@ -96,7 +104,7 @@ vjs.Player.prototype.addTextTracks = function(trackList){
 
 // Show a text track
 // disableSameKind: disable all other tracks of the same kind. Value should be a track kind (captions, etc.)
-vjs.Player.prototype.showTextTrack = function(id, disableSameKind){
+Player.prototype.showTextTrack = function(id, disableSameKind){
   var tracks = this.textTracks_,
       i = 0,
       j = tracks.length,
@@ -135,7 +143,7 @@ vjs.Player.prototype.showTextTrack = function(id, disableSameKind){
  * @param {Object=} options
  * @constructor
  */
-vjs.TextTrack = Component.extend({
+TextTrack = Component.extend({
   /** @constructor */
   init: function(player, options){
     Component.call(this, player, options);
@@ -164,13 +172,13 @@ vjs.TextTrack = Component.extend({
  * Track kind value. Captions, subtitles, etc.
  * @private
  */
-vjs.TextTrack.prototype.kind_;
+TextTrack.prototype.kind_;
 
 /**
  * Get the track kind value
  * @return {String}
  */
-vjs.TextTrack.prototype.kind = function(){
+TextTrack.prototype.kind = function(){
   return this.kind_;
 };
 
@@ -178,13 +186,13 @@ vjs.TextTrack.prototype.kind = function(){
  * Track src value
  * @private
  */
-vjs.TextTrack.prototype.src_;
+TextTrack.prototype.src_;
 
 /**
  * Get the track src value
  * @return {String}
  */
-vjs.TextTrack.prototype.src = function(){
+TextTrack.prototype.src = function(){
   return this.src_;
 };
 
@@ -193,13 +201,13 @@ vjs.TextTrack.prototype.src = function(){
  * If default is used, subtitles/captions to start showing
  * @private
  */
-vjs.TextTrack.prototype.dflt_;
+TextTrack.prototype.dflt_;
 
 /**
  * Get the track default value. ('default' is a reserved keyword)
  * @return {Boolean}
  */
-vjs.TextTrack.prototype.dflt = function(){
+TextTrack.prototype.dflt = function(){
   return this.dflt_;
 };
 
@@ -207,13 +215,13 @@ vjs.TextTrack.prototype.dflt = function(){
  * Track title value
  * @private
  */
-vjs.TextTrack.prototype.title_;
+TextTrack.prototype.title_;
 
 /**
  * Get the track title value
  * @return {String}
  */
-vjs.TextTrack.prototype.title = function(){
+TextTrack.prototype.title = function(){
   return this.title_;
 };
 
@@ -222,13 +230,13 @@ vjs.TextTrack.prototype.title = function(){
  * Spec def: readonly attribute DOMString language;
  * @private
  */
-vjs.TextTrack.prototype.language_;
+TextTrack.prototype.language_;
 
 /**
  * Get the track language value
  * @return {String}
  */
-vjs.TextTrack.prototype.language = function(){
+TextTrack.prototype.language = function(){
   return this.language_;
 };
 
@@ -237,13 +245,13 @@ vjs.TextTrack.prototype.language = function(){
  * Spec def: readonly attribute DOMString label;
  * @private
  */
-vjs.TextTrack.prototype.label_;
+TextTrack.prototype.label_;
 
 /**
  * Get the track label value
  * @return {String}
  */
-vjs.TextTrack.prototype.label = function(){
+TextTrack.prototype.label = function(){
   return this.label_;
 };
 
@@ -252,13 +260,13 @@ vjs.TextTrack.prototype.label = function(){
  * Spec def: readonly attribute TextTrackCueList cues;
  * @private
  */
-vjs.TextTrack.prototype.cues_;
+TextTrack.prototype.cues_;
 
 /**
  * Get the track cues
  * @return {Array}
  */
-vjs.TextTrack.prototype.cues = function(){
+TextTrack.prototype.cues = function(){
   return this.cues_;
 };
 
@@ -267,13 +275,13 @@ vjs.TextTrack.prototype.cues = function(){
  * Spec def: readonly attribute TextTrackCueList activeCues;
  * @private
  */
-vjs.TextTrack.prototype.activeCues_;
+TextTrack.prototype.activeCues_;
 
 /**
  * Get the track active cues
  * @return {Array}
  */
-vjs.TextTrack.prototype.activeCues = function(){
+TextTrack.prototype.activeCues = function(){
   return this.activeCues_;
 };
 
@@ -286,13 +294,13 @@ vjs.TextTrack.prototype.activeCues = function(){
  * readonly attribute unsigned short readyState;
  * @private
  */
-vjs.TextTrack.prototype.readyState_;
+TextTrack.prototype.readyState_;
 
 /**
  * Get the track readyState
  * @return {Number}
  */
-vjs.TextTrack.prototype.readyState = function(){
+TextTrack.prototype.readyState = function(){
   return this.readyState_;
 };
 
@@ -304,13 +312,13 @@ vjs.TextTrack.prototype.readyState = function(){
  * attribute unsigned short mode;
  * @private
  */
-vjs.TextTrack.prototype.mode_;
+TextTrack.prototype.mode_;
 
 /**
  * Get the track mode
  * @return {Number}
  */
-vjs.TextTrack.prototype.mode = function(){
+TextTrack.prototype.mode = function(){
   return this.mode_;
 };
 
@@ -318,7 +326,7 @@ vjs.TextTrack.prototype.mode = function(){
  * Change the font size of the text track to make it larger when playing in fullscreen mode
  * and restore it to its normal size when not in fullscreen mode.
  */
-vjs.TextTrack.prototype.adjustFontSize = function(){
+TextTrack.prototype.adjustFontSize = function(){
     if (this.player_.isFullScreen()) {
         // Scale the font by the same factor as increasing the video width to the full screen window width.
         // Additionally, multiply that factor by 1.4, which is the default font size for
@@ -334,7 +342,7 @@ vjs.TextTrack.prototype.adjustFontSize = function(){
  * Create basic div to hold cue text
  * @return {Element}
  */
-vjs.TextTrack.prototype.createEl = function(){
+TextTrack.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-' + this.kind_ + ' vjs-text-track'
   });
@@ -350,13 +358,13 @@ vjs.TextTrack.prototype.createEl = function(){
  * The showing by default state is used in conjunction with the default attribute on track elements to indicate that the text track was enabled due to that attribute.
  * This allows the user agent to override the state if a later track is discovered that is more appropriate per the user's preferences.
  */
-vjs.TextTrack.prototype.show = function(){
+TextTrack.prototype.show = function(){
   this.activate();
 
   this.mode_ = 2;
 
   // Show element.
-  vjs.Component.prototype.show.call(this);
+  Component.prototype.show.call(this);
 };
 
 /**
@@ -365,7 +373,7 @@ vjs.TextTrack.prototype.show = function(){
  * If no attempt has yet been made to obtain the track's cues, the user agent will perform such an attempt momentarily.
  * The user agent is maintaining a list of which cues are active, and events are being fired accordingly.
  */
-vjs.TextTrack.prototype.hide = function(){
+TextTrack.prototype.hide = function(){
   // When hidden, cues are still triggered. Disable to stop triggering.
   this.activate();
 
@@ -380,7 +388,7 @@ vjs.TextTrack.prototype.hide = function(){
  * Indicates that the text track is not active. Other than for the purposes of exposing the track in the DOM, the user agent is ignoring the text track.
  * No cues are active, no events are fired, and the user agent will not attempt to obtain the track's cues.
  */
-vjs.TextTrack.prototype.disable = function(){
+TextTrack.prototype.disable = function(){
   // If showing, hide.
   if (this.mode_ == 2) { this.hide(); }
 
@@ -394,7 +402,7 @@ vjs.TextTrack.prototype.disable = function(){
 /**
  * Turn on cue tracking. Tracks that are showing OR hidden are active.
  */
-vjs.TextTrack.prototype.activate = function(){
+TextTrack.prototype.activate = function(){
   // Load text file if it hasn't been yet.
   if (this.readyState_ === 0) { this.load(); }
 
@@ -417,7 +425,7 @@ vjs.TextTrack.prototype.activate = function(){
 /**
  * Turn off cue tracking.
  */
-vjs.TextTrack.prototype.deactivate = function(){
+TextTrack.prototype.deactivate = function(){
   // Using unique ID for bind function so other tracks don't remove listener
   this.player_.off('timeupdate', vjslib.bind(this, this.update, this.id_));
   this.player_.off('ended', vjslib.bind(this, this.reset, this.id_));
@@ -441,7 +449,7 @@ vjs.TextTrack.prototype.deactivate = function(){
 //
 // Failed to load
 // Indicates that the text track was enabled, but when the user agent attempted to obtain it, this failed in some way (e.g. URL could not be resolved, network error, unknown text track format). Some or all of the cues are likely missing and will not be obtained.
-vjs.TextTrack.prototype.load = function(){
+TextTrack.prototype.load = function(){
 
   // Only load if not loaded yet.
   if (this.readyState_ === 0) {
@@ -451,7 +459,7 @@ vjs.TextTrack.prototype.load = function(){
 
 };
 
-vjs.TextTrack.prototype.onError = function(err){
+TextTrack.prototype.onError = function(err){
   this.error = err;
   this.readyState_ = 3;
   this.trigger('error');
@@ -459,7 +467,7 @@ vjs.TextTrack.prototype.onError = function(err){
 
 // Parse the WebVTT text format for cue times.
 // TODO: Separate parser into own class so alternative timed text formats can be used. (TTML, DFXP)
-vjs.TextTrack.prototype.parseCues = function(srcContent) {
+TextTrack.prototype.parseCues = function(srcContent) {
   var cue, time, text,
       lines = srcContent.split('\n'),
       line = '', id;
@@ -513,7 +521,7 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
 };
 
 
-vjs.TextTrack.prototype.parseCueTime = function(timeText) {
+TextTrack.prototype.parseCueTime = function(timeText) {
   var parts = timeText.split(':'),
       time = 0,
       hours, minutes, other, seconds, ms;
@@ -554,7 +562,7 @@ vjs.TextTrack.prototype.parseCueTime = function(timeText) {
 };
 
 // Update active cues whenever timeupdate events are triggered on the player.
-vjs.TextTrack.prototype.update = function(){
+TextTrack.prototype.update = function(){
   if (this.cues_.length > 0) {
 
     // Get current player time, adjust for track offset
@@ -663,7 +671,7 @@ vjs.TextTrack.prototype.update = function(){
 };
 
 // Add cue HTML to display
-vjs.TextTrack.prototype.updateDisplay = function(){
+TextTrack.prototype.updateDisplay = function(){
   var cues = this.activeCues_,
       html = '',
       i=0,j=cues.length;
@@ -676,7 +684,7 @@ vjs.TextTrack.prototype.updateDisplay = function(){
 };
 
 // Set all loop helper values back
-vjs.TextTrack.prototype.reset = function(){
+TextTrack.prototype.reset = function(){
   this.nextChange = 0;
   this.prevChange = this.player_.duration();
   this.firstActiveIndex = 0;
@@ -689,8 +697,8 @@ vjs.TextTrack.prototype.reset = function(){
  *
  * @constructor
  */
-vjs.CaptionsTrack = vjs.TextTrack.extend();
-vjs.CaptionsTrack.prototype.kind_ = 'captions';
+CaptionsTrack = TextTrack.extend();
+CaptionsTrack.prototype.kind_ = 'captions';
 // Exporting here because Track creation requires the track kind
 // to be available on global object. e.g. new window['videojs'][Kind + 'Track']
 
@@ -699,16 +707,16 @@ vjs.CaptionsTrack.prototype.kind_ = 'captions';
  *
  * @constructor
  */
-vjs.SubtitlesTrack = vjs.TextTrack.extend();
-vjs.SubtitlesTrack.prototype.kind_ = 'subtitles';
+SubtitlesTrack = TextTrack.extend();
+SubtitlesTrack.prototype.kind_ = 'subtitles';
 
 /**
  * The track component for managing the hiding and showing of chapters
  *
  * @constructor
  */
-vjs.ChaptersTrack = vjs.TextTrack.extend();
-vjs.ChaptersTrack.prototype.kind_ = 'chapters';
+ChaptersTrack = TextTrack.extend();
+ChaptersTrack.prototype.kind_ = 'chapters';
 
 
 /* Text Track Display
@@ -720,7 +728,7 @@ vjs.ChaptersTrack.prototype.kind_ = 'chapters';
  *
  * @constructor
  */
-vjs.TextTrackDisplay = Component.extend({
+TextTrackDisplay = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     Component.call(this, player, options, ready);
@@ -735,7 +743,7 @@ vjs.TextTrackDisplay = Component.extend({
   }
 });
 
-vjs.TextTrackDisplay.prototype.createEl = function(){
+TextTrackDisplay.prototype.createEl = function(){
   return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-text-track-display'
   });
@@ -747,7 +755,7 @@ vjs.TextTrackDisplay.prototype.createEl = function(){
  *
  * @constructor
  */
-vjs.TextTrackMenuItem = vjsmenu.MenuItem.extend({
+TextTrackMenuItem = vjsmenu.MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     var track = this.track = options['track'];
@@ -761,12 +769,12 @@ vjs.TextTrackMenuItem = vjsmenu.MenuItem.extend({
   }
 });
 
-vjs.TextTrackMenuItem.prototype.onClick = function(){
+TextTrackMenuItem.prototype.onClick = function(){
   vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player_.showTextTrack(this.track.id_, this.track.kind());
 };
 
-vjs.TextTrackMenuItem.prototype.update = function(){
+TextTrackMenuItem.prototype.update = function(){
   this.selected(this.track.mode() == 2);
 };
 
@@ -775,7 +783,7 @@ vjs.TextTrackMenuItem.prototype.update = function(){
  *
  * @constructor
  */
-vjs.OffTextTrackMenuItem = vjs.TextTrackMenuItem.extend({
+OffTextTrackMenuItem = TextTrackMenuItem.extend({
   /** @constructor */
   init: function(player, options){
     // Create pseudo track info
@@ -787,17 +795,17 @@ vjs.OffTextTrackMenuItem = vjs.TextTrackMenuItem.extend({
       dflt: function(){ return false; },
       mode: function(){ return false; }
     };
-    vjs.TextTrackMenuItem.call(this, player, options);
+    TextTrackMenuItem.call(this, player, options);
     this.selected(true);
   }
 });
 
-vjs.OffTextTrackMenuItem.prototype.onClick = function(){
-  vjs.TextTrackMenuItem.prototype.onClick.call(this);
+OffTextTrackMenuItem.prototype.onClick = function(){
+  TextTrackMenuItem.prototype.onClick.call(this);
   this.player_.showTextTrack(this.track.id_, this.track.kind());
 };
 
-vjs.OffTextTrackMenuItem.prototype.update = function(){
+OffTextTrackMenuItem.prototype.update = function(){
   var tracks = this.player_.textTracks(),
       i=0, j=tracks.length, track,
       off = true;
@@ -817,7 +825,7 @@ vjs.OffTextTrackMenuItem.prototype.update = function(){
  *
  * @constructor
  */
-vjs.TextTrackButton = vjsmenu.MenuButton.extend({
+TextTrackButton = vjsmenu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
     vjsmenu.MenuButton.call(this, player, options);
@@ -854,16 +862,16 @@ vjs.TextTrackButton = vjsmenu.MenuButton.extend({
 // };
 
 // Create a menu item for each text track
-vjs.TextTrackButton.prototype.createItems = function(){
+TextTrackButton.prototype.createItems = function(){
   var items = [], track;
 
   // Add an OFF menu item to turn all tracks off
-  items.push(new vjs.OffTextTrackMenuItem(this.player_, { 'kind': this.kind_ }));
+  items.push(new OffTextTrackMenuItem(this.player_, { 'kind': this.kind_ }));
 
   for (var i = 0; i < this.player_.textTracks().length; i++) {
     track = this.player_.textTracks()[i];
     if (track.kind() === this.kind_) {
-      items.push(new vjs.TextTrackMenuItem(this.player_, {
+      items.push(new TextTrackMenuItem(this.player_, {
         'track': track
       }));
     }
@@ -877,32 +885,32 @@ vjs.TextTrackButton.prototype.createItems = function(){
  *
  * @constructor
  */
-vjs.CaptionsButton = vjs.TextTrackButton.extend({
+CaptionsButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.TextTrackButton.call(this, player, options, ready);
+    TextTrackButton.call(this, player, options, ready);
     this.el_.setAttribute('aria-label','Captions Menu');
   }
 });
-vjs.CaptionsButton.prototype.kind_ = 'captions';
-vjs.CaptionsButton.prototype.buttonText = 'Captions';
-vjs.CaptionsButton.prototype.className = 'vjs-captions-button';
+CaptionsButton.prototype.kind_ = 'captions';
+CaptionsButton.prototype.buttonText = 'Captions';
+CaptionsButton.prototype.className = 'vjs-captions-button';
 
 /**
  * The button component for toggling and selecting subtitles
  *
  * @constructor
  */
-vjs.SubtitlesButton = vjs.TextTrackButton.extend({
+SubtitlesButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.TextTrackButton.call(this, player, options, ready);
+    TextTrackButton.call(this, player, options, ready);
     this.el_.setAttribute('aria-label','Subtitles Menu');
   }
 });
-vjs.SubtitlesButton.prototype.kind_ = 'subtitles';
-vjs.SubtitlesButton.prototype.buttonText = 'Subtitles';
-vjs.SubtitlesButton.prototype.className = 'vjs-subtitles-button';
+SubtitlesButton.prototype.kind_ = 'subtitles';
+SubtitlesButton.prototype.buttonText = 'Subtitles';
+SubtitlesButton.prototype.className = 'vjs-subtitles-button';
 
 // Chapters act much differently than other text tracks
 // Cues are navigation vs. other tracks of alternative languages
@@ -911,25 +919,25 @@ vjs.SubtitlesButton.prototype.className = 'vjs-subtitles-button';
  *
  * @constructor
  */
-vjs.ChaptersButton = vjs.TextTrackButton.extend({
+ChaptersButton = TextTrackButton.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.TextTrackButton.call(this, player, options, ready);
+    TextTrackButton.call(this, player, options, ready);
     this.el_.setAttribute('aria-label','Chapters Menu');
   }
 });
-vjs.ChaptersButton.prototype.kind_ = 'chapters';
-vjs.ChaptersButton.prototype.buttonText = 'Chapters';
-vjs.ChaptersButton.prototype.className = 'vjs-chapters-button';
+ChaptersButton.prototype.kind_ = 'chapters';
+ChaptersButton.prototype.buttonText = 'Chapters';
+ChaptersButton.prototype.className = 'vjs-chapters-button';
 
 // Create a menu item for each text track
-vjs.ChaptersButton.prototype.createItems = function(){
+ChaptersButton.prototype.createItems = function(){
   var items = [], track;
 
   for (var i = 0; i < this.player_.textTracks().length; i++) {
     track = this.player_.textTracks()[i];
     if (track.kind() === this.kind_) {
-      items.push(new vjs.TextTrackMenuItem(this.player_, {
+      items.push(new TextTrackMenuItem(this.player_, {
         'track': track
       }));
     }
@@ -938,7 +946,7 @@ vjs.ChaptersButton.prototype.createItems = function(){
   return items;
 };
 
-vjs.ChaptersButton.prototype.createMenu = function(){
+ChaptersButton.prototype.createMenu = function(){
   var tracks = this.player_.textTracks(),
       i = 0,
       j = tracks.length,
@@ -976,7 +984,7 @@ vjs.ChaptersButton.prototype.createMenu = function(){
     for (;i<j;i++) {
       cue = cues[i];
 
-      mi = new vjs.ChaptersTrackMenuItem(this.player_, {
+      mi = new ChaptersTrackMenuItem(this.player_, {
         'track': chaptersTrack,
         'cue': cue
       });
@@ -999,7 +1007,7 @@ vjs.ChaptersButton.prototype.createMenu = function(){
 /**
  * @constructor
  */
-vjs.ChaptersTrackMenuItem = vjsmenu.MenuItem.extend({
+ChaptersTrackMenuItem = vjsmenu.MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     var track = this.track = options['track'],
@@ -1015,13 +1023,13 @@ vjs.ChaptersTrackMenuItem = vjsmenu.MenuItem.extend({
   }
 });
 
-vjs.ChaptersTrackMenuItem.prototype.onClick = function(){
+ChaptersTrackMenuItem.prototype.onClick = function(){
   vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player_.currentTime(this.cue.startTime);
   this.update(this.cue.startTime);
 };
 
-vjs.ChaptersTrackMenuItem.prototype.update = function(){
+ChaptersTrackMenuItem.prototype.update = function(){
   var cue = this.cue,
       currentTime = this.player_.currentTime();
 
@@ -1043,4 +1051,20 @@ vjslib.obj.merge(require('./control-bar/control-bar.js').prototype.options_['chi
 //   }
 // });
 
-module.exports = vjs;
+module.exports = {
+  TextTrack: TextTrack,
+  CaptionsTrack: CaptionsTrack,
+  SubtitlesTrack: SubtitlesTrack,
+  ChaptersTrack: ChaptersTrack,
+
+  TextTrackDisplay: TextTrackDisplay,
+  TextTrackMenuItem: TextTrackMenuItem,
+  OffTextTrackMenuItem: OffTextTrackMenuItem,
+  TextTrackButton: TextTrackButton,
+
+  CaptionsButton: CaptionsButton,
+  SubtitlesButton: SubtitlesButton,
+  ChaptersButton: ChaptersButton,
+
+  ChaptersTrackMenuItem: ChaptersTrackMenuItem
+};

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -1,3 +1,9 @@
+var vjs = {};
+var vjslib = require('./lib.js');
+var Component = require('./component.js');
+var vjsmenu = require('./menu.js');
+vjs.Player = require('./player.js');
+
 /**
  * @fileoverview Text Tracks
  * Text tracks are tracks of timed text events.
@@ -47,10 +53,10 @@ vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
 
   // HTML5 Spec says default to subtitles.
   // Uppercase first letter to match class names
-  var Kind = vjs.capitalize(kind || 'subtitles');
+  var Kind = vjslib.capitalize(kind || 'subtitles');
 
   // Create correct texttrack class. CaptionsTrack, etc.
-  var track = new window['videojs'][Kind + 'Track'](this, options);
+  var track = new vjs[Kind + 'Track'](this, options);
 
   tracks.push(track);
 
@@ -129,16 +135,16 @@ vjs.Player.prototype.showTextTrack = function(id, disableSameKind){
  * @param {Object=} options
  * @constructor
  */
-vjs.TextTrack = vjs.Component.extend({
+vjs.TextTrack = Component.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.Component.call(this, player, options);
+    Component.call(this, player, options);
 
     // Apply track info to track object
     // Options will often be a track element
 
     // Build ID if one doesn't exist
-    this.id_ = options['id'] || ('vjs_' + options['kind'] + '_' + options['language'] + '_' + vjs.guid++);
+    this.id_ = options['id'] || ('vjs_' + options['kind'] + '_' + options['language'] + '_' + vjslib.guid++);
     this.src_ = options['src'];
     // 'default' is a reserved keyword in js so we use an abbreviated version
     this.dflt_ = options['default'] || options['dflt'];
@@ -150,7 +156,7 @@ vjs.TextTrack = vjs.Component.extend({
     this.readyState_ = 0;
     this.mode_ = 0;
 
-    this.player_.on('fullscreenchange', vjs.bind(this, this.adjustFontSize));
+    this.player_.on('fullscreenchange', vjslib.bind(this, this.adjustFontSize));
   }
 });
 
@@ -329,7 +335,7 @@ vjs.TextTrack.prototype.adjustFontSize = function(){
  * @return {Element}
  */
 vjs.TextTrack.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-' + this.kind_ + ' vjs-text-track'
   });
 };
@@ -366,7 +372,7 @@ vjs.TextTrack.prototype.hide = function(){
   this.mode_ = 1;
 
   // Hide element.
-  vjs.Component.prototype.hide.call(this);
+  Component.prototype.hide.call(this);
 };
 
 /**
@@ -396,10 +402,10 @@ vjs.TextTrack.prototype.activate = function(){
   if (this.mode_ === 0) {
     // Update current cue on timeupdate
     // Using unique ID for bind function so other tracks don't remove listener
-    this.player_.on('timeupdate', vjs.bind(this, this.update, this.id_));
+    this.player_.on('timeupdate', vjslib.bind(this, this.update, this.id_));
 
     // Reset cue time on media end
-    this.player_.on('ended', vjs.bind(this, this.reset, this.id_));
+    this.player_.on('ended', vjslib.bind(this, this.reset, this.id_));
 
     // Add to display
     if (this.kind_ === 'captions' || this.kind_ === 'subtitles') {
@@ -413,8 +419,8 @@ vjs.TextTrack.prototype.activate = function(){
  */
 vjs.TextTrack.prototype.deactivate = function(){
   // Using unique ID for bind function so other tracks don't remove listener
-  this.player_.off('timeupdate', vjs.bind(this, this.update, this.id_));
-  this.player_.off('ended', vjs.bind(this, this.reset, this.id_));
+  this.player_.off('timeupdate', vjslib.bind(this, this.update, this.id_));
+  this.player_.off('ended', vjslib.bind(this, this.reset, this.id_));
   this.reset(); // Reset
 
   // Remove from display
@@ -440,7 +446,7 @@ vjs.TextTrack.prototype.load = function(){
   // Only load if not loaded yet.
   if (this.readyState_ === 0) {
     this.readyState_ = 1;
-    vjs.get(this.src_, vjs.bind(this, this.parseCues), vjs.bind(this, this.onError));
+    vjslib.get(this.src_, vjslib.bind(this, this.parseCues), vjslib.bind(this, this.onError));
   }
 
 };
@@ -461,7 +467,7 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
   for (var i=1, j=lines.length; i<j; i++) {
     // Line 0 should be 'WEBVTT', so skipping i=0
 
-    line = vjs.trim(lines[i]); // Trim whitespace and linebreaks
+    line = vjslib.trim(lines[i]); // Trim whitespace and linebreaks
 
     if (line) { // Loop until a line with content
 
@@ -470,7 +476,7 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
       if (line.indexOf('-->') == -1) {
         id = line;
         // Advance to next line for timing.
-        line = vjs.trim(lines[++i]);
+        line = vjslib.trim(lines[++i]);
       } else {
         id = this.cues_.length;
       }
@@ -491,7 +497,7 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
 
       // Loop until a blank line or end of lines
       // Assumeing trim('') returns false for blank lines
-      while (lines[++i] && (line = vjs.trim(lines[i]))) {
+      while (lines[++i] && (line = vjslib.trim(lines[i]))) {
         text.push(line);
       }
 
@@ -714,10 +720,10 @@ vjs.ChaptersTrack.prototype.kind_ = 'chapters';
  *
  * @constructor
  */
-vjs.TextTrackDisplay = vjs.Component.extend({
+vjs.TextTrackDisplay = Component.extend({
   /** @constructor */
   init: function(player, options, ready){
-    vjs.Component.call(this, player, options, ready);
+    Component.call(this, player, options, ready);
 
     // This used to be called during player init, but was causing an error
     // if a track should show by default and the display hadn't loaded yet.
@@ -730,7 +736,7 @@ vjs.TextTrackDisplay = vjs.Component.extend({
 });
 
 vjs.TextTrackDisplay.prototype.createEl = function(){
-  return vjs.Component.prototype.createEl.call(this, 'div', {
+  return Component.prototype.createEl.call(this, 'div', {
     className: 'vjs-text-track-display'
   });
 };
@@ -741,7 +747,7 @@ vjs.TextTrackDisplay.prototype.createEl = function(){
  *
  * @constructor
  */
-vjs.TextTrackMenuItem = vjs.MenuItem.extend({
+vjs.TextTrackMenuItem = vjsmenu.MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     var track = this.track = options['track'];
@@ -749,14 +755,14 @@ vjs.TextTrackMenuItem = vjs.MenuItem.extend({
     // Modify options for parent MenuItem class's init.
     options['label'] = track.label();
     options['selected'] = track.dflt();
-    vjs.MenuItem.call(this, player, options);
+    vjsmenu.MenuItem.call(this, player, options);
 
-    this.player_.on(track.kind() + 'trackchange', vjs.bind(this, this.update));
+    this.player_.on(track.kind() + 'trackchange', vjslib.bind(this, this.update));
   }
 });
 
 vjs.TextTrackMenuItem.prototype.onClick = function(){
-  vjs.MenuItem.prototype.onClick.call(this);
+  vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player_.showTextTrack(this.track.id_, this.track.kind());
 };
 
@@ -811,10 +817,10 @@ vjs.OffTextTrackMenuItem.prototype.update = function(){
  *
  * @constructor
  */
-vjs.TextTrackButton = vjs.MenuButton.extend({
+vjs.TextTrackButton = vjsmenu.MenuButton.extend({
   /** @constructor */
   init: function(player, options){
-    vjs.MenuButton.call(this, player, options);
+    vjsmenu.MenuButton.call(this, player, options);
 
     if (this.items.length <= 1) {
       this.hide();
@@ -944,7 +950,7 @@ vjs.ChaptersButton.prototype.createMenu = function(){
     if (track.kind() == this.kind_) {
       if (track.readyState() === 0) {
         track.load();
-        track.on('loaded', vjs.bind(this, this.createMenu));
+        track.on('loaded', vjslib.bind(this, this.createMenu));
       } else {
         chaptersTrack = track;
         break;
@@ -954,10 +960,10 @@ vjs.ChaptersButton.prototype.createMenu = function(){
 
   var menu = this.menu;
   if (menu === undefined) {
-    menu = new vjs.Menu(this.player_);
-    menu.contentEl().appendChild(vjs.createEl('li', {
+    menu = new vjsmenu.Menu(this.player_);
+    menu.contentEl().appendChild(vjslib.createEl('li', {
       className: 'vjs-menu-title',
-      innerHTML: vjs.capitalize(this.kind_),
+      innerHTML: vjslib.capitalize(this.kind_),
       tabindex: -1
     }));
   }
@@ -993,7 +999,7 @@ vjs.ChaptersButton.prototype.createMenu = function(){
 /**
  * @constructor
  */
-vjs.ChaptersTrackMenuItem = vjs.MenuItem.extend({
+vjs.ChaptersTrackMenuItem = vjsmenu.MenuItem.extend({
   /** @constructor */
   init: function(player, options){
     var track = this.track = options['track'],
@@ -1003,14 +1009,14 @@ vjs.ChaptersTrackMenuItem = vjs.MenuItem.extend({
     // Modify options for parent MenuItem class's init.
     options['label'] = cue.text;
     options['selected'] = (cue.startTime <= currentTime && currentTime < cue.endTime);
-    vjs.MenuItem.call(this, player, options);
+    vjsmenu.MenuItem.call(this, player, options);
 
-    track.on('cuechange', vjs.bind(this, this.update));
+    track.on('cuechange', vjslib.bind(this, this.update));
   }
 });
 
 vjs.ChaptersTrackMenuItem.prototype.onClick = function(){
-  vjs.MenuItem.prototype.onClick.call(this);
+  vjsmenu.MenuItem.prototype.onClick.call(this);
   this.player_.currentTime(this.cue.startTime);
   this.update(this.cue.startTime);
 };
@@ -1024,7 +1030,7 @@ vjs.ChaptersTrackMenuItem.prototype.update = function(){
 };
 
 // Add Buttons to controlBar
-vjs.obj.merge(vjs.ControlBar.prototype.options_['children'], {
+vjslib.obj.merge(require('./control-bar/control-bar.js').prototype.options_['children'], {
   'subtitlesButton': {},
   'captionsButton': {},
   'chaptersButton': {}
@@ -1036,3 +1042,5 @@ vjs.obj.merge(vjs.ControlBar.prototype.options_['children'], {
 //     vjs.Component.call(this, player, options);
 //   }
 // });
+
+module.exports = vjs;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,3 +1,6 @@
+var vjs = {};
+var vjslib = require('./lib.js');
+
 /**
  * Utility functions namespace
  * @namespace
@@ -19,7 +22,7 @@ vjs.util.mergeOptions = function(obj1, obj2){
 
   // make a copy of obj1 so we're not ovewriting original values.
   // like prototype.options_ and all sub options objects
-  obj1 = vjs.obj.copy(obj1);
+  obj1 = vjslib.obj.copy(obj1);
 
   for (key in obj2){
     if (obj2.hasOwnProperty(key)) {
@@ -27,7 +30,7 @@ vjs.util.mergeOptions = function(obj1, obj2){
       val2 = obj2[key];
 
       // Check if both properties are pure objects and do a deep merge if so
-      if (vjs.obj.isPlain(val1) && vjs.obj.isPlain(val2)) {
+      if (vjslib.obj.isPlain(val1) && vjslib.obj.isPlain(val2)) {
         obj1[key] = vjs.util.mergeOptions(val1, val2);
       } else {
         obj1[key] = obj2[key];
@@ -37,4 +40,4 @@ vjs.util.mergeOptions = function(obj1, obj2){
   return obj1;
 };
 
-
+module.exports = vjs.util;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,4 +1,3 @@
-var vjs = {};
 var vjslib = require('./lib.js');
 
 /**
@@ -6,7 +5,6 @@ var vjslib = require('./lib.js');
  * @namespace
  * @type {Object}
  */
-vjs.util = {};
 
 /**
  * Merge two options objects, 
@@ -17,7 +15,7 @@ vjs.util = {};
  * @param  {Object} obj2 Overriding object
  * @return {Object}      New object -- obj1 and obj2 will be untouched
  */
-vjs.util.mergeOptions = function(obj1, obj2){
+module.exports.mergeOptions = function(obj1, obj2){
   var key, val1, val2;
 
   // make a copy of obj1 so we're not ovewriting original values.
@@ -39,5 +37,3 @@ vjs.util.mergeOptions = function(obj1, obj2){
   }
   return obj1;
 };
-
-module.exports = vjs.util;

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -12,3 +12,6 @@ if (typeof HTMLVideoElement === 'undefined') {
 setup.autoSetupTimeout(1);
 
 module.exports = videojs;
+module.exports.components = function() {
+  return require('./components.js');
+}

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -1,5 +1,7 @@
-var videojs = require('./core.js');
-var setup = require('./setup.js');
+var videojs, setup;
+
+videojs = require('./core.js');
+setup = require('./setup.js');
 
 if (typeof HTMLVideoElement === 'undefined') {
   videojs.elementShiv();

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -1,0 +1,12 @@
+var videojs = require('./core.js');
+var setup = require('./setup.js');
+
+if (typeof HTMLVideoElement === 'undefined') {
+  videojs.elementShiv();
+}
+
+// Run Auto-load players
+// You have to wait at least once in case this script is loaded after your video in the DOM (weird behavior only with minified version)
+setup.autoSetupTimeout(1);
+
+module.exports = videojs;


### PR DESCRIPTION
DO NOT MERGE.

This is the work-in-progress for browserifying videojs. The `bundle.js` file is built using
```sh
browserify -d --standalone 'videojs' . -o bundle.js
```
from within the videojs directory. Can also just run `npm run build`.

This will create a `bundle.js` file which is a standalone (UMD) build of videojs. You can then load the bundle file directly in the browser together with the generated CSS and you have a working videojs player.
You can also consume videojs directly from another app/module that uses browserify by just `require('video.js')` and then when you run browserify it'll figure things out.

Unfortunately, this isn't backwards compatible right now. The various components aren't really exposed directly right now and if you add more components it won't find them on the videojs object since it excepts them on the `./components.js` module. Though, more modules could be added by requiring the components.js module (`require('video.js/components`)` and then adding the extra component to it.
Probably a better way is to create a function for registering components and techs.

I'm going to see whether I can make it backwards compatible. Also, this needs to be cleaned up because we don't need all the `var vjs = {}; /* ... */ module.exports = vjs` everywhere. That var is superfluous.