### PR TITLE
Issue #1309: fix adding/removing event handlers in IE8

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -57,9 +57,9 @@ vjs.on = function(elem, type, fn){
   }
 
   if (data.handlers[type].length == 1) {
-    if (document.addEventListener) {
+    if (elem.addEventListener) {
       elem.addEventListener(type, data.dispatcher, false);
-    } else if (document.attachEvent) {
+    } else if (elem.attachEvent) {
       elem.attachEvent('on' + type, data.dispatcher);
     }
   }
@@ -136,9 +136,9 @@ vjs.cleanUpEvents = function(elem, type) {
     // Setting to null was causing an error with data.handlers
 
     // Remove the meta-handler from the element
-    if (document.removeEventListener) {
+    if (elem.removeEventListener) {
       elem.removeEventListener(type, data.dispatcher, false);
-    } else if (document.detachEvent) {
+    } else if (elem.detachEvent) {
       elem.detachEvent('on' + type, data.dispatcher);
     }
   }


### PR DESCRIPTION
Small fix for IE8 compatibility regarding event handlers.

P.S. I tried using the contrib flow, but it doesn't appear to finish the flow properly (after providing username, password, title and description, it just returns undefined. It might be because I have some 'funny' characters in my password, but I'm not sure).
