### PR TITLE
Remove default class on subtitle off

### DIFF
--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -63,7 +63,7 @@ vjs.Player.prototype.addTextTrack = function(kind, label, language, options){
   if (track.dflt()) {
     this.ready(function(){
       setTimeout(function(){
-        track.player_.showTextTrack(track.id_);
+        track.player().showTextTrack(track.id());
       }, 0);
     });
   }


### PR DESCRIPTION
A fix for https://github.com/videojs/video.js/issues/1370
