### PR TITLE
Added a class for when slider is "sliding"

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -48,6 +48,7 @@ vjs.Slider.prototype.createEl = function(type, props) {
 vjs.Slider.prototype.onMouseDown = function(event){
   event.preventDefault();
   vjs.blockTextSelection();
+  this.addClass('vjs-sliding');
 
   this.boundEvents.move = vjs.bind(this, this.onMouseMove);
   this.boundEvents.end = vjs.bind(this, this.onMouseUp);
@@ -62,6 +63,8 @@ vjs.Slider.prototype.onMouseDown = function(event){
 
 vjs.Slider.prototype.onMouseUp = function() {
   vjs.unblockTextSelection();
+  this.removeClass('vjs-sliding');
+
   vjs.off(document, 'mousemove', this.boundEvents.move, false);
   vjs.off(document, 'mouseup', this.boundEvents.end, false);
   vjs.off(document, 'touchmove', this.boundEvents.move, false);


### PR DESCRIPTION
If you've used YouTube their volume control "expands/collapses" on hover and to guarantee the collapse doesn't occur until the user let's go a sliding class is required.
