### PR TITLE
Inherit tech 'features' from 'MediaTechController'

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -13,11 +13,11 @@ vjs.MuteToggle = vjs.Button.extend({
     player.on('volumechange', vjs.bind(this, this.update));
 
     // hide mute toggle if the current tech doesn't support volume control
-    if (player.tech && player.tech['volumeControl'] === false) {
+    if (player.tech && player.tech['volumeControlFeature'] === false) {
       this.addClass('vjs-hidden');
     }
     player.on('loadstart', vjs.bind(this, function(){
-      if (player.tech['volumeControl'] === false) {
+      if (player.tech['volumeControlFeature'] === false) {
         this.addClass('vjs-hidden');
       } else {
         this.removeClass('vjs-hidden');

--- a/src/js/control-bar/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu-button.js
@@ -72,7 +72,7 @@ vjs.PlaybackRateMenuButton.prototype.onClick = function(){
 
 vjs.PlaybackRateMenuButton.prototype.playbackRateSupported = function(){
   return this.player().tech
-    && this.player().tech['playbackRate']
+    && this.player().tech['playbackRateFeature']
     && this.player().options()['playbackRates']
     && this.player().options()['playbackRates'].length > 0
   ;

--- a/src/js/control-bar/volume-control.js
+++ b/src/js/control-bar/volume-control.js
@@ -11,11 +11,11 @@ vjs.VolumeControl = vjs.Component.extend({
     vjs.Component.call(this, player, options);
 
     // hide volume controls when they're not supported by the current tech
-    if (player.tech && player.tech['volumeControl'] === false) {
+    if (player.tech && player.tech['volumeControlFeature'] === false) {
       this.addClass('vjs-hidden');
     }
     player.on('loadstart', vjs.bind(this, function(){
-      if (player.tech['volumeControl'] === false) {
+      if (player.tech['volumeControlFeature'] === false) {
         this.addClass('vjs-hidden');
       } else {
         this.removeClass('vjs-hidden');

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -11,11 +11,11 @@ vjs.VolumeMenuButton = vjs.MenuButton.extend({
     player.on('volumechange', vjs.bind(this, this.update));
 
     // hide mute toggle if the current tech doesn't support volume control
-    if (player.tech && player.tech.volumeControl === false) {
+    if (player.tech && player.tech['volumeControlFeature'] === false) {
       this.addClass('vjs-hidden');
     }
     player.on('loadstart', vjs.bind(this, function(){
-      if (player.tech.volumeControl === false) {
+      if (player.tech['volumeControlFeature'] === false) {
         this.addClass('vjs-hidden');
       } else {
         this.removeClass('vjs-hidden');

--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -121,10 +121,11 @@ goog.exportSymbol('videojs.CaptionsButton', vjs.CaptionsButton);
 goog.exportSymbol('videojs.ChaptersButton', vjs.ChaptersButton);
 
 goog.exportSymbol('videojs.MediaTechController', vjs.MediaTechController);
-goog.exportProperty(vjs.MediaTechController.prototype, 'volumeControl', vjs.MediaTechController.prototype.volumeControl);
-goog.exportProperty(vjs.MediaTechController.prototype, 'fullscreenResize', vjs.MediaTechController.prototype.fullscreenResize);
-goog.exportProperty(vjs.MediaTechController.prototype, 'progressEvents', vjs.MediaTechController.prototype.progressEvents);
-goog.exportProperty(vjs.MediaTechController.prototype, 'timeupdateEvents', vjs.MediaTechController.prototype.timeupdateEvents);
+goog.exportProperty(vjs.MediaTechController.prototype, 'volumeControlFeature', vjs.MediaTechController.prototype.volumeControlFeature);
+goog.exportProperty(vjs.MediaTechController.prototype, 'fullscreenResizeFeature', vjs.MediaTechController.prototype.fullscreenResizeFeature);
+goog.exportProperty(vjs.MediaTechController.prototype, 'playbackRateFeature', vjs.MediaTechController.prototype.playbackRateFeature);
+goog.exportProperty(vjs.MediaTechController.prototype, 'progressEventsFeature', vjs.MediaTechController.prototype.progressEventsFeature);
+goog.exportProperty(vjs.MediaTechController.prototype, 'timeupdateEventsFeature', vjs.MediaTechController.prototype.timeupdateEventsFeature);
 goog.exportProperty(vjs.MediaTechController.prototype, 'setPoster', vjs.MediaTechController.prototype.setPoster);
 
 

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -13,16 +13,16 @@ vjs.Html5 = vjs.MediaTechController.extend({
   /** @constructor */
   init: function(player, options, ready){
     // volume cannot be changed from 1 on iOS
-    this['volumeControl'] = vjs.Html5.canControlVolume();
+    this['volumeControlFeature'] = vjs.Html5.canControlVolume();
 
     // just in case; or is it excessively...
-    this['playbackRate'] = vjs.Html5.canControlPlaybackRate();
+    this['playbackRateFeature'] = vjs.Html5.canControlPlaybackRate();
 
     // In iOS, if you move a video element in the DOM, it breaks video playback.
     this['movingMediaElementInDOM'] = !vjs.IS_IOS;
 
     // HTML video is able to automatically resize when going to fullscreen
-    this['fullscreenResize'] = true;
+    this['fullscreenResizeFeature'] = true;
 
     vjs.MediaTechController.call(this, player, options, ready);
     this.setupTriggers();

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -13,7 +13,6 @@ vjs.MediaTechController = vjs.Component.extend({
   /** @constructor */
   init: function(player, options, ready){
     options = options || {};
-
     // we don't want the tech to report user activity automatically.
     // This is done manually in addControlsListeners
     options.reportTouchActivity = false;
@@ -162,15 +161,15 @@ vjs.MediaTechController.prototype.onTap = function(){
  */
 vjs.MediaTechController.prototype.setPoster = function(){};
 
-vjs.MediaTechController.prototype[ 'volumeControl' ] = true;
+vjs.MediaTechController.prototype['volumeControlFeature'] = true;
 
 // Resizing plugins using request fullscreen reloads the plugin
-vjs.MediaTechController.prototype[ 'fullscreenResize' ] = false;
-vjs.MediaTechController.prototype[ 'playbackRate' ] = false;
+vjs.MediaTechController.prototype['fullscreenResizeFeature'] = false;
+vjs.MediaTechController.prototype['playbackRateFeature'] = false;
 
 // Optional events that we can manually mimic with timers
 // currently not triggered by video-js-swf
-vjs.MediaTechController.prototype[ 'progressEvents' ] = false;
-vjs.MediaTechController.prototype[ 'timeupdateEvents' ] = false;
+vjs.MediaTechController.prototype['progressEventsFeature'] = false;
+vjs.MediaTechController.prototype['timeupdateEventsFeature'] = false;
 
 vjs.media = {};

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -313,12 +313,12 @@ vjs.Player.prototype.loadTech = function(techName, source){
     this.player_.triggerReady();
 
     // Manually track progress in cases where the browser/flash player doesn't report it.
-    if (!this['progressEvents']) {
+    if (!this['progressEventsFeature']) {
       this.player_.manualProgressOn();
     }
 
     // Manually track timeudpates in cases where the browser/flash player doesn't report it.
-    if (!this['timeupdateEvents']) {
+    if (!this['timeupdateEventsFeature']) {
       this.player_.manualTimeUpdatesOn();
     }
   };
@@ -386,7 +386,7 @@ vjs.Player.prototype.manualProgressOn = function(){
     this.tech.one('progress', function(){
 
       // Update known progress support for this playback technology
-      this['progressEvents'] = true;
+      this['progressEventsFeature'] = true;
 
       // Turn off manual progress tracking
       this.player_.manualProgressOff();
@@ -431,7 +431,7 @@ vjs.Player.prototype.manualTimeUpdatesOn = function(){
   if (this.tech) {
     this.tech.one('timeupdate', function(){
       // Update known progress support for this playback technology
-      this['timeupdateEvents'] = true;
+      this['timeupdateEventsFeature'] = true;
       // Turn off manual progress tracking
       this.player_.manualTimeUpdatesOff();
     });
@@ -1641,7 +1641,7 @@ vjs.Player.prototype.playbackRate = function(rate) {
     return this;
   }
 
-  if (this.tech && this.tech['playbackRate']) {
+  if (this.tech && this.tech['playbackRateFeature']) {
     return this.techGet('playbackRate');
   } else {
     return 1.0;

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -12,9 +12,7 @@ test('should hide volume control if it\'s not supported', function(){
     language: noop,
     languages: noop,
     tech: {
-      features: {
-        'volumeControl': false
-      }
+      'volumeControlFeature': false
     },
     volume: function(){},
     muted: function(){},
@@ -47,9 +45,7 @@ test('should test and toggle volume control on `loadstart`', function(){
       return false;
     },
     tech: {
-      features: {
-        'volumeControl': true
-      }
+      'volumeControlFeature': true
     },
     reportUserActivity: function(){}
   };
@@ -62,7 +58,7 @@ test('should test and toggle volume control on `loadstart`', function(){
   ok(muteToggle.el().className.indexOf('vjs-hidden') < 0,
      'muteToggle is hidden initially');
 
-  player.tech.features['volumeControl'] = false;
+  player.tech['volumeControlFeature'] = false;
   for (i = 0; i < listeners.length; i++) {
     listeners[i]();
   }
@@ -72,7 +68,7 @@ test('should test and toggle volume control on `loadstart`', function(){
   ok(muteToggle.el().className.indexOf('vjs-hidden') >= 0,
      'muteToggle does not hide itself');
 
-  player.tech.features['volumeControl'] = true;
+  player.tech['volumeControlFeature'] = true;
   for (i = 0; i < listeners.length; i++) {
     listeners[i]();
   }

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -42,7 +42,6 @@ vjs.MediaFaker.prototype.muted = function(){ return false; };
 vjs.MediaFaker.prototype.pause = function(){ return false; };
 vjs.MediaFaker.prototype.paused = function(){ return true; };
 vjs.MediaFaker.prototype.supportsFullScreen = function(){ return false; };
-vjs.MediaFaker.prototype.features = {};
 vjs.MediaFaker.prototype.buffered = function(){ return {}; };
 vjs.MediaFaker.prototype.duration = function(){ return {}; };
 


### PR DESCRIPTION
Use vjs.obj.create to inherit 'features' from
'MediaTechController.prototype.features'. Because we are inheriting, if
the defaults change (prototype.features), we can receive these updates
in our tech if we had not changed properties of features manually.

This fixes #1407.
