### PR TITLE
removing required files from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,11 +14,7 @@
     "player"
   ],
   "ignore": [
-    "**/.*",
     "node_modules",
     "bower_components",
-    "test",
-    "tests",
-    "build"
   ]
 }


### PR DESCRIPTION
`ignore` stops `bower install` from pulling these files down yet they are required for running grunt / building.
