### PR TITLE
Publish videojs.Player.prototype.selectSource function.

### DIFF
--- a/src/js/player.externs.js
+++ b/src/js/player.externs.js
@@ -82,3 +82,8 @@ videojs.Player.prototype.userActive = function(){};
  * Native controls
  */
 videojs.Player.prototype.usingNativeControls = function(){};
+
+/**
+ * Source selection
+ */
+videojs.Player.prototype.selectSource = function(){};


### PR DESCRIPTION
As discussed offline with @heff and in Issue https://github.com/videojs/video.js/issues/1384, allowing developers to patch, replace, and/or experiment with source selection algorithms is a desirable feature. Such capability is currently blocked because the selectSource function's name is obfuscated by the closure compiler. This change adds the selectSource function to the set of functions that are exported by VideoJS, preventing it from name obfuscation.
