### PR TITLE
return src value from HTML5 tech

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -225,7 +225,13 @@ vjs.Html5.prototype.enterFullScreen = function(){
 vjs.Html5.prototype.exitFullScreen = function(){
   this.el_.webkitExitFullScreen();
 };
-vjs.Html5.prototype.src = function(src){ this.el_.src = src; };
+vjs.Html5.prototype.src = function(src) {
+  if (src === undefined) {
+    return this.el_.src;
+  } else {
+    this.el_.src = src;
+  }
+};
 vjs.Html5.prototype.load = function(){ this.el_.load(); };
 vjs.Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
 


### PR DESCRIPTION
Calling `player.src()` with no arguments overwrites the HTML5 `src` attribute with undefined instead of returning the current value.

https://github.com/guardian/video.js/blob/21f2d3c150b3573337030758f7dfb634f6798052/src/js/player.js#L1111
