### PR TITLE
Make sure the error property is set before proxying through the tech.

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -123,9 +123,11 @@ vjs.Html5.prototype.setupTriggers = function(){
 };
 
 vjs.Html5.prototype.eventHandler = function(evt){
-  // In the case of an error, set the error prop on the player
-  // and let the player handle triggering the event.
-  if (evt.type == 'error') {
+  // In the case of an error on the video element, set the error prop
+  // on the player and let the player handle triggering the event. On
+  // some platforms, error events fire that do not cause the error
+  // property on the video element to be set. See #1465 for an example.
+  if (evt.type == 'error' && this.error()) {
     this.player().error(this.error().code);
 
   // in some cases we pass the event directly to the player

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -124,3 +124,9 @@ test('should return a maybe for mp4 on OLD ANDROID', function() {
   vjs.IS_OLD_ANDROID = isOldAndroid;
   vjs.Html5.unpatchCanPlayType();
 });
+
+test('error events may not set the errors property', function() {
+  equal(tech.error(), undefined, 'no tech-level error');
+  tech.trigger('error');
+  ok(true, 'no error was thrown');
+});


### PR DESCRIPTION
Some error events don't cause the error property on the video element to be set. In that case, handle the event like any other. Fixes #1465.
