### PR TITLE
Move language methods into externs

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -77,8 +77,6 @@ goog.exportProperty(vjs.Player.prototype, 'preload', vjs.Player.prototype.preloa
 goog.exportProperty(vjs.Player.prototype, 'remainingTime', vjs.Player.prototype.remainingTime);
 goog.exportProperty(vjs.Player.prototype, 'supportsFullScreen', vjs.Player.prototype.supportsFullScreen);
 goog.exportProperty(vjs.Player.prototype, 'currentType', vjs.Player.prototype.currentType);
-goog.exportProperty(vjs.Player.prototype, 'language', vjs.Player.prototype.language);
-goog.exportProperty(vjs.Player.prototype, 'languages', vjs.Player.prototype.languages);
 
 goog.exportSymbol('videojs.MediaLoader', vjs.MediaLoader);
 goog.exportSymbol('videojs.TextTrackDisplay', vjs.TextTrackDisplay);

--- a/src/js/player.externs.js
+++ b/src/js/player.externs.js
@@ -63,6 +63,12 @@ videojs.Player.prototype.cancelFullScreen = function(){}; /* deprecated */
 videojs.Player.prototype.textTracks = function(){};
 
 /**
+ * Language support
+ */
+videojs.Player.prototype.language = function(){};
+videojs.Player.prototype.languages = function(){};
+
+/**
  * Component functions
  */
 videojs.Player.prototype.dispose = function(){};

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -208,3 +208,16 @@ test('fullscreenToggle does not depend on minified player methods', function(){
 
   ok(exitFullscreen, 'exitFullscreen called');
 });
+
+test('component can be subclassed externally', function(){
+  var player = new (videojs.Component.extend({
+    languages: function(){},
+    reportUserActivity: function(){},
+    language: function(){},
+    textTracks: function(){ return []; }
+  }))({
+    id: function(){},
+    reportUserActivity: function(){}
+  });
+  ok(new videojs.ControlBar(player), 'created a control bar without throwing');
+});


### PR DESCRIPTION
Trying to create a player-like subclass of component requires overriding languages() but that method was being minified. Add it to externs so that it can be overridden after minification. Fixes #1420.
