### PR TITLE
Chrome still shows outline of the play button

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -528,6 +528,7 @@ easily in the skin designer. http://designer.videojs.com/
   .border-radius(@big-play-border-radius);
   .box-shadow(0px 0px 1em rgba(255, 255, 255, 0.25));
   .transition(all 0.4s);
+  outline: 0;
 }
 
 /* Optionally center */


### PR DESCRIPTION
Chrome still shows outline of the play button when clicked for split secound, this fixes the issue.
