### PR TITLE
Return self when setting poster. Fixes #1551.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1279,6 +1279,8 @@ vjs.Player.prototype.poster = function(src){
 
   // alert components that the poster has been set
   this.trigger('posterchange');
+
+  return this;
 };
 
 /**

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -211,6 +211,8 @@ test('should set and update the poster value', function(){
   ok(pcEmitted, 'posterchange event was emitted');
   equal(player.poster(), updatedPoster, 'the updated poster is returned');
 
+  equal(player.poster(poster), player, 'the player is returned when setting a poster');
+
   player.dispose();
 });
 


### PR DESCRIPTION
When setting the poster via `player.poster(src)`, `player` is now returned.
