### PR TITLE
Don't always add controls to the video element

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -69,6 +69,7 @@ vjs.Html5.prototype.createEl = function(){
   var player = this.player_,
       // If possible, reuse original tag for HTML5 playback technology element
       el = player.tag,
+      attributes,
       newEl,
       clone;
 
@@ -85,8 +86,15 @@ vjs.Html5.prototype.createEl = function(){
       player.tag = null;
     } else {
       el = vjs.createEl('video');
+
+      // determine if native controls should be used
+      attributes = videojs.util.mergeOptions({}, player.tagAttributes);
+      if (!vjs.TOUCH_ENABLED || player.options()['nativeControlsForTouch'] === false) {
+        delete attributes.controls;
+      }
+
       vjs.setElementAttributes(el,
-        vjs.obj.merge(player.tagAttributes || {}, {
+        vjs.obj.merge(attributes, {
           id:player.id() + '_html5_api',
           'class':'vjs-tech'
         })

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -71,6 +71,17 @@ test('test playbackRate', function() {
   strictEqual(tech.playbackRate(), 0.75);
 });
 
+test('should remove the controls attribute when recreating the element', function() {
+  var el;
+  player.tagAttributes = {
+    controls: true
+  };
+  el = tech.createEl();
+
+  ok(!el.controls, 'controls attribute is absent');
+  ok(player.tagAttributes.controls, 'tag attribute is still present');
+});
+
 test('patchCanPlayType patches canplaytype with our function, conditionally', function() {
   // the patch runs automatically so we need to first unpatch
   vjs.Html5.unpatchCanPlayType();

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -536,7 +536,7 @@ test('should restore attributes from the original video tag when creating a new 
   // simulate attributes stored from the original tag
   player.tagAttributes = {
     'preload': 'auto',
-    'controls': true,
+    'autoplay': true,
     'webkit-playsinline': true
   };
 
@@ -547,7 +547,7 @@ test('should restore attributes from the original video tag when creating a new 
   el = vjs.Html5.prototype.createEl.call(html5Mock);
 
   equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
-  equal(el.getAttribute('controls'), '', 'controls attribute was set properly');
+  equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
   equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
 });
 


### PR DESCRIPTION
Fix for #1561. If the HTML tech is being constructed without a video element to work off of, make sure that the controls attribute is only added under the same circumstances it would be at player init. Before this fix, if you loaded the Flash tech and then switched to the HTML tech, you would see the native controls underneath the video.js controls.