### PR TITLE
Fix a simple mistake that make native JSON.parse never been used

### DIFF
--- a/src/js/json.js
+++ b/src/js/json.js
@@ -15,7 +15,7 @@
  */
 vjs.JSON;
 
-if (typeof window.JSON !== 'undefined' && window.JSON.parse === 'function') {
+if (typeof window.JSON !== 'undefined' && typeof window.JSON.parse === 'function') {
   vjs.JSON = window.JSON;
 
 } else {


### PR DESCRIPTION
``` javascript
window.JSON.parse === 'function'
```

should be

``` javascript
typeof window.JSON.parse === 'function'
```
