### PR TITLE
Updated poster to use CSS styles to hide instead of show/hide methods. fixes #1567

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,6 +25,7 @@
         "process",
 
         "PlayerTest",
+        "TestHelpers",
         "asyncTest",
         "deepEqual",
         "equal",

--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -936,6 +936,22 @@ body.vjs-full-window {
   width: 100%;
 }
 
+/* Hide the poster after the video has started playing */
+.video-js.vjs-has-started .vjs-poster {
+  display: none;
+}
+
+/* Don't hide the poster if we're playing audio */
+.video-js.vjs-audio.vjs-has-started .vjs-poster {
+  display: block;
+}
+
+/* Hide the poster when controls are disabled because it's clickable
+    and the native poster can take over */
+.video-js.vjs-controls-disabled .vjs-poster {
+  display: none;
+}
+
 /* Hide the poster when native controls are used otherwise it covers them */
 .video-js.vjs-using-native-controls .vjs-poster {
   display: none;

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -47,8 +47,14 @@ vjs.Component = vjs.CoreObject.extend({
     // Updated options with supplied options
     options = this.options(options);
 
-    // Get ID from options, element, or create using player ID and unique ID
-    this.id_ = options['id'] || ((options['el'] && options['el']['id']) ? options['el']['id'] : player.id() + '_component_' + vjs.guid++ );
+    // Get ID from options or options element if one is supplied
+    this.id_ = options['id'] || (options['el'] && options['el']['id']);
+
+    // If there was no ID from the options, generate one
+    if (!this.id_) {
+      // Don't require the player ID function in the case of mock players
+      this.id_ = ((player.id && player.id()) || 'no_player') + '_component_' + vjs.guid++;
+    }
 
     this.name_ = options['name'] || null;
 
@@ -975,6 +981,11 @@ vjs.Component.prototype.emitTapEvents = function(){
  */
 vjs.Component.prototype.enableTouchActivity = function() {
   var report, touchHolding, touchEnd;
+
+  // Don't continue if the root player doesn't support reporting user activity
+  if (!this.player().reportUserActivity) {
+    return;
+  }
 
   // listener for reporting that the user is active
   report = vjs.bind(this.player(), this.player().reportUserActivity);

--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -412,6 +412,7 @@ vjs.IS_FIREFOX = (/Firefox/i).test(vjs.USER_AGENT);
 vjs.IS_CHROME = (/Chrome/i).test(vjs.USER_AGENT);
 
 vjs.TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);
+vjs.BACKGROUND_SIZE_SUPPORTED = 'backgroundSize' in vjs.TEST_VID.style;
 
 /**
  * Apply attributes to an HTML element.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -55,9 +55,10 @@ vjs.Player = vjs.Component.extend({
     this.cache_ = {};
 
     // Set poster
-    this.poster_ = options['poster'];
+    this.poster_ = options['poster'] || '';
+
     // Set controls
-    this.controls_ = options['controls'];
+    this.controls_ = !!options['controls'];
     // Original tag settings stored in options
     // now remove immediately so native controls don't flash.
     // May be turned back on by HTML5 tech if nativeControlsForTouch is true
@@ -1282,6 +1283,12 @@ vjs.Player.prototype.poster_;
 vjs.Player.prototype.poster = function(src){
   if (src === undefined) {
     return this.poster_;
+  }
+
+  // The correct way to remove a poster is to set as an empty string
+  // other falsey values will throw errors
+  if (!src) {
+    src = '';
   }
 
   // update the internal poster variable

--- a/test/index.html
+++ b/test/index.html
@@ -3,6 +3,9 @@
 <head>
   <title>Video.js Test Suite</title>
 
+  <!-- Video.js CSS -->
+  <link rel="stylesheet" href="../build/files/video-js.css" type="text/css">
+
   <!-- Sinon -->
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/sinon/pkg/sinon-ie.js"></script>
@@ -10,9 +13,6 @@
   <!-- QUnit -->
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" />
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-
-  <!-- Video.js CSS -->
-  <link rel="stylesheet" href="../build/files/video-js.css" type="text/css">
 
   <script type="text/javascript">
     (function(){

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -59,6 +59,7 @@ module.exports = function(config) {
     customLaunchers: customLaunchers,
 
     files: [
+      '../build/files/video-js.css',
       '../test/karma-qunit-shim.js',
       "../src/js/core.js",
       "../src/js/core-object.js",

--- a/test/karma.minified.api.conf.js
+++ b/test/karma.minified.api.conf.js
@@ -7,6 +7,7 @@ module.exports = function(config) {
     singleRun: true,
 
     files: [
+      '../build/files/video-js.min.css',
       '../test/karma-qunit-shim.js',
       '../node_modules/sinon/pkg/sinon.js',
       '../build/files/minified.video.js',

--- a/test/karma.minified.conf.js
+++ b/test/karma.minified.conf.js
@@ -7,6 +7,7 @@ module.exports = function(config) {
     singleRun: true,
 
     files: [
+      '../build/files/video-js.min.css',
       '../test/karma-qunit-shim.js',
       '../node_modules/sinon/pkg/sinon.js',
       '../build/files/test.minified.video.js'

--- a/test/minified.html
+++ b/test/minified.html
@@ -3,6 +3,9 @@
 <head>
   <title>Video.js Test Suite</title>
 
+  <!-- Video.js CSS -->
+  <link rel="stylesheet" href="../build/files/video-js.css" type="text/css">
+
   <!-- Sinon -->
   <script src="../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../node_modules/sinon/pkg/sinon-ie.js"></script>
@@ -10,9 +13,6 @@
   <!-- QUnit -->
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" />
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-
-  <!-- Video.js CSS -->
-  <link rel="stylesheet" href="../build/files/video-js.css" type="text/css">
 
   <!-- SOURCE COMPILED WITH TESTS
   grunt-contrib-qunit doesn't support query vars, so making this script

--- a/test/unit/test-helpers.js
+++ b/test/unit/test-helpers.js
@@ -19,3 +19,18 @@ var PlayerTest = {
     return player = new videojs.Player(videoTag, playerOptions);
   }
 };
+
+var TestHelpers = {
+  getComputedStyle: function(el, rule){
+    var val;
+
+    if(window.getComputedStyle){
+      val = window.getComputedStyle(el, null).getPropertyValue(rule);
+    // IE8
+    } else if(el.currentStyle){
+      val = el.currentStyle[rule];
+    }
+
+    return val;
+  }
+};


### PR DESCRIPTION
- Poster will now reshow itself when a poster source is set after a non-source
- Relying on CSS instead of show/hide methods now
- Made it so empty strings would hide the poster image element
- Updated a few component methods that made it annoying to create a mock player (@dmlap)
- Refactored poster image tests
