### PR TITLE
Revert making volumeMenuButton vertical by default

### DIFF
--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -29,7 +29,7 @@ vjs.VolumeMenuButton.prototype.createMenu = function(){
   var menu = new vjs.Menu(this.player_, {
     contentElType: 'div'
   });
-  var vc = new vjs.VolumeBar(this.player_, vjs.obj.merge({'vertical': true}, this.options_.volumeBar));
+  var vc = new vjs.VolumeBar(this.player_, this.options_.volumeBar);
   vc.on('focus', function() {
     menu.lockShowing();
   });


### PR DESCRIPTION
There's currently no way to disable the vertical volume bar when using `volumeMenuButton`, but it seems like the default should more closely match the existing functionality regardless. If `volumeMenuButton` is used instead of `volumeControl` with no other settings, the expected behavior should be the same slider behavior as before, just in a menu. If someone wants to make it vertical, that should be explicitly set in the options.

I originally set out with this PR to also fix the CSS if someone did set the vertical option, but I've since thought better of it for multiple reasons (being a pain in the butt not being the least of those). Until #1553 is resolved, I don't think it's reasonable for us (or someone working on a skin) to need to account for both layouts. If someone explicitly sets vertical to true, they would also need to customize their own skin to account for the vertical slider. Someone should _not_ need to customize the CSS for something that's a default. Also, it's a pain in the butt to fix now, so I'm deferring that fix until we come up with a good fix for #1553.
