### PR TITLE
Changed custom controls to be the default on touch devices (!)

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -44,7 +44,8 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if (vjs.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] !== false) {
+    if (vjs.TOUCH_ENABLED && player.options()['nativeControlsForTouch'] === true) {
+      alert('useNativeControls');
       this.useNativeControls();
     }
 


### PR DESCRIPTION
Previously we've relied on native controls on touch devices, but now switching to use the video.js custom controls by default.

This can be reverted by setting the option `nativeControlsForTouch: true`.

I've tested across Android, iOS, and Windows 8.1 and it all works decently. There's a few things we could improve, like the size of the controls on touch devices, but better to get this out now than wait any longer.
