### PR TITLE
Hide native controls after creating the video tag

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -94,6 +94,8 @@ vjs.Html5.prototype.createEl = function(){
           'class':'vjs-tech'
         })
       );
+      
+      el.removeAttribute('controls'); // Hide the native controls
     }
     // associate the player with the new tag
     el['player'] = player;


### PR DESCRIPTION
When we switch from YouTube to html5, the native controls of the newly created video tag are not hidden. To prevent this, we need to get rid of the attribute on the HTML5 tag. 

I don't know if it is the right fix, but it certainly fix this problem.

See https://github.com/eXon/videojs-youtube/issues/209 for references
