### PR TITLE
fix exception on html5.js

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -36,7 +36,7 @@ vjs.Html5 = vjs.MediaTechController.extend({
     // 1) Check if the source is new (if not, we want to keep the original so playback isn't interrupted)
     // 2) Check to see if the network state of the tag was failed at init, and if so, reset the source
     // anyway so the error gets fired.
-    if (source && (this.el_.currentSrc !== source.src) || (player.tag && player.tag.initNetworkState_ === 3)) {
+    if (source && ((this.el_.currentSrc !== source.src) || (player.tag && player.tag.initNetworkState_ === 3))) {
       this.el_.src = source.src;
     }
 


### PR DESCRIPTION
fix exception when `source` is undefined but `(player.tag && player.tag.initNetworkState_ === 3)` is valid
