### PR TITLE
Fix playback state classes on loadstart. Fix for #1671.

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -10,8 +10,17 @@ vjs.PlayToggle = vjs.Button.extend({
   init: function(player, options){
     vjs.Button.call(this, player, options);
 
+    this.on(player, 'ready', function(){
+      if (this.player_.paused()) {
+        this.addClass('vjs-paused');
+      } else {
+        this.addClass('vjs-playing');
+      }
+    });
+
     this.on(player, 'play', this.onPlay);
     this.on(player, 'pause', this.onPause);
+    this.on(player, 'loadstart', this.onLoadStart);
   }
 });
 
@@ -30,7 +39,19 @@ vjs.PlayToggle.prototype.onClick = function(){
   }
 };
 
-  // OnPlay - Add the vjs-playing class to the element so it can change appearance
+// OnLoadStart - determine whether the playback state has changed and
+// update the element if it has
+vjs.PlayToggle.prototype.onLoadStart = function(){
+  // invoke the approprate event handlers if the player's paused
+  // attribute has changed
+  if (!this.player_.paused() && !this.hasClass('vjs-playing')) {
+    this.onPlay();
+  } else if (!this.hasClass('vjs-paused')) {
+    this.onPause();
+  }
+};
+
+// OnPlay - Add the vjs-playing class to the element so it can change appearance
 vjs.PlayToggle.prototype.onPlay = function(){
   this.removeClass('vjs-paused');
   this.addClass('vjs-playing');

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -397,12 +397,18 @@ vjs.Player.prototype.onLoadStart = function() {
   // which can happen in any order for a new source
   if (!this.paused()) {
     this.trigger('firstplay');
+    if (this.hasClass('vjs-paused')) {
+      this.onPlay();
+    }
   } else {
     // reset the hasStarted state
     this.hasStarted(false);
     this.one('play', function(){
       this.hasStarted(true);
     });
+    if (this.hasClass('vjs-playing')) {
+      this.onPause();
+    }
   }
 };
 

--- a/test/unit/controls.js
+++ b/test/unit/controls.js
@@ -3,8 +3,8 @@ module('Controls');
 test('should hide volume control if it\'s not supported', function(){
   expect(2);
 
-  var noop, player, volumeControl, muteToggle;
-  noop = function(){};
+  var player, volumeControl, noop, muteToggle;
+  noop = function() {};
   player = {
     id: noop,
     on: noop,
@@ -27,8 +27,8 @@ test('should hide volume control if it\'s not supported', function(){
 });
 
 test('should test and toggle volume control on `loadstart`', function(){
-  var noop, listeners, player, volumeControl, muteToggle, i;
-  noop = function(){};
+  var listeners, player, volumeControl, noop, muteToggle, i;
+  noop = function() {};
   listeners = [];
   player = {
     id: noop,
@@ -76,9 +76,28 @@ test('should test and toggle volume control on `loadstart`', function(){
   equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle does not show itself');
 });
 
+test('should test and toggle play control on `loadstart`', function(){
+  var player, playToggle, paused;
+  player = PlayerTest.makePlayer();
+  player.paused = function() {
+    return paused;
+  };
+  paused = true;
+  playToggle = new vjs.PlayToggle(player);
+  player.trigger('ready');
+
+  ok((/\bvjs-paused\b/).test(playToggle.el().className), 'has class vjs-paused');
+  ok(!(/\bvjs-playing\b/).test(playToggle.el().className), 'does not have class vjs-playing');
+
+  paused = false;
+  player.trigger('loadstart');
+  ok(!(/\bvjs-paused\b/).test(playToggle.el().className), 'does not have class vjs-paused');
+  ok((/\bvjs-playing\b/).test(playToggle.el().className), 'has class vjs-playing');
+});
+
 test('calculateDistance should use changedTouches, if available', function() {
   var noop, player, slider, event;
-  noop = function(){};
+  noop = function() {};
   player = {
     id: noop,
     on: noop,

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -647,6 +647,24 @@ test('pause is not called if the player is paused and ended is fired', function(
   equal(pauses, 0, 'pause was not called when ended fired');
 });
 
+test('classes reflect paused attribute after loadstart', function() {
+  var video = document.createElement('video'),
+      player = PlayerTest.makePlayer({}, video),
+      paused = true;
+  player.paused = function() {
+    return paused;
+  };
+
+  player.trigger('loadstart');
+  ok((/\bvjs-paused\b/).test(player.el().className), 'has class vjs-paused');
+  ok(!(/\bvjs-playing\b/).test(player.el().className), 'does not have class vjs-playing');
+
+  paused = false;
+  player.trigger('loadstart');
+  ok(!(/\bvjs-paused\b/).test(player.el().className), 'does not have class vjs-paused');
+  ok((/\bvjs-playing\b/).test(player.el().className), 'has class vjs-playing');
+});
+
 test('should add an audio class if an audio el is used', function() {
   var audio = document.createElement('audio'),
       player = PlayerTest.makePlayer({}, audio),


### PR DESCRIPTION
Make sure vjs-playing or vjs-paused is correctly applied to the player and play toggle control whenever loadstart fires.