### PR TITLE
Fixed XML markup.

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -356,7 +356,7 @@ vjs.Flash.embed = function(swf, placeHolder, flashVars, params, attributes){
 
 vjs.Flash.getEmbedCode = function(swf, flashVars, params, attributes){
 
-  var objTag = '<object type="application/x-shockwave-flash"',
+  var objTag = '<object type="application/x-shockwave-flash" ',
       flashVarsString = '',
       paramsString = '',
       attrsString = '';


### PR DESCRIPTION
This fixes an invalid markup issue that is problematic for **XHTML** pages that imply strict XML parsing.

Attributes are appended afterwards with space after the attribute but not before it, so the resulted markups looks like this:

``` xml
<object type="application/x-shockwave-flash"data="...
```

The space could be added elsewhere, but it's not worth adding it in a loop with additional string concatenation operation and larger script size.
