### PR TITLE
Warn if options / ready function are passed to a previously created player instance 

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -41,6 +41,8 @@ Step 2: Add an HTML5 video tag to your page.
 --------------------------------------------
 With Video.js you just use an HTML5 video tag to embed a video. Video.js will then read the tag and make it work in all browsers, not just ones that support HTML5 video. Beyond the basic markup, Video.js needs a few extra pieces.
 
+> Note: The `data-setup` attribute described here should not be used if you use the alternative setup described in the next section.
+
   1. The 'data-setup' Attribute tells Video.js to automatically set up the video when the page is ready, and read any options (in JSON format) from the attribute (see [options](options.md)). There are other methods for initializing the player, but this is the easiest.
 
   2. The 'id' Attribute: Should be used and unique for every video on the same page.

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -37,6 +37,15 @@ var vjs = function(id, options, ready){
 
     // If a player instance has already been created for this ID return it.
     if (vjs.players[id]) {
+
+      // If options or ready funtion are passed, warn
+      if (options) {
+        vjs.log.warn ('Player "' + id + '" is already initialised. Options will not be applied.');
+      }
+      if (ready) {
+        vjs.log.warn ('Player "' + id + '" is already initialised. Ready function will not be executed.');
+      }
+
       return vjs.players[id];
 
     // Otherwise get element for ID


### PR DESCRIPTION
There are questions fairly regularly on Stack Overflow that come down to confusion over using both `data-setup` and passing options and/or a ready function to `videojs()`.

This change logs a message with `vjs.log` if options or a ready function are passed as arguments, if a previously created player is returned. It also adds note in the setup doc.
