### PR TITLE
Make sure that setSource is directly on prototype

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1175,7 +1175,7 @@ vjs.Player.prototype.src = function(source){
 
         // The setSource tech method was added with source handlers
         // so older techs won't support it
-        if (this.tech['setSource']) {
+        if (window['videojs'][this.techName].prototype.hasOwnProperty('setSource')) {
           this.techCall('setSource', source);
         } else {
           this.techCall('src', source.src);


### PR DESCRIPTION
This is to make the new source handlers backwards compatible and so it
wont break techs that extend existing techs that were converted to use
source handlers.
