### PR TITLE
moved event.preventDefault() inside of if-then structure

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -182,7 +182,6 @@ vjs.MenuButton.prototype.onClick = function(){
 };
 
 vjs.MenuButton.prototype.onKeyPress = function(event){
-  event.preventDefault();
 
   // Check for space bar (32) or enter (13) keys
   if (event.which == 32 || event.which == 13) {
@@ -191,11 +190,13 @@ vjs.MenuButton.prototype.onKeyPress = function(event){
     } else {
       this.pressButton();
     }
+    event.preventDefault();
   // Check for escape (27) key
   } else if (event.which == 27){
     if (this.buttonPressed_){
       this.unpressButton();
     }
+    event.preventDefault();
   }
 };
 


### PR DESCRIPTION
(resubmit)
I moved the event.preventDefault to inside the if-then structure, so that other key commands will still work. It is necessary for the Tab key to get passed to the browser so a keyboard-only user can navigate through this UI element. If the Tab key is prevented, a keyboard-only user has no way of leaving the UI element once they are in it. See also https://github.com/videojs/video.js/issues/1758
