### PR TITLE
Let the progress bar fill the space at 100%,fixes #1247

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -462,7 +462,7 @@ fonts to show/hide properly.
 }
 
 .vjs-default-skin .vjs-seek-handle {
-  width: 1.5em;
+  width: 1em;
   height: 100%;
 }
 

--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -101,16 +101,8 @@ vjs.Slider.prototype.update = function(){
         // The width of the handle in percent of the containing box
         // In IE, widths may not be ready yet causing NaN
         handlePercent = (handleWidth) ? handleWidth / boxWidth : 0,
-
-        // Get the adjusted size of the box, considering that the handle's center never touches the left or right side.
-        // There is a margin of half the handle's width on both sides.
-        boxAdjustedPercent = 1 - handlePercent,
-
-        // Adjust the progress that we'll use to set widths to the new adjusted box width
-        adjustedProgress = progress * boxAdjustedPercent;
-
-    // The bar does reach the left side, so we need to account for this in the bar's width
-    barProgress = adjustedProgress + (handlePercent / 2);
+        //make the center of the handler is align to the left side of the progress bar horizontally
+        adjustedProgress = progress - handlePercent/2;
 
     // Move the handle from the left based on the adjected progress
     handle.el().style.left = vjs.round(adjustedProgress * 100, 2) + '%';


### PR DESCRIPTION
I choosed the second way
>Allow the handle edges to go beyond the edges of the progress bar, i.e. the center of the handle is always locked to the mouse, even at 0 and 100%.


So the progress bar will fill the space as expected, and at the beginning or the end, the handler will beyond the edges of the progress bar like below.
![2014-12-31 5 52 46](https://cloud.githubusercontent.com/assets/1410176/5586561/f888bb0e-9115-11e4-967f-82d8d1aea68f.png)
![2014-12-31 5 53 13](https://cloud.githubusercontent.com/assets/1410176/5586562/fe4b9354-9115-11e4-93a6-66f2f3662eee.png)
