### PR TITLE
Export source handler functions for use externally

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -127,13 +127,13 @@ goog.exportSymbol('videojs.CaptionsButton', vjs.CaptionsButton);
 goog.exportSymbol('videojs.ChaptersButton', vjs.ChaptersButton);
 
 goog.exportSymbol('videojs.MediaTechController', vjs.MediaTechController);
+goog.exportProperty(vjs.MediaTechController, 'withSourceHandlers', vjs.MediaTechController.withSourceHandlers);
 goog.exportProperty(vjs.MediaTechController.prototype, 'featuresVolumeControl', vjs.MediaTechController.prototype.featuresVolumeControl);
 goog.exportProperty(vjs.MediaTechController.prototype, 'featuresFullscreenResize', vjs.MediaTechController.prototype.featuresFullscreenResize);
 goog.exportProperty(vjs.MediaTechController.prototype, 'featuresPlaybackRate', vjs.MediaTechController.prototype.featuresPlaybackRate);
 goog.exportProperty(vjs.MediaTechController.prototype, 'featuresProgressEvents', vjs.MediaTechController.prototype.featuresProgressEvents);
 goog.exportProperty(vjs.MediaTechController.prototype, 'featuresTimeupdateEvents', vjs.MediaTechController.prototype.featuresTimeupdateEvents);
 goog.exportProperty(vjs.MediaTechController.prototype, 'setPoster', vjs.MediaTechController.prototype.setPoster);
-
 
 goog.exportSymbol('videojs.Html5', vjs.Html5);
 goog.exportProperty(vjs.Html5, 'Events', vjs.Html5.Events);
@@ -154,7 +154,11 @@ goog.exportProperty(vjs.Html5.prototype, 'enterFullScreen', vjs.Html5.prototype.
 goog.exportProperty(vjs.Html5.prototype, 'exitFullScreen', vjs.Html5.prototype.exitFullScreen);
 goog.exportProperty(vjs.Html5.prototype, 'playbackRate', vjs.Html5.prototype.playbackRate);
 goog.exportProperty(vjs.Html5.prototype, 'setPlaybackRate', vjs.Html5.prototype.setPlaybackRate);
+// Source Handler Functions
+goog.exportProperty(vjs.Html5, 'registerSourceHandler', vjs.Html5.registerSourceHandler);
+goog.exportProperty(vjs.Html5, 'selectSourceHandler', vjs.Html5.selectSourceHandler);
 goog.exportProperty(vjs.Html5.prototype, 'setSource', vjs.Html5.prototype.setSource);
+goog.exportProperty(vjs.Html5.prototype, 'disposeSourceHandler', vjs.Html5.prototype.disposeSourceHandler);
 
 goog.exportSymbol('videojs.Flash', vjs.Flash);
 goog.exportProperty(vjs.Flash, 'isSupported', vjs.Flash.isSupported);
@@ -163,6 +167,11 @@ goog.exportProperty(vjs.Flash, 'onReady', vjs.Flash['onReady']);
 goog.exportProperty(vjs.Flash, 'embed', vjs.Flash.embed);
 goog.exportProperty(vjs.Flash, 'version', vjs.Flash.version);
 goog.exportProperty(vjs.Flash.prototype, 'setSource', vjs.Flash.prototype.setSource);
+// Source Handler Functions
+goog.exportProperty(vjs.Flash, 'registerSourceHandler', vjs.Flash.registerSourceHandler);
+goog.exportProperty(vjs.Flash, 'selectSourceHandler', vjs.Flash.selectSourceHandler);
+goog.exportProperty(vjs.Flash.prototype, 'setSource', vjs.Flash.prototype.setSource);
+goog.exportProperty(vjs.Flash.prototype, 'disposeSourceHandler', vjs.Flash.prototype.disposeSourceHandler);
 
 goog.exportSymbol('videojs.TextTrack', vjs.TextTrack);
 goog.exportProperty(vjs.TextTrack.prototype, 'label', vjs.TextTrack.prototype.label);

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -94,19 +94,34 @@ test('should be able to access expected component API methods', function() {
 });
 
 test('should be able to access expected MediaTech API methods', function() {
-  var techProto = videojs.MediaTechController.prototype;
+  var media = videojs.MediaTechController;
+  var mediaProto = videojs.MediaTechController.prototype;
+  var html5 = videojs.Html5;
   var html5Proto = videojs.Html5.prototype;
+  var flash = videojs.Flash;
   var flashProto = videojs.Flash.prototype;
 
-  ok(techProto.setPoster, 'setPoster should exist on the Media tech');
+  ok(mediaProto.setPoster, 'setPoster should exist on the Media tech');
   ok(html5Proto.setPoster, 'setPoster should exist on the HTML5 tech');
   ok(flashProto.setPoster, 'setPoster should exist on the Flash tech');
 
   ok(videojs.Html5.patchCanPlayType, 'patchCanPlayType should exist for HTML5');
   ok(videojs.Html5.unpatchCanPlayType, 'unpatchCanPlayType should exist for HTML5');
 
+  // Source Handler Functions
+  ok(media.withSourceHandlers, 'withSourceHandlers should exist for Media Tech');
+
   ok(videojs.Html5.canPlaySource, 'canPlaySource should exist for HTML5');
+  ok(videojs.Html5.registerSourceHandler, 'registerSourceHandler should exist for Html5');
+  ok(videojs.Html5.selectSourceHandler, 'selectSourceHandler should exist for Html5');
+  ok(videojs.Html5.prototype.setSource, 'setSource should exist for Html5');
+  ok(videojs.Html5.prototype.disposeSourceHandler, 'disposeSourceHandler should exist for Html5');
+
   ok(videojs.Flash.canPlaySource, 'canPlaySource should exist for Flash');
+  ok(videojs.Flash.registerSourceHandler, 'registerSourceHandler should exist for Flash');
+  ok(videojs.Flash.selectSourceHandler, 'selectSourceHandler should exist for Flash');
+  ok(videojs.Flash.prototype.setSource, 'setSource should exist for Flash');
+  ok(videojs.Flash.prototype.disposeSourceHandler, 'disposeSourceHandler should exist for Flash');
 });
 
 test('should export ready api call to public', function() {


### PR DESCRIPTION
This should have been done along with the original release of source handlers.

(@videojs/core-committers, I need someone to review and sign off)