### PR TITLE
Feature/tab order

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -169,14 +169,14 @@ The default control bar that is a container for most of the controls.
 
 /* The right side of the control bar */
 .vjs-default-skin .vjs-control-bar .vjs-control-bar-right {
-    float:right;
+    float: right;
 }
 
 /* The middle section of the control bar 
 It's technically the content that is visually just to the left of the right-most controls.
 */
 .vjs-default-skin .vjs-control-bar .vjs-control-bar-middle {
-    float:left;
+    float: left;
 }
 
 /* Show the control bar only once the video has started playing */
@@ -749,7 +749,7 @@ easily in the skin designer. http://designer.videojs.com/
 --------------------------------------------------------------------------------
 */
 .vjs-default-skin .vjs-menu-button {
-  float: right;
+  float: left;
   cursor: pointer;
 }
 

--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -167,6 +167,18 @@ The default control bar that is a container for most of the controls.
   .background-color-with-alpha(@control-bg-color, @control-bg-alpha);
 }
 
+/* The right side of the control bar */
+.vjs-default-skin .vjs-control-bar .vjs-control-bar-right {
+    float:right;
+}
+
+/* The middle section of the control bar 
+It's technically the content that is visually just to the left of the right-most controls.
+*/
+.vjs-default-skin .vjs-control-bar .vjs-control-bar-middle {
+    float:left;
+}
+
 /* Show the control bar only once the video has started playing */
 .vjs-default-skin.vjs-has-started .vjs-control-bar {
   display: block;
@@ -300,7 +312,7 @@ fonts to show/hide properly.
 .vjs-default-skin .vjs-mute-control,
 .vjs-default-skin .vjs-volume-menu-button {
   cursor: pointer;
-  float: right;
+  float: left;
 }
 .vjs-default-skin .vjs-mute-control:before,
 .vjs-default-skin .vjs-volume-menu-button:before {
@@ -321,7 +333,7 @@ fonts to show/hide properly.
 
 .vjs-default-skin .vjs-volume-control {
   width: 5em;
-  float: right;
+  float: left;
 }
 .vjs-default-skin .vjs-volume-bar {
   width: 5em;
@@ -511,7 +523,7 @@ fonts to show/hide properly.
 .vjs-default-skin .vjs-fullscreen-control {
   width: 3.8em;
   cursor: pointer;
-  float: right;
+  float: left;
 }
 .vjs-default-skin .vjs-fullscreen-control:before {
   content: @fullscreen-enter-icon;

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -18,16 +18,87 @@ vjs.ControlBar.prototype.options_ = {
     'remainingTimeDisplay': {},
     'liveDisplay': {},
     'progressControl': {},
-    'fullscreenToggle': {},
-    'volumeControl': {},
-    'muteToggle': {},
-    // 'volumeMenuButton': {},
-    'playbackRateMenuButton': {}
+    'RightControlsSubBar': {}
   }
 };
 
 vjs.ControlBar.prototype.createEl = function(){
   return vjs.createEl('div', {
     className: 'vjs-control-bar'
+  });
+};
+
+/**
+ * Right side container for the control bar
+ * This holds all of the UI elements that are floated to the right of
+ * the control bar. This is primarily the captions, subtitles, and chapters
+ * menu. This, along with the MiddleControlSubBar is needed to reconcile the
+ * onscreen order of the UI elements and the tab order of the elements in the
+ * DOM.
+ * 
+ * For accessibility, their should be a logical order to the tab sequence. While
+ * it is not essential that the tab order exactly match the visual layout, it
+ * is suggested to not add any additional confusion to the UI.
+ * 
+ * http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html
+
+ * @param {vjs.Player|Object} player
+ * @param {Object=} options
+ * @class
+ * @constructor
+ * @extends vjs.Component
+ */
+
+vjs.RightControlsSubBar = vjs.Component.extend();
+
+vjs.RightControlsSubBar.prototype.options_ = {
+  loadEvent: 'play',
+  children: {
+    'MiddleControlsSubBar': {},
+    'playbackRateMenuButton': {},
+    // 'volumeMenuButton': {},
+    'muteToggle': {},
+    'volumeControl': {},
+    'fullscreenToggle': {}
+   }
+};
+
+vjs.RightControlsSubBar.prototype.createEl = function(){
+  return vjs.createEl('div', {
+    className: 'vjs-control-bar-right'
+  });
+};
+
+/**
+ * Middle container for the control bar
+ * This holds all of the UI elements that are added at a later time
+ * to the container that is floated to the right of the control bar.
+ * This is primarily the captions, subtitles, and chapters menu. This,
+ * along with the RightControlSubBar is needed to reconcile the onscreen
+ * order of the UI elements and the tab order of the elements in the DOM.
+ * 
+ * For accessibility, their should be a logical order to the tab sequence. While
+ * it is not essential that the tab order exactly match the visual layout, it
+ * is suggested to not add any additional confusion to the UI.
+ * 
+ * http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html
+ * 
+ * @param {vjs.Player|Object} player
+ * @param {Object=} options
+ * @class
+ * @constructor
+ * @extends vjs.Component
+ */
+
+vjs.MiddleControlsSubBar = vjs.Component.extend();
+
+vjs.MiddleControlsSubBar.prototype.options_ = {
+  loadEvent: 'play',
+  children: {}
+};
+
+vjs.MiddleControlsSubBar.prototype.createEl = function(){
+  return vjs.createEl('div', {
+    className: 'vjs-control-bar-middle'
   });
 };

--- a/src/js/tracks.js
+++ b/src/js/tracks.js
@@ -1014,7 +1014,7 @@ vjs.ChaptersTrackMenuItem.prototype.update = function(){
 };
 
 // Add Buttons to controlBar
-vjs.obj.merge(vjs.ControlBar.prototype.options_['children'], {
+vjs.obj.merge(vjs.MiddleControlsSubBar.prototype.options_['children'], {
   'subtitlesButton': {},
   'captionsButton': {},
   'chaptersButton': {}


### PR DESCRIPTION
This is a proposed solution to part of the discussion in #1500. This reorders the DOM elements so the tab order make more sense for keyboard users. It does this by creating two containers to store some of the UI elements in the control bar. The basic concept is this.
```
<div class="vjs-control-bar-right">
   <div class="vjs-control-bar-middle">
       Caption Menu
       Subtitle Menu
       Chapters Menu
   </div>
   Mute Control
   Volume Control
   Full Screen Control
</div> 
```
vjs-control-bar-right is float:right
vjs-control-bar-middle is float:left
all of the containing controls are float:left

The reason the inner vjs-control-bar-middle is needed is because those items are not loaded initially with all of the other controls, so I can't set when to load them in the DOM. Creating this area gives me a target where I can insert them at a later time.

Thoughts?

