### PR TITLE
ManualTimeUpdatesOff was not de-registering events

### DIFF
--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -215,10 +215,12 @@ vjs.MediaTechController.prototype.manualTimeUpdatesOn = function(){
 };
 
 vjs.MediaTechController.prototype.manualTimeUpdatesOff = function(){
+  var player = this.player_;
+
   this.manualTimeUpdates = false;
   this.stopTrackingCurrentTime();
-  this.off('play', this.trackCurrentTime);
-  this.off('pause', this.stopTrackingCurrentTime);
+  this.off(player, 'play', this.trackCurrentTime);
+  this.off(player, 'pause', this.stopTrackingCurrentTime);
 };
 
 vjs.MediaTechController.prototype.trackCurrentTime = function(){

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -105,6 +105,7 @@ test('dispose removes the object element even before ready fires', function() {
       tech = new vjs.Flash({
         id: noop,
         on: noop,
+        off: noop,
         trigger: noop,
         options_: {}
       }, {

--- a/test/unit/media.js
+++ b/test/unit/media.js
@@ -39,6 +39,7 @@ test('stops timeupdates if the tech produces them natively', function() {
   var timeupdates = 0, tech, playHandler, expected;
   tech = new videojs.MediaTechController({
     id: this.noop,
+    off: this.noop,
     on: function(event, handler) {
       if (event === 'play') {
         playHandler = handler;


### PR DESCRIPTION
`ManualTimeUpdatesOff` was trying to de-register `trackCurrentTime` and
`stopTrackingCurrentTime` against itself rather than the player, which is
where these events were registered against.

This manifests itself if you have flash-based tech that is loaded initially and then try to unload it and switch to an html5-based tech.