### PR TITLE
Copy touch object for firstTouch

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1043,7 +1043,7 @@ vjs.Component.prototype.emitTapEvents = function(){
   this.on('touchstart', function(event) {
     // If more than one finger, don't consider treating this as a click
     if (event.touches.length === 1) {
-      firstTouch = event.touches[0];
+      firstTouch = vjs.obj.copy(event.touches[0]);
       // Record start time so we can detect a tap vs. "touch and hold"
       touchStart = new Date().getTime();
       // Reset couldBeTap tracking

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -462,13 +462,14 @@ test('should use a defined content el for appending children', function(){
 });
 
 test('should emit a tap event', function(){
-  expect(2);
+  expect(3);
 
   // Fake touch support. Real touch support isn't needed for this test.
   var origTouch = vjs.TOUCH_ENABLED;
   vjs.TOUCH_ENABLED = true;
 
   var comp = new vjs.Component(getFakePlayer());
+  var singleTouch = {};
 
   comp.emitTapEvents();
   comp.on('tap', function(){
@@ -495,6 +496,24 @@ test('should emit a tap event', function(){
   vjs.trigger(comp.el(), {type: 'touchmove', touches: [
     { pageX: 10, pageY: 10 }
   ]});
+  comp.trigger('touchend');
+
+  // A touchmove with a lot of movement by modifying the exisiting touch object
+  // should not trigger a tap
+  singleTouch = { pageX: 0, pageY: 0 };
+  vjs.trigger(comp.el(), {type: 'touchstart', touches: [singleTouch]});
+  singleTouch.pageX = 100;
+  singleTouch.pageY = 100;
+  vjs.trigger(comp.el(), {type: 'touchmove', touches: [singleTouch]});
+  comp.trigger('touchend');
+
+  // A touchmove with not much movement by modifying the exisiting touch object
+  // should still allow a tap
+  singleTouch = { pageX: 0, pageY: 0 };
+  vjs.trigger(comp.el(), {type: 'touchstart', touches: [singleTouch]});
+  singleTouch.pageX = 10;
+  singleTouch.pageY = 10;
+  vjs.trigger(comp.el(), {type: 'touchmove', touches: [singleTouch]});
   comp.trigger('touchend');
 
   // Reset to orignial value


### PR DESCRIPTION
Using object reference will result in touchDistance value is always 0.
By copying touch object, firstTouch.pageX and firstTouch.pageY values
will not change during touchmove event.