### PR TITLE
Match vimeo direct urls

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -324,7 +324,7 @@ vjs.Html5.nativeSourceHandler.canHandleSource = function(source){
     return canPlayType(source.type);
   } else if (source.src) {
     // If no type, fall back to checking 'video/[EXTENSION]'
-    match = source.src.match(/\.([^\/\?]+)(\?[^\/]+)?$/i);
+    match = source.src.match(/\.([^.\/\?]+)(\?[^\/]+)?$/i);
     ext = match && match[1];
 
     return canPlayType('video/'+ext);

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -151,6 +151,9 @@ test('native source handler canHandleSource', function(){
 
   equal(canHandleSource({ type: 'video/mp4', src: 'video.flv' }), 'maybe', 'Native source handler reported type support');
   equal(canHandleSource({ src: 'http://www.example.com/video.mp4' }), 'maybe', 'Native source handler reported extension support');
+  equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo&token=bar' }), 'maybe', 'Native source handler reported extension support');
+  equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo' }), 'maybe', 'Native source handler reported extension support');
+
   // Test for issue videojs/video.js#1785 and other potential failures
   equal(canHandleSource({ src: '' }), '', 'Native source handler handled empty src');
   equal(canHandleSource({}), '', 'Native source handler handled empty object');


### PR DESCRIPTION
Sometimes video.js parse url to detect file type. There was a bug in parsing regexp. Details #1813 

Hope `stable` is the right branch to merge. `contrib` doesn't work for me due to this bug https://github.com/contrib/contrib/issues/11