### PR TITLE
Update swf version to 4.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "./dist/video-js/video.js",
   "dependencies": {
-    "videojs-swf": "4.5.2"
+    "videojs-swf": "4.5.3"
   },
   "devDependencies": {
     "calcdeps": "~0.1.7",


### PR DESCRIPTION
Let me know if there is something more I need to do, but we pushed this new version to stable branch of video-js-swf earlier this evening.  I am aware that it still needs to be pushed to the cdn.