### PR TITLE
Allow events to be prefixed

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -85,6 +85,7 @@ goog.exportProperty(vjs.Player.prototype, 'cancelFullScreen', vjs.Player.prototy
 goog.exportProperty(vjs.Player.prototype, 'exitFullscreen', vjs.Player.prototype.exitFullscreen);
 goog.exportProperty(vjs.Player.prototype, 'isFullScreen', vjs.Player.prototype.isFullScreen);
 goog.exportProperty(vjs.Player.prototype, 'isFullscreen', vjs.Player.prototype.isFullscreen);
+goog.exportProperty(vjs.Player.prototype, 'trigger', vjs.Player.prototype.trigger);
 goog.exportProperty(vjs.Player.prototype, 'eventPrefix', vjs.Player.prototype.eventPrefix);
 
 goog.exportSymbol('videojs.MediaLoader', vjs.MediaLoader);

--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -85,6 +85,7 @@ goog.exportProperty(vjs.Player.prototype, 'cancelFullScreen', vjs.Player.prototy
 goog.exportProperty(vjs.Player.prototype, 'exitFullscreen', vjs.Player.prototype.exitFullscreen);
 goog.exportProperty(vjs.Player.prototype, 'isFullScreen', vjs.Player.prototype.isFullScreen);
 goog.exportProperty(vjs.Player.prototype, 'isFullscreen', vjs.Player.prototype.isFullscreen);
+goog.exportProperty(vjs.Player.prototype, 'eventPrefix', vjs.Player.prototype.eventPrefix);
 
 goog.exportSymbol('videojs.MediaLoader', vjs.MediaLoader);
 goog.exportSymbol('videojs.TextTrackDisplay', vjs.TextTrackDisplay);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -88,6 +88,9 @@ vjs.Player = vjs.Component.extend({
       this.addClass('vjs-audio');
     }
 
+    // by default, there is no event prefix
+    this.eventPrefix_ = '';
+
     // TODO: Make this smarter. Toggle user state between touching/mousing
     // using events, since devices can have both touch and mouse events.
     // if (vjs.TOUCH_ENABLED) {
@@ -1657,6 +1660,37 @@ vjs.Player.prototype.isAudio = function(bool) {
   }
 
   return this.isAudio_;
+};
+
+/**
+ * Trigger an event on the player.
+ *
+ *     myPlayer.trigger('eventName');
+ *     myPlayer.trigger({'type':'eventName'});
+ *
+ * Event names will be prefixed with the current value of this.eventPrefix()
+ *
+ * @param  {Event|Object|String} event  A string (the type) or an event object with a type attribute
+ * @return {vjs.Player}       self
+ */
+vjs.Player.prototype.trigger = function(event) {
+  if (this.eventPrefix_ !== '') {
+    if (typeof event === 'string') {
+      event = this.eventPrefix_ + event;
+    } else if (typeof event === 'object') {
+      event.type = this.eventPrefix_ + event.type;
+    }
+  }
+  return vjs.Component.prototype.trigger.apply(this, arguments);
+};
+vjs.Player.prototype.eventPrefix = function(prefix) {
+  if (prefix !== undefined) {
+
+    // force a string conversion immediately rather than doing it for
+    // every event
+    this.eventPrefix_ = '' + prefix;
+  }
+  return this.eventPrefix_;
 };
 
 // Methods to add support for

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1663,6 +1663,9 @@ vjs.Player.prototype.isAudio = function(bool) {
 };
 
 /**
+ * This is an advanced feature. Prefixing player events may cause
+ * plugins and functionality that relies on video events to break.
+ *
  * Trigger an event on the player.
  *
  *     myPlayer.trigger('eventName');

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1663,9 +1663,6 @@ vjs.Player.prototype.isAudio = function(bool) {
 };
 
 /**
- * This is an advanced feature. Prefixing player events may cause
- * plugins and functionality that relies on video events to break.
- *
  * Trigger an event on the player.
  *
  *     myPlayer.trigger('eventName');
@@ -1686,6 +1683,25 @@ vjs.Player.prototype.trigger = function(event) {
   }
   return vjs.Component.prototype.trigger.apply(this, arguments);
 };
+
+/**
+ * This is an advanced feature. Prefixing player events may cause
+ * plugins and functionality that relies on video events to break.
+ *
+ * Set a prefix to be inserted in front of the event type for all
+ * events triggered on the player. For instance, this code:
+ *
+ *     myPlayer.eventPrefix('custom');
+ *     myPlayer.trigger('seeked');
+ *
+ * will dispatch events to handlers registered on "customseeked" but
+ * _not_ event handlers that have been registered for "seeked". Set
+ * the event prefix to the empty string to return to the default
+ * behavior.
+ *
+ * @param {String} prefix  the string to prefix to all player emitted events
+ * @return {String}  the current player event prefix
+ */
 vjs.Player.prototype.eventPrefix = function(prefix) {
   if (prefix !== undefined) {
 

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -47,6 +47,7 @@ test('should be able to access expected player API methods', function() {
   ok(player.userActive, 'userActive exists');
   ok(player.usingNativeControls, 'usingNativeControls exists');
   ok(player.isFullscreen, 'isFullscreen exists');
+  ok(player.eventPrefix, 'eventPrefix exists');
 
   // Deprecated methods that should still exist
   ok(player.requestFullScreen, 'requestFullScreen exists');

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -652,3 +652,47 @@ test('should add an audio class if an audio el is used', function() {
 
   ok(player.el().className.indexOf(audioClass) !== -1, 'added '+ audioClass +' css class');
 });
+
+test('allows events player events to be prefixed', function() {
+  var player = PlayerTest.makePlayer(),
+      unprefixed = [],
+      prefixed = [];
+
+  player.on('test', function(event) {
+    unprefixed.push(event);
+  });
+  player.on('prefixtest', function(event) {
+    prefixed.push(event);
+  });
+
+  // default behavior should be unprefixed
+  equal('', player.eventPrefix(), 'no prefix by default');
+  player.trigger('test');
+  player.trigger({
+    type: 'test'
+  });
+  equal(unprefixed.length, 2, 'triggered an unprefixed event');
+  equal(prefixed.length, 0, 'did not trigger a prefixed event');
+
+  // try out prefixed behavior
+  prefixed.length = 0;
+  unprefixed.length = 0;
+  player.eventPrefix('prefix');
+  player.trigger('test');
+  player.trigger({
+    type: 'test'
+  });
+  equal(unprefixed.length, 0, 'did not trigger an unprefixed event');
+  equal(prefixed.length, 2, 'triggered a prefixed event');
+
+  // reset things back to normal
+  prefixed.length = 0;
+  unprefixed.length = 0;
+  player.eventPrefix('');
+  player.trigger('test');
+  player.trigger({
+    type: 'test'
+  });
+  equal(unprefixed.length, 2, 'triggered an unprefixed event');
+  equal(prefixed.length, 0, 'did not trigger a prefixed event');
+});


### PR DESCRIPTION
For #1825. Allow a prefix to be added to all player level events. On some devices, the video element has to be re-used for advertisement playback. This can be very confusing to downstream plugins that aren't written with ads in mind. To simplify this situation, contrib-ads will use the new eventPrefix() method to prefix video events emitted during ad playback with the prefix 'ad' so that only consumers that are interested in ad-related video events will have to be distracted by them.