### PR TITLE
Hide the poster when play fires

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -400,9 +400,6 @@ vjs.Player.prototype.onLoadStart = function() {
   } else {
     // reset the hasStarted state
     this.hasStarted(false);
-    this.one('play', function(){
-      this.hasStarted(true);
-    });
   }
 };
 
@@ -451,6 +448,12 @@ vjs.Player.prototype.onLoadedAllData;
 vjs.Player.prototype.onPlay = function(){
   this.removeClass('vjs-paused');
   this.addClass('vjs-playing');
+
+  // hide the poster when the user hits play
+  // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play
+  if (!this.hasStarted()) {
+    this.hasStarted(true);
+  }
 };
 
 /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -451,9 +451,7 @@ vjs.Player.prototype.onPlay = function(){
 
   // hide the poster when the user hits play
   // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play
-  if (!this.hasStarted()) {
-    this.hasStarted(true);
-  }
+  this.hasStarted(true);
 };
 
 /**

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -41,6 +41,9 @@ vjs.MediaFaker.prototype.volume = function(){ return 0; };
 vjs.MediaFaker.prototype.muted = function(){ return false; };
 vjs.MediaFaker.prototype.pause = function(){ return false; };
 vjs.MediaFaker.prototype.paused = function(){ return true; };
+vjs.MediaFaker.prototype.play = function() {
+  this.player().trigger('play');
+};
 vjs.MediaFaker.prototype.supportsFullScreen = function(){ return false; };
 vjs.MediaFaker.prototype.buffered = function(){ return {}; };
 vjs.MediaFaker.prototype.duration = function(){ return {}; };

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -212,6 +212,8 @@ test('should set and update the poster value', function(){
   player.dispose();
 });
 
+// hasStarted() is equivalent to the "show poster flag" in the
+// standard, for the purpose of displaying the poster image
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play
 test('should hide the poster when play is called', function() {
   var player = PlayerTest.makePlayer({

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -212,6 +212,25 @@ test('should set and update the poster value', function(){
   player.dispose();
 });
 
+// https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play
+test('should hide the poster when play is called', function() {
+  var player = PlayerTest.makePlayer({
+    poster: 'https://example.com/poster.jpg'
+  });
+
+  equal(player.hasStarted(), false, 'the show poster flag is true before play');
+  player.play();
+  equal(player.hasStarted(), true, 'the show poster flag is false after play');
+
+  player.trigger('loadstart');
+  equal(player.hasStarted(),
+        false,
+        'the resource selection algorithm sets the show poster flag to true');
+
+  player.play();
+  equal(player.hasStarted(), true, 'the show poster flag is false after play');
+});
+
 test('should load a media controller', function(){
   var player = PlayerTest.makePlayer({
     preload: 'none',


### PR DESCRIPTION
Registering a play handler after loadstart means that another play listener could stop propagation and prevent the poster image from being hidden. Instead, handle the poster toggling in a play handler that is registered immediately on initialization so that the poster display logic more closely matches the standard.