### PR TITLE
Export video.js as a named AMD module

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -170,7 +170,7 @@ vjs.players = {};
  * compiler compatible, so string keys are used.
  */
 if (typeof define === 'function' && define['amd']) {
-  define([], function(){ return videojs; });
+  define('videojs', [], function(){ return videojs; });
 
 // checking that module is an object too because of umdjs/umd#35
 } else if (typeof exports === 'object' && typeof module === 'object') {


### PR DESCRIPTION
If video.js is packaged in a file with another AMD module, tools like RequireJS may not be able to resolve a name for anonymous module definitions. Using the named module syntax should allow video.js to be packaged in whatever format is convenient and still work with AMD loaders. For https://github.com/videojs/video.js/issues/1843