### PR TITLE
Add network and ready state properties

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -281,7 +281,7 @@ vjs.Html5.prototype.playbackRate = function(){ return this.el_.playbackRate; };
 vjs.Html5.prototype.setPlaybackRate = function(val){ this.el_.playbackRate = val; };
 
 vjs.Html5.prototype.networkState = function(){ return this.el_.networkState; };
-
+vjs.Html5.prototype.readyState = function(){ return this.el_.readyState; };
 
 /**
  * Check if HTML5 video is supported by this browser/device

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1659,6 +1659,30 @@ vjs.Player.prototype.isAudio = function(bool) {
   return this.isAudio_;
 };
 
+/**
+ * Returns the current state of network activity for the element, from
+ * the codes in the list below.
+ * - NETWORK_EMPTY (numeric value 0)
+ *   The element has not yet been initialised. All attributes are in
+ *   their initial states.
+ * - NETWORK_IDLE (numeric value 1)
+ *   The element's resource selection algorithm is active and has
+ *   selected a resource, but it is not actually using the network at
+ *   this time.
+ * - NETWORK_LOADING (numeric value 2)
+ *   The user agent is actively trying to download data.
+ * - NETWORK_NO_SOURCE (numeric value 3)
+ *   The element's resource selection algorithm is active, but it has
+ *   not yet found a resource to use.
+ * @return {Number} the current network activity state
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#network-states
+ */
+vjs.Player.prototype.networkState = function(){
+  return this.techGet('networkState');
+};
+
+};
+
 // Methods to add support for
 // networkState: function(){ return this.techCall('networkState'); },
 // readyState: function(){ return this.techCall('readyState'); },

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1681,11 +1681,33 @@ vjs.Player.prototype.networkState = function(){
   return this.techGet('networkState');
 };
 
+/**
+ * Returns a value that expresses the current state of the element
+ * with respect to rendering the current playback position, from the
+ * codes in the list below.
+ * - HAVE_NOTHING (numeric value 0)
+ *   No information regarding the media resource is available.
+ * - HAVE_METADATA (numeric value 1)
+ *   Enough of the resource has been obtained that the duration of the
+ *   resource is available.
+ * - HAVE_CURRENT_DATA (numeric value 2)
+ *   Data for the immediate current playback position is available.
+ * - HAVE_FUTURE_DATA (numeric value 3)
+ *   Data for the immediate current playback position is available, as
+ *   well as enough data for the user agent to advance the current
+ *   playback position in the direction of playback.
+ * - HAVE_ENOUGH_DATA (numeric value 4)
+ *   The user agent estimates that enough data is available for
+ *   playback to proceed uninterrupted.
+ * @return {Number} the current playback rendering state
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-readystate
+ */
+vjs.Player.prototype.readyState = function(){
+  return this.techGet('readyState');
 };
 
 // Methods to add support for
-// networkState: function(){ return this.techCall('networkState'); },
-// readyState: function(){ return this.techCall('readyState'); },
+
 // initialTime: function(){ return this.techCall('initialTime'); },
 // startOffsetTime: function(){ return this.techCall('startOffsetTime'); },
 // played: function(){ return this.techCall('played'); },

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -29,10 +29,10 @@ test('should be able to access expected player API methods', function() {
   ok(player.exitFullscreen, 'exitFullscreen exists');
   ok(player.playbackRate, 'playbackRate exists');
   ok(player.networkState, 'networkState exists');
+  ok(player.readyState, 'readyState exists');
 
   // Unsupported Native HTML5 Methods
   // ok(player.canPlayType, 'canPlayType exists');
-  // ok(player.readyState, 'readyState exists');
   // ok(player.startTime, 'startTime exists');
   // ok(player.defaultPlaybackRate, 'defaultPlaybackRate exists');
   // ok(player.playbackRate, 'playbackRate exists');

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -28,11 +28,11 @@ test('should be able to access expected player API methods', function() {
   ok(player.requestFullscreen, 'requestFullscreen exists');
   ok(player.exitFullscreen, 'exitFullscreen exists');
   ok(player.playbackRate, 'playbackRate exists');
+  ok(player.networkState, 'networkState exists');
 
   // Unsupported Native HTML5 Methods
   // ok(player.canPlayType, 'canPlayType exists');
   // ok(player.readyState, 'readyState exists');
-  // ok(player.networkState, 'networkState exists');
   // ok(player.startTime, 'startTime exists');
   // ok(player.defaultPlaybackRate, 'defaultPlaybackRate exists');
   // ok(player.playbackRate, 'playbackRate exists');

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -44,6 +44,7 @@ vjs.MediaFaker.prototype.paused = function(){ return true; };
 vjs.MediaFaker.prototype.supportsFullScreen = function(){ return false; };
 vjs.MediaFaker.prototype.buffered = function(){ return {}; };
 vjs.MediaFaker.prototype.duration = function(){ return {}; };
+vjs.MediaFaker.prototype.networkState = function(){ return 0; };
 
 // Export vars for Closure Compiler
 vjs['MediaFaker'] = vjs.MediaFaker;

--- a/test/unit/mediafaker.js
+++ b/test/unit/mediafaker.js
@@ -45,6 +45,7 @@ vjs.MediaFaker.prototype.supportsFullScreen = function(){ return false; };
 vjs.MediaFaker.prototype.buffered = function(){ return {}; };
 vjs.MediaFaker.prototype.duration = function(){ return {}; };
 vjs.MediaFaker.prototype.networkState = function(){ return 0; };
+vjs.MediaFaker.prototype.readyState = function(){ return 0; };
 
 // Export vars for Closure Compiler
 vjs['MediaFaker'] = vjs.MediaFaker;


### PR DESCRIPTION
The network and ready state properties of the video element expose important information about playback and buffering that cannot be obtained otherwise. For the HTML5 tech, the player can simply pass through the respective properties. The Flash tech has some level of support for both states, though it's probably simplistic. Even if the Flash implementation isn't perfect, having access to the properties without having to dig through the player internals is worth it.