### PR TITLE
Implement vjs-ended class

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -446,6 +446,7 @@ vjs.Player.prototype.onLoadedAllData;
  * @event play
  */
 vjs.Player.prototype.onPlay = function(){
+  this.removeClass('vjs-ended');
   this.removeClass('vjs-paused');
   this.addClass('vjs-playing');
 
@@ -540,6 +541,7 @@ vjs.Player.prototype.onProgress = function(){
  * @event ended
  */
 vjs.Player.prototype.onEnded = function(){
+  this.addClass('vjs-ended');
   if (this.options_['loop']) {
     this.currentTime(0);
     this.play();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -389,6 +389,8 @@ vjs.Player.prototype.unloadTech = function(){
 vjs.Player.prototype.onLoadStart = function() {
   // TODO: Update to use `emptied` event instead. See #1277.
 
+  this.removeClass('vjs-ended');
+
   // reset the error state
   this.error(null);
 

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -483,6 +483,20 @@ test('should remove vjs-has-started class', function(){
   ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added again');
 });
 
+test('should add and remove vjs-ended class', function() {
+  expect(2);
+
+  var player = PlayerTest.makePlayer({});
+
+  player.trigger('loadstart');
+  player.trigger('play');
+  player.trigger('ended');
+  ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class added');
+
+  player.trigger('play');
+  ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
+});
+
 test('player should handle different error types', function(){
   expect(8);
   var player = PlayerTest.makePlayer({});

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -484,7 +484,7 @@ test('should remove vjs-has-started class', function(){
 });
 
 test('should add and remove vjs-ended class', function() {
-  expect(2);
+  expect(4);
 
   var player = PlayerTest.makePlayer({});
 
@@ -494,6 +494,12 @@ test('should add and remove vjs-ended class', function() {
   ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class added');
 
   player.trigger('play');
+  ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
+
+  player.trigger('ended');
+  ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class re-added');
+
+  player.trigger('loadstart');
   ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
 });
 


### PR DESCRIPTION
Adds a `vjs-ended` class when playback ends, and removes it on a replay. Closes #1675.