### PR TITLE
removeData doesn't properly remove the id on Chrome

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -245,6 +245,8 @@ vjs.getData = function(el){
   var id = el[vjs.expando];
   if (!id) {
     id = el[vjs.expando] = vjs.guid++;
+  }
+  if (!vjs.cache[id]) {
     vjs.cache[id] = {};
   }
   return vjs.cache[id];


### PR DESCRIPTION
After updated to 4.11.4, I saw the error below many times.
```
Uncaught TypeError: Cannot read property 'handlers' of undefined
```

This is because `getData` returns null in `vjs.on` and prior to that, 'removeData' failed to delete the id with `delete el[vjs.expando]`.
````js
  try {
    delete el[vjs.expando];
  } catch(e) {
    if (el.removeAttribute) {
      el.removeAttribute(vjs.expando);
    } else {
      // IE doesn't appear to support removeAttribute on the document element
      el[vjs.expando] = null;
    }
  }
```

So far this happens only on Chrome(40.0.2214.111) and only when `el` is `object` element.
I tested `delete` syntax itself with `object` element on Chrome, but it actually failed to delete the property even though it returns `true`.

So I guess it should be Chrome's bug but I would suggest to make a change to `getData` to make sure it doesn't return `null` all the time.