### PR TITLE
Added background-color to vjs-poster to remove transparent borders around scaled poster image

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -924,6 +924,7 @@ body.vjs-full-window {
   background-repeat: no-repeat;
   background-position: 50% 50%;
   background-size: contain;
+  background-color: #000000;
   cursor: pointer;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Just found a minor issue that is when you have a cover art image that doesn't fit the player and it is scaled down, the player element is visible outside the scaled image.

This tweak sets the background-color property which means the player will always be completely covered if the poster does not fit exactly, or if the poster image cannot be loaded for some reason/whilst it's loading.

Here is what happens currently:
![image](https://cloud.githubusercontent.com/assets/3259993/6211607/ca41e670-b5d3-11e4-88f0-9ca8d9ee3fd3.png)

And here is what it looks like with the background-color property applied:
![image](https://cloud.githubusercontent.com/assets/3259993/6211617/e98dcdd2-b5d3-11e4-8eb9-8c177f39c242.png)
