### PR TITLE
Store tracks on player

### DIFF
--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -345,13 +345,13 @@ vjs.MediaTechController.prototype.emulateTextTracks = function() {
 vjs.MediaTechController.prototype.textTracks_;
 
 vjs.MediaTechController.prototype.textTracks = function() {
-  this.textTracks_ = this.textTracks_ || new vjs.TextTrackList();
-  return this.textTracks_;
+  this.player_.textTracks_ = this.player_.textTracks_ || new vjs.TextTrackList();
+  return this.player_.textTracks_;
 };
 
 vjs.MediaTechController.prototype.remoteTextTracks = function() {
-  this.remoteTextTracks_ = this.remoteTextTracks_ || new vjs.TextTrackList();
-  return this.remoteTextTracks_;
+  this.player_.remoteTextTracks_ = this.player_.remoteTextTracks_ || new vjs.TextTrackList();
+  return this.player_.remoteTextTracks_;
 };
 
 createTrackHelper = function(self, kind, label, language, options) {

--- a/test/unit/tracks/tracks.js
+++ b/test/unit/tracks/tracks.js
@@ -285,3 +285,23 @@ test('html5 tech supports native text tracks if the video supports it, unless it
   vjs.TEST_VID = oldTestVid;
   vjs.IS_FIREFOX = oldIsFirefox;
 });
+
+test('when switching techs, we should not get a new text track', function() {
+  var player = PlayerTest.makePlayer({
+        html5: {
+          nativeTextTracks: false
+        }
+      }),
+      htmltracks,
+      flashtracks;
+
+  player.loadTech('Html5');
+
+  htmltracks = player.textTracks();
+
+  player.loadTech('Flash');
+
+  flashtracks = player.textTracks();
+
+  ok(htmltracks === flashtracks, 'the tracks are equal');
+});


### PR DESCRIPTION
Previously, we were storing the text tracks on the techs. However, if you switched techs, and you were emulating captions, you would end up getting new text tracks. This meant that UI elements which registered against the initial tech's text tracks would no longer get any events.