### PR TITLE
playbackRate takes a number

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1598,10 +1598,13 @@ vjs.Player.prototype.listenForUserActivity = function(){
 };
 
 /**
- * Gets or sets the current playback rate.
+ * Gets or sets the current playback rate.  A playback rate of 
+ * 1.0 represents normal speed and 0.5 would indicate half-speed
+ * playback, for instance.
  * @param  {Number} rate    New playback rate to set.
  * @return {Number}         Returns the new playback rate when setting
  * @return {Number}         Returns the current playback rate when getting
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-playbackrate
  */
 vjs.Player.prototype.playbackRate = function(rate) {
   if (rate !== undefined) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1599,7 +1599,7 @@ vjs.Player.prototype.listenForUserActivity = function(){
 
 /**
  * Gets or sets the current playback rate.
- * @param  {Boolean} rate   New playback rate to set.
+ * @param  {Number} rate    New playback rate to set.
  * @return {Number}         Returns the new playback rate when setting
  * @return {Number}         Returns the current playback rate when getting
  */


### PR DESCRIPTION
The playbackRate() function does not take a boolean, it takes a (double-precision) number.