### PR TITLE
Only rely on selectedIndex to set select option.

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -163,10 +163,6 @@
       }
     }
 
-    if (target.selectedOptions) {
-      target.selectedOptions[0] = option;
-    }
-
     target.selectedIndex = i;
   }
 


### PR DESCRIPTION
Firefox recently added selectedOptions support, however, unlike chrome
and other browsers, they made it read-only and have it throw an error.
In my testing (via http://jsfiddle.net/vwvdywf9/), on various browsers and platforms, just using selectedIndex was sufficient to change the selected option.