### PR TITLE
Loop through track elements for default attr

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -167,7 +167,7 @@ vjs.Html5.prototype.createEl = function(){
 
 
 vjs.Html5.prototype.hideCaptions = function() {
-  var tracks = this.el_.textTracks,
+  var tracks = this.el_.querySelectorAll('track'),
       track,
       i = tracks.length,
       kinds = {
@@ -176,8 +176,9 @@ vjs.Html5.prototype.hideCaptions = function() {
       };
 
   while (i--) {
-    track = tracks[i];
-    if (track && track['kind'] in kinds) {
+    track = tracks[i].track;
+    if ((track && track['kind'] in kinds) &&
+        (!tracks[i]['default'])) {
       track.mode = 'disabled';
     }
   }


### PR DESCRIPTION
Use track's track attribute to refer to the text track itself
but use the track element to check the default attribute to decide
whether to disable or not to disable.

This should be mostly good to go. My home machine's chrome wasn't working quite right, so, someone (me) should double check that it works as expected.

Fixes #1884.