### PR TITLE
use tarball dependency of vtt.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./dist/video-js/video.js",
   "dependencies": {
     "videojs-swf": "4.5.3",
-    "vtt.js": "git+https://github.com/gkatsev/vtt.js.git#shim-build"
+    "vtt.js": "https://github.com/gkatsev/vtt.js/archive/shim-build.tar.gz"
   },
   "devDependencies": {
     "calcdeps": "~0.1.7",


### PR DESCRIPTION
This uses the tarball download instead of git to obtain the vtt.js fork, fixing my issue encountered in #1895.

Technically, there is no difference, except that npm apparently doesn't strip down the dependency as defined by `files` when downloaded as tarball, but that seems like a npm bug of its own.