### PR TITLE
Legend in pt-Br is wrong.

### DIFF
--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -7,7 +7,7 @@
   "Stream Type": "Tipo de Stream",
   "LIVE": "AO VIVO",
   "Loaded": "Carregado",
-  "Progress": "Progressão",
+  "Progress": "Progresso",
   "Fullscreen": "Tela Cheia",
   "Non-Fullscreen": "Tela Normal",
   "Mute": "Mudo",


### PR DESCRIPTION
Legend in pt-BR is wrong.
Progress is not "Progressão" in portugues, the correct word is "Progresso".