### PR TITLE
Research Spike: Switching buttons to use the button element

### DIFF
--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -64,8 +64,23 @@ replace all occurrences of 'vjs-default-skin' with a new name. Then add your new
 skin name to your video tag instead of the default skin.
 e.g. <video class="video-js my-skin-name">
 */
-.vjs-default-skin {
+.vjs-default-skin,
+.vjs-default-skin button {
   color: @main-font-color;
+}
+
+/* Button reset */
+button.vjs-control {
+  -webkit-appearance: none;
+  -moz-appearance:    none;
+  appearance:         none;
+
+  border: none;
+  background: none;
+  box-sizing: border-box;
+  font-size: 1em;
+
+  overflow: visible; /* IE8 */
 }
 
 /* Custom Icon Font

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -27,6 +27,8 @@ vjs.Button = vjs.Component.extend({
 vjs.Button.prototype.createEl = function(type, props){
   var el;
 
+  type = type || 'button';
+
   // Add standard Aria and Tabindex info
   props = vjs.obj.merge({
     className: this.buildCSSClass(),
@@ -36,6 +38,7 @@ vjs.Button.prototype.createEl = function(type, props){
   }, props);
 
   el = vjs.Component.prototype.createEl.call(this, type, props);
+  el.setAttribute('type', 'button');
 
   // if innerHTML hasn't been overridden (bigPlayButton), add content elements
   if (!props.innerHTML) {


### PR DESCRIPTION
For v5.0 we've been discussing switching to `<button>` instead of `<div>` for all the UI buttons. The general opinion among usability experts is that `<button>` is still better than `<div>` even with all the accessibility enhancements you can do (e.g. ARIA) because certain screen readers still won't support the enhanced divs. A [comment on css-tricks](https://css-tricks.com/use-button-element/#comment-1068889) confirms this for the Nuance Natural Speak app at least, though it would be great to have more specific examples if anyone knows of a resource or has details on specific screen readers to add here.

This PR has the very minimum required to switch to buttons so that they still look right in all browsers. Tested so far in IE8, IE11, Chrome, Firefox, and Safari Desktop.

This does not consider additional specificity that will be need to protect the buttons from being affected by external styles. The next steps will be to add additional property settings and a more specific scope. We at least need enough to be safe within a framework like Foundation that [adds a ton of styles to the base button element](https://github.com/zurb/foundation/blob/af84aa4153d5ee25197ec9f38b735072d80fd316/scss/foundation/components/_buttons.scss#L213).

Related issues: #841, #1499, #1880
Related contributors: @gdkraus, @OwenEdwards, @baloneysandwiches, @karlgroves
