### PR TITLE
Fluid widths and aspect ratios with metadata defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "browserify-istanbul": "^0.2.1",
     "browserify-versionify": "^1.0.4",
     "chg": "~0.2.0",
+    "css": "^2.2.0",
     "grunt": "^0.4.4",
     "grunt-aws-s3": "^0.12.1",
     "grunt-banner": "^0.3.1",

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -1,6 +1,14 @@
 .video-js {
-  display: block;
+  /* inline-block is as close as we get to the video el's display:inline */
+  display: inline-block;
+  /* Make video.js videos align top when next to video elements */
+  vertical-align: top;
   box-sizing: border-box;
+
+  /* Default to the video element width/height. This will be overridden by
+   * the source width height unless changed elsewhere. */
+  width: 300px;
+  height: 150px;
 
   color: $primary-text;
   background-color: $primary-bg;
@@ -9,8 +17,6 @@
   /* Start with 10px for base font size so other dimensions can be em based and
   easily calculable. */
   font-size: $base-font-size;
-  /* Allow poster to be vertially aligned. */
-  vertical-align: middle;
 
   /* Provide some basic defaults for fonts */
   font-weight: normal;
@@ -35,6 +41,28 @@
 .video-js *:before,
 .video-js *:after {
   box-sizing: inherit;
+}
+
+/* Fill the width of the containing element and use padding to create the
+   desired aspect ratio. Default to 16x9 unless another ratio is given. */
+.video-js.vjs-fluid,
+.video-js.vjs-16-9 {
+  width: 100%;
+  max-width:100%;
+  height: 0;
+  padding-top: 56.25%;
+}
+
+.video-js.vjs-4-3 {
+  width: 100%;
+  max-width:100%;
+  height: 0;
+  padding-top: 75%;
+}
+
+.video-js.vjs-fill {
+  width: 100%;
+  height: 100%;
 }
 
 /* Playback technology elements expand to the width/height of the containing div
@@ -65,6 +93,8 @@ body.vjs-full-window {
   right: 0;
   width: 100% !important;
   height: 100% !important;
+  /* Undo any aspect ratio padding for fluid layouts */
+  padding-top: 0 !important;
 }
 .video-js.vjs-fullscreen.vjs-user-inactive {
   cursor: none;

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -45,19 +45,20 @@
 
 /* Fill the width of the containing element and use padding to create the
    desired aspect ratio. Default to 16x9 unless another ratio is given. */
+@mixin apply-aspect-ratio($width, $height) {
+  width: 100%;
+  max-width: 100%;
+  height: 0;
+  padding-top: 100% * ($height/$width);
+}
+
 .video-js.vjs-fluid,
 .video-js.vjs-16-9 {
-  width: 100%;
-  max-width:100%;
-  height: 0;
-  padding-top: 56.25%;
+  @include apply-aspect-ratio(16, 9);
 }
 
 .video-js.vjs-4-3 {
-  width: 100%;
-  max-width:100%;
-  height: 0;
-  padding-top: 75%;
+  @include apply-aspect-ratio(4, 3);
 }
 
 .video-js.vjs-fill {

--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -1,4 +1,6 @@
 .vjs-poster {
+  display: inline-block;
+  vertical-align: middle;
   background-repeat: no-repeat;
   background-position: 50% 50%;
   background-size: contain;
@@ -10,9 +12,11 @@
   right: 0;
   bottom: 0;
   left: 0;
+  height: 100%;
 }
 .vjs-poster img {
   display: block;
+  vertical-align: middle;
   margin: 0 auto;
   max-height: 100%;
   padding: 0;

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -17,9 +17,6 @@ export default {
   'html5': {},
   'flash': {},
 
-  // Default of web browser is 300x150. Should rely on source width/height.
-  'width': 300,
-  'height': 150,
   // defaultVolume: 0.85,
   'defaultVolume': 0.00, // The freakin seaguls are driving me crazy!
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -268,7 +268,7 @@ class Player extends Component {
       // If an empty string is given, reset the dimension to be automatic
       this[property] = undefined;
     } else {
-      this[property] = parseInt(value, 10);
+      this[property] = parseFloat(value);
 
       if (isNaN(this[property])) {
         Lib.log.error(`Improper value "${value}" supplied for for ${dimension}`);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -249,20 +249,32 @@ class Player extends Component {
     return el;
   }
 
-  width(width) {
-    if (width === undefined) {
-      return this.width_ || 0;
-    }
-    this.width_ = parseInt(width, 10);
-    this.updateStyleEl_();
-    return this;
+  width(value) {
+    return this.dimension('width', value);
   }
 
-  height(height) {
-    if (height === undefined) {
-      return this.height_ || 0;
+  height(value) {
+    return this.dimension('height', value);
+  }
+
+  dimension(dimension, value) {
+    let property = dimension + '_';
+
+    if (value === undefined) {
+      return this[property] || 0;
     }
-    this.height_ = parseInt(height, 10);
+
+    if (value === '') {
+      // If an empty string is given, reset the dimension to be automatic
+      this[property] = undefined;
+    } else {
+      this[property] = parseInt(value, 10);
+
+      if (isNaN(this[property])) {
+        Lib.log.error(`Improper value "${value}" supplied for for ${dimension}`);
+      }
+    }
+
     this.updateStyleEl_();
     return this;
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -258,21 +258,24 @@ class Player extends Component {
   }
 
   dimension(dimension, value) {
-    let property = dimension + '_';
+    let privDimension = dimension + '_';
 
     if (value === undefined) {
-      return this[property] || 0;
+      return this[privDimension] || 0;
     }
 
     if (value === '') {
       // If an empty string is given, reset the dimension to be automatic
-      this[property] = undefined;
+      this[privDimension] = undefined;
     } else {
-      this[property] = parseFloat(value);
+      let parsedVal = parseFloat(value);
 
-      if (isNaN(this[property])) {
+      if (isNaN(parsedVal)) {
         Lib.log.error(`Improper value "${value}" supplied for for ${dimension}`);
+        return this;
       }
+
+      this[privDimension] = parsedVal;
     }
 
     this.updateStyleEl_();
@@ -450,7 +453,7 @@ class Player extends Component {
     this.on(this.tech, 'ratechange', this.handleTechRateChange);
     this.on(this.tech, 'volumechange', this.handleTechVolumeChange);
     this.on(this.tech, 'texttrackchange', this.onTextTrackChange);
-	this.on(this.tech, 'loadedmetadata', this.updateStyleEl_);
+    this.on(this.tech, 'loadedmetadata', this.updateStyleEl_);
 
     if (this.controls() && !this.usingNativeControls()) {
       this.addTechControlsListeners();

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -270,6 +270,9 @@ class Html5 extends Tech {
   networkState() { return this.el_.networkState; }
   readyState() { return this.el_.readyState; }
 
+  videoWidth() { return this.el_.videoWidth; }
+  videoHeight() { return this.el_.videoHeight; }
+
   textTracks() {
     if (!this['featuresNativeTextTracks']) {
       return super.textTracks();

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -152,23 +152,36 @@ test('should asynchronously fire error events during source selection', function
   Lib.log.error.restore();
 });
 
-test('should set the width and height of the player', function(){
-  var player = TestHelpers.makePlayer({ width: 123, height: '100%' });
+// test('should set the width and height of the player', function(){
+//   var player = TestHelpers.makePlayer({ width: 123, height: '100%' });
+//
+//   ok(player.width() === 123);
+//   ok(player.el().style.width === '123px');
+//
+//   var fixture = document.getElementById('qunit-fixture');
+//   var container = document.createElement('div');
+//   fixture.appendChild(container);
+//
+//   // Player container needs to have height in order to have height
+//   // Don't want to mess with the fixture itself
+//   container.appendChild(player.el());
+//   container.style.height = '1000px';
+//   ok(player.height() === 1000);
+//
+//   player.dispose();
+// });
 
-  ok(player.width() === 123);
-  ok(player.el().style.width === '123px');
+test('should set the width, height, and aspect ratio via a css class', function(){
+  let player = TestHelpers.makePlayer();
+  let styleEls = player.el().getElementsByTagName('style');
 
-  var fixture = document.getElementById('qunit-fixture');
-  var container = document.createElement('div');
-  fixture.appendChild(container);
+  ok(styleEls[0] && player.styleEl_ === styleEls[0], 'player has a style element');
 
-  // Player container needs to have height in order to have height
-  // Don't want to mess with the fixture itself
-  container.appendChild(player.el());
-  container.style.height = '1000px';
-  ok(player.height() === 1000);
+  function getStyleText(styleEl){
+    return (styleEl.styleSheet && styleEl.styleSheet.cssText) || styleEl.innerHTML;
+  }
 
-  player.dispose();
+  console.log(getStyleText(styleEls[0]));
 });
 
 test('should not force width and height', function() {

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -153,25 +153,6 @@ test('should asynchronously fire error events during source selection', function
   Lib.log.error.restore();
 });
 
-// test('should set the width and height of the player', function(){
-//   var player = TestHelpers.makePlayer({ width: 123, height: '100%' });
-//
-//   ok(player.width() === 123);
-//   ok(player.el().style.width === '123px');
-//
-//   var fixture = document.getElementById('qunit-fixture');
-//   var container = document.createElement('div');
-//   fixture.appendChild(container);
-//
-//   // Player container needs to have height in order to have height
-//   // Don't want to mess with the fixture itself
-//   container.appendChild(player.el());
-//   container.style.height = '1000px';
-//   ok(player.height() === 1000);
-//
-//   player.dispose();
-// });
-
 test('should set the width, height, and aspect ratio via a css class', function(){
   let player = TestHelpers.makePlayer();
   let getStyleText = function(styleEl){

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -228,7 +228,7 @@ test('should set the width, height, and aspect ratio via a css class', function(
   // Change the aspect ratio
   player.aspectRatio('4:1');
   rules = getStyleRules();
-  equal(rules['.example_1-dimensions.vjs-fluid']['padding-top'], '56.25%', 'aspect ratio percent should match the newly set aspect ratio');
+  equal(rules['.example_1-dimensions.vjs-fluid']['padding-top'], '25%', 'aspect ratio percent should match the newly set aspect ratio');
 });
 
 test('should wrap the original tag in the player div', function(){


### PR DESCRIPTION
Building on #1440 from @baloneysandwiches. (Would appreciate your feedback Alex.) This isn't completely finished and needs tests but wanted to get it out for review.

The big diff here is that I'm creating a style element and using that to add widths (user-set, metadata-provided, and defaults) and aspect ratios for fluid layouts. The goal was to let the video.js user override player dimensions with CSS the same way they can with the video element. Previously we were using inline styles to add width and height, and we were doing that with the default values, which meant you couldn't easily use CSS to size the player. (I'm able to make this change now because we're in 5.0 development)

I've included a screen shot of all the different user stories from #982 passing.

One question that's come out of this is whether or not we need the width/height functions on other components, since everything is getting sized in the main stylesheet. It would be nice to drop or at least simplify those. In this PR I'm overriding the player's width/height functions so now they work differently from other components.

Amazingly this works in IE8 with Flash, including the metadata widths. I'm just having an issue getting the poster image centered again.

![responsive-examples](https://cloud.githubusercontent.com/assets/166/6679437/da42ad4c-cc04-11e4-927c-5061598f0b0f.png)

Related Issues: #983, #1440, #982