### PR TITLE
Extended canHandleSource in media files to consistently guess mime types. Fixes #1833

### DIFF
--- a/src/js/lib.js
+++ b/src/js/lib.js
@@ -849,3 +849,25 @@ vjs.arr.forEach = function(array, callback, thisArg) {
 
   return array;
 };
+
+/**
+ * Returns the extension of the passed file name. It will return an empty string if you pass an invalid path
+ *
+ * @param {String}    path    The fileName path like '/path/to/file.mp4'
+ * @returns {String}          The extension in lower case or an empty string if no extension could be found.
+ */
+vjs.getFileExtension = function(path) {
+  var splitPathRe;
+  var pathParts;
+
+  if(typeof path === 'string'){
+    splitPathRe = /^(\/?)([\s\S]*?)((?:\.{1,2}|[^\/]+?)(\.([^\.\/\?]+)))(?:[\/]*|[\?].*)$/i;
+    pathParts = splitPathRe.exec(path);
+
+    if (pathParts) {
+      return pathParts.pop().toLowerCase();
+    }
+  }
+
+  return '';
+};

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -233,15 +233,24 @@ vjs.Flash.nativeSourceHandler = {};
  * @param  {Object} source  The source object
  * @return {String}         'probably', 'maybe', or '' (empty string)
  */
-vjs.Flash.nativeSourceHandler.canHandleSource = function(source){
+
+vjs.Flash.nativeSourceHandler.canHandleSource = function (source) {
   var type;
 
-  if (!source.type) {
+  function guessMimeType(src) {
+    var ext = vjs.getFileExtension(src);
+    if (ext) {
+      return 'video/' + ext;
+    }
     return '';
   }
 
-  // Strip code information from the type because we don't get that specific
-  type = source.type.replace(/;.*/,'').toLowerCase();
+  if (!source.type) {
+    type = guessMimeType(source.src);
+  } else {
+    // Strip code information from the type because we don't get that specific
+    type = source.type.replace(/;.*/, '').toLowerCase();
+  }
 
   if (type in vjs.Flash.formats) {
     return 'maybe';

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -477,7 +477,7 @@ vjs.Html5.nativeSourceHandler = {};
  * @return {String}         'probably', 'maybe', or '' (empty string)
  */
 vjs.Html5.nativeSourceHandler.canHandleSource = function(source){
-  var match, ext;
+  var ext;
 
   function canPlayType(type){
     // IE9 on Windows 7 without MediaPlayer throws an error here
@@ -494,8 +494,7 @@ vjs.Html5.nativeSourceHandler.canHandleSource = function(source){
     return canPlayType(source.type);
   } else if (source.src) {
     // If no type, fall back to checking 'video/[EXTENSION]'
-    match = source.src.match(/\.([^.\/\?]+)(\?[^\/]+)?$/i);
-    ext = match && match[1];
+    ext = vjs.getFileExtension(source.src);
 
     return canPlayType('video/'+ext);
   }

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -152,3 +152,12 @@ test('ready triggering before and after disposing the tech', function() {
 test('should have the source handler interface', function() {
   ok(vjs.Flash.registerSourceHandler, 'has the registerSourceHandler function');
 });
+
+test('canHandleSource should be able to work with src objects without a type', function () {
+  var canHandleSource = vjs.Flash.nativeSourceHandler.canHandleSource;
+  equal('maybe', canHandleSource({src: 'test.video.mp4'}), 'should guess that it is a mp4 video');
+  equal('maybe', canHandleSource({src: 'test.video.m4v'}), 'should guess that it is a m4v video');
+  equal('maybe', canHandleSource({src: 'test.video.flv'}), 'should guess that it is a flash video');
+  equal('', canHandleSource({src: 'test.video.wgg'}), 'should return empty string if it can not play the video');
+});
+

--- a/test/unit/lib.js
+++ b/test/unit/lib.js
@@ -403,3 +403,22 @@ test('should loop through each element of an array', function() {
     }
   });
 });
+
+//getFileExtension tests
+test('should get the file extension of the passed path', function() {
+  equal(vjs.getFileExtension('/foo/bar/test.video.wgg'), 'wgg');
+  equal(vjs.getFileExtension('test./video.mp4'), 'mp4');
+  equal(vjs.getFileExtension('.bar/test.video.m4v'), 'm4v');
+  equal(vjs.getFileExtension('foo/.bar/test.video.flv'), 'flv');
+  equal(vjs.getFileExtension('foo/.bar/test.video.flv?foo=bar'), 'flv');
+
+  //edge cases
+  equal(vjs.getFileExtension('foo/.bar/testvideo'), '');
+  equal(vjs.getFileExtension(''), '');
+  equal(vjs.getFileExtension(null), '');
+  equal(vjs.getFileExtension(undefined), '');
+
+  //with capital letters
+  equal(vjs.getFileExtension('test.video.MP4'), 'mp4');
+  equal(vjs.getFileExtension('test.video.FLV'), 'flv');
+});

--- a/test/unit/lib.js
+++ b/test/unit/lib.js
@@ -411,8 +411,11 @@ test('should get the file extension of the passed path', function() {
   equal(vjs.getFileExtension('.bar/test.video.m4v'), 'm4v');
   equal(vjs.getFileExtension('foo/.bar/test.video.flv'), 'flv');
   equal(vjs.getFileExtension('foo/.bar/test.video.flv?foo=bar'), 'flv');
+  equal(vjs.getFileExtension('http://www.test.com/video.mp4'), 'mp4');
+  equal(vjs.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
 
   //edge cases
+  equal(vjs.getFileExtension('http://...'), '');
   equal(vjs.getFileExtension('foo/.bar/testvideo'), '');
   equal(vjs.getFileExtension(''), '');
   equal(vjs.getFileExtension(null), '');


### PR DESCRIPTION
Added getFileExtension to libs. And used it on Html5 and Flash canHandleSource method to guess the mime type if necessary.