### PR TITLE
Update minified video.js name

### DIFF
--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -4,13 +4,13 @@
   <title>Video.js | HTML5 Video Player</title>
 
   <!-- Chang URLs to wherever Video.js files will be hosted -->
-  <link href="../../video-js.css" rel="stylesheet" type="text/css">
+  <link href="../../../build/temp/video-js.min.css" rel="stylesheet" type="text/css">
   <!-- video.js must be in the <head> for older IEs to work. -->
-  <script src="../../video.js"></script>
+  <script src="../../../build/temp/video.min.js"></script>
 
   <!-- Unless using the CDN hosted version, update the URL to the Flash SWF -->
   <script>
-    videojs.options.flash.swf = "../../video-js.swf";
+    videojs.options.flash.swf = "../../../build/temp/video-js.swf";
   </script>
 
 </head>

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -20,8 +20,8 @@ You can download the Video.js source and host it on your own servers, or use the
 
 ### CDN Version ###
 ```html
-<link href="//vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/4.12/video.js"></script>
+<link href="//vjs.zencdn.net/4.12/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/4.12/video.min.js"></script>
 ```
 
 
@@ -43,8 +43,8 @@ To entirely self-host, you'll need to pull in the font files and let Video.js kn
 should Just Work™, but the paths can easily be changed by editing the LESS file and re-building, or by modifying the generated CSS file.
 
 ```html
-<link href="//example.com/path/to/video-js.css" rel="stylesheet">
-<script src="//example.com/path/to/video.js"></script>
+<link href="//example.com/path/to/video-js.min.css" rel="stylesheet">
+<script src="//example.com/path/to/video.min.js"></script>
 <script>
   videojs.options.flash.swf = "http://example.com/path/to/video-js.swf"
 </script>


### PR DESCRIPTION
Change the docs to point to the new minified name for video.js. For #1013.