### PR TITLE
Throw an error if techOrder isn't in options. For #1998

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -263,6 +263,21 @@ module.exports = function(grunt) {
       }
     },
     browserify: {
+      options: {
+        transform: [
+          require('babelify').configure({
+            sourceMapRelative: './src/js'
+          }),
+          ['browserify-versionify', {
+            placeholder: '__VERSION__',
+            version: pkg.version
+          }],
+          ['browserify-versionify', {
+            placeholder: '__VERSION_NO_PATCH__',
+            version: version.majorMinor
+          }]
+        ]
+      },
       build: {
         files: {
           'build/temp/video.js': ['src/js/video.js']
@@ -275,19 +290,15 @@ module.exports = function(grunt) {
           banner: license,
           plugin: [
             [ 'browserify-derequire' ]
-          ],
-          transform: [
-            require('babelify').configure({
-              sourceMapRelative: './src/js'
-            }),
-            ['browserify-versionify', {
-              placeholder: '__VERSION__',
-              version: pkg.version
-            }],
-            ['browserify-versionify', {
-              placeholder: '__VERSION_NO_PATCH__',
-              version: version.majorMinor
-            }]
+          ]
+        }
+      },
+      test: {
+        files: {
+          'build/temp/tests.js': [
+            'test/globals-shim.js',
+            'test/unit/**/*.js',
+            'test/api/**.js'
           ]
         }
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -312,6 +312,9 @@ module.exports = function(grunt) {
       }
     },
     coveralls: {
+      options: {
+        force: true
+      },
       all: {
         src: 'test/coverage/lcov.info'
       }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -76,6 +76,17 @@ class Player extends Component {
     // Run base component initializing with new options
     super(null, options, ready);
 
+
+    // if the global option object was accidentally blown away by
+    // someone, bail early with an informative error
+    if (!this.options_ ||
+        !this.options_.techOrder ||
+        !this.options_.techOrder.length) {
+      throw new Error('No techOrder specified. Did you overwrite ' +
+                      'videojs.options instead of just changing the ' +
+                      'properties you want to override?');
+    }
+
     this.tag = tag; // Store the original tag used to set options
 
     // Store the tag attributes used to restore html5 element

--- a/test/globals-shim.js
+++ b/test/globals-shim.js
@@ -1,0 +1,10 @@
+import window from 'global/window';
+import sinon from 'sinon';
+
+window.q = QUnit;
+window.sinon = sinon;
+
+// This may not be needed anymore, but double check before removing
+window.fixture = document.createElement('div');
+fixture.id = 'qunit-fixture';
+document.body.appendChild(fixture);

--- a/test/index.html
+++ b/test/index.html
@@ -4,13 +4,12 @@
   <meta charset="utf-8">
   <title>VideoJS Tests</title>
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+  <link rel="stylesheet" href="../build/temp/video-js.min.css">
 </head>
 <body>
   <div id="qunit"></div>
-  <div id="qunit-fixture"></div>
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-  <script>
-  </script>
   <script src="../build/temp/tests.js"></script>
+  <script src="api/api.js"></script>
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>VideoJS Tests</title>
+  <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
+  <script>
+  </script>
+  <script src="../build/temp/tests.js"></script>
+</body>
+</html>

--- a/test/karma-qunit-shim.js
+++ b/test/karma-qunit-shim.js
@@ -1,6 +1,0 @@
-var q = QUnit;
-
-// This may not be needed anymore, but double check before removing
-var fixture = document.createElement('div');
-fixture.id = 'qunit-fixture';
-document.body.appendChild(fixture);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -50,20 +50,16 @@ module.exports = function(config) {
   config.set({
     basePath: '',
 
-    frameworks: ['browserify', 'qunit', 'sinon'],
+    frameworks: ['browserify', 'qunit'],
 
     autoWatch: false,
 
     singleRun: true,
 
-    // customLaunchers: customLaunchers,
-
     files: [
       '../build/temp/video-js.min.css',
-      '../test/karma-qunit-shim.js',
-      '../test/unit/**/*.js',
       '../build/temp/video.min.js',
-      '../test/api/**/*.js',
+      '../build/temp/tests.js',
     ],
 
     preprocessors: {
@@ -84,7 +80,6 @@ module.exports = function(config) {
       'karma-phantomjs-launcher',
       'karma-safari-launcher',
       'karma-sauce-launcher',
-      'karma-sinon',
       'karma-browserify',
       'karma-coverage'
     ],

--- a/test/unit/player.js
+++ b/test/unit/player.js
@@ -717,3 +717,14 @@ test('should be scrubbing while seeking', function(){
   equal(player.scrubbing(), true, 'player is scrubbing');
   ok(player.el().className.indexOf('scrubbing') !== -1, 'scrubbing class is present');
 });
+
+test('should throw on startup no techs are specified', function() {
+  const techOrder = Options.techOrder;
+
+  Options.techOrder = null;
+  q.throws(function() {
+    videojs(TestHelpers.makeTag());
+  }, 'a falsey techOrder should throw');
+
+  Options.techOrder = techOrder;
+});


### PR DESCRIPTION
Bail with a friendly error if techOrder isn't defined during player construction. Add in a qunit test page at the root of the tests directory for simpler browser debugging.