### PR TITLE
Add vjs standard

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function(grunt) {
   var pkg = grunt.file.readJSON('package.json');
   var license = grunt.file.read('build/license-header.txt');
   var verParts = pkg.version.split('.');
+  var testBuildArray;
   var version = {
     full: pkg.version,
     major: verParts[0],
@@ -404,12 +405,16 @@ module.exports = function(grunt) {
   grunt.registerTask('skin-dev', ['connect:dev', 'watch:skin']);
 
   // Tests.
+  testBuildArray = ['standard', 'build'];
+
   // We want to run things a little differently if it's coming from Travis vs local
   if (process.env.TRAVIS) {
-    grunt.registerTask('test', ['build', 'test-travis', 'coveralls']);
+    testBuildArray = testBuildArray.concat(['test-travis', 'coveralls']);
   } else {
-    grunt.registerTask('test', ['build', 'test-local']);
+    testBuildArray = testBuildArray.concat(['test-local']);
   }
+
+  grunt.registerTask('test', testBuildArray);
 
   // Load all the tasks in the tasks directory
   grunt.loadTasks('build/tasks');

--- a/build/tasks/standard.js
+++ b/build/tasks/standard.js
@@ -1,0 +1,11 @@
+module.exports = function(grunt) {
+  grunt.registerTask('standard', 'Run videojs-standard', function() {
+    var done = this.async();
+    grunt.util.spawn({
+      cmd: 'videojs-standard',
+      opts: {
+        stdio: 'inherit'
+      }
+    }, done);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "sinon": "~1.9.1",
     "uglify-js": "~2.3.6",
     "videojs-doc-generator": "0.0.1",
-    "videojs-standard": "^3.7.4"
+    "videojs-standard": "^3.7.5"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "qunitjs": "~1.14.0",
     "sinon": "~1.9.1",
     "uglify-js": "~2.3.6",
-    "videojs-doc-generator": "0.0.1"
+    "videojs-doc-generator": "0.0.1",
+    "videojs-standard": "^3.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "sinon": "~1.9.1",
     "uglify-js": "~2.3.6",
     "videojs-doc-generator": "0.0.1",
-    "videojs-standard": "^3.7.3"
+    "videojs-standard": "^3.7.4"
   },
   "standard": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -76,5 +76,16 @@
     "uglify-js": "~2.3.6",
     "videojs-doc-generator": "0.0.1",
     "videojs-standard": "^3.7.3"
+  },
+  "standard": {
+    "ignore": [
+      "**/build/**",
+      "**/dist/**",
+      "**/docs/**",
+      "**/lang/**",
+      "**/sandbox/**",
+      "**/test/**",
+      "**/Gruntfile.js"
+    ]
   }
 }


### PR DESCRIPTION
So far, this adds in videojs-standard. `standard --format` is currently broken because it doesn't support the ES6 module syntax.

I'll be working towards making the changes to pass standard.
Addresses #2034.

TODO
* [ ] Remove jshint and others
* [ ] Update code
* [ ] ???
* [ ] Profit