### PR TITLE
Expose videojs.plugin()

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -17,7 +17,7 @@ import * as Lib from './lib';
 import * as Util from './util.js';
 import Player from './player';
 import extendsFn from './extends.js';
-import plugin from './Plugins.js';
+import plugin from './plugins.js';
 
 if (typeof HTMLVideoElement === 'undefined') {
   document.createElement('video');

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -17,6 +17,7 @@ import * as Lib from './lib';
 import * as Util from './util.js';
 import Player from './player';
 import extendsFn from './extends.js';
+import plugin from './Plugins.js';
 
 if (typeof HTMLVideoElement === 'undefined') {
   document.createElement('video');
@@ -40,6 +41,8 @@ videojs.util = Util;
 videojs.players = Player.players;
 
 videojs.extends = extendsFn;
+
+videojs.plugin = plugin;
 
 // REMOVING: We probably should not include this in 5.0 thought it would make it
 // more backwards compatible

--- a/test/unit/video.js
+++ b/test/unit/video.js
@@ -1,0 +1,23 @@
+import videojs from '../../src/js/video.js';
+import TestHelpers from './test-helpers.js';
+
+q.module('video.js');
+
+test('should expose plugin registry function', function() {
+  var pluginName, pluginFunction, player;
+
+  pluginName = 'foo';
+  pluginFunction = function(options) {
+    console.log(this);
+  };
+
+  ok(videojs.plugin, 'should exist');
+
+  videojs.plugin(pluginName, pluginFunction);
+
+  player = TestHelpers.makePlayer();
+
+  ok(player.foo, 'should exist');
+  equal(player.foo, pluginFunction, 'should be equal');
+
+});


### PR DESCRIPTION
So that plugins can be registered with the same api!  Also a unit test
module for the video.js entrypoint.

Fixes #2102