### PR TITLE
Text descriptions track support

### DIFF
--- a/sandbox/descriptions.html.example
+++ b/sandbox/descriptions.html.example
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Text Descriptions Example</title>
+
+  <link href="../build/files/video-js.css" rel="stylesheet" type="text/css">
+
+  <!-- LOAD VIDEO.JS SOURCE FILES IN ORDER -->
+  <script src="../build/source-loader.js"></script>
+
+</head>
+<body>
+  <p style="background-color:#eee; border: 1px solid #777; padding: 10px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">This page demonstrates a text descriptions track (intended primarily for blind and visually impaired consumers of visual media)</p>
+
+  <!-- NOTE: we have to disable native Text Track support for the HTML5 tech,
+             since even HTML5 video players with native Text Track support
+             don't currently support 'description' text tracks in any
+             useful way! -->
+  <video id="example_video_1" class="video-js vjs-default-skin" controls preload="none" width="640" height="360"
+      data-setup='{ "html5" : { "nativeTextTracks" : false } }'>
+    <source src="https://archive.org/download/ElephantsDream/ed_hd.mp4" type="video/mp4">
+    <source src="https://archive.org/download/ElephantsDream/ed_hd.ogv" type="video/ogv">
+
+    <track kind="descriptions" src="elephantsdream.ad.vtt.example" srclang="en" label="English">
+
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video>
+</body>
+</html>

--- a/sandbox/elephantsdream.ad.vtt.example
+++ b/sandbox/elephantsdream.ad.vtt.example
@@ -1,0 +1,278 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:05.000
+The orange open movie project presents
+
+2
+00:00:05.010 --> 00:00:12.000
+Introductory titles are showing on the background of a water pool with fishes swimming and mechanical objects lying on a stone floor.
+
+3
+00:00:12.010 --> 00:00:14.800
+elephants dream
+
+4
+00:00:26.100 --> 00:00:28.206
+Two people stand on a small bridge.
+
+5
+00:00:30.010 --> 00:00:40.000
+The old man, Proog, shoves the younger and less experienced Emo on the ground to save him from being mowed down by a barrage of jack plugs that whir back and forth between the two massive switch-board-like walls.
+
+6
+00:00:40.000 --> 00:00:47.000
+The plugs are oblivious of the two, endlessly channeling streams of bizarre sounds and data.
+
+7
+00:00:48.494 --> 00:00:51.994
+Emo sits on the bridge and checks his limbs.
+
+8
+00:01:09.150 --> 00:01:16.030
+After the squealing plugs move on, Proog makes sure that Emo is unharmed and urges him onwards through a crack in one of the plug-walls.
+
+9
+00:01:18.050 --> 00:01:24.000
+They walk through the narrow hall into a massive room that fades away into blackness on all sides.
+
+10
+00:01:24.050 --> 00:01:34.200
+Only one path is visible, suspended in mid-air that runs between thousands of dangling electric cables on which sit crowds of robin-like robotic birds.
+
+11
+00:01:36.000 --> 00:01:40.000
+As Proog and Emo enter the room, the birds begin to wake up and notice them.
+
+12
+00:01:42.000 --> 00:01:50.000
+Realizing the danger, Proog grabs Emo by the arm.
+
+13
+00:01:50.050 --> 00:02:00.000
+They run along the increasingly bizarre path as the birds begin to swarm.
+
+14
+00:02:00.050 --> 00:02:11.000
+All sound is blocked out by the birds which are making the same noises as the jack-plugs, garbled screaming and obscure sentences and static.
+
+15
+00:02:12.600 --> 00:02:17.000
+The path dead-ends, stopping in the middle of no-where above the infinite drop.
+
+16
+00:02:17.600 --> 00:02:22.000
+Proog turns around as the birds reach them and begin to dive-bomb at them.
+
+17
+00:02:22.600 --> 00:02:28.000
+At the last moment, Proog takes out an old candlestick phone and the birds dive into the speaker piece.
+
+18
+00:02:28.600 --> 00:02:31.000
+The screen cuts to black.
+
+19
+00:02:31.600 --> 00:02:38.000
+In the next scene, Proog stands at one end of a room, suspiciously watching what is probably the same candlestick phone, which is ringing.
+
+20
+00:02:38.500 --> 00:02:41.000
+Emo watches from the other side of the room.
+
+21
+00:02:41.500 --> 00:02:43.000
+The phone continues to ring.
+
+22
+00:02:43.500 --> 00:02:48.000
+After a while Emo approaches it to answer it, but Proog slaps his hand away.
+
+23
+00:02:57.972 --> 00:02:59.100
+Proog takes the ear-piece off the hook.
+
+24
+00:03:13.500 --> 00:03:18.054
+The phone speaker revealed a mass of clawed, fleshy polyps which scream and gibber obscenely.
+
+25
+00:03:25.000 --> 00:03:33.000
+There is a solemn silence as Emo looks around the room and the technical objects therein.
+
+26
+00:03:38.000 --> 00:03:44.000
+Emo laughs disbelievingly and Proog walks away.
+
+27
+00:03:46.000 --> 00:03:54.000
+In the next scene, the two enter another massive black room.
+
+28
+00:03:54.500 --> 00:04:04.000
+There is no path, the entry platform is the only structure that seems to be there except for another exit, lit distantly at the far side.
+
+29
+00:04:04.500 --> 00:04:14.000
+Proog takes a step forward into the void, and his feet are suddenly caught by giant typewriter arms that rocket up out of the blackness to catch his feet as he dances across mid-air.
+
+30
+00:04:14.500 --> 00:04:22.000
+Emo follows Proog with somewhat less enthusiasm as the older man leads the way.
+
+31
+00:04:52.000 --> 00:04:58.000
+They reach the end of the room and go through a hall into a small compartment.
+
+32
+00:05:02.000 --> 00:05:06.000
+Proog presses a button, and the door shuts.
+
+33
+00:05:06.500 --> 00:05:09.000
+It is an elevator.
+
+34
+00:05:09.500 --> 00:05:24.000
+The elevator lurches suddenly as it is grabbed by a giant mechanical arm and thrown upwards, rushing up through an ever-widening tunnel.
+
+35
+00:05:26.500 --> 00:05:32.000
+When it begins to slow down, another arm grabs the capsule and throws it even further up.
+
+36
+00:05:32.500 --> 00:05:40.000
+As it moves up, the walls unlock and fall away, leaving only the floor with the two on it, rushing higher and higher.
+
+37
+00:05:54.500 --> 00:05:59.000
+They exit the tunnel into a black sky and the platform reaches the peak of its arc.
+
+38
+00:06:19.500 --> 00:06:26.000
+The elevator begins to drop down another shaft, coming to rest as it slams into the floor of another room and bringing the two to a level stop.
+
+39
+00:06:26.500 --> 00:06:28.000
+A camera flashes.
+
+40
+00:06:28.010 --> 00:06:34.000
+They are in a large, dingy room filled with strange, generator-like devices and dotted with boxy holographic projectors.
+
+41
+00:06:34.500 --> 00:06:38.000
+One of them is projecting a portion of wall with a door in it right beside them.
+
+42
+00:06:38.500 --> 00:06:40.000
+The door seems harmless enough.
+
+43
+00:06:42.800 --> 00:06:45.100
+From behind the door comes light music.
+
+44
+00:06:56.000 --> 00:07:00.100
+Proog presses a button on his cane, which changes the holograph to another wall.
+
+45
+00:07:05.100 --> 00:07:11.000
+Proog finishes the wall, and boxes them into a Safe Room, out of the view of anything outside.
+
+46
+00:07:39.000 --> 00:07:42.500
+Proog slaps him, trying to bring him to his senses.
+
+47
+00:07:45.000 --> 00:07:52.000
+Emo storms away down the length of the room towards a wall he apparently cannot see and the wall begins to move, extending the length of the room.
+
+48
+00:08:00.000 --> 00:08:07.000
+The walls begin to discolour and mechanical roots start tearing through the walls to his left.
+
+49
+00:08:07.010 --> 00:08:09.000
+The roots move forwards toward Proog.
+
+50
+00:08:22.000 --> 00:08:31.000
+The rest of the safety wall crumples away as a pair of massive hands heave out of the ground and begin to attack.
+
+51
+00:08:31.010 --> 00:08:37.000
+Proog is knocked down by the shockwave, while Emo turns and begins to walk away, waving his finger around his temple in the 'crazy' sign.
+
+52
+00:08:37.010 --> 00:08:44.000
+In a last effort, Proog extricates himself from the tentacle roots, and cracks Emo over the back of the head with his cane.
+
+53
+00:08:44.500 --> 00:08:51.000
+As Emo collapses, everything falls away, and Proog and Emo are left in one tiny patch of light in the middle of blackness.
+
+54
+00:09:00.000 --> 00:09:20.000
+The scene fades to black while panning over a pile of tentacle roots lying on the ground.
+
+55
+00:09:26.000 --> 00:09:28.000
+Credits begin:
+
+56
+00:09:28.500 --> 00:09:35.000
+Orange Open Movie Team
+Director: Bassum Kurdali
+Art Director: Andreas Goralczyk
+
+57
+00:09:35.500 --> 00:09:39.000
+Music and Sound Design: Jan Morgenstern
+
+58
+00:09:39.500 --> 00:09:44.000
+Emo: Cas Jansen
+Proog: Tygo Gernandt
+
+59
+00:09:44.500 --> 00:09:50.000
+Screenplay: Pepijn Zwanenberg
+Original Concept & Scenario: Andreas Goralczyk, Bassam Kurdali, Ton Roosendaal
+
+60
+00:09:50.500 --> 00:10:24.000
+More people for
+Additional Artwork and Animation
+Texture Photography
+Software Development
+3D Modelling, Animation, Rendering, Compiling Software
+Special Thanks to Open Source Projects
+Rendering Services Provided
+Hardware  Sponsored
+Casting
+Sound FX, Foley, Dialogue Editing, Audio Mix and Post
+Voice Recording
+HDCam conversion
+Netherlands Media Art Institute Staff
+Blender Foundation Staff
+
+61
+00:10:24.500 --> 00:10:30.000
+Many Thanks to our Donation and DVD sponsors
+
+62
+00:10:30.500 --> 00:10:47.000
+Elephants Dream has been realised with financial support from
+The Netherlands Film Fund
+Mondriaan Foundation
+VSBfonds
+Uni-Verse / EU Sixth Framework Programme
+
+63
+00:10:47.500 --> 00:10:53.000
+Produced By
+Ton Roosendaal
+Copyright 2006
+Netherlands Media Art Institute / Montevideo
+Blender Foundation

--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -102,6 +102,7 @@ The control icons are from a custom font. Each icon corresponds to a character
 @spinner4-icon: "\e01f";
 @subtitles-icon: "\e00c";
 @captions-icon: "\e008";
+@descriptions-icon: "D))"; //TODO Add a proper 'AD))' icon to the font
 @chapters-icon: "\e00c";
 @share-icon: "\e00e";
 @cog-icon: "\e600";
@@ -825,6 +826,11 @@ easily in the skin designer. http://designer.videojs.com/
   content: @captions-icon;
 }
 
+/* Descriptions Button */
+.vjs-default-skin .vjs-descriptions-button:before {
+  content: @descriptions-icon;
+}
+
 /* Chapters Button */
 .vjs-default-skin .vjs-chapters-button:before {
   content: @chapters-icon;
@@ -963,13 +969,35 @@ body.vjs-full-window {
 }
 
 /* Text Track Styles */
-/* Overall track holder for both captions and subtitles */
+/* Overall track holder for all text tracks */
 .video-js .vjs-text-track-display {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  pointer-events: none;
+}
+
+/* Overall track holder for both captions and subtitles */
+.video-js .vjs-text-track-visible-display {
   position: absolute;
   top: 0;
   left: 0;
   bottom: 3em;
   right: 0;
+  pointer-events: none;
+}
+
+/* Overall track holder for tracks which are not visible,
+   (but accessible with a screen reader) */
+.video-js .vjs-text-track-hidden-display {
+/* See http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/C7.html */
+	position: absolute !important;
+	top: -10000px;
+	overflow: hidden;
+	width: 1px;
+	height: 1px;
   pointer-events: none;
 }
 

--- a/src/css/video-js.less
+++ b/src/css/video-js.less
@@ -1010,7 +1010,7 @@ body.vjs-full-window {
   color: #FFF;
   margin: 0 auto;
   padding: 0.5em;
-  height: 15em;
+  height: 20em;
   font-family: Arial, Helvetica, sans-serif;
   font-size: 12px;
   width: 40em;

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -25,6 +25,7 @@ vjs.ControlBar.prototype.options_ = {
     'playbackRateMenuButton': {},
     'subtitlesButton': {},
     'captionsButton': {},
+    'descriptionsButton': {},
     'chaptersButton': {}
   }
 };

--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -146,6 +146,7 @@ goog.exportProperty(vjs.ChaptersButton.prototype, 'createItems', vjs.ChaptersBut
 
 goog.exportSymbol('videojs.SubtitlesButton', vjs.SubtitlesButton);
 goog.exportSymbol('videojs.CaptionsButton', vjs.CaptionsButton);
+goog.exportSymbol('videojs.DescriptionsButton', vjs.DescriptionsButton);
 goog.exportSymbol('videojs.ChaptersButton', vjs.ChaptersButton);
 
 goog.exportSymbol('videojs.MediaTechController', vjs.MediaTechController);
@@ -222,6 +223,7 @@ goog.exportProperty(vjs.TextTrackCueList.prototype, 'getCueById', vjs.TextTrackL
 
 goog.exportSymbol('videojs.CaptionsTrack', vjs.CaptionsTrack);
 goog.exportSymbol('videojs.SubtitlesTrack', vjs.SubtitlesTrack);
+goog.exportSymbol('videojs.DescriptionsTrack', vjs.DescriptionsTrack);
 goog.exportSymbol('videojs.ChaptersTrack', vjs.ChaptersTrack);
 
 goog.exportSymbol('videojs.autoSetup', vjs.autoSetup);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1693,7 +1693,7 @@ vjs.Player.prototype.readyState = function(){
  * Captions - text displayed over the video for the hearing impaired
  * Subtitles - text displayed over the video for those who don't understand language in the video
  * Chapters - text displayed in a menu allowing the user to jump to particular points (chapters) in the video
- * Descriptions (not supported yet) - audio descriptions that are read back to the user by a screen reading device
+ * Descriptions - audio descriptions that are read back to the user by a screen reading device
  */
 
 /**

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -21,6 +21,7 @@
         this.el().querySelector('.vjs-edge-style select').selectedIndex = 0;
         this.el().querySelector('.vjs-font-family select').selectedIndex = 0;
         this.el().querySelector('.vjs-font-percent select').selectedIndex = 2;
+        this.el().querySelector('.vjs-descriptions-playback select').selectedIndex = 0;
         this.updateDisplay();
       }));
 
@@ -33,6 +34,7 @@
       vjs.on(this.el().querySelector('.vjs-font-percent select'), 'change', vjs.bind(this, this.updateDisplay));
       vjs.on(this.el().querySelector('.vjs-edge-style select'), 'change', vjs.bind(this, this.updateDisplay));
       vjs.on(this.el().querySelector('.vjs-font-family select'), 'change', vjs.bind(this, this.updateDisplay));
+      vjs.on(this.el().querySelector('.vjs-descriptions-playback select'), 'change', vjs.bind(this, this.updateDisplay));
 
       if (player.options()['persistTextTrackSettings']) {
         this.restoreSettings();
@@ -48,7 +50,7 @@
   };
 
   vjs.TextTrackSettings.prototype.getValues = function() {
-    var el, bgOpacity, textOpacity, windowOpacity, textEdge, fontFamily, fgColor, bgColor, windowColor, result, name, fontPercent;
+    var el, bgOpacity, textOpacity, windowOpacity, textEdge, fontFamily, fgColor, bgColor, windowColor, result, name, fontPercent, descriptionsPlayback;
 
     el = this.el();
 
@@ -61,6 +63,7 @@
     windowColor = getSelectedOptionValue(el.querySelector('.window-color > select'));
     windowOpacity = getSelectedOptionValue(el.querySelector('.vjs-window-opacity > select'));
     fontPercent = window['parseFloat'](getSelectedOptionValue(el.querySelector('.vjs-font-percent > select')));
+    descriptionsPlayback = getSelectedOptionValue(el.querySelector('.vjs-descriptions-playback > select'));
 
     result = {
       'backgroundOpacity': bgOpacity,
@@ -71,7 +74,8 @@
       'color': fgColor,
       'backgroundColor': bgColor,
       'windowColor': windowColor,
-      'fontPercent': fontPercent
+      'fontPercent': fontPercent,
+      'descriptionsPlayback' : descriptionsPlayback
     };
     for (name in result) {
       if (result[name] === '' || result[name] === 'none' || (name === 'fontPercent' && result[name] === 1.00)) {
@@ -92,6 +96,7 @@
     setSelectedOption(el.querySelector('.vjs-bg-opacity > select'), values.backgroundOpacity);
     setSelectedOption(el.querySelector('.window-color > select'), values.windowColor);
     setSelectedOption(el.querySelector('.vjs-window-opacity > select'), values.windowOpacity);
+    setSelectedOption(el.querySelector('.vjs-descriptions-playback > select'), values.descriptionsPlayback);
 
     fontPercent = values.fontPercent;
 
@@ -100,6 +105,8 @@
     }
 
     setSelectedOption(el.querySelector('.vjs-font-percent > select'), fontPercent);
+
+    setSelectedOption(el.querySelector('.vjs-descriptions-playback > select'), values.descriptionsPlayback);
   };
 
   vjs.TextTrackSettings.prototype.restoreSettings = function() {
@@ -273,6 +280,13 @@
               '<option value="small-caps">Small Caps</option>' +
             '</select>' +
           '</div>' + // vjs-font-family
+          '<div class="vjs-descriptions-playback vjs-tracksetting">' +
+            '<label class="vjs-label">Descriptions</label>' +
+            '<select>' +
+              '<option value="">Visible</option>' +
+              '<option value="screenReaderOnly">Hidden (for screen reader users)</option>' +
+            '</select>' +
+          '</div>' + // vjs-descriptions-playback
         '</div>' +
       '</div>' +
       '<div class="vjs-tracksettings-controls">' +

--- a/test/unit/tracks/text-track-controls.js
+++ b/test/unit/tracks/text-track-controls.js
@@ -111,9 +111,10 @@ test('menu should contain "Settings", "Off" and one track', function() {
     }),
     menuItems = player.controlBar.descriptionsButton.items;
 
-  equal(menuItems.length, 2, 'menu contains two items');
-  equal(menuItems[0].track.label, 'descriptions off', 'menu contains "descriptions off"');
-  equal(menuItems[1].track.label, 'desc', 'menu contains "desc" track');
+  equal(menuItems.length, 3, 'menu contains three items');
+  equal(menuItems[0].track.label, 'descriptions settings', 'menu contains "descriptions settings"');
+  equal(menuItems[1].track.label, 'descriptions off', 'menu contains "descriptions off"');
+  equal(menuItems[2].track.label, 'desc', 'menu contains "desc" track');
 });
 
 if (!vjs.IS_IE8) {

--- a/test/unit/tracks/text-track-controls.js
+++ b/test/unit/tracks/text-track-controls.js
@@ -75,6 +75,47 @@ test('menu should update with removeRemoteTextTrack', function() {
   equal(player.textTracks().length, 1, 'textTracks contains one item');
 });
 
+var descriptionstrack = {
+  kind: 'descriptions',
+  label: 'desc'
+};
+
+test('should be displayed when text tracks list is not empty', function() {
+  var player = PlayerTest.makePlayer({
+    tracks: [descriptionstrack]
+  });
+
+  ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'), 'descriptions control is displayed');
+  equal(player.textTracks().length, 1, 'textTracks contains one item');
+});
+
+test('should be displayed when a text track is added to an empty track list', function() {
+  var player = PlayerTest.makePlayer();
+
+  player.addRemoteTextTrack(descriptionstrack);
+
+  ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'), 'control is displayed');
+  equal(player.textTracks().length, 1, 'textTracks contains one item');
+});
+
+test('should not be displayed when text tracks list is empty', function() {
+  var player = PlayerTest.makePlayer();
+
+  ok(player.controlBar.descriptionsButton.hasClass('vjs-hidden'), 'descriptions control is not displayed');
+  equal(player.textTracks().length, 0, 'textTracks is empty');
+});
+
+test('menu should contain "Settings", "Off" and one track', function() {
+  var player = PlayerTest.makePlayer({
+      tracks: [descriptionstrack]
+    }),
+    menuItems = player.controlBar.descriptionsButton.items;
+
+  equal(menuItems.length, 2, 'menu contains two items');
+  equal(menuItems[0].track.label, 'descriptions off', 'menu contains "descriptions off"');
+  equal(menuItems[1].track.label, 'desc', 'menu contains "desc" track');
+});
+
 if (!vjs.IS_IE8) {
   // This test doesn't work on IE8.
   // However, this test tests a specific with iOS7 where the TextTrackList doesn't report track mode changes.

--- a/test/unit/tracks/text-track-settings.js
+++ b/test/unit/tracks/text-track-settings.js
@@ -21,6 +21,7 @@ test('should update settings', function() {
       'edgeStyle': 'raised',
       'fontFamily': 'monospaceSerif',
       'color': '#FFF',
+      'descriptionsPlayback': 'screenReaderOnly',
       'backgroundColor': '#FFF',
       'windowColor': '#FFF',
       'fontPercent': 1.25
@@ -38,6 +39,7 @@ test('should update settings', function() {
   equal(player.el().querySelector('.vjs-edge-style select').selectedIndex, 1, 'edge-style is set to new value');
   equal(player.el().querySelector('.vjs-font-family select').selectedIndex, 1, 'font-family is set to new value');
   equal(player.el().querySelector('.vjs-font-percent select').selectedIndex, 3, 'font-percent is set to new value');
+  equal(player.el().querySelector('.vjs-descriptions-playback select').selectedIndex, 1, 'descriptions playback is set to new value');
 
   vjs.trigger(player.el().querySelector('.vjs-done-button'), 'click');
   deepEqual(JSON.parse(window.localStorage.getItem('vjs-text-track-settings')), newSettings, 'values are saved');
@@ -58,6 +60,7 @@ test('should restore default settings', function() {
   player.el().querySelector('.vjs-edge-style select').selectedIndex = 1;
   player.el().querySelector('.vjs-font-family select').selectedIndex = 1;
   player.el().querySelector('.vjs-font-percent select').selectedIndex = 3;
+  player.el().querySelector('.vjs-descriptions-playback select').selectedIndex = 1;
 
   vjs.trigger(player.el().querySelector('.vjs-done-button'), 'click');
   vjs.trigger(player.el().querySelector('.vjs-default-button'), 'click');
@@ -75,6 +78,7 @@ test('should restore default settings', function() {
   equal(player.el().querySelector('.vjs-edge-style select').selectedIndex, 0, 'edge-style is set to default value');
   equal(player.el().querySelector('.vjs-font-family select').selectedIndex, 0, 'font-family is set to default value');
   equal(player.el().querySelector('.vjs-font-percent select').selectedIndex, 2, 'font-percent is set to default value');
+  equal(player.el().querySelector('.vjs-descriptions-playback select').selectedIndex, 0, 'descriptions playback is set to default value');
 });
 
 test('should open on click', function() {
@@ -171,6 +175,7 @@ test('should restore saved settings', function() {
       'edgeStyle': 'raised',
       'fontFamily': 'monospaceSerif',
       'color': '#FFF',
+      'descriptionsPlayback': 'screenReaderOnly',
       'backgroundColor': '#FFF',
       'windowColor': '#FFF',
       'fontPercent': 1.25
@@ -195,6 +200,7 @@ test('should not restore saved settings', function() {
       'edgeStyle': 'raised',
       'fontFamily': 'monospaceSerif',
       'color': '#FFF',
+      'descriptionsPlayback': 'screenReaderOnly',
       'backgroundColor': '#FFF',
       'windowColor': '#FFF',
       'fontPercent': 1.25

--- a/test/unit/tracks/tracks.js
+++ b/test/unit/tracks/tracks.js
@@ -123,10 +123,12 @@ test('update texttrack buttons on removetrack or addtrack', function() {
       events = {},
       oldCaptionsUpdate,
       oldSubsUpdate,
+      oldDescriptionsUpdate,
       oldChaptersUpdate;
 
   oldCaptionsUpdate = vjs.CaptionsButton.prototype.update;
   oldSubsUpdate = vjs.SubtitlesButton.prototype.update;
+  oldDescriptionsUpdate = vjs.DescriptionsButton.prototype.update;
   oldChaptersUpdate = vjs.ChaptersButton.prototype.update;
   vjs.CaptionsButton.prototype.update = function() {
     update++;
@@ -135,6 +137,10 @@ test('update texttrack buttons on removetrack or addtrack', function() {
   vjs.SubtitlesButton.prototype.update = function() {
     update++;
     oldSubsUpdate.call(this);
+  };
+  vjs.DescriptionsButton.prototype.update = function() {
+    update++;
+    oldDescriptionsUpdate.call(this);
   };
   vjs.ChaptersButton.prototype.update = function() {
     update++;
@@ -173,19 +179,19 @@ test('update texttrack buttons on removetrack or addtrack', function() {
 
   player.player_ = player;
 
-  equal(update, 3, 'update was called on the three buttons during init');
+  equal(update, 4, 'update was called on the four buttons during init');
 
   for (i = 0; i < events['removetrack'].length; i++) {
     events['removetrack'][i]();
   }
 
-  equal(update, 6, 'update was called on the three buttons for remove track');
+  equal(update, 8, 'update was called on the four buttons for remove track');
 
   for (i = 0; i < events['addtrack'].length; i++) {
     events['addtrack'][i]();
   }
 
-  equal(update, 9, 'update was called on the three buttons for remove track');
+  equal(update, 12, 'update was called on the four buttons for remove track');
 
   vjs.MediaTechController.prototype.textTracks = oldTextTracks;
   vjs.MediaTechController.prototype['featuresNativeTextTracks'] = false;


### PR DESCRIPTION
Add support for text description tracks, and a demo in the sandbox.

By default, when a text description track is enabled, it is shown visually and also read out by a screen reader if the user has one. There is an option in the Captions/Descriptions Setting Menu to __hide__ the description track, so it is __only__ read by a screen reader. (Although note that the Settings Menu is not currently accessible by keyboard-only users, including screen reader users).
