### PR TITLE
Fixed all uses of registerComponent that relied on __proto__ inheritance

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -1,4 +1,5 @@
-import Button from './button';
+import Button from './button.js';
+import Component from './component.js';
 
 /* Big Play Button
 ================================================================================ */
@@ -26,5 +27,5 @@ class BigPlayButton extends Button {
 
 }
 
-Button.registerComponent('BigPlayButton', BigPlayButton);
+Component.registerComponent('BigPlayButton', BigPlayButton);
 export default BigPlayButton;

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -1,4 +1,5 @@
-import Button from '../button';
+import Button from '../button.js';
+import Component from '../component.js';
 
 /**
  * Toggle fullscreen video
@@ -27,5 +28,5 @@ class FullscreenToggle extends Button {
 
 FullscreenToggle.prototype.buttonText = 'Fullscreen';
 
-Button.registerComponent('FullscreenToggle', FullscreenToggle);
+Component.registerComponent('FullscreenToggle', FullscreenToggle);
 export default FullscreenToggle;

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -1,4 +1,5 @@
-import Button from '../button';
+import Button from '../button.js';
+import Component from '../component.js';
 
 /**
  * Button to toggle between play and pause
@@ -47,5 +48,5 @@ class PlayToggle extends Button {
 
 PlayToggle.prototype.buttonText = 'Play';
 
-Button.registerComponent('PlayToggle', PlayToggle);
+Component.registerComponent('PlayToggle', PlayToggle);
 export default PlayToggle;

--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-item.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-item.js
@@ -1,4 +1,5 @@
 import MenuItem from '../../menu/menu-item.js';
+import Component from '../../component.js';
 
 /**
  * The specific menu item type for selecting a playback rate
@@ -35,5 +36,5 @@ class PlaybackRateMenuItem extends MenuItem {
 
 PlaybackRateMenuItem.prototype.contentElType = 'button';
 
-MenuItem.registerComponent('PlaybackRateMenuItem', PlaybackRateMenuItem);
+Component.registerComponent('PlaybackRateMenuItem', PlaybackRateMenuItem);
 export default PlaybackRateMenuItem;

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -1,4 +1,5 @@
 import Slider from '../../slider/slider.js';
+import Component from '../../component.js';
 import LoadProgressBar from './load-progress-bar.js';
 import PlayProgressBar from './play-progress-bar.js';
 import SeekHandle from './seek-handle.js';
@@ -90,5 +91,5 @@ SeekBar.prototype.options_ = {
 
 SeekBar.prototype.playerEvent = 'timeupdate';
 
-Slider.registerComponent('SeekBar', SeekBar);
+Component.registerComponent('SeekBar', SeekBar);
 export default SeekBar;

--- a/src/js/control-bar/progress-control/seek-handle.js
+++ b/src/js/control-bar/progress-control/seek-handle.js
@@ -1,4 +1,5 @@
 import SliderHandle from '../../slider/slider-handle.js';
+import Component from '../../component.js';
 import formatTime from '../../utils/format-time.js';
 
 /**
@@ -39,5 +40,5 @@ class SeekHandle extends SliderHandle {
  */
 SeekHandle.prototype.defaultValue = '00:00';
 
-SliderHandle.registerComponent('SeekHandle', SeekHandle);
+Component.registerComponent('SeekHandle', SeekHandle);
 export default SeekHandle;

--- a/src/js/control-bar/spacer-controls/custom-control-spacer.js
+++ b/src/js/control-bar/spacer-controls/custom-control-spacer.js
@@ -1,4 +1,5 @@
 import Spacer from './spacer.js';
+import Component from '../../component.js';
 
 /**
  * Spacer specifically meant to be used as an insertion point for new plugins, etc.
@@ -18,6 +19,5 @@ class CustomControlSpacer extends Spacer {
   }
 }
 
-Spacer.registerComponent('CustomControlSpacer', CustomControlSpacer);
-
+Component.registerComponent('CustomControlSpacer', CustomControlSpacer);
 export default CustomControlSpacer;

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -1,4 +1,5 @@
 import TextTrackMenuItem from './text-track-menu-item.js';
+import Component from '../../component.js';
 
 class CaptionSettingsMenuItem extends TextTrackMenuItem {
 
@@ -21,5 +22,5 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
 
 }
 
-TextTrackMenuItem.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);
+Component.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);
 export default CaptionSettingsMenuItem;

--- a/src/js/control-bar/text-track-controls/captions-button.js
+++ b/src/js/control-bar/text-track-controls/captions-button.js
@@ -1,4 +1,5 @@
 import TextTrackButton from './text-track-button.js';
+import Component from '../../component.js';
 import CaptionSettingsMenuItem from './caption-settings-menu-item.js';
 
 /**
@@ -45,5 +46,5 @@ CaptionsButton.prototype.kind_ = 'captions';
 CaptionsButton.prototype.buttonText = 'Captions';
 CaptionsButton.prototype.className = 'vjs-captions-button';
 
-TextTrackButton.registerComponent('CaptionsButton', CaptionsButton);
+Component.registerComponent('CaptionsButton', CaptionsButton);
 export default CaptionsButton;

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -1,4 +1,5 @@
 import TextTrackButton from './text-track-button.js';
+import Component from '../../component.js';
 import TextTrackMenuItem from './text-track-menu-item.js';
 import ChaptersTrackMenuItem from './chapters-track-menu-item.js';
 import Menu from '../../menu/menu.js';
@@ -107,5 +108,5 @@ ChaptersButton.prototype.kind_ = 'chapters';
 ChaptersButton.prototype.buttonText = 'Chapters';
 ChaptersButton.prototype.className = 'vjs-chapters-button';
 
-TextTrackButton.registerComponent('ChaptersButton', ChaptersButton);
+Component.registerComponent('ChaptersButton', ChaptersButton);
 export default ChaptersButton;

--- a/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
@@ -1,4 +1,5 @@
 import MenuItem from '../../menu/menu-item.js';
+import Component from '../../component.js';
 import * as Fn from '../../utils/fn.js';
 
 /**
@@ -37,5 +38,5 @@ class ChaptersTrackMenuItem extends MenuItem {
 
 }
 
-MenuItem.registerComponent('ChaptersTrackMenuItem', ChaptersTrackMenuItem);
+Component.registerComponent('ChaptersTrackMenuItem', ChaptersTrackMenuItem);
 export default ChaptersTrackMenuItem;

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -1,4 +1,5 @@
 import TextTrackMenuItem from './text-track-menu-item.js';
+import Component from '../../component.js';
 
 /**
  * A special menu item for turning of a specific type of text track
@@ -39,5 +40,5 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
 
 }
 
-TextTrackMenuItem.registerComponent('OffTextTrackMenuItem', OffTextTrackMenuItem);
+Component.registerComponent('OffTextTrackMenuItem', OffTextTrackMenuItem);
 export default OffTextTrackMenuItem;

--- a/src/js/control-bar/text-track-controls/subtitles-button.js
+++ b/src/js/control-bar/text-track-controls/subtitles-button.js
@@ -1,4 +1,5 @@
 import TextTrackButton from './text-track-button.js';
+import Component from '../../component.js';
 
 /**
  * The button component for toggling and selecting subtitles
@@ -18,5 +19,5 @@ SubtitlesButton.prototype.kind_ = 'subtitles';
 SubtitlesButton.prototype.buttonText = 'Subtitles';
 SubtitlesButton.prototype.className = 'vjs-subtitles-button';
 
-TextTrackButton.registerComponent('SubtitlesButton', SubtitlesButton);
+Component.registerComponent('SubtitlesButton', SubtitlesButton);
 export default SubtitlesButton;

--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -1,4 +1,5 @@
 import MenuButton from '../../menu/menu-button.js';
+import Component from '../../component.js';
 import * as Fn from '../../utils/fn.js';
 import TextTrackMenuItem from './text-track-menu-item.js';
 import OffTextTrackMenuItem from './off-text-track-menu-item.js';
@@ -60,5 +61,5 @@ class TextTrackButton extends MenuButton {
 
 }
 
-MenuButton.registerComponent('TextTrackButton', TextTrackButton);
+Component.registerComponent('TextTrackButton', TextTrackButton);
 export default TextTrackButton;

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -1,4 +1,5 @@
 import MenuItem from '../../menu/menu-item.js';
+import Component from '../../component.js';
 import * as Fn from '../../utils/fn.js';
 import window from 'global/window';
 import document from 'global/document';
@@ -86,5 +87,5 @@ class TextTrackMenuItem extends MenuItem {
 
 }
 
-MenuItem.registerComponent('TextTrackMenuItem', TextTrackMenuItem);
+Component.registerComponent('TextTrackMenuItem', TextTrackMenuItem);
 export default TextTrackMenuItem;

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -1,4 +1,5 @@
 import Slider from '../../slider/slider.js';
+import Component from '../../component.js';
 import * as Fn from '../../utils/fn.js';
 import roundFloat from '../../utils/round-float.js';
 
@@ -71,5 +72,5 @@ VolumeBar.prototype.options_ = {
 
 VolumeBar.prototype.playerEvent = 'volumechange';
 
-Slider.registerComponent('VolumeBar', VolumeBar);
+Component.registerComponent('VolumeBar', VolumeBar);
 export default VolumeBar;

--- a/src/js/control-bar/volume-control/volume-handle.js
+++ b/src/js/control-bar/volume-control/volume-handle.js
@@ -1,4 +1,5 @@
 import SliderHandle from '../../slider/slider-handle.js';
+import Component from '../../component.js';
 
 /**
  * The volume handle can be dragged to adjust the volume level
@@ -20,5 +21,5 @@ class VolumeHandle extends SliderHandle {
 
 VolumeHandle.prototype.defaultValue = '00:00';
 
-SliderHandle.registerComponent('VolumeHandle', VolumeHandle);
+Component.registerComponent('VolumeHandle', VolumeHandle);
 export default VolumeHandle;

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -1,4 +1,5 @@
 import Button from '../button.js';
+import Component from '../component.js';
 import Menu from '../menu/menu.js';
 import MenuButton from '../menu/menu-button.js';
 import MuteToggle from './mute-toggle.js';
@@ -67,5 +68,5 @@ class VolumeMenuButton extends MenuButton {
 
 VolumeMenuButton.prototype.volumeUpdate = MuteToggle.prototype.update;
 
-Button.registerComponent('VolumeMenuButton', VolumeMenuButton);
+Component.registerComponent('VolumeMenuButton', VolumeMenuButton);
 export default VolumeMenuButton;

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -1,4 +1,5 @@
 import Button from '../button.js';
+import Component from '../component.js';
 import Menu from './menu.js';
 import * as Dom from '../utils/dom.js';
 import * as Fn from '../utils/fn.js';
@@ -139,5 +140,5 @@ class MenuButton extends Button {
   }
 }
 
-Button.registerComponent('MenuButton', MenuButton);
+Component.registerComponent('MenuButton', MenuButton);
 export default MenuButton;

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -1,4 +1,5 @@
 import Button from '../button.js';
+import Component from '../component.js';
 import assign from 'object.assign';
 
 /**
@@ -47,5 +48,5 @@ class MenuItem extends Button {
 
 }
 
-Button.registerComponent('MenuItem', MenuItem);
+Component.registerComponent('MenuItem', MenuItem);
 export default MenuItem;

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -1,4 +1,5 @@
-import Button from './button';
+import Button from './button.js';
+import Component from './component.js';
 import * as Fn from './utils/fn.js';
 import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
@@ -103,5 +104,5 @@ class PosterImage extends Button {
 
 }
 
-Button.registerComponent('PosterImage', PosterImage);
+Component.registerComponent('PosterImage', PosterImage);
 export default PosterImage;

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -394,5 +394,5 @@ Flash.getEmbedCode = function(swf, flashVars, params, attributes){
 // Run Flash through the RTMP decorator
 FlashRtmpDecorator(Flash);
 
-Tech.registerComponent('Flash', Flash);
+Component.registerComponent('Flash', Flash);
 export default Flash;

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -2,6 +2,7 @@
 // can run without HTML5 or Flash, of which PhantomJS supports neither.
 
 import Tech from '../../../src/js/tech/tech.js';
+import Component from '../../../src/js/component.js';
 
 /**
  * @constructor
@@ -51,5 +52,5 @@ class TechFaker extends Tech {
   static canPlaySource(srcObj) { return srcObj.type !== 'video/unsupported-format'; }
 }
 
-Tech.registerComponent('TechFaker', TechFaker);
+Component.registerComponent('TechFaker', TechFaker);
 export default TechFaker;


### PR DESCRIPTION
Didn't make the connection that the reason class method inheritance worked was the `__proto__` usage in babel... It breaks in IE8. Reverted those uses.