### PR TITLE
Updated player.ready to always be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ CHANGELOG
 * @heff Cleaned up and documented src/js/video.js and DOM functions ([view](https://github.com/videojs/video.js/pull/2182))
 * @mmcc Changed to pure CSS slider handles ([view](https://github.com/videojs/video.js/pull/2132))
 * @mister-ben updated language support to handle language codes with regions ([view](https://github.com/videojs/video.js/pull/2177))
+* @heff changed the 'ready' event to always be asynchronous  ([view](https://github.com/videojs/video.js/pull/2188))
 
 --------------------
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -715,7 +715,8 @@ class Component {
   ready(fn) {
     if (fn) {
       if (this.isReady_) {
-        fn.call(this);
+        // Ensure function is always called asynchronously
+        this.setTimeout(fn, 1);
       } else {
         this.readyQueue_ = this.readyQueue_ || [];
         this.readyQueue_.push(fn);
@@ -732,20 +733,22 @@ class Component {
   triggerReady() {
     this.isReady_ = true;
 
-    let readyQueue = this.readyQueue_;
+    // Ensure ready is triggerd asynchronously
+    this.setTimeout(function(){
+      let readyQueue = this.readyQueue_;
 
-    if (readyQueue && readyQueue.length > 0) {
+      if (readyQueue && readyQueue.length > 0) {
+        readyQueue.forEach(function(fn){
+          fn.call(this);
+        }, this);
 
-      for (let i = 0; i < readyQueue.length; i++) {
-        readyQueue[i].call(this);
+        // Reset Ready Queue
+        this.readyQueue_ = [];
       }
 
-      // Reset Ready Queue
-      this.readyQueue_ = [];
-
-      // Allow for using event listeners also, in case you want to do something everytime a source is ready.
+      // Allow for using event listeners also
       this.trigger('ready');
-    }
+    }, 1);
   }
 
   /**

--- a/test/globals-shim.js
+++ b/test/globals-shim.js
@@ -1,3 +1,4 @@
+import document from 'global/document';
 import window from 'global/window';
 import sinon from 'sinon';
 
@@ -6,5 +7,5 @@ window.sinon = sinon;
 
 // This may not be needed anymore, but double check before removing
 window.fixture = document.createElement('div');
-fixture.id = 'qunit-fixture';
-document.body.appendChild(fixture);
+window.fixture.id = 'qunit-fixture';
+document.body.appendChild(window.fixture);

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -360,11 +360,14 @@ test('should trigger a listener when ready', function(){
   var comp = new Component(getFakePlayer(), {}, optionsReadyListener);
 
   comp.triggerReady();
+  this.clock.tick(1);
 
   comp.ready(methodReadyListener);
+  this.clock.tick(1);
 
   // First two listeners should only be fired once and then removed
   comp.triggerReady();
+  this.clock.tick(1);
 });
 
 test('should add and remove a CSS class', function(){

--- a/test/unit/tracks/text-track-controls.test.js
+++ b/test/unit/tracks/text-track-controls.test.js
@@ -2,7 +2,14 @@ import TextTrackMenuItem from '../../../src/js/control-bar/text-track-controls/t
 import TestHelpers from '../test-helpers.js';
 import * as browser from '../../../src/js/utils/browser.js';
 
-q.module('Text Track Controls');
+q.module('Text Track Controls', {
+  'setup': function() {
+    this.clock = sinon.useFakeTimers();
+  },
+  'teardown': function() {
+    this.clock.restore();
+  }
+});
 
 var track = {
   kind: 'captions',
@@ -10,9 +17,11 @@ var track = {
 };
 
 test('should be displayed when text tracks list is not empty', function() {
-  var player = TestHelpers.makePlayer({
+  let player = TestHelpers.makePlayer({
     tracks: [track]
   });
+
+  this.clock.tick(1000);
 
   ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'), 'control is displayed');
   equal(player.textTracks().length, 1, 'textTracks contains one item');
@@ -49,7 +58,11 @@ test('menu should contain "Settings", "Off" and one track', function() {
   var player = TestHelpers.makePlayer({
       tracks: [track]
     }),
-    menuItems = player.controlBar.captionsButton.items;
+    menuItems;
+
+  this.clock.tick(1000);
+
+  menuItems = player.controlBar.captionsButton.items;
 
   equal(menuItems.length, 3, 'menu contains three items');
   equal(menuItems[0].track.label, 'captions settings', 'menu contains "captions settings"');
@@ -62,6 +75,8 @@ test('menu should update with addRemoteTextTrack', function() {
     tracks: [track]
   });
 
+  this.clock.tick(1000);
+
   player.addRemoteTextTrack(track);
 
   equal(player.controlBar.captionsButton.items.length, 4, 'menu does contain added track');
@@ -72,6 +87,8 @@ test('menu should update with removeRemoteTextTrack', function() {
   var player = TestHelpers.makePlayer({
     tracks: [track, track]
   });
+
+  this.clock.tick(1000);
 
   player.removeRemoteTextTrack(player.textTracks()[0]);
 


### PR DESCRIPTION
Addresses #1667 

I've changed ready() and triggerReady() to always be async. However now a bunch of track tests are falling. 

@gkatsev, can you provide any insight here? I would guess it has to do with the text track display.
https://github.com/videojs/video.js/blob/1ff361a825400a2be803d6d4f0b72e0ecfbc8e6f/src/js/tracks/text-track-display.js#L41
```
Text Track Controls should be displayed when text tracks list is not empty FAILED
  control is displayed
  textTracks contains one item. Expected: 1 Actual: 0
```

If I move the addRemoteTextTrack part out of the ready listener the tests actually pass, but then other tracks tests fail.
```
Tracks TextTrackDisplay initializes tracks on player ready FAILED
  TypeError: Cannot read property 'tracks' of undefined
```