### PR TITLE
Load text tracks on demand.

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -112,7 +112,7 @@ vjs.TextTrack = function(options) {
 	loadTrack(this.src_, this);
       }
 
-      if (mode === 'showing') {
+      if (mode !== 'disabled') {
         this.player_.on('timeupdate', timeupdateHandler);
       }
       this.trigger('modechange');

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -179,7 +179,7 @@ vjs.TextTrack = function(options) {
   if (options.src) {
     tt.loaded_ = true;
     tt.src_ = options.src;
-    if (options.default) {
+    if (options['default']) {
       loadTrack(options.src, tt);
     }
   } else {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -107,6 +107,11 @@ vjs.TextTrack = function(options) {
         return;
       }
       mode = newMode;
+
+      if (mode !== 'disabled' && this['cues'].length === 0) {
+	loadTrack(this.src_, this);
+      }
+
       if (mode === 'showing') {
         this.player_.on('timeupdate', timeupdateHandler);
       }
@@ -172,7 +177,11 @@ vjs.TextTrack = function(options) {
   });
 
   if (options.src) {
-    loadTrack(options.src, tt);
+    tt.loaded_ = true;
+    tt.src_ = options.src;
+    if (options.default) {
+      loadTrack(options.src, tt);
+    }
   } else {
     tt.loaded_ = true;
   }
@@ -184,6 +193,10 @@ vjs.TextTrack = function(options) {
 
 vjs.TextTrack.prototype = vjs.obj.create(vjs.EventEmitter.prototype);
 vjs.TextTrack.prototype.constructor = vjs.TextTrack;
+
+vjs.TextTrack.prototype.load_ = function() {
+  loadTrack(this.src_, this);
+};
 
 /*
  * cuechange - One or more cues in the track have become active or stopped being active.
@@ -233,6 +246,10 @@ vjs.TextTrack.prototype.removeCue = function(removeCue) {
 var loadTrack, parseCues, indexOf;
 
 loadTrack = function(src, track) {
+  if (!src) {
+    return;
+  }
+
   vjs.xhr(src, vjs.bind(this, function(err, response, responseBody){
     if (err) {
       return vjs.log.error(err);

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -179,7 +179,7 @@ vjs.TextTrack = function(options) {
   if (options.src) {
     tt.loaded_ = true;
     tt.src_ = options.src;
-    if (options['default']) {
+    if (options['default'] || (kind !== 'subtitles' && kind !== 'captions')) {
       loadTrack(options.src, tt);
     }
   } else {
@@ -254,7 +254,6 @@ loadTrack = function(src, track) {
     if (err) {
       return vjs.log.error(err);
     }
-
 
     track.loaded_ = true;
     parseCues(responseBody, track);


### PR DESCRIPTION
This PR is also a place for discussion around how we want to handle tracks.
Currently, I've changed it so that tracks get loaded on demand, i.e., when you select them to display, and not all at once when the player is loaded. `default` tracks get loaded on player creation, still.
The menu should still be showing up because the TextTrack object is being created, just that the cues aren't being populated.
Also, this might be causing issues with chapters as it is right now, but could be fixed by loading those initially along with the default tracks.

This fixex #1913 and related issues.

@dmlap @heff 