### PR TITLE
added IE10 flex support check

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2248,10 +2248,13 @@ Player.prototype.handleError;
 Player.prototype.flexNotSupported_ = function() {
   var elem = document.createElement('i');
 
+  // Note: We don't actually use flexBasis (or flexOrder), but it's one of the more
+  // common flex features that we can rely on when checking for flex support.
   return !('flexBasis' in elem.style ||
           'webkitFlexBasis' in elem.style ||
           'mozFlexBasis' in elem.style ||
-          'msFlexBasis' in elem.style);
+          'msFlexBasis' in elem.style ||
+          'msFlexOrder' in elem.style /* IE10-specific (2012 flex spec) */);
 };
 
 Component.registerComponent('Player', Player);


### PR DESCRIPTION
IE10 only implements the 2012 version of the Flex spec, which doesn't support `flex-basis`. Because of this, we were left in a weird middle ground where IE10 was getting the `no-flex` class but overriding the no-flex table styles with flex things. Closes #2212.