### PR TITLE
added display: none; to fix the custom spacer in ie8

### DIFF
--- a/src/css/components/_control-spacer.scss
+++ b/src/css/components/_control-spacer.scss
@@ -1,0 +1,3 @@
+.video-js .vjs-custom-control-spacer {
+  display: none;
+}

--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -7,6 +7,7 @@
 @import "components/button";
 @import "components/control-bar";
 @import "components/control";
+@import "components/control-spacer";
 @import "components/progress";
 @import "components/slider";
 @import "components/volume";


### PR DESCRIPTION
The spacer, as a table-cell, seemed to be defaulting to width: auto