### PR TITLE
Return currentSource_.src instead of blob-urls in html5 tech

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -329,7 +329,13 @@ vjs.Html5.prototype.setSrc = function(src) {
 };
 
 vjs.Html5.prototype.load = function(){ this.el_.load(); };
-vjs.Html5.prototype.currentSrc = function(){ return this.el_.currentSrc; };
+vjs.Html5.prototype.currentSrc = function(){
+  if (this.currentSource_) {
+    return this.currentSource_.src;
+  } else {
+    return this.el_.currentSrc;
+  }
+};
 
 vjs.Html5.prototype.poster = function(){ return this.el_.poster; };
 vjs.Html5.prototype.setPoster = function(val){ this.el_.poster = val; };

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -513,7 +513,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
 
     // Set currentSource_ asynchronously to simulate the media element's
     // asynchronous execution of the `resource selection algorithm`
-    setTimeout(function () {
+    this.setTimeout(function () {
       if (source && source.src !== '') {
         tech.currentSource_ = source;
       }

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -495,7 +495,6 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
    */
   Tech.prototype.setSource = function(source){
     var sh = Tech.selectSourceHandler(source);
-    var tech = this;
 
     if (!sh) {
       // Fall back to a native source hander when unsupported sources are
@@ -513,11 +512,11 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
 
     // Set currentSource_ asynchronously to simulate the media element's
     // asynchronous execution of the `resource selection algorithm`
-    this.setTimeout(function () {
+    this.setTimeout(vjs.bind(this, function () {
       if (source && source.src !== '') {
-        tech.currentSource_ = source;
+        this.currentSource_ = source;
       }
-    }, 0);
+    }), 0);
 
     this.sourceHandler_ = sh.handleSource(source, this);
     this.on('dispose', this.disposeSourceHandler);

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -495,6 +495,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
    */
   Tech.prototype.setSource = function(source){
     var sh = Tech.selectSourceHandler(source);
+    var tech = this;
 
     if (!sh) {
       // Fall back to a native source hander when unsupported sources are
@@ -510,7 +511,14 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
     this.disposeSourceHandler();
     this.off('dispose', this.disposeSourceHandler);
 
-    this.currentSource_ = source;
+    // Set currentSource_ asynchronously to simulate the media element's
+    // asynchronous execution of the `resource selection algorithm`
+    setTimeout(function () {
+      if (source && source.src !== '') {
+        tech.currentSource_ = source;
+      }
+    }, 0);
+
     this.sourceHandler_ = sh.handleSource(source, this);
     this.on('dispose', this.disposeSourceHandler);
 


### PR DESCRIPTION
The Flash tech already does this and it makes sense to return the URL of the resource instead of a blob-url if the SourceHandler uses MSE.