### PR TITLE
Slider handle current time

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -58,6 +58,19 @@
   }
 }
 
+// Current Time "tooltip"
+.video-js .vjs-progress-control:hover .vjs-play-progress:after {
+  position: absolute;
+  top: -2.4em;
+  right: -1.5em;
+  font-size: 0.6em;
+  color: $primary-bg;
+  content: attr(data-current-time);
+  padding: 0.2em 0.5em;
+  @include background-color-with-alpha($primary-text, 0.8);
+  @include border-radius(0.3em);
+}
+
 .video-js .vjs-load-progress {
   background: rgb(100, 100, 100) /* IE8- Fallback */;
   background: rgba(255, 255, 255, 0.2);

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -27,6 +27,16 @@
 /* We need an increased hit area on hover */
 .video-js .vjs-progress-control:hover .vjs-progress-holder { font-size: 1.666666666666666666em }
 
+/* Also show the current time tooltip */
+.video-js .vjs-progress-control:hover .vjs-play-progress:after {
+  display: block;
+
+  /* If we let the font size grow as much as everything else, the current time tooltip ends up
+     ginormous. If you'd like to enable the current time tooltip all the time, this should be disabled
+     to avoid a weird hitch when you roll off the hover. */
+  font-size: 0.6em;
+}
+
 /* Progress Bars */
 .video-js .vjs-progress-holder .vjs-play-progress,
 .video-js .vjs-progress-holder .vjs-load-progress,
@@ -59,11 +69,13 @@
 }
 
 // Current Time "tooltip"
-.video-js .vjs-progress-control:hover .vjs-play-progress:after {
+.video-js .vjs-play-progress:after {
+  /* By default this is hidden and only shown when hovering over the progress control */
+  display: none;
   position: absolute;
   top: -2.4em;
   right: -1.5em;
-  font-size: 0.6em;
+  font-size: 0.9em;
   color: $primary-bg;
   content: attr(data-current-time);
   padding: 0.2em 0.5em;

--- a/src/css/components/_time.scss
+++ b/src/css/components/_time.scss
@@ -5,5 +5,6 @@
 }
 
 /* We need the extra specificity that referencing .vjs-no-flex provides. */
+.video-js .vjs-current-time, .video-js.vjs-no-flex .vjs-current-time { display: none; }
 .video-js .vjs-duration, .video-js.vjs-no-flex .vjs-duration { display: none; }
 .vjs-time-divider { display: none; line-height: 3em; }

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -1,4 +1,6 @@
 import Component from '../../component.js';
+import * as Fn from '../../utils/fn.js';
+import formatTime from '../../utils/format-time.js';
 
 /**
  * Shows play progress
@@ -9,11 +11,22 @@ import Component from '../../component.js';
  */
 class PlayProgressBar extends Component {
 
+  constructor(player, options){
+    super(player, options);
+    this.on(player, 'timeupdate', this.updateDataAttr);
+    player.ready(Fn.bind(this, this.updateDataAttr));
+  }
+
   createEl() {
     return super.createEl('div', {
       className: 'vjs-play-progress',
       innerHTML: `<span class="vjs-control-text"><span>${this.localize('Progress')}</span>: 0%</span>`
     });
+  }
+
+  updateDataAttr() {
+    let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
+    this.el_.setAttribute('data-current-time', formatTime(time, this.player_.duration()));
   }
 
 }


### PR DESCRIPTION
This adds a `data-current-time` attr to the play progress bar, and adds CSS necessary to show that when you hover over the progress control.

![handle hover](https://cloudup.com/cuNMAVh75TO+)