### PR TITLE
More fixes for async currentSrc behavior

### DIFF
--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -36,7 +36,7 @@ vjs.MediaTechController = vjs.Component.extend({
       this.emulateTextTracks();
     }
 
-    this.on('loadstart', this.updateCurrentSource);
+    this.on('loadstart', this.updateCurrentSource_);
 
     this.initTextTrackListeners();
   }
@@ -178,7 +178,7 @@ vjs.MediaTechController.prototype.onTap = function(){
  * in a timeout to make sure it is set asynchronously before anything else
  * but before other loadstart handlers have had a chance to execute
  */
-vjs.MediaTechController.prototype.updateCurrentSource = function () {
+vjs.MediaTechController.prototype.updateCurrentSource_ = function () {
   // We could have been called with a 0-ms setTimeout OR via loadstart (which ever
   // happens first) so we should clear the timeout to be a good citizen
   this.clearTimeout(this.updateSourceTimer_);
@@ -535,7 +535,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
     // Schedule currentSource_ to be set asynchronously
     if (source && source.src !== '') {
       this.pendingSource_ = source;
-      this.updateSourceTimer_ = this.setTimeout(vjs.bind(this, this.updateCurrentSource), 0);
+      this.updateSourceTimer_ = this.setTimeout(vjs.bind(this, this.updateCurrentSource_), 0);
     }
 
     this.sourceHandler_ = sh.handleSource(source, this);

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -446,6 +446,8 @@ vjs.MediaTechController.prototype['featuresNativeTextTracks'] = false;
  *
  */
 vjs.MediaTechController.withSourceHandlers = function(Tech){
+  Tech.prototype.currentSource_ = {src: ''};
+
   /**
    * Register a source handler
    * Source handlers are scripts for handling specific formats.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1228,7 +1228,12 @@ vjs.Player.prototype.load = function(){
  * @return {String} The current source
  */
 vjs.Player.prototype.currentSrc = function(){
-  return this.techGet('currentSrc') || this.cache_.src || '';
+  var techSrc = this.techGet('currentSrc');
+
+  if (techSrc === undefined) {
+    return this.cache_.src || '';
+  }
+  return techSrc;
 };
 
 /**

--- a/test/unit/media.js
+++ b/test/unit/media.js
@@ -287,7 +287,7 @@ test('should emulate the video element\'s behavior for currentSrc when src is se
   tech.setSource(sourceA);
 
   // Test that currentSource_ is not immediately specified
-  strictEqual(tech.currentSource_, undefined, 'sourceA was not stored immediately');
+  deepEqual(tech.currentSource_, {src:''}, 'sourceA was not stored immediately');
 
   this.clock.tick(1);
 


### PR DESCRIPTION
Two main fixes here:

1. The `player.currentSrc` function didn't allow an empty string to be returned from techs - it would always use `src` in that case
2. In my testing it appears that `currentSrc` should always be updated by the time any other `loadstart` listener is triggered which wasn't always the case using only a setTimeout of 0.

The second bug has the potential to cause problems in plugins that rely on `currentSrc` being properly updated by the time `loadstart` is emitted. Since events are triggered synchronously, there are cases where the `setTimeout` is simply "too late" to match the video element's behavior.

These changes bring it much more in-line with what the video element does 

As an example, I ran the test @heff created http://jsbin.com/wulomalopu/1/edit?js,console,output (but modified to use video.js) and the output with these changes on Chrome 43 is:

```
"el created"
""
""
2
"source set"
"http://vjs.zencdn.net/v/oceans.mp4"
""
3
"async"
"http://vjs.zencdn.net/v/oceans.mp4"
"http://vjs.zencdn.net/v/oceans.mp4"
4
"source set again"
"http://vjs.zencdn.net/v/oceans.webm"
"http://vjs.zencdn.net/v/oceans.mp4"
5
"async again"
"http://vjs.zencdn.net/v/oceans.webm"
"http://vjs.zencdn.net/v/oceans.webm"
6
"empty source set"
"file:///Users/jrivera/projects/video.js/tester.html"
"http://vjs.zencdn.net/v/oceans.webm"
7
"loadstart"
"file:///Users/jrivera/projects/video.js/tester.html"
"http://vjs.zencdn.net/v/oceans.webm"
8
"async for empty source"
"file:///Users/jrivera/projects/video.js/tester.html"
"http://vjs.zencdn.net/v/oceans.webm"
```

..and that is very, very close to the test's output on Chrome.