### PR TITLE
Crossorigin

### DIFF
--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -325,7 +325,11 @@ vjs.Html5.prototype.src = function(src) {
 };
 
 vjs.Html5.prototype.setSrc = function(src) {
+  this.toggleCrossorigin({crossorigin: null});
   this.el_.src = src;
+  setTimeout(vjs.bind(this, function() {
+    this.toggleCrossorigin({crossorigin: 'anonymous'});
+  }));
 };
 
 vjs.Html5.prototype.load = function(){ this.el_.load(); };
@@ -447,6 +451,35 @@ vjs.Html5.prototype.removeRemoteTextTrack = function(track) {
       tracks[i]['parentNode']['removeChild'](tracks[i]);
       break;
     }
+  }
+};
+
+/*
+ * This toggles the crossorigin attribute on the element.
+ * If no options object is specified it will toggle between presence and absence of the crossorigin attribute.
+ * The input to the function is an options object with a property called `crossorigin`.
+ * The value can be either 'anonymous' or 'use-credentials' as seen here <https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes>.
+ * Falsey values will remove the attribute, truthy values other than the two above strings will be interpreted as default (or 'anonymous').
+ */
+vjs.Html5.prototype.toggleCrossorigin = function(opt) {
+  var el = this.el(),
+      remove = false,
+      value = 'anonymous';
+
+  if (!opt) {
+    remove = el.hasAttribute('crossorigin');
+  } else if (opt.crossorigin === 'use-credentials') {
+    value = 'use-credentials';
+  } else if (opt.crossorigin) {
+    value = 'anonymous';
+  } else {
+    remove = true;
+  }
+
+  if (remove) {
+    el.removeAttribute('crossorigin');
+  } else {
+    el.setAttribute('crossorigin', value);
   }
 };
 

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -477,7 +477,7 @@ vjs.Html5.prototype.addCrossorigin = function(value) {
 vjs.Html5.prototype.enableCrossorigin_ = function(value) {
   var attrVal = value;
 
-  if (value !== 'anonymous' || value !== 'use-credentials') {
+  if (value !== 'anonymous' && value !== 'use-credentials') {
     attrVal = 'anonymous';
   }
 

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -391,8 +391,6 @@ vjs.Html5.prototype.addRemoteTextTrack = function(options) {
     return vjs.MediaTechController.prototype.addRemoteTextTrack.call(this, options);
   }
 
-  this.addCrossorigin();
-
   var track = document.createElement('track');
   options = options || {};
 
@@ -416,6 +414,8 @@ vjs.Html5.prototype.addRemoteTextTrack = function(options) {
   }
 
   this.el().appendChild(track);
+
+  this.addCrossorigin();
 
   if (track.track['kind'] === 'metadata') {
     track['track']['mode'] = 'hidden';

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -217,6 +217,7 @@ test('native source handler canHandleSource', function(){
 
 test('set crossorigin on loadstart if native text tracks and textTracks', function() {
   var el;
+  tech['featuresNativeTextTracks'] = true;
   tech.textTracks = function() {
     return ['track'];
   };
@@ -233,6 +234,7 @@ test('set crossorigin on loadstart if native text tracks and textTracks', functi
 
 test('do not set crossorigin on loadstart if native text tracks and no text tracks', function() {
   var el;
+  tech['featuresNativeTextTracks'] = true;
 
   el = tech.el();
   ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute before loadstart');
@@ -245,6 +247,7 @@ test('do not set crossorigin on loadstart if native text tracks and no text trac
 
 test('unset crossorigin during setSrc and re-set on loadstart or timeout afterwards, if necessary', function() {
   var el;
+  tech['featuresNativeTextTracks'] = true;
 
   tech.textTracks = function() {
     return ['track'];
@@ -280,6 +283,8 @@ test('unset crossorigin during setSrc and re-set on loadstart or timeout afterwa
 
 test('add and remove corssorigin work add if textTracks and remove always', function() {
   var el = tech.el();
+  tech['featuresNativeTextTracks'] = true;
+
   ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute at the start');
 
   tech.addCrossorigin();

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -214,3 +214,105 @@ test('native source handler canHandleSource', function(){
   // Reset test video canPlayType
   vjs.TEST_VID.canPlayType = origCPT;
 });
+
+test('set crossorigin on loadstart if native text tracks and textTracks', function() {
+  var el;
+  tech.textTracks = function() {
+    return ['track'];
+  };
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute before loadstart');
+
+  tech.trigger('loadstart');
+
+  el = tech.el();
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after a loadstart');
+  equal(el.getAttribute('crossorigin'), 'anonymous', 'the value should be "anonymous"');
+});
+
+test('do not set crossorigin on loadstart if native text tracks and no text tracks', function() {
+  var el;
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute before loadstart');
+
+  tech.trigger('loadstart');
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after a loadstart');
+});
+
+test('unset crossorigin during setSrc and re-set on loadstart or timeout afterwards, if necessary', function() {
+  var el;
+
+  tech.textTracks = function() {
+    return ['track'];
+  };
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute at the beginning');
+
+  tech.setSrc('foo');
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after a setSrc');
+
+  tech.trigger('loadstart');
+
+  el = tech.el();
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after a setSrc and loadstart');
+  equal(el.getAttribute('crossorigin'), 'anonymous', 'the value should be "anonymous"');
+
+  tech.textTracks = function() {
+    return [];
+  };
+
+  tech.setSrc('bar');
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after a setSrc');
+
+  tech.trigger('loadstart');
+
+  el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after a loadstart');
+});
+
+test('add and remove corssorigin work add if textTracks and remove always', function() {
+  var el = tech.el();
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute at the start');
+
+  tech.addCrossorigin();
+
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after add if no text tracks');
+
+  tech.textTracks = function() {
+    return ['track'];
+  };
+
+  tech.addCrossorigin();
+
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after add if text tracks');
+  equal(el.getAttribute('crossorigin'), 'anonymous', 'there is a crossorigin attribute after add if text tracks');
+
+  tech.removeCrossorigin();
+
+  ok(!el.hasAttribute('crossorigin'), 'there is no crossorigin attribute after remove');
+
+  tech.addCrossorigin('use-credentials');
+
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after add if text tracks');
+  equal(el.getAttribute('crossorigin'), 'use-credentials', 'the value is set to "use-credentials"');
+
+  tech.removeCrossorigin();
+  tech.addCrossorigin('anonymous');
+
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after add if text tracks');
+  equal(el.getAttribute('crossorigin'), 'anonymous', 'the value is set to "anonymous"');
+
+  tech.removeCrossorigin();
+  tech.addCrossorigin('foo');
+
+  ok(el.hasAttribute('crossorigin'), 'there is a crossorigin attribute after add if text tracks');
+  equal(el.getAttribute('crossorigin'), 'anonymous', 'the value is set to "anonymous"');
+});


### PR DESCRIPTION
This tries to manage the lifecycle of the `crossorigin` attribute on the video element. We don't want it available when we're setting the source but we want to make sure it's available before text tracks get loaded. So, we add it back conditionally on `loadstart` or when `addRemoteTextTrack` is called.
It's removed and re-applied when the source of the video is changed. This behavior is only applicable to the Html tech and the Flash tech is unchanged.

Fixes #1888, #1904.

Things left to do:
* [x] Tests
* [ ] Forward port it to master/5.0