### PR TITLE
Make sure it's safe to call bufferedPercent before the SWF loads

### DIFF
--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -174,7 +174,17 @@ vjs.Flash.prototype.seekable = function() {
 };
 
 vjs.Flash.prototype.buffered = function(){
+  if (!this.el_.vjs_getProperty) {
+    return vjs.createTimeRange();
+  }
   return vjs.createTimeRange(0, this.el_.vjs_getProperty('buffered'));
+};
+
+vjs.Flash.prototype.duration = function(){
+  if (!this.el_.vjs_getProperty) {
+    return 0;
+  }
+  return this.el_.vjs_getProperty('duration');
 };
 
 vjs.Flash.prototype.supportsFullScreen = function(){
@@ -189,7 +199,7 @@ vjs.Flash.prototype.enterFullScreen = function(){
   // Create setters and getters for attributes
   var api = vjs.Flash.prototype,
     readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(','),
-    readOnly = 'error,networkState,readyState,seeking,initialTime,duration,startOffsetTime,paused,played,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(','),
+    readOnly = 'error,networkState,readyState,seeking,initialTime,startOffsetTime,paused,played,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(','),
     // Overridden: buffered, currentTime, currentSrc
     i;
 

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -186,3 +186,17 @@ test('seekable should be empty if no video is loaded', function() {
 
   equal(tech.seekable().length, 0, 'seekable is empty');
 });
+
+test('calling methods before the SWF loads is safe', function() {
+  var player = PlayerTest.makePlayer(),
+      tech = new vjs.Flash(player, {
+        'parentEl': player.el()
+      });
+
+  // force Flash callbacks to be undefined as they would be before the
+  // SWF is ready
+  tech.el().vjs_getProperty = undefined;
+
+  equal(tech.buffered().length, 0, 'buffered percent is 0');
+  equal(tech.duration(), 0, 'duration is 0');
+});


### PR DESCRIPTION
Manual time tracking calles bufferedPercent() on an interval and doesn't wait for the tech to be ready. If it's called before the SWF is loaded, it will throw an error. Make sure the methods required by bufferedPercent() don't throw if they're called early. Fixes #2288.