### PR TITLE
Added 'rtmp/mp3' to the list of supported formats

### DIFF
--- a/src/js/tech/flash-rtmp.js
+++ b/src/js/tech/flash-rtmp.js
@@ -1,7 +1,8 @@
 function FlashRtmpDecorator(Flash) {
   Flash.streamingFormats = {
     'rtmp/mp4': 'MP4',
-    'rtmp/flv': 'FLV'
+    'rtmp/flv': 'FLV',
+    'rtmp/mp3': 'MP3'
   };
 
   Flash.streamFromParts = function(connection, stream) {


### PR DESCRIPTION
Corresponding changes was done for flash tech https://github.com/slidepresenter/video-js-swf/commit/50f3e9b427c2079508ee1cd0926d6c2705487f7e