### PR TITLE
Enable simple class extensions without any constructor

### DIFF
--- a/src/js/extends.js
+++ b/src/js/extends.js
@@ -47,8 +47,10 @@ const extendsFn = function(superClass, subClassMethods={}) {
   };
   let methods = {};
 
-  if (subClassMethods.constructor !== Object.prototype.constructor) {
-    subClass = subClassMethods.constructor;
+  if (typeof subClassMethods === 'object') {
+    if (subClassMethods.constructor !== Object.prototype.constructor) {
+      subClass = subClassMethods.constructor;
+    }
     methods = subClassMethods;
   } else if (typeof subClassMethods === 'function') {
     subClass = subClassMethods;

--- a/test/unit/extends.test.js
+++ b/test/unit/extends.test.js
@@ -1,0 +1,16 @@
+import extendsFn from '../../src/js/extends.js';
+
+q.module('extends.js');
+
+test('should add implicit parent constructor call', function(){
+  var superCalled = false;
+  var Parent = function() {
+    superCalled = true;
+  };
+  var Child = extendsFn(Parent, {
+      foo: 'bar'
+  });
+  var child = new Child();
+  ok(superCalled, 'super constructor called');
+  ok(child.foo, 'child properties set');
+});


### PR DESCRIPTION
Allows `videojs.extends` to properly handle creating a subclass without any specified constructor. Previous implementation just threw child properties/methods away. Fixes #2303.