### PR TITLE
don't track progress until ready

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -98,7 +98,9 @@ class Tech extends Component {
     this.manualProgress = true;
 
     // Trigger progress watching when a source begins loading
-    this.trackProgress();
+    this.one('ready', () => {
+      this.trackProgress();
+    });
   }
 
   manualProgressOff() {
@@ -109,6 +111,7 @@ class Tech extends Component {
   }
 
   trackProgress() {
+    this.stopTrackingProgress();
     this.progressInterval = this.setInterval(Fn.bind(this, function(){
       // Don't trigger unless buffered amount is greater than last time
 

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -61,14 +61,26 @@ test('stops manual timeupdates while paused', function() {
 });
 
 test('should synthesize progress events by default', function() {
-  var progresses = 0, tech;
+  var progresses = 0, bufferedPercent = 0.5, tech;
   tech = new Tech();
   tech.on('progress', function() {
     progresses++;
   });
+  tech.bufferedPercent = function() {
+    return bufferedPercent;
+  };
 
   this.clock.tick(500);
+  equal(progresses, 0, 'waits until ready');
+
+  tech.trigger('ready');
+  this.clock.tick(500);
   equal(progresses, 1, 'triggered one event');
+
+  tech.trigger('ready');
+  bufferedPercent = 0.75;
+  this.clock.tick(500);
+  equal(progresses, 2, 'repeated readies are ok');
 });
 
 test('dispose() should stop time tracking', function() {


### PR DESCRIPTION
Delay manual progress checks until the tech is ready to avoid errors. The Flash tech errors if buffered() is called before the SWF has loaded, for instance. Fixes https://github.com/videojs/video.js/issues/2288, obsoletes https://github.com/videojs/video.js/pull/2289.