### PR TITLE
Export videojs.log

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -307,6 +307,13 @@ videojs.addLanguage = function(code, data){
   return merge(globalOptions.languages, { [code]: data })[code];
 };
 
+/**
+ * Log debug messages.
+ *
+ * @param {...Object} messages One or more messages to log
+ */
+videojs.log = log;
+
 // REMOVING: We probably should add this to the migration plugin
 // // Expose but deprecate the window[componentName] method for accessing components
 // Object.getOwnPropertyNames(Component.components).forEach(function(name){


### PR DESCRIPTION
Sometimes you want to prefix all your console logs with VIDEOJS: