### PR TITLE
Fixes so that the source handler mixin adds the expected API after minification

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -183,7 +183,6 @@ goog.exportProperty(vjs.Html5.prototype, 'exitFullScreen', vjs.Html5.prototype.e
 goog.exportProperty(vjs.Html5.prototype, 'playbackRate', vjs.Html5.prototype.playbackRate);
 goog.exportProperty(vjs.Html5.prototype, 'setPlaybackRate', vjs.Html5.prototype.setPlaybackRate);
 // Source Handler Functions
-goog.exportProperty(vjs.Html5, 'registerSourceHandler', vjs.Html5.registerSourceHandler);
 goog.exportProperty(vjs.Html5, 'selectSourceHandler', vjs.Html5.selectSourceHandler);
 goog.exportProperty(vjs.Html5.prototype, 'setSource', vjs.Html5.prototype.setSource);
 goog.exportProperty(vjs.Html5.prototype, 'disposeSourceHandler', vjs.Html5.prototype.disposeSourceHandler);
@@ -201,7 +200,6 @@ goog.exportProperty(vjs.Flash, 'embed', vjs.Flash.embed);
 goog.exportProperty(vjs.Flash, 'version', vjs.Flash.version);
 goog.exportProperty(vjs.Flash.prototype, 'setSource', vjs.Flash.prototype.setSource);
 // Source Handler Functions
-goog.exportProperty(vjs.Flash, 'registerSourceHandler', vjs.Flash.registerSourceHandler);
 goog.exportProperty(vjs.Flash, 'selectSourceHandler', vjs.Flash.selectSourceHandler);
 goog.exportProperty(vjs.Flash.prototype, 'setSource', vjs.Flash.prototype.setSource);
 goog.exportProperty(vjs.Flash.prototype, 'disposeSourceHandler', vjs.Flash.prototype.disposeSourceHandler);

--- a/src/js/media/flash.js
+++ b/src/js/media/flash.js
@@ -239,14 +239,14 @@ vjs.MediaTechController.withSourceHandlers(vjs.Flash);
  * @param  {Object} source   The source object
  * @param  {vjs.Flash} tech  The instance of the Flash tech
  */
-vjs.Flash.nativeSourceHandler = {};
+vjs.Flash['nativeSourceHandler'] = {};
 
 /**
  * Check Flash can handle the source natively
  * @param  {Object} source  The source object
  * @return {String}         'probably', 'maybe', or '' (empty string)
  */
-vjs.Flash.nativeSourceHandler.canHandleSource = function(source){
+vjs.Flash['nativeSourceHandler']['canHandleSource'] = function(source){
   var type;
 
   if (!source.type) {
@@ -270,7 +270,7 @@ vjs.Flash.nativeSourceHandler.canHandleSource = function(source){
  * @param  {Object} source    The source object
  * @param  {vjs.Flash} tech   The instance of the Flash tech
  */
-vjs.Flash.nativeSourceHandler.handleSource = function(source, tech){
+vjs.Flash['nativeSourceHandler']['handleSource'] = function(source, tech){
   tech.setSrc(source.src);
 };
 
@@ -278,10 +278,10 @@ vjs.Flash.nativeSourceHandler.handleSource = function(source, tech){
  * Clean up the source handler when disposing the player or switching sources..
  * (no cleanup is needed when supporting the format natively)
  */
-vjs.Flash.nativeSourceHandler.dispose = function(){};
+vjs.Flash['nativeSourceHandler']['dispose'] = function(){};
 
 // Register the native source handler
-vjs.Flash.registerSourceHandler(vjs.Flash.nativeSourceHandler);
+vjs.Flash['registerSourceHandler'](vjs.Flash['nativeSourceHandler']);
 
 vjs.Flash.formats = {
   'video/flv': 'FLV',

--- a/src/js/media/flash.rtmp.js
+++ b/src/js/media/flash.rtmp.js
@@ -62,7 +62,7 @@ vjs.Flash.rtmpSourceHandler = {};
  * @param  {Object} source  The source object
  * @return {String}         'probably', 'maybe', or '' (empty string)
  */
-vjs.Flash.rtmpSourceHandler.canHandleSource = function(source){
+vjs.Flash.rtmpSourceHandler['canHandleSource'] = function(source){
   if (vjs.Flash.isStreamingType(source.type) || vjs.Flash.isStreamingSrc(source.src)) {
     return 'maybe';
   }
@@ -77,7 +77,7 @@ vjs.Flash.rtmpSourceHandler.canHandleSource = function(source){
  * @param  {Object} source    The source object
  * @param  {vjs.Flash} tech   The instance of the Flash tech
  */
-vjs.Flash.rtmpSourceHandler.handleSource = function(source, tech){
+vjs.Flash.rtmpSourceHandler['handleSource'] = function(source, tech){
   var srcParts = vjs.Flash.streamToParts(source.src);
 
   tech['setRtmpConnection'](srcParts.connection);
@@ -85,4 +85,4 @@ vjs.Flash.rtmpSourceHandler.handleSource = function(source, tech){
 };
 
 // Register the native source handler
-vjs.Flash.registerSourceHandler(vjs.Flash.rtmpSourceHandler);
+vjs.Flash['registerSourceHandler'](vjs.Flash.rtmpSourceHandler);

--- a/src/js/media/html5.js
+++ b/src/js/media/html5.js
@@ -517,14 +517,14 @@ vjs.MediaTechController.withSourceHandlers(vjs.Html5);
  * @param  {Object} source   The source object
  * @param  {vjs.Html5} tech  The instance of the HTML5 tech
  */
-vjs.Html5.nativeSourceHandler = {};
+vjs.Html5['nativeSourceHandler'] = {};
 
 /**
  * Check if the video element can handle the source natively
  * @param  {Object} source  The source object
  * @return {String}         'probably', 'maybe', or '' (empty string)
  */
-vjs.Html5.nativeSourceHandler.canHandleSource = function(source){
+vjs.Html5['nativeSourceHandler']['canHandleSource'] = function(source){
   var match, ext;
 
   function canPlayType(type){
@@ -558,7 +558,7 @@ vjs.Html5.nativeSourceHandler.canHandleSource = function(source){
  * @param  {Object} source    The source object
  * @param  {vjs.Html5} tech   The instance of the Html5 tech
  */
-vjs.Html5.nativeSourceHandler.handleSource = function(source, tech){
+vjs.Html5['nativeSourceHandler']['handleSource'] = function(source, tech){
   tech.setSrc(source.src);
 };
 
@@ -566,10 +566,10 @@ vjs.Html5.nativeSourceHandler.handleSource = function(source, tech){
  * Clean up the source handler when disposing the player or switching sources..
  * (no cleanup is needed when supporting the format natively)
  */
-vjs.Html5.nativeSourceHandler.dispose = function(){};
+vjs.Html5['nativeSourceHandler']['dispose'] = function(){};
 
 // Register the native source handler
-vjs.Html5.registerSourceHandler(vjs.Html5.nativeSourceHandler);
+vjs.Html5['registerSourceHandler'](vjs.Html5['nativeSourceHandler']);
 
 /**
  * Check if the volume can be changed in this browser/device.

--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -434,7 +434,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
    * @param  {Function} handler  The source handler
    * @param  {Boolean}  first    Register it before any existing handlers
    */
-  Tech.registerSourceHandler = function(handler, index){
+  Tech['registerSourceHandler'] = function(handler, index){
     var handlers = Tech.sourceHandlers;
 
     if (!handlers) {
@@ -461,7 +461,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
         can;
 
     for (var i = 0; i < handlers.length; i++) {
-      can = handlers[i].canHandleSource(source);
+      can = handlers[i]['canHandleSource'](source);
 
       if (can) {
         return handlers[i];
@@ -480,7 +480,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
     var sh = Tech.selectSourceHandler(srcObj);
 
     if (sh) {
-      return sh.canHandleSource(srcObj);
+      return sh['canHandleSource'](srcObj);
     }
 
     return '';
@@ -499,8 +499,8 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
     if (!sh) {
       // Fall back to a native source hander when unsupported sources are
       // deliberately set
-      if (Tech.nativeSourceHandler) {
-        sh = Tech.nativeSourceHandler;
+      if (Tech['nativeSourceHandler']) {
+        sh = Tech['nativeSourceHandler'];
       } else {
         vjs.log.error('No source hander found for the current source.');
       }
@@ -511,7 +511,7 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
     this.off('dispose', this.disposeSourceHandler);
 
     this.currentSource_ = source;
-    this.sourceHandler_ = sh.handleSource(source, this);
+    this.sourceHandler_ = sh['handleSource'](source, this);
     this.on('dispose', this.disposeSourceHandler);
 
     return this;
@@ -521,8 +521,8 @@ vjs.MediaTechController.withSourceHandlers = function(Tech){
    * Clean up any existing source handler
    */
   Tech.prototype.disposeSourceHandler = function(){
-    if (this.sourceHandler_ && this.sourceHandler_.dispose) {
-      this.sourceHandler_.dispose();
+    if (this.sourceHandler_ && this.sourceHandler_['dispose']) {
+      this.sourceHandler_['dispose']();
     }
   };
 

--- a/test/unit/api.js
+++ b/test/unit/api.js
@@ -116,16 +116,16 @@ test('should be able to access expected MediaTech API methods', function() {
   ok(videojs.Html5.unpatchCanPlayType, 'unpatchCanPlayType should exist for HTML5');
 
   // Source Handler Functions
-  ok(media.withSourceHandlers, 'withSourceHandlers should exist for Media Tech');
+  ok(media['withSourceHandlers'], 'withSourceHandlers should exist for Media Tech');
 
   ok(videojs.Html5.canPlaySource, 'canPlaySource should exist for HTML5');
-  ok(videojs.Html5.registerSourceHandler, 'registerSourceHandler should exist for Html5');
+  ok(videojs.Html5['registerSourceHandler'], 'registerSourceHandler should exist for Html5');
   ok(videojs.Html5.selectSourceHandler, 'selectSourceHandler should exist for Html5');
   ok(videojs.Html5.prototype.setSource, 'setSource should exist for Html5');
   ok(videojs.Html5.prototype.disposeSourceHandler, 'disposeSourceHandler should exist for Html5');
 
   ok(videojs.Flash.canPlaySource, 'canPlaySource should exist for Flash');
-  ok(videojs.Flash.registerSourceHandler, 'registerSourceHandler should exist for Flash');
+  ok(videojs.Flash['registerSourceHandler'], 'registerSourceHandler should exist for Flash');
   ok(videojs.Flash.selectSourceHandler, 'selectSourceHandler should exist for Flash');
   ok(videojs.Flash.prototype.setSource, 'setSource should exist for Flash');
   ok(videojs.Flash.prototype.disposeSourceHandler, 'disposeSourceHandler should exist for Flash');

--- a/test/unit/flash.js
+++ b/test/unit/flash.js
@@ -150,7 +150,7 @@ test('ready triggering before and after disposing the tech', function() {
 });
 
 test('should have the source handler interface', function() {
-  ok(vjs.Flash.registerSourceHandler, 'has the registerSourceHandler function');
+  ok(vjs.Flash['registerSourceHandler'], 'has the registerSourceHandler function');
 });
 
 test('seekable should be for the length of the loaded video', function() {

--- a/test/unit/media.html5.js
+++ b/test/unit/media.html5.js
@@ -150,7 +150,7 @@ test('error events may not set the errors property', function() {
 });
 
 test('should have the source handler interface', function() {
-  ok(vjs.Html5.registerSourceHandler, 'has the registerSourceHandler function');
+  ok(vjs.Html5['registerSourceHandler'], 'has the registerSourceHandler function');
 });
 
 test('should not autoplay if there is no source', function() {
@@ -198,7 +198,7 @@ test('native source handler canHandleSource', function(){
     return '';
   };
 
-  var canHandleSource = vjs.Html5.nativeSourceHandler.canHandleSource;
+  var canHandleSource = vjs.Html5['nativeSourceHandler']['canHandleSource'];
 
   equal(canHandleSource({ type: 'video/mp4', src: 'video.flv' }), 'maybe', 'Native source handler reported type support');
   equal(canHandleSource({ src: 'http://www.example.com/video.mp4' }), 'maybe', 'Native source handler reported extension support');

--- a/test/unit/media.js
+++ b/test/unit/media.js
@@ -159,10 +159,10 @@ test('should add the source hanlder interface to a tech', function(){
   var Tech = videojs.MediaTechController.extend();
 
   // Extend Tech with source handlers
-  vjs.MediaTechController.withSourceHandlers(Tech);
+  vjs.MediaTechController['withSourceHandlers'](Tech);
 
   // Check for the expected class methods
-  ok(Tech.registerSourceHandler, 'added a registerSourceHandler function to the Tech');
+  ok(Tech['registerSourceHandler'], 'added a registerSourceHandler function to the Tech');
   ok(Tech.selectSourceHandler, 'added a selectSourceHandler function to the Tech');
 
   // Create an instance of Tech
@@ -183,13 +183,13 @@ test('should add the source hanlder interface to a tech', function(){
 
   // Create source handlers
   var handlerOne = {
-    canHandleSource: function(source){
+    'canHandleSource': function(source){
       if (source.type !=='no-support') {
         return 'probably';
       }
       return '';
     },
-    handleSource: function(s, t){
+    'handleSource': function(s, t){
       strictEqual(tech, t, 'the tech instance was passed to the source handler');
       strictEqual(sourceA, s, 'the tech instance was passed to the source handler');
       return new handlerInternalState();
@@ -197,18 +197,18 @@ test('should add the source hanlder interface to a tech', function(){
   };
 
   var handlerTwo = {
-    canHandleSource: function(source){
+    'canHandleSource': function(source){
       return ''; // no support
     },
-    handleSource: function(source, tech){
+    'handleSource': function(source, tech){
       ok(false, 'handlerTwo supports nothing and should never be called');
     }
   };
 
   // Test registering source handlers
-  Tech.registerSourceHandler(handlerOne);
+  Tech['registerSourceHandler'](handlerOne);
   strictEqual(Tech.sourceHandlers[0], handlerOne, 'handlerOne was added to the source handler array');
-  Tech.registerSourceHandler(handlerTwo, 0);
+  Tech['registerSourceHandler'](handlerTwo, 0);
   strictEqual(Tech.sourceHandlers[0], handlerTwo, 'handlerTwo was registered at the correct index (0)');
 
   // Test handler selection
@@ -230,7 +230,7 @@ test('should add the source hanlder interface to a tech', function(){
   ok(disposeCalled, 'the handler dispose method was called when the tech was disposed');
 });
 
-test('should handle unsupported sources with the source hanlder API', function(){
+test('should handle unsupported sources with the source handler API', function(){
   var mockPlayer = {
     off: this.noop,
     trigger: this.noop
@@ -239,13 +239,13 @@ test('should handle unsupported sources with the source hanlder API', function()
   // Define a new tech class
   var Tech = videojs.MediaTechController.extend();
   // Extend Tech with source handlers
-  vjs.MediaTechController.withSourceHandlers(Tech);
+  vjs.MediaTechController['withSourceHandlers'](Tech);
   // Create an instance of Tech
   var tech = new Tech(mockPlayer);
 
   var usedNative;
-  Tech.nativeSourceHandler = {
-    handleSource: function(){ usedNative = true; }
+  Tech['nativeSourceHandler'] = {
+    'handleSource': function(){ usedNative = true; }
   };
 
   tech.setSource('');


### PR DESCRIPTION
Issue:

In video.js, the `withSourceHandlers` mixin was getting all the names of the functions it used in the SourceHandlers (`canHandleSource`, `handleSource`, and `dispose`) mangled by Closure Compiler.

As a result, it worked only with native source handlers that were compiled together with video.js but not any source handler that was registered later. 

In addition, the `nativeSourceHandler` property was also mangled which meant that any Techs not compiled with video.js would not be able to *fall-back* to their `nativeSourceHandler` as a last ditch attempt to play the source if no SourceHandler was found that matched the type.

Finally, the tests were written expecting any SourceHandlers that were registered to use the same mangling as video.js instead of testing that the SourceHandler interface worked as expected.

Changes:

**Source**
- No longer explicitly export `registerSourceHandler` since it is properly mixed-in unmangled
- Mixin code now calls functions `canHandleSource`, `dispose`, and `handleSource` explicitly instead of by their mangled names
- A tech's `nativeSourceHandler` property is no longer mangled in the code and is called explicitly unmangled

**Tests**
- `withSourceHandlers` and `registerSourceHandler` are used explicitly instead of using the mangled names
- `canHandleSource` and `handleSource` are quoted to avoid mangling