### PR TITLE
Fix vertical option check on volumeMenuButton

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -24,6 +24,10 @@
   @include display-flex(center);
 }
 
+.video-js .vjs-volume-bar {
+  margin: 1.3em;
+}
+
 .video-js .vjs-volume-bar.vjs-slider-horizontal {
   width: 5em;
   height: 0.3em;
@@ -32,7 +36,6 @@
 .video-js .vjs-volume-bar.vjs-slider-vertical {
   width: 0.3em;
   height: 5em;
-  margin: 1.3em;
 }
 
 .video-js .vjs-volume-level {
@@ -82,8 +85,13 @@ width and height to zero. */
   display: block;
   width: 0;
   height: 0;
-  left: 0.5em;
   border-top-color: transparent;
+}
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-vertical .vjs-menu {
+  left: 0.5em;
+}
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-horizontal .vjs-menu {
+  left: -2em;
 }
 
 .video-js .vjs-menu-button.vjs-volume-menu-button .vjs-menu .vjs-menu-content {
@@ -100,10 +108,17 @@ width and height to zero. */
   // border-top-color: rgba(7, 40, 50, 0.5); /* Same as ul background */
 }
 
-.video-js .vjs-volume-menu-button:hover .vjs-menu .vjs-menu-content,
-.video-js .vjs-volume-menu-button .vjs-menu.vjs-lock-showing .vjs-menu-content {
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-vertical:hover .vjs-menu .vjs-menu-content,
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-vertical .vjs-menu.vjs-lock-showing .vjs-menu-content {
   height: 8em;
   width: 2.9em;
+}
+
+
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-horizontal:hover .vjs-menu .vjs-menu-content,
+.video-js .vjs-volume-menu-button.vjs-volume-menu-button-horizontal .vjs-menu.vjs-lock-showing .vjs-menu-content {
+  height: 2.9em;
+  width: 8em;
 }
 
 // By default, all menu items are shown, but we hide .vjs-mute-control and .vjs-volume-control

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -55,7 +55,14 @@ class VolumeMenuButton extends MenuButton {
    * @method buildCSSClass
    */
   buildCSSClass() {
-    return `vjs-volume-menu-button ${super.buildCSSClass()} ${this.orientationClassName()}`;
+    let orientationClass = '';
+    if (!!this.options_.vertical) {
+      orientationClass = 'vjs-volume-menu-button-vertical';
+    } else {
+      orientationClass = 'vjs-volume-menu-button-horizontal';
+    }
+
+    return `vjs-volume-menu-button ${super.buildCSSClass()} ${orientationClass}`;
   }
 
   /**
@@ -79,19 +86,6 @@ class VolumeMenuButton extends MenuButton {
     });
     menu.addChild(vc);
     return menu;
-  }
-
-  /**
-   * Generates a class name with the appropriate orientation for the slider
-   *
-   * @method orientationClassName
-   */
-  orientationClassName() {
-    if (!!this.options_.vertical) {
-      return 'vjs-volume-menu-button-vertical';
-    }
-
-    return 'vjs-volume-menu-button-horizontal';
   }
 
   /**

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -20,14 +20,14 @@ class VolumeMenuButton extends MenuButton {
 
   constructor(player, options={}){
     // If the vertical option isn't passed at all, default to true.
-    if (options['vertical'] === undefined) {
-      options['vertical'] = true;
+    if (options.vertical === undefined) {
+      options.vertical = true;
     }
 
     // The vertical option needs to be set on the volumeBar as well, since that will
     // need to be passed along to the VolumeBar constructor
-    options['volumeBar'] = options['volumeBar'] || {};
-    options['volumeBar']['vertical'] = !!options['vertical'];
+    options.volumeBar = options.volumeBar || {};
+    options.volumeBar.vertical = !!options.vertical;
 
     super(player, options);
 
@@ -69,7 +69,7 @@ class VolumeMenuButton extends MenuButton {
       contentElType: 'div'
     });
 
-    let vc = new VolumeBar(this.player_, this.options_['volumeBar']);
+    let vc = new VolumeBar(this.player_, this.options_.volumeBar);
 
     vc.on('focus', function() {
       menu.lockShowing();
@@ -87,7 +87,7 @@ class VolumeMenuButton extends MenuButton {
    * @method orientationClassName
    */
   orientationClassName() {
-    if (!!this.options_['vertical']) {
+    if (!!this.options_.vertical) {
       return 'vjs-volume-menu-button-vertical';
     }
 

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -18,7 +18,17 @@ import VolumeBar from './volume-control/volume-bar.js';
  */
 class VolumeMenuButton extends MenuButton {
 
-  constructor(player, options){
+  constructor(player, options={}){
+    // If the vertical option isn't passed at all, default to true.
+    if (options['vertical'] === undefined) {
+      options['vertical'] = true;
+    }
+
+    // The vertical option needs to be set on the volumeBar as well, since that will
+    // need to be passed along to the VolumeBar constructor
+    options['volumeBar'] = options['volumeBar'] || {};
+    options['volumeBar']['vertical'] = !!options['vertical'];
+
     super(player, options);
 
     // Same listeners as MuteToggle
@@ -45,7 +55,7 @@ class VolumeMenuButton extends MenuButton {
    * @method buildCSSClass
    */
   buildCSSClass() {
-    return `vjs-volume-menu-button ${super.buildCSSClass()}`;
+    return `vjs-volume-menu-button ${super.buildCSSClass()} ${this.orientationClassName()}`;
   }
 
   /**
@@ -59,11 +69,7 @@ class VolumeMenuButton extends MenuButton {
       contentElType: 'div'
     });
 
-    // The volumeBar is vertical by default in the base theme when used with a VolumeMenuButton
-    var options = this.options_['volumeBar'] || {};
-    options['vertical'] = options['vertical'] || true;
-
-    let vc = new VolumeBar(this.player_, options);
+    let vc = new VolumeBar(this.player_, this.options_['volumeBar']);
 
     vc.on('focus', function() {
       menu.lockShowing();
@@ -73,6 +79,19 @@ class VolumeMenuButton extends MenuButton {
     });
     menu.addChild(vc);
     return menu;
+  }
+
+  /**
+   * Generates a class name with the appropriate orientation for the slider
+   *
+   * @method orientationClassName
+   */
+  orientationClassName() {
+    if (!!this.options_['vertical']) {
+      return 'vjs-volume-menu-button-vertical';
+    }
+
+    return 'vjs-volume-menu-button-horizontal';
   }
 
   /**


### PR DESCRIPTION
Previously, a horizontal volume menu button would not have worked. Even
once the vertical option was set to false (which was impossible before
due to an ill conceived `||` assignment), a lot of very specific styling
would have been required to make the menu look correct. This fixes both
issues by setting an orientation class on the parent menu button and
adding styling to account for both orientations.