### PR TITLE
Export videojs.createTimeRange

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -11,6 +11,7 @@ import mergeOptions from '../../src/js/utils/merge-options.js';
 import * as Fn from './utils/fn.js';
 
 import assign from 'object.assign';
+import { createTimeRange } from './utils/time-ranges.js';
 import log from './utils/log.js';
 import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
@@ -345,6 +346,16 @@ videojs.addLanguage = function(code, data){
  * @param {...Object} messages One or more messages to log
  */
 videojs.log = log;
+
+/**
+ * Creates an emulated TimeRange object.
+ *
+ * @param  {Number} start Start time in seconds
+ * @param  {Number} end   End time in seconds
+ * @return {Object}       Fake TimeRange object
+ * @method createTimeRange
+ */
+videojs.createTimeRange = createTimeRange;
 
 // REMOVING: We probably should add this to the migration plugin
 // // Expose but deprecate the window[componentName] method for accessing components


### PR DESCRIPTION
Source handlers and custom techs may want to create time range objects to pass to downstream users.