### PR TITLE
Use node.js 0.12 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - iojs
+  - 0.12
 before_script:
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then curl https://gist.githubusercontent.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash; fi
 before_install:


### PR DESCRIPTION
libsass may be running into issues with bindings and iojs so use a version-pegged node.js for now.

(Testing to see if this fixed Travis)