### PR TITLE
Restore options/players Globals

### DIFF
--- a/src/js/utils/create-deprecation-proxy.js
+++ b/src/js/utils/create-deprecation-proxy.js
@@ -1,0 +1,50 @@
+import log from './log.js';
+
+/**
+ * Object containing the default behaviors for available handler methods.
+ *
+ * @private
+ * @type {Object}
+ */
+const defaultBehaviors = {
+  get(obj, key) {
+    return obj[key];
+  },
+  set(obj, key, value) {
+    obj[key] = value;
+    return true;
+  }
+};
+
+/**
+ * Expose private objects publicly using a Proxy to log deprecation warnings.
+ *
+ * Browsers that do not support Proxy objects will simply return the `target`
+ * object, so it can be directly exposed.
+ *
+ * @param {Object} target The target object.
+ * @param {Object} messages Messages to display from a Proxy. Only operations
+ *                          with an associated message will be proxied.
+ * @param {String} [messages.get]
+ * @param {String} [messages.set]
+ * @return {Object} A Proxy if supported or the `target` argument.
+ */
+export default (target, messages={}) => {
+  if (typeof Proxy === 'function') {
+    let handler = {};
+
+    // Build a handler object based on those keys that have both messages
+    // and default behaviors.
+    Object.keys(messages).forEach(key => {
+      if (defaultBehaviors.hasOwnProperty(key)) {
+        handler[key] = function() {
+          log.warn(messages[key]);
+          return defaultBehaviors[key].apply(this, arguments);
+        };
+      }
+    });
+
+    return new Proxy(target, handler);
+  }
+  return target;
+};

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -99,17 +99,18 @@ var videojs = function(id, options, ready){
  * @private
  * @param {String} name The key name for the deprecated property.
  * @param {Object} target The target object.
+ * @param {Object} messages String messages to display from a Proxy, mapping to get/set operations.
  * @return {Object} A Proxy if supported or the `target` argument.
  */
-const createDeprecationProxy = (name, target) => {
+const createDeprecationProxy = (name, target, messages) => {
   if (typeof Proxy === 'function') {
     videojs[name] = new Proxy(target, {
       get: function(obj, key) {
-        log.warn(`access to videojs.${name} is deprecated; getting ${key}`);
+        log.warn(messages.get);
         return obj[key];
       },
       set: function(obj, key, value) {
-        log.warn(`modification of videojs.${name} is deprecated; setting ${key}`);
+        log.warn(messages.set);
         obj[key] = value;
       }
     });
@@ -146,7 +147,10 @@ videojs.getGlobalOptions = () => globalOptions;
  * @memberOf videojs
  * @property {Object|Proxy} options
  */
-createDeprecationProxy('options', globalOptions);
+createDeprecationProxy('options', globalOptions, {
+  get: 'access to videojs.options is deprecated; use videojs.getGlobalOptions instead',
+  set: 'modification of videojs.options is deprecated; use videojs.setGlobalOptions instead'
+});
 
 /**
  * Set options that will apply to every player
@@ -185,7 +189,10 @@ videojs.getPlayers = function() {
  * @memberOf videojs
  * @property {Object|Proxy} players
  */
-createDeprecationProxy('players', Player.players);
+createDeprecationProxy('players', Player.players, {
+  get: 'access to videojs.players is deprecated; use videojs.getPlayers instead',
+  set: 'modification of videojs.players is deprecated'
+});
 
 /**
  * Get a component class object by name

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -120,8 +120,8 @@ videojs.getGlobalOptions = () => globalOptions;
  * @property {Object|Proxy} options
  */
 videojs.options = createDeprecationProxy(globalOptions, {
-  get: 'access to videojs.options is deprecated; use videojs.getGlobalOptions instead',
-  set: 'modification of videojs.options is deprecated; use videojs.setGlobalOptions instead'
+  get: 'Access to videojs.options is deprecated; use videojs.getGlobalOptions instead',
+  set: 'Modification of videojs.options is deprecated; use videojs.setGlobalOptions instead'
 });
 
 /**
@@ -162,8 +162,8 @@ videojs.getPlayers = function() {
  * @property {Object|Proxy} players
  */
 videojs.players = createDeprecationProxy(Player.players, {
-  get: 'access to videojs.players is deprecated; use videojs.getPlayers instead',
-  set: 'modification of videojs.players is deprecated'
+  get: 'Access to videojs.players is deprecated; use videojs.getPlayers instead',
+  set: 'Modification of videojs.players is deprecated'
 });
 
 /**

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -112,6 +112,7 @@ const createDeprecationProxy = (name, target, messages) => {
       set: function(obj, key, value) {
         log.warn(messages.set);
         obj[key] = value;
+        return true;
       }
     });
   } else {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -112,6 +112,14 @@ videojs.VERSION = '__VERSION__';
 videojs.getGlobalOptions = () => globalOptions;
 
 /**
+ * For backward compatibility, expose global options.
+ *
+ * @deprecated
+ * @type {Object}
+ */
+videojs.options = globalOptions;
+
+/**
  * Set options that will apply to every player
  * ```js
  *     videojs.setGlobalOptions({
@@ -140,6 +148,14 @@ videojs.setGlobalOptions = function(newOptions) {
 videojs.getPlayers = function() {
   return Player.players;
 };
+
+/**
+ * For backward compatibility, expose players object.
+ *
+ * @deprecated
+ * @type {Object}
+ */
+videojs.players = Player.players;
 
 /**
  * Get a component class object by name

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -18,6 +18,7 @@ import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
 import extendsFn from './extends.js';
 import merge from 'lodash-compat/object/merge';
+import createDeprecationProxy from './utils/create-deprecation-proxy.js';
 
 // Include the built-in techs
 import Html5 from './tech/html5.js';
@@ -91,36 +92,6 @@ var videojs = function(id, options, ready){
   return tag['player'] || new Player(tag, options, ready);
 };
 
-/**
- * Expose private objects on the global videojs namespace using a Proxy if
- * supported. Browsers that support Proxy will log a deprecation warning for
- * directly accessing or modifying a deprecated object.
- *
- * @private
- * @param {String} name The key name for the deprecated property.
- * @param {Object} target The target object.
- * @param {Object} messages String messages to display from a Proxy, mapping to get/set operations.
- * @return {Object} A Proxy if supported or the `target` argument.
- */
-const createDeprecationProxy = (name, target, messages) => {
-  if (typeof Proxy === 'function') {
-    videojs[name] = new Proxy(target, {
-      get: function(obj, key) {
-        log.warn(messages.get);
-        return obj[key];
-      },
-      set: function(obj, key, value) {
-        log.warn(messages.set);
-        obj[key] = value;
-        return true;
-      }
-    });
-  } else {
-    videojs[name] = target;
-  }
-  return videojs[name];
-};
-
 // Run Auto-load players
 // You have to wait at least once in case this script is loaded after your video in the DOM (weird behavior only with minified version)
 setup.autoSetupTimeout(1, videojs);
@@ -148,7 +119,7 @@ videojs.getGlobalOptions = () => globalOptions;
  * @memberOf videojs
  * @property {Object|Proxy} options
  */
-createDeprecationProxy('options', globalOptions, {
+videojs.options = createDeprecationProxy(globalOptions, {
   get: 'access to videojs.options is deprecated; use videojs.getGlobalOptions instead',
   set: 'modification of videojs.options is deprecated; use videojs.setGlobalOptions instead'
 });
@@ -190,7 +161,7 @@ videojs.getPlayers = function() {
  * @memberOf videojs
  * @property {Object|Proxy} players
  */
-createDeprecationProxy('players', Player.players, {
+videojs.players = createDeprecationProxy(Player.players, {
   get: 'access to videojs.players is deprecated; use videojs.getPlayers instead',
   set: 'modification of videojs.players is deprecated'
 });

--- a/test/unit/utils/create-deprecation-proxy.test.js
+++ b/test/unit/utils/create-deprecation-proxy.test.js
@@ -1,0 +1,45 @@
+import createDeprecationProxy from '../../../src/js/utils/create-deprecation-proxy.js';
+import log from '../../../src/js/utils/log.js';
+
+const proxySupported = typeof Proxy === 'function';
+
+test('should return a Proxy object when supported or the target object by reference', function() {
+  let target = {foo: 1};
+  let subject = createDeprecationProxy(target, {
+    get: 'get message',
+    set: 'set message'
+  });
+
+  // Testing for a Proxy is really difficult because Proxy objects by their
+  // nature disguise the fact that they are in fact Proxy objects. So, this
+  // tests that the log.warn method gets called on property get/set operations
+  // to detect the Proxy.
+  if (proxySupported) {
+    sinon.stub(log, 'warn');
+
+    subject.foo; // Triggers a "get"
+    subject.foo = 2; // Triggers a "set"
+
+    equal(log.warn.callCount, 2, 'proxied operations cause deprecation warnings');
+    ok(log.warn.calledWith('get message'), 'proxied get logs expected message');
+    ok(log.warn.calledWith('set message'), 'proxied set logs expected message');
+
+    log.warn.restore();
+  } else {
+    strictEqual(target, subject, 'identical to target');
+  }
+});
+
+// Tests run only in Proxy-supporting environments.
+if (proxySupported) {
+  test('no deprecation warning is logged for operations without a message', function() {
+    let subject = createDeprecationProxy({}, {
+      get: 'get message'
+    });
+
+    sinon.stub(log, 'warn');
+    subject.foo = 'bar'; // Triggers a "set," but not a "get"
+    equal(log.warn.callCount, 0, 'no deprecation warning expected');
+    log.warn.restore();
+  });
+}

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -78,29 +78,6 @@ test('should expose plugin registry function', function() {
 });
 
 test('should expose options and players properties for backward-compatibility', function() {
-
-  // This test forks based on Proxy support because there is slightly different
-  // behavior and test cases (i.e., wanting to ensure that deprecation warnings
-  // were logged.
-  if (typeof Proxy === 'function') {
-    let fixture = document.getElementById('qunit-fixture');
-    fixture.innerHTML += '<video id="test_vid_id"></video>';
-
-    let player = videojs('test_vid_id');
-
-    sinon.stub(log, 'warn');
-
-    strictEqual(videojs.options.html5, globalOptions.html5, 'proxies global options object');
-    strictEqual(videojs.players.test_vid_id, Player.players.test_vid_id, 'proxies players object');
-
-    videojs.options.foo = videojs.players.foo = 'bar';
-
-    // Expecting 2 gets and 2 sets.
-    equal(log.warn.callCount, 4, 'each proxy operation logged a deprecation warning');
-
-    log.warn.restore();
-  } else {
-    strictEqual(videojs.options, videojs.getGlobalOptions(), 'identical to global options object');
-    strictEqual(videojs.players, videojs.getPlayers(), 'identical to players object');
-  }
+  ok(typeof videojs.options, 'object', 'options should be an object');
+  ok(typeof videojs.players, 'object', 'players should be an object');
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -92,7 +92,11 @@ test('should expose options and players properties for backward-compatibility', 
 
     strictEqual(videojs.options.html5, globalOptions.html5, 'proxies global options object');
     strictEqual(videojs.players.test_vid_id, Player.players.test_vid_id, 'proxies players object');
-    ok(log.warn.calledTwice, 'each proxy logged a deprecation warning');
+
+    videojs.options.foo = videojs.players.foo = 'bar';
+
+    // Expecting 2 gets and 2 sets.
+    equal(log.warn.callCount, 4, 'each proxy operation logged a deprecation warning');
 
     log.warn.restore();
   } else {

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -2,6 +2,7 @@ import videojs from '../../src/js/video.js';
 import TestHelpers from './test-helpers.js';
 import Player from '../../src/js/player.js';
 import globalOptions from '../../src/js/global-options.js';
+import log from '../../src/js/utils/log.js';
 import document from 'global/document';
 
 q.module('video.js');
@@ -74,4 +75,28 @@ test('should expose plugin registry function', function() {
 
   ok(player.foo, 'should exist');
   equal(player.foo, pluginFunction, 'should be equal');
+});
+
+test('should expose options and players properties for backward-compatibility', function() {
+
+  // This test forks based on Proxy support because there is slightly different
+  // behavior and test cases (i.e., wanting to ensure that deprecation warnings
+  // were logged.
+  if (typeof Proxy === 'function') {
+    let fixture = document.getElementById('qunit-fixture');
+    fixture.innerHTML += '<video id="test_vid_id"></video>';
+
+    let player = videojs('test_vid_id');
+
+    sinon.stub(log, 'warn');
+
+    strictEqual(videojs.options.html5, globalOptions.html5, 'proxies global options object');
+    strictEqual(videojs.players.test_vid_id, Player.players.test_vid_id, 'proxies players object');
+    ok(log.warn.calledTwice, 'each proxy logged a deprecation warning');
+
+    log.warn.restore();
+  } else {
+    strictEqual(videojs.options, videojs.getGlobalOptions(), 'identical to global options object');
+    strictEqual(videojs.players, videojs.getPlayers(), 'identical to players object');
+  }
 });


### PR DESCRIPTION
Addresses #2311.

This restores the `options` and `players` properties of `videojs`.

Browsers with `Proxy` support (Firefox and IE Edge at the moment) will additionally log a warning on both get/set operations only through these specific properties. That is, modifying `videojs.players` will log a deprecation warning where internal modifications to `Player.players` will not.

Both cases - using `Proxy` and not - are tested.