### PR TITLE
Fix potential triggerReady infinite-loop

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -790,14 +790,14 @@ vjs.Component.prototype.triggerReady = function(){
 
   var readyQueue = this.readyQueue_;
 
+  // Reset Ready Queue
+  this.readyQueue_ = [];
+
   if (readyQueue && readyQueue.length > 0) {
 
     for (var i = 0, j = readyQueue.length; i < j; i++) {
       readyQueue[i].call(this);
     }
-
-    // Reset Ready Queue
-    this.readyQueue_ = [];
 
     // Allow for using event listeners also, in case you want to do something everytime a source is ready.
     this.trigger('ready');

--- a/test/unit/component.js
+++ b/test/unit/component.js
@@ -360,6 +360,29 @@ test('should trigger a listener when ready', function(){
   comp.triggerReady();
 });
 
+test('should not retrigger a listener when the listener calls triggerReady', function(){
+  var timesCalled = 0;
+  var selfTriggered = false;
+
+  var readyListener = function(){
+    timesCalled++;
+
+    // Don't bother calling again if we have
+    // already failed
+    if (!selfTriggered) {
+      selfTriggered = true;
+      comp.triggerReady();
+    }
+  };
+
+  var comp = new vjs.Component(getFakePlayer(), {});
+
+  comp.ready(readyListener);
+  comp.triggerReady();
+
+  equal(timesCalled, 1, 'triggerReady from inside a ready handler does not result in an infinite loop');
+});
+
 test('should add and remove a CSS class', function(){
   var comp = new vjs.Component(getFakePlayer(), {});
 


### PR DESCRIPTION
If the `readyQueue_` is not reset *before* processing, a `triggerReady` later on in the call graph potentially results in an infinite loop.