### PR TITLE
Reset seekable function when no source handler in tech

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -537,6 +537,17 @@ Tech.withSourceHandlers = function(_Tech){
     return '';
   };
 
+  let originalSeekable = _Tech.prototype.seekable;
+
+  // when a source handler is registered, prefer its implementation of
+  // seekable when present.
+  _Tech.prototype.seekable = function() {
+    if (this.sourceHandler_ && this.sourceHandler_.seekable) {
+      return this.sourceHandler_.seekable();
+    }
+    return originalSeekable.call(this);
+  };
+
    /*
     * Create a function for setting the source using a source object
     * and source handlers.
@@ -565,16 +576,6 @@ Tech.withSourceHandlers = function(_Tech){
     this.sourceHandler_ = sh.handleSource(source, this);
     this.on('dispose', this.disposeSourceHandler);
 
-    this.originalSeekable_ = this.seekable;
-    // when a source handler is registered, prefer its implementation of
-    // seekable when present.
-    this.seekable = function() {
-      if (this.sourceHandler_ && this.sourceHandler_.seekable) {
-        return this.sourceHandler_.seekable();
-      }
-      return this.originalSeekable_.call(this);
-    };
-
     return this;
   };
 
@@ -584,9 +585,6 @@ Tech.withSourceHandlers = function(_Tech){
    _Tech.prototype.disposeSourceHandler = function(){
     if (this.sourceHandler_ && this.sourceHandler_.dispose) {
       this.sourceHandler_.dispose();
-    }
-    if (this.originalSeekable_) {
-      this.seekable = this.originalSeekable_;
     }
   };
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -584,6 +584,8 @@ Tech.withSourceHandlers = function(_Tech){
    _Tech.prototype.disposeSourceHandler = function(){
     if (this.sourceHandler_ && this.sourceHandler_.dispose) {
       this.sourceHandler_.dispose();
+    }
+    if (this.originalSeekable_) {
       this.seekable = this.originalSeekable_;
     }
   };


### PR DESCRIPTION
The `seekable` function was only reset back to its original implementation when a source handler was set.

However, the seekable function is overwritten even if no source handler is set in `setSource`.

This resulted in a bug in the Flash tech when calling `player.src()` more than once during the lifetime of the player.

This should fix this issue.