### PR TITLE
Restore Html5.Events

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -850,6 +850,37 @@ Html5.supportsNativeTextTracks = function() {
   return supportsTextTracks;
 };
 
+/**
+ * An array of events available on the Html5 tech.
+ *
+ * @private
+ * @type {Array}
+ */
+Html5.Events = [
+  'loadstart',
+  'suspend',
+  'abort',
+  'error',
+  'emptied',
+  'stalled',
+  'loadedmetadata',
+  'loadeddata',
+  'canplay',
+  'canplaythrough',
+  'playing',
+  'waiting',
+  'seeking',
+  'seeked',
+  'ended',
+  'durationchange',
+  'timeupdate',
+  'progress',
+  'play',
+  'pause',
+  'ratechange',
+  'volumechange'
+];
+
 /*
  * Set the tech's volume control support status
  *


### PR DESCRIPTION
There are a number of plugins that use the `Events` property of the `Html5` tech. This restores that; though, it's only one solution to that issue. If another solution is preferred, let's discuss.