### PR TITLE
Restore child components configured as `true`

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -507,6 +507,12 @@ class Component {
           return;
         }
 
+        // Allow options to be passed as a simple boolean if no configuration
+        // is necessary.
+        if (opts === true) {
+          opts = {};
+        }
+
         // We also want to pass the original player options to each component as well so they don't need to
         // reach back into the player for options later.
         opts.playerOptions = this.options_.playerOptions;


### PR DESCRIPTION
Previously, child components could be configured using `true`, `false`, or an object. Support for `true` appears to have been lost in the transition to 5.0. This restores that capability.