### PR TITLE
Restore novtt version of VideoJS

### DIFF
--- a/build/license-header.txt
+++ b/build/license-header.txt
@@ -1,11 +1,11 @@
 /**
  * @license
- * Video.js <%= pkg.version %> <http://videojs.com/>
- * <%= pkg.copyright %>
+ * Video.js <%= version %> <http://videojs.com/>
+ * <%= copyright %>
  * Available under Apache License Version 2.0
  * <https://github.com/videojs/video.js/blob/master/LICENSE>
- *
+<% if (includesVtt) { %> *
  * Includes vtt.js <https://github.com/mozilla/vtt.js>
  * Available under Apache License Version 2.0
  * <https://github.com/mozilla/vtt.js/blob/master/LICENSE>
- */
+<% } %> */

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "es5-shim": "^4.1.3",
     "grunt": "^0.4.4",
     "grunt-aws-s3": "^0.12.1",
-    "grunt-banner": "^0.3.1",
+    "grunt-banner": "^0.4.0",
     "grunt-browserify": "3.5.1",
     "grunt-cli": "~0.1.0",
     "grunt-concurrent": "^1.0.0",


### PR DESCRIPTION
The novtt version of VideoJS was not being created (though there was a `copy` task for it). This restores it and moves the generation of banners out of the browserify process so that the license banner can be programmatically generated depending on the presence of vtt.js. Relevant changes are:

- Lodash is pulled into the Gruntfile, but it was already a dependency.
- License banner templates are processed by customized processor functions, which manually render.