### PR TITLE
Pass vtt.js option to tech

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -505,7 +505,8 @@ class Player extends Component {
       'loop': this.options_.loop,
       'muted': this.options_.muted,
       'poster': this.poster(),
-      'language': this.language()
+      'language': this.language(),
+      'vtt.js': this.options_['vtt.js']
     }, this.options_[techName.toLowerCase()]);
 
     if (this.tag) {


### PR DESCRIPTION
This is needed by the `emulateTextTracks` method when vtt.js is not bundled with video.js, so it can load vtt.js on demand from a custom location.