### PR TITLE
Update Sauce Labs configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
   - 0.12
-before_script:
-  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then curl https://gist.githubusercontent.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash; fi
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+addons:
+  sauce_connect: true
 notifications:
   irc:
     channels:

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -62,7 +62,7 @@ module.exports = function(config) {
     browserNoActivityTimeout: 60000,
 
     sauceLabs: {
-      startConnect: true,
+      startConnect: false,
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
       build: process.env.TRAVIS_BUILD_NUMBER,
       testName: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH,
@@ -111,45 +111,37 @@ module.exports = function(config) {
 function getCustomLaunchers(){
   return {
     chrome_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'chrome',
-      platform: 'Windows 8.1',
-      version: '34'
+      platform: 'Windows 8.1'
     },
 
     firefox_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'firefox',
-      platform: 'Linux',
-      version: '29'
+      platform: 'Linux'
     },
 
     safari_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'safari',
       platform: 'OS X 10.10'
     },
 
     ipad_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'ipad',
-      platform:'OS X 10.9',
-      version: '7.1'
+      platform: 'OS X 10.10',
+      version: '8.4'
     },
 
     android_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'android',
       platform:'Linux'
     },
 
     ie_sl: {
-      singleRun: true,
       base: 'SauceLabs',
       browserName: 'internet explorer',
       platform: 'Windows 8.1',


### PR DESCRIPTION
This PR closes #2149. 

- Removes 'singleRun' duplicates
- Uses latest default Sauce Labs browsers
- Doesn't start Sauce Connect twice and uses the Travis addon