### PR TITLE
Update the SWF

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "./dist/video-js/video.js",
   "dependencies": {
-    "videojs-swf": "4.7.2",
+    "videojs-swf": "4.7.3",
     "vtt.js": "git+https://github.com/gkatsev/vtt.js.git#vjs-v0.12.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump up to 4.7.3 to pick up fixes for loading events in data generation mode and seeking after a video has ended.