### PR TITLE
Null check native tracks

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -95,7 +95,7 @@ class Html5 extends Tech {
     let emulatedTt = this.textTracks();
 
     // remove native event listeners
-    if (tt && tt.removeEventListener) {
+    if (tt) {
       tt.removeEventListener('change', this.handleTextTrackChange_);
       tt.removeEventListener('addtrack', this.handleTextTrackAdd_);
       tt.removeEventListener('removetrack', this.handleTextTrackRemove_);
@@ -208,7 +208,7 @@ class Html5 extends Tech {
   proxyNativeTextTracks_() {
     let tt = this.el().textTracks;
 
-    if (tt && tt.addEventListener) {
+    if (tt) {
       tt.addEventListener('change', this.handleTextTrackChange_);
       tt.addEventListener('addtrack', this.handleTextTrackAdd_);
       tt.addEventListener('removetrack', this.handleTextTrackRemove_);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -95,9 +95,11 @@ class Html5 extends Tech {
     let emulatedTt = this.textTracks();
 
     // remove native event listeners
-    tt.removeEventListener('change', this.handleTextTrackChange_);
-    tt.removeEventListener('addtrack', this.handleTextTrackAdd_);
-    tt.removeEventListener('removetrack', this.handleTextTrackRemove_);
+    if (tt && tt.removeEventListener) {
+      tt.removeEventListener('change', this.handleTextTrackChange_);
+      tt.removeEventListener('addtrack', this.handleTextTrackAdd_);
+      tt.removeEventListener('removetrack', this.handleTextTrackRemove_);
+    }
 
     // clearout the emulated text track list.
     let i = emulatedTt.length;
@@ -206,9 +208,11 @@ class Html5 extends Tech {
   proxyNativeTextTracks_() {
     let tt = this.el().textTracks;
 
-    tt.addEventListener('change', this.handleTextTrackChange_);
-    tt.addEventListener('addtrack', this.handleTextTrackAdd_);
-    tt.addEventListener('removetrack', this.handleTextTrackRemove_);
+    if (tt && tt.addEventListener) {
+      tt.addEventListener('change', this.handleTextTrackChange_);
+      tt.addEventListener('addtrack', this.handleTextTrackAdd_);
+      tt.addEventListener('removetrack', this.handleTextTrackRemove_);
+    }
   }
 
   handleTextTrackChange(e) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -893,6 +893,9 @@ Html5.supportsNativeTextTracks = function() {
   if (supportsTextTracks && browser.IS_FIREFOX) {
     supportsTextTracks = false;
   }
+  if (supportsTextTracks && ('onremovetrack' in Html5.TEST_VID.textTracks)) {
+    supportsTextTracks = false;
+  }
 
   return supportsTextTracks;
 };

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -893,7 +893,7 @@ Html5.supportsNativeTextTracks = function() {
   if (supportsTextTracks && browser.IS_FIREFOX) {
     supportsTextTracks = false;
   }
-  if (supportsTextTracks && ('onremovetrack' in Html5.TEST_VID.textTracks)) {
+  if (supportsTextTracks && !('onremovetrack' in Html5.TEST_VID.textTracks)) {
     supportsTextTracks = false;
   }
 

--- a/test/unit/tracks/text-track-list-converter.test.js
+++ b/test/unit/tracks/text-track-list-converter.test.js
@@ -9,6 +9,7 @@ q.module('Text Track List Converter');
 let clean = (item) => {
   delete item.id;
   delete item.inBandMetadataTrackDispatchType;
+  delete item.cues;
 };
 
 let cleanup = (item) => {
@@ -34,8 +35,7 @@ if (Html5.supportsNativeTextTracks()) {
       kind: 'captions',
       label: 'English',
       language: 'en',
-      mode: 'disabled',
-      cues: null
+      mode: 'disabled'
     }, 'the json output is same');
   });
 
@@ -76,15 +76,13 @@ if (Html5.supportsNativeTextTracks()) {
       kind: 'captions',
       label: 'Spanish',
       language: 'es',
-      mode: 'disabled',
-      cues: null
+      mode: 'disabled'
     }, {
       src: 'http://example.com/english.vtt',
       kind: 'captions',
       label: 'English',
       language: 'en',
-      mode: 'disabled',
-      cues: null
+      mode: 'disabled'
     }], 'the output is correct');
   });
 
@@ -147,8 +145,7 @@ q.test('trackToJson_ produces correct representation for emulated track object',
     kind: 'captions',
     label: 'English',
     language: 'en',
-    mode: 'disabled',
-    cues: null
+    mode: 'disabled'
   }, 'the json output is same');
 });
 
@@ -191,15 +188,13 @@ q.test('textTracksToJson produces good json output for emulated only', function(
     kind: 'captions',
     label: 'Spanish',
     language: 'es',
-    mode: 'disabled',
-    cues: null
+    mode: 'disabled'
   }, {
     src: 'http://example.com/english.vtt',
     kind: 'captions',
     label: 'English',
     language: 'en',
-    mode: 'disabled',
-    cues: null
+    mode: 'disabled'
   }], 'the output is correct');
 });
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -308,8 +308,8 @@ test('when switching techs, we should not get a new text track', function() {
   ok(htmltracks === flashtracks, 'the tracks are equal');
 });
 
-if (Html5.supportsNativeTextTracks()) {
-  test('listen to remove and add track events in native text tracks', function(assert) {
+if (Html5.supportsNativeTextTracks() && ('removetrack' in Html5.TEST_VID.textTracks)) {
+  test('listen to native remove and add track events in native text tracks', function(assert) {
     let done = assert.async();
 
     let el = document.createElement('video');
@@ -357,6 +357,5 @@ if (Html5.supportsNativeTextTracks()) {
       done();
     };
     emulatedTt.on('addtrack', addtrack);
-
   });
 }

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -308,7 +308,7 @@ test('when switching techs, we should not get a new text track', function() {
   ok(htmltracks === flashtracks, 'the tracks are equal');
 });
 
-if (Html5.supportsNativeTextTracks() && ('removetrack' in Html5.TEST_VID.textTracks)) {
+if (Html5.supportsNativeTextTracks() && ('onremovetrack' in Html5.TEST_VID.textTracks)) {
   test('listen to native remove and add track events in native text tracks', function(assert) {
     let done = assert.async();
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -308,7 +308,7 @@ test('when switching techs, we should not get a new text track', function() {
   ok(htmltracks === flashtracks, 'the tracks are equal');
 });
 
-if (Html5.supportsNativeTextTracks() && ('onremovetrack' in Html5.TEST_VID.textTracks)) {
+if (Html5.supportsNativeTextTracks()) {
   test('listen to native remove and add track events in native text tracks', function(assert) {
     let done = assert.async();
 


### PR DESCRIPTION
This fixes #2454 and hopefully any of the text-track related CI test failures in master.
One thing I've noticed when working on this is that IE11 doesn't have `removetrack` handler (and seems like `addtrack` handler doesn't work if added via `addEventListener`). I've disabled the native text track tests that depend on `removetrack` if not available but this does mean that our custom controls won't update on IE11 and we need a solution for it. I've filed #2465 to figure that out since this PR should be just for fixing the tests.