### PR TITLE
Add the ability to obtain the current source object when dynamical…

### DIFF
--- a/src/js/media/media.js
+++ b/src/js/media/media.js
@@ -332,6 +332,14 @@ vjs.MediaTechController.prototype.emulateTextTracks = function() {
 };
 
 /**
+ * Returns the current source object that was sent to a source handler.
+ * @returns {Object} current source object
+ */
+vjs.MediaTechController.prototype.currentSource = function(){
+  return this.currentSource_;
+};
+
+/**
  * Provide default methods for text tracks.
  *
  * Html5 tech overrides these.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1223,6 +1223,14 @@ vjs.Player.prototype.load = function(){
 };
 
 /**
+ * Returns the currently configured source object.
+ * @return {String} The current source object
+ */
+vjs.Player.prototype.currentSource = function(){
+    return this.techGet('currentSource') || {};
+};
+
+/**
  * Returns the fully qualified URL of the current source value e.g. http://mysite.com/video.mp4
  * Can be used in conjuction with `currentType` to assist in rebuilding the current source object.
  * @return {String} The current source

--- a/test/unit/media.js
+++ b/test/unit/media.js
@@ -222,6 +222,7 @@ test('should add the source hanlder interface to a tech', function(){
   // Pass a source through the source handler process of a tech instance
   tech.setSource(sourceA);
   strictEqual(tech.currentSource_, sourceA, 'sourceA was handled and stored');
+  strictEqual(tech.currentSource(), sourceA, 'sourceA was retrievable after being handled and stored.');
   ok(tech.sourceHandler_.dispose, 'the handlerOne state instance was stored');
 
   // Check that the handler dipose method works


### PR DESCRIPTION
…ly setting the src.

This is needed for source retrival for two use cases:
- preroll
- resolution switch (kind of)

Currently there is no way of accessing the source object of any DRM specified content. Plugin access only has API methods to `currentSrc` and `currentType`.
This will allow for `currentSource` which will return a valid source handled source object.

Partially addresses https://github.com/videojs/video.js/issues/2443