### PR TITLE
Add tracks to techOptions

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -499,6 +499,7 @@ class Player extends Component {
       'playerId': this.id(),
       'techId': `${this.id()}_${techName}_api`,
       'textTracks': this.textTracks_,
+      'tracks': this.options_.tracks,
       'autoplay': this.options_.autoplay,
       'preload': this.options_.preload,
       'loop': this.options_.loop,


### PR DESCRIPTION
There was an issue on the iPhone were we weren't getting tracks passed properly.

This was discovered by @gkatsev and myself during another marathon "WTF is iOS even doing with captions/subtitles" session, but was lost in one of the closed PRs related to those issues.