### PR TITLE
Changed all component child lists to arrays instead of objects

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -121,21 +121,6 @@ is a child of `controlBar`, you can just set that component to false:
 
 ```javascript
 var player = videojs('video-id', {
-  children: {
-    controlBar: {
-      children: {
-        muteToggle: false
-      }
-    }
-  }
-});
-```
-
-All the children can start getting a little verbose, so to simplify things, you can also set options for child components directly on the parent options.
-This is functionally the exact same as the above, for instance.
-
-```javascript
-var player = videojs('video-id', {
   controlBar: {
     muteToggle: false
   }
@@ -146,7 +131,7 @@ This also works using the `data-setup` attribute on the video element, just reme
 notation.
 
 ```html
-<video ... data-setup='{ "children": { "controlBar": { "children": { "muteToggle": false } } } }'></video>
+<video ... data-setup='{ "controlBar": { "muteToggle": false } }'></video>
 ```
 
 The [components guide](components.md) has an excellent breakdown of the structure of a player, you

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -146,19 +146,17 @@ class Component {
    * Deep merge of options objects
    * Whenever a property is an object on both options objects
    * the two properties will be merged using mergeOptions.
-   * This is used for merging options for child components. We
-   * want it to be easy to override individual options on a child
-   * component without having to rewrite all the other default options.
+   *
    * ```js
    *     Parent.prototype.options_ = {
-   *       children: {
+   *       optionSet: {
    *         'childOne': { 'foo': 'bar', 'asdf': 'fdsa' },
    *         'childTwo': {},
    *         'childThree': {}
    *       }
    *     }
    *     newOptions = {
-   *       children: {
+   *       optionSet: {
    *         'childOne': { 'foo': 'baz', 'abc': '123' }
    *         'childTwo': null,
    *         'childFour': {}
@@ -170,7 +168,7 @@ class Component {
    * RESULT
    * ```js
    *     {
-   *       children: {
+   *       optionSet: {
    *         'childOne': { 'foo': 'baz', 'asdf': 'fdsa', 'abc': '123' },
    *         'childTwo': null, // Disabled. Won't be initialized.
    *         'childThree': {},
@@ -324,16 +322,14 @@ class Component {
    *
    *     var myButton = myComponent.addChild('MyButton');
    *     // -> <div class='my-component'><div class="my-button">myButton<div></div>
-   *     // -> myButton === myComonent.children()[0];
+   *     // -> myButton === myComponent.children()[0];
    * ```
    * Pass in options for child constructors and options for children of the child
    * ```js
    *     var myButton = myComponent.addChild('MyButton', {
    *       text: 'Press Me',
-   *       children: {
-   *         buttonChildExample: {
-   *           buttonChildOption: true
-   *         }
+   *       buttonChildExample: {
+   *         buttonChildOption: true
    *       }
    *     });
    * ```
@@ -449,24 +445,29 @@ class Component {
    * ```js
    *     // when an instance of MyComponent is created, all children in options
    *     // will be added to the instance by their name strings and options
-   *     MyComponent.prototype.options_.children = {
+   *     MyComponent.prototype.options_ = {
+   *       children: [
+   *         'myChildComponent'
+   *       ],
    *       myChildComponent: {
    *         myChildOption: true
    *       }
-   *     }
-   * ```
+   *     };
+   *
    *     // Or when creating the component
-   * ```js
    *     var myComp = new MyComponent(player, {
-   *       children: {
-   *         myChildComponent: {
-   *           myChildOption: true
-   *         }
+   *       children: [
+   *         'myChildComponent'
+   *       ],
+   *       myChildComponent: {
+   *         myChildOption: true
    *       }
    *     });
    * ```
-   * The children option can also be an Array of child names or
+   * The children option can also be an array of
    * child options objects (that also include a 'name' key).
+   * This can be used if you have two child components of the
+   * same type that need different options.
    * ```js
    *     var myComp = new MyComponent(player, {
    *       children: [
@@ -474,6 +475,10 @@ class Component {
    *         {
    *           name: 'button',
    *           someOtherOption: true
+   *         },
+   *         {
+   *           name: 'button',
+   *           someOtherOption: false
    *         }
    *       ]
    *     });

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -30,9 +30,9 @@ class ProgressControl extends Component {
 }
 
 ProgressControl.prototype.options_ = {
-  children: {
-    'seekBar': {}
-  }
+  children: [
+    'seekBar'
+  ]
 };
 
 Component.registerComponent('ProgressControl', ProgressControl);

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -126,11 +126,11 @@ class SeekBar extends Slider {
 }
 
 SeekBar.prototype.options_ = {
-  children: {
-    'loadProgressBar': {},
-    'mouseTimeDisplay': {},
-    'playProgressBar': {}
-  },
+  children: [
+    'loadProgressBar',
+    'mouseTimeDisplay',
+    'playProgressBar'
+  ],
   'barName': 'playProgressBar'
 };
 

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -98,9 +98,9 @@ class VolumeBar extends Slider {
 }
 
 VolumeBar.prototype.options_ = {
-  children: {
-    'volumeLevel': {}
-  },
+  children: [
+    'volumeLevel'
+  ],
   'barName': 'volumeLevel'
 };
 

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -47,9 +47,9 @@ class VolumeControl extends Component {
 }
 
 VolumeControl.prototype.options_ = {
-  children: {
-    'volumeBar': {}
-  }
+  children: [
+    'volumeBar'
+  ]
 };
 
 Component.registerComponent('VolumeControl', VolumeControl);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2566,16 +2566,16 @@ Player.prototype.options_ = {
   // 'playbackRates': [0.5, 1, 1.5, 2],
 
   // Included control sets
-  children: {
-    mediaLoader: {},
-    posterImage: {},
-    textTrackDisplay: {},
-    loadingSpinner: {},
-    bigPlayButton: {},
-    controlBar: {},
-    errorDisplay: {},
-    textTrackSettings: {}
-  },
+  children: [
+    'mediaLoader',
+    'posterImage',
+    'textTrackDisplay',
+    'loadingSpinner',
+    'bigPlayButton',
+    'controlBar',
+    'errorDisplay',
+    'textTrackSettings'
+  ],
 
   language: document.getElementsByTagName('html')[0].getAttribute('lang') || navigator.languages && navigator.languages[0] || navigator.userLanguage || navigator.language || 'en',
 


### PR DESCRIPTION
Udpated the docs to match. This is a necessary change because object key order is not consistent in Chrome and children have a specific order. Somehow this hasn't actually affect us yet. But also there's not an easy way to insert a child into a specific spot in the order if it's an object.

The biggest issue here is that **player** children has been changed to an array. This would break anywhere that previously used
```
// any control bar or control bar child options under the children key. Same for other player children.
playerOptions = { children: { controlBar: { ... } } };
// Add a child to the children object
playerOptions = { children: { newChild: {} } };
```
Child options will no longer merge when they're under the children key, because children is now an array by default that will simply be overwritten by the new children object when options are merged.

You instead do:
```
playerOptions = { controlBar: { ... } };
// I'm not sure if adding children through options is real use case, but it wouldn't work with the array
// you can still use the addChild API, which I think is the primary one
player.addChild('newChild');
// or the prototype options
Player.prototype.options_.children.push('newChild'); // though this API has changed anyway
```

I know this is important but also don't have a good grasp of the significance, in case anyone else has any additional input. If we think it's really significant we can look into a patch or reconsider.