### PR TITLE
Fix texttrack handling in IE10

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -95,7 +95,7 @@ class Html5 extends Tech {
     let emulatedTt = this.textTracks();
 
     // remove native event listeners
-    if (tt) {
+    if (tt && tt.removeEventListener) {
       tt.removeEventListener('change', this.handleTextTrackChange_);
       tt.removeEventListener('addtrack', this.handleTextTrackAdd_);
       tt.removeEventListener('removetrack', this.handleTextTrackRemove_);
@@ -208,7 +208,7 @@ class Html5 extends Tech {
   proxyNativeTextTracks_() {
     let tt = this.el().textTracks;
 
-    if (tt) {
+    if (tt && tt.addEventListener) {
       tt.addEventListener('change', this.handleTextTrackChange_);
       tt.addEventListener('addtrack', this.handleTextTrackAdd_);
       tt.addEventListener('removetrack', this.handleTextTrackRemove_);


### PR DESCRIPTION
Apparantly IE10 does have `textTracks` on the video element, but does not support `addEventListener` and `removeEventListener` on it.

This should fix that problem.