### PR TITLE
Increase BrowserStack polling

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -63,7 +63,8 @@ module.exports = function(config) {
     browserNoActivityTimeout: 60000,
 
     browserStack: {
-      name: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH
+      name: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH,
+      pollingTimeout: 10000
     },
     customLaunchers: getCustomLaunchers(),
 


### PR DESCRIPTION
This is to increase the polling timeout so that the API rate limit of 120 requests/min is not hit as easily (default is 1000ms).