### PR TITLE
Native controls updates

### DIFF
--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -29,9 +29,9 @@
   @include transition($trans);
 }
 
-.video-js.vjs-controls-disabled .vjs-control-bar,
-.video-js.vjs-using-native-controls .vjs-control-bar,
-.video-js.vjs-error .vjs-control-bar {
+.video-js.video-js.video-js.vjs-controls-disabled .vjs-control-bar,
+.video-js.video-js.video-js.vjs-using-native-controls .vjs-control-bar,
+.video-js.video-js.video-js.vjs-error .vjs-control-bar {
   display: none;
 }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1953,6 +1953,7 @@ class Player extends Component {
             */
           this.trigger('usingnativecontrols');
         } else {
+          this.addTechControlsListeners();
           this.removeClass('vjs-using-native-controls');
           this.techCall('setControls', false);
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -501,6 +501,7 @@ class Player extends Component {
 
     // Grab tech-specific options from player options and add source and parent element to use.
     var techOptions = assign({
+      'nativeControlsForTouch': this.options_.nativeControlsForTouch,
       'source': source,
       'playerId': this.id(),
       'techId': `${this.id()}_${techName}_api`,
@@ -534,7 +535,6 @@ class Player extends Component {
     textTrackConverter.jsonToTextTracks(this.textTracksJson_ || [], this.tech);
 
     this.on(this.tech, 'ready', this.handleTechReady);
-    this.on(this.tech, 'usenativecontrols', this.handleTechUseNativeControls);
 
     // Listen to every HTML5 events and trigger them back on the player for the plugins
     this.on(this.tech, 'loadstart', this.handleTechLoadStart);
@@ -563,6 +563,8 @@ class Player extends Component {
     this.on(this.tech, 'volumechange', this.handleTechVolumeChange);
     this.on(this.tech, 'texttrackchange', this.onTextTrackChange);
     this.on(this.tech, 'loadedmetadata', this.updateStyleEl_);
+
+    this.usingNativeControls(this.techGet('controls'));
 
     if (this.controls() && !this.usingNativeControls()) {
       this.addTechControlsListeners();
@@ -663,16 +665,6 @@ class Player extends Component {
       delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
       this.play();
     }
-  }
-
-  /**
-   * Fired when the native controls are used
-   *
-   * @private
-   * @method handleTechUseNativeControls
-   */
-  handleTechUseNativeControls() {
-    this.usingNativeControls(true);
   }
 
   /**
@@ -1947,7 +1939,9 @@ class Player extends Component {
       if (this.usingNativeControls_ !== bool) {
         this.usingNativeControls_ = bool;
         if (bool) {
+          this.removeTechControlsListeners();
           this.addClass('vjs-using-native-controls');
+          this.techCall('setControls', true);
 
           /**
             * player is using the native device controls
@@ -1960,6 +1954,7 @@ class Player extends Component {
           this.trigger('usingnativecontrols');
         } else {
           this.removeClass('vjs-using-native-controls');
+          this.techCall('setControls', false);
 
           /**
             * player is using the custom HTML controls

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1941,7 +1941,6 @@ class Player extends Component {
         if (bool) {
           this.removeTechControlsListeners();
           this.addClass('vjs-using-native-controls');
-          this.techCall('setControls', true);
 
           /**
             * player is using the native device controls
@@ -1955,7 +1954,6 @@ class Player extends Component {
         } else {
           this.addTechControlsListeners();
           this.removeClass('vjs-using-native-controls');
-          this.techCall('setControls', false);
 
           /**
             * player is using the custom HTML controls

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -76,10 +76,8 @@ class Html5 extends Tech {
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if ((browser.TOUCH_ENABLED && options.nativeControlsForTouch === true) || browser.IS_IPHONE) {
-      this.setTimeout(function() {
-        this.trigger('usenativecontrols');
-      }, 0);
+    if (browser.TOUCH_ENABLED && options.nativeControlsForTouch === true) {
+      this.setControls(true);
     }
 
     this.triggerReady();

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -76,7 +76,9 @@ class Html5 extends Tech {
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if (browser.TOUCH_ENABLED && options.nativeControlsForTouch === true) {
+    if (browser.TOUCH_ENABLED && options.nativeControlsForTouch === true ||
+        browser.IS_IPHONE ||
+        browser.IS_NATIVE_ANDROID) {
       this.setControls(true);
     }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -76,8 +76,10 @@ class Html5 extends Tech {
     // Our goal should be to get the custom controls on mobile solid everywhere
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
-    if (browser.TOUCH_ENABLED && options.nativeControlsForTouch === true) {
-      this.trigger('usenativecontrols');
+    if ((browser.TOUCH_ENABLED && options.nativeControlsForTouch === true) || browser.IS_IPHONE) {
+      this.setTimeout(function() {
+        this.trigger('usenativecontrols');
+      }, 0);
     }
 
     this.triggerReady();

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -5,6 +5,8 @@ import document from 'global/document';
 import window from 'global/window';
 
 const USER_AGENT = window.navigator.userAgent;
+const webkitVersionMap = (/AppleWebKit\/([\d.]+)/i).exec(USER_AGENT);
+const appleWebkitVersion = webkitVersionMap ? parseFloat(webkitVersionMap.pop()) : null;
 
 /*
  * Device is an iPhone
@@ -48,6 +50,7 @@ export const ANDROID_VERSION = (function() {
 })();
 // Old Android is defined as Version older than 2.3, and requiring a webkit version of the android browser
 export const IS_OLD_ANDROID = IS_ANDROID && (/webkit/i).test(USER_AGENT) && ANDROID_VERSION < 2.3;
+export const IS_NATIVE_ANDROID = IS_ANDROID && ANDROID_VERSION < 5 && appleWebkitVersion < 537;
 
 export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_CHROME = (/Chrome/i).test(USER_AGENT);

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -46,6 +46,7 @@ class TechFaker extends Tech {
   duration() { return {}; }
   networkState() { return 0; }
   readyState() { return 0; }
+  controls() { return false; }
 
   // Support everything except for "video/unsupported-format"
   static isSupported() { return true; }


### PR DESCRIPTION
Previously, native controls were enabled by firing an event from the tech to the player. However, the player only bound events on the tech after the tech may have fired the event. Instead, the player will ask the tech whether controls are enabled or not. If the controls are enabled, it means we should be using native controls.
Also in this PR: when on iphones or native android browser, we should be using native controls.