### PR TITLE
Expose start and end buffered times

### DIFF
--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -264,7 +264,11 @@ class Flash extends Tech {
    * @method buffered
    */
   buffered() {
-    return createTimeRange(0, this.el_.vjs_getProperty('buffered'));
+    let ranges = this.el_.vjs_getProperty('buffered');
+    if (ranges.length === 0) {
+      return createTimeRange();
+    }
+    return createTimeRange(ranges[0][0], ranges[0][1]);
   }
 
   /**


### PR DESCRIPTION
Requires videojs/video-js-swf#180. Pick up changes from the SWF that expose the start time of the current buffered region.