### PR TITLE
30s Browserstack polling

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -64,7 +64,7 @@ module.exports = function(config) {
 
     browserStack: {
       name: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH,
-      pollingTimeout: 10000
+      pollingTimeout: 30000
     },
     customLaunchers: getCustomLaunchers(),
 


### PR DESCRIPTION
Previously the 10 second polling allowed for 2.8 builds to be run at the same time before hitting the api limit. Increasing the polling to 30 seconds should allow 8.5 simultaneous builds.