### PR TITLE
handle error getter on flash tech better

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -998,7 +998,8 @@ class Player extends Component {
    * @event error
    */
   handleTechError() {
-    this.error(this.tech.error().code);
+    let error = this.tech.error();
+    this.error(error && error.code);
   }
 
   /**

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -456,12 +456,9 @@ Flash.onError = function(swfID, err){
 
   if (err === 'srcnotfound') {
     errorObj.code = 4;
-    tech.trigger('error', errorObj);
-
-  // errors we haven't categorized into the media errors
-  } else {
-    tech.trigger('error', errorObj);
   }
+
+  tech.trigger('error', errorObj);
 };
 
 // Flash Version Check

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -268,6 +268,16 @@ class Flash extends Tech {
   }
 
   /**
+   * Get the last error object
+   *
+   * @return {Object}
+   * @method error
+   */
+  error() {
+    return this.error_ || {};
+  }
+
+  /**
    * Get fullscreen support -
    * Flash does not allow fullscreen through javascript
    * so always returns false
@@ -297,7 +307,7 @@ class Flash extends Tech {
 // Create setters and getters for attributes
 const _api = Flash.prototype;
 const _readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(',');
-const _readOnly = 'error,networkState,readyState,initialTime,duration,startOffsetTime,paused,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(',');
+const _readOnly = 'networkState,readyState,initialTime,duration,startOffsetTime,paused,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(',');
 
 function _createSetter(attr){
   var attrUpper = attr.charAt(0).toUpperCase() + attr.slice(1);
@@ -438,13 +448,19 @@ Flash.onEvent = function(swfID, eventName){
 Flash.onError = function(swfID, err){
   const tech = Dom.getEl(swfID).tech;
   const msg = 'FLASH: '+err;
+  const errorObj = {
+    message: msg
+  };
+
+  tech.error_ = errorObj;
 
   if (err === 'srcnotfound') {
-    tech.trigger('error', { code: 4, message: msg });
+    errorObj.code = 4;
+    tech.trigger('error', errorObj);
 
   // errors we haven't categorized into the media errors
   } else {
-    tech.trigger('error', msg);
+    tech.trigger('error', errorObj);
   }
 };
 

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -274,7 +274,9 @@ class Flash extends Tech {
    * @method error
    */
   error() {
-    return this.error_ || {};
+    let error = this.error_;
+    this.error_ = null;
+    return error || null;
   }
 
   /**


### PR DESCRIPTION
The swf doesn't have [an error getter](https://github.com/videojs/video-js-swf/blob/master/src/VideoJS.as#L213-L299) and seems like all the info we have about the error is available in the `onError` method. So, instead of trying to call `vjs_getProperty` to the swf (which will never work or return a valid value), we'll store the error that we got there and return it in the error getter.

One thing I'm not certain off is when to clear out our reference to the error. Seems like when the error getter gets called is a good place to do so because it gets called from the player and player stores its own reference to the error which it clears out as necessary.