### PR TITLE
Create an error setter on the base tech

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -998,7 +998,8 @@ class Player extends Component {
    * @event error
    */
   handleTechError() {
-    this.error(this.tech.error().code);
+    let error = this.tech.error();
+    this.error(error && error.code);
   }
 
   /**

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -456,12 +456,9 @@ Flash.onError = function(swfID, err){
 
   if (err === 'srcnotfound') {
     errorObj.code = 4;
-    tech.trigger('error', errorObj);
-
-  // errors we haven't categorized into the media errors
-  } else {
-    tech.trigger('error', errorObj);
   }
+
+  tech.trigger('error', errorObj);
 };
 
 // Flash Version Check

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -268,18 +268,6 @@ class Flash extends Tech {
   }
 
   /**
-   * Get the last error object
-   *
-   * @return {Object}
-   * @method error
-   */
-  error() {
-    let error = this.error_;
-    this.error_ = null;
-    return error || null;
-  }
-
-  /**
    * Get fullscreen support -
    * Flash does not allow fullscreen through javascript
    * so always returns false
@@ -449,18 +437,14 @@ Flash.onEvent = function(swfID, eventName){
 // Log errors from the swf
 Flash.onError = function(swfID, err){
   const tech = Dom.getEl(swfID).tech;
-  const msg = 'FLASH: '+err;
-  const errorObj = {
-    message: msg
-  };
 
-  tech.error_ = errorObj;
-
+  // trigger MEDIA_ERR_SRC_NOT_SUPPORTED
   if (err === 'srcnotfound') {
-    errorObj.code = 4;
+    return tech.error(4);
   }
 
-  tech.trigger('error', errorObj);
+  // trigger a custom error
+  tech.error('FLASH: ' + err);
 };
 
 // Flash Version Check

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -268,6 +268,16 @@ class Flash extends Tech {
   }
 
   /**
+   * Get the last error object
+   *
+   * @return {Object}
+   * @method error
+   */
+  error() {
+    return this.error_ || {};
+  }
+
+  /**
    * Get fullscreen support -
    * Flash does not allow fullscreen through javascript
    * so always returns false
@@ -297,7 +307,7 @@ class Flash extends Tech {
 // Create setters and getters for attributes
 const _api = Flash.prototype;
 const _readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(',');
-const _readOnly = 'error,networkState,readyState,initialTime,duration,startOffsetTime,paused,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(',');
+const _readOnly = 'networkState,readyState,initialTime,duration,startOffsetTime,paused,ended,videoTracks,audioTracks,videoWidth,videoHeight'.split(',');
 
 function _createSetter(attr){
   var attrUpper = attr.charAt(0).toUpperCase() + attr.slice(1);
@@ -438,13 +448,19 @@ Flash.onEvent = function(swfID, eventName){
 Flash.onError = function(swfID, err){
   const tech = Dom.getEl(swfID).tech;
   const msg = 'FLASH: '+err;
+  const errorObj = {
+    message: msg
+  };
+
+  tech.error_ = errorObj;
 
   if (err === 'srcnotfound') {
-    tech.trigger('error', { code: 4, message: msg });
+    errorObj.code = 4;
+    tech.trigger('error', errorObj);
 
   // errors we haven't categorized into the media errors
   } else {
-    tech.trigger('error', msg);
+    tech.trigger('error', errorObj);
   }
 };
 

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -274,7 +274,9 @@ class Flash extends Tech {
    * @method error
    */
   error() {
-    return this.error_ || {};
+    let error = this.error_;
+    this.error_ = null;
+    return error || null;
   }
 
   /**

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -11,6 +11,7 @@ import * as Fn from '../utils/fn.js';
 import log from '../utils/log.js';
 import { createTimeRange } from '../utils/time-ranges.js';
 import { bufferedPercent } from '../utils/buffer.js';
+import MediaError from '../media-error.js';
 import window from 'global/window';
 import document from 'global/document';
 
@@ -263,6 +264,27 @@ class Tech extends Component {
     if (this.manualTimeUpdates) { this.manualTimeUpdatesOff(); }
 
     super.dispose();
+  }
+
+  /**
+   * When invoked without an argument, returns a MediaError object
+   * representing the current error state of the player or null if
+   * there is no error. When invoked with an argument, set the current
+   * error state of the player.
+   * @param {MediaError=} err    Optional an error object
+   * @return {MediaError}        the current error object or null
+   * @method error
+   */
+  error(err) {
+    if (err !== undefined) {
+      if (err instanceof MediaError) {
+        this.error_ = err;
+      } else {
+        this.error_ = new MediaError(err);
+      }
+      this.trigger('error');
+    }
+    return this.error_;
   }
 
   /**

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -3,6 +3,7 @@ var noop = function() {}, clock, oldTextTracks;
 import Tech from '../../../src/js/tech/tech.js';
 import { createTimeRange } from '../../../src/js/utils/time-ranges.js';
 import extendsFn from '../../../src/js/extends.js';
+import MediaError from '../../../src/js/media-error.js';
 
 q.module('Media Tech', {
   'setup': function() {
@@ -193,6 +194,24 @@ test('should handle unsupported sources with the source handler API', function()
 
   tech.setSource('');
   ok(usedNative, 'native source handler was used when an unsupported source was set');
+});
+
+test('should allow custom error events to be set', function() {
+  let tech = new Tech();
+  let errors = [];
+  tech.on('error', function() {
+    errors.push(tech.error());
+  });
+
+  equal(tech.error(), null, 'error is null by default');
+
+  tech.error(new MediaError(1));
+  equal(errors.length, 1, 'triggered an error event');
+  equal(errors[0].code, 1, 'set the proper code');
+
+  tech.error(2);
+  equal(errors.length, 2, 'triggered an error event');
+  equal(errors[1].code, 2, 'wrapped the error code');
 });
 
 test('should track whether a video has played', function() {


### PR DESCRIPTION
For #2323. Source Handlers may need to trigger player errors if they encounter unrecoverable playback issues. Provide a base implementation of an error setter they can use to do so at the tech level. The setter is overridden for HTML since Source Handlers should probably use something like MediaSource.endOfStream('network') to signal errors in that case. Update Flash error handling to take advantage of the new mechanism.

Pull in @gkatsev's improvements to Flash error handling in #2515 