### PR TITLE
Seek to the beginning on replay

### DIFF
--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -113,6 +113,9 @@ class Flash extends Tech {
    * @method play
    */
   play() {
+    if (this.ended()) {
+      this.setCurrentTime(0);
+    }
     this.el_.vjs_play();
   }
 

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -166,6 +166,28 @@ test('seekable', function() {
   equal(result.length, mockFlash.duration_, 'seekable is empty with a zero duration');
 });
 
+test('play after ended seeks to the beginning', function() {
+  let plays = 0, seeks = [];
+
+  Flash.prototype.play.call({
+    el_: {
+      vjs_play() {
+        plays++;
+      }
+    },
+    ended() {
+      return true;
+    },
+    setCurrentTime(time) {
+      seeks.push(time);
+    }
+  });
+
+  equal(plays, 1, 'called play on the SWF');
+  equal(seeks.length, 1, 'seeked on play');
+  equal(seeks[0], 0, 'seeked to the beginning');
+});
+
 // fake out the <object> interaction but leave all the other logic intact
 class MockFlash extends Flash {
   constructor() {


### PR DESCRIPTION
The video.js SWF no longer seeks back to the beginning automatically. Instead, check whether the video has ended on play and seek back to the beginning if necessary.