### PR TITLE
Added iOS and Android to unit tests

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -156,7 +156,9 @@ module.exports = function(grunt) {
       ie11_bs:      { browsers: ['ie11_bs'] },
       ie10_bs:      { browsers: ['ie10_bs'] },
       ie9_bs:       { browsers: ['ie9_bs'] },
-      ie8_bs:       { browsers: ['ie8_bs'] }
+      ie8_bs:       { browsers: ['ie8_bs'] },
+      android_bs:   { browsers: ['android_bs'] },
+      ios_bs:       { browsers: ['ios_bs'] }
     },
     vjsdocs: {
       all: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -59,12 +59,12 @@ module.exports = function(config) {
     runnerPort: 9100,
     colors: true,
     logLevel: config.LOG_INFO,
-    captureTimeout: 60000,
-    browserNoActivityTimeout: 60000,
+    captureTimeout: 300000,
+    browserNoActivityTimeout: 300000,
 
     browserStack: {
       name: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH,
-      pollingTimeout: 10000
+      pollingTimeout: 30000
     },
     customLaunchers: getCustomLaunchers(),
 
@@ -99,7 +99,9 @@ module.exports = function(config) {
         'ie11_bs',
         'ie10_bs',
         'ie9_bs',
-        'ie8_bs'
+        'ie8_bs',
+        'android_bs',
+        'ios_bs'
       ];
     } else {
       settings.browsers = ['Firefox'];
@@ -162,6 +164,18 @@ function getCustomLaunchers(){
       browser_version: '8',
       os: 'Windows',
       os_version: '7'
+    },
+
+    android_bs: {
+      base: 'BrowserStack',
+      os: 'android',
+      os_version: '4.4'
+    },
+
+    ios_bs: {
+      base: 'BrowserStack',
+      os: 'ios',
+      os_version: '8.3'
     }
   };
 }


### PR DESCRIPTION
This PR is to add Android and iOS as browsers for the unit tests. For some reason the BrowserStack tunnel isn't working correctly when using a 5.0 Android VM so I have targeted 4.4. 

I have also increased the timeouts to handle all this testing. All the browser VMs start simultaneously which means that if a VM doesn't start its testing before the capture timeout or no activity timeout is hit then it will give a warning, restart the browser VM and fail the build in the end. To avoid this the timeouts need to be bumped up to account for the total testing time. Polling timeout was also bumped up to avoid hitting the API rate limit.
 
This closes #2512 and closes #2529