### PR TITLE
Allow passing body to XHR request

### DIFF
--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -127,6 +127,18 @@ vjs.xhr = function(options, callback){
   try {
     // Third arg is async, or ignored by XDomainRequest
     request.open(options.method || 'GET', options.uri, true);
+
+    var headers = request.headers = options.headers || {},
+      key;
+
+    if (request.setRequestHeader) {
+      for (key in headers) {
+        if (headers.hasOwnProperty(key)) {
+          // set custom request headers, ie 'Content-Type'
+          request.setRequestHeader(key, headers[key]);
+        }
+      }
+    }
   } catch(err) {
     return errorHandler(err);
   }

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -142,7 +142,11 @@ vjs.xhr = function(options, callback){
 
   // send the request
   try {
-    request.send();
+    if (options.body) {
+      request.send(options.body);
+    } else {
+      request.send();
+    }
   } catch(err) {
     return errorHandler(err);
   }


### PR DESCRIPTION
For POST requests for example, it allows to pass a body content to the request as the XHR library can do (option.body) : https://github.com/Raynos/xhr/blob/master/README.md