### PR TITLE
Added a default data attribute to fix the progress handle display in IE8

### DIFF
--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -17,6 +17,7 @@ class PlayProgressBar extends Component {
 
   constructor(player, options){
     super(player, options);
+    this.updateDataAttr();
     this.on(player, 'timeupdate', this.updateDataAttr);
     player.ready(Fn.bind(this, this.updateDataAttr));
   }


### PR DESCRIPTION
fixes #2449

The data attribute needed a default value (or just needed to exist from the start), otherwise IE8 would render it too small initially and never readjust to fit the time.