### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "~0.6.0",
-    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-less": "~0.6.4",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "~0.1.4",


### PR DESCRIPTION
Since jshint was having problems wih 2.9.0 instead update by version since from now on the grunt jshint is updating verision everytime jshint is released to prevent having the problem again.