### PR TITLE
Skip copying webkitMovementX/Y

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -236,7 +236,9 @@ export function fixEvent(event) {
     for (var key in old) {
       // Safari 6.0.3 warns you if you try to copy deprecated layerX/Y
       // Chrome warns you if you try to copy deprecated keyboardEvent.keyLocation
-      if (key !== 'layerX' && key !== 'layerY' && key !== 'keyLocation') {
+      // and webkitMovementX/Y
+      if (key !== 'layerX' && key !== 'layerY' && key !== 'keyLocation' &&
+          key !== 'webkitMovementX' && key !== 'webkitMovementY') {
         // Chrome 32+ warns if you try to copy deprecated returnValue, but
         // we still want to if preventDefault isn't supported (IE8).
         if (!(key === 'returnValue' && old.preventDefault)) {


### PR DESCRIPTION
webkitMovementX/Y seem to be deprecated in Chrome 45+, this fix skips those keys.
Fixes #2548