### PR TITLE
Fixed event bubbling in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ CHANGELOG
 * @heff added a default data attribute to fix the progress handle display in IE8 ([view](https://github.com/videojs/video.js/pull/2547))
 * @heff added back the default cdn url for the swf ([view](https://github.com/videojs/video.js/pull/2533))
 * @gkatsev fixed the default state of userActive ([view](https://github.com/videojs/video.js/pull/2557))
+* @heff fixed event bubbling in IE8 ([view](https://github.com/videojs/video.js/pull/2563))
 
 --------------------
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -111,7 +111,7 @@ class Button extends Component {
     // Check for space bar (32) or enter (13) keys
     if (event.which === 32 || event.which === 13) {
       event.preventDefault();
-      this.handleClick();
+      this.handleClick(event);
     }
   }
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -263,6 +263,7 @@ export function fixEvent(event) {
         old.preventDefault();
       }
       event.returnValue = false;
+      old.returnValue = false;
       event.defaultPrevented = true;
     };
 
@@ -274,6 +275,7 @@ export function fixEvent(event) {
         old.stopPropagation();
       }
       event.cancelBubble = true;
+      old.cancelBubble = true;
       event.isPropagationStopped = returnTrue;
     };
 


### PR DESCRIPTION
fixes #2414 

Our fixEvent script makes a copy of the original event, but it was failing to also set `cancelBubble = true` and `returnValue = false` on the original event, which is needed to make IE8 work like modern browsers.