### PR TITLE
IE8 JScript_DontEnum_Bug

### DIFF
--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -21,7 +21,9 @@ let TextTrackCueList = function(cues) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackCueList.prototype) {
-      list[prop] = TextTrackCueList.prototype[prop];
+      if(prop!='constructor'){
+        list[prop] = TextTrackCueList.prototype[prop];
+      }
     }
   }
 

--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -21,7 +21,7 @@ let TextTrackCueList = function(cues) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackCueList.prototype) {
-      if(prop!='constructor'){
+      if(prop!=='constructor'){
         list[prop] = TextTrackCueList.prototype[prop];
       }
     }

--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -21,7 +21,7 @@ let TextTrackCueList = function(cues) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackCueList.prototype) {
-      if(prop!=='constructor'){
+      if (prop !== 'constructor') {
         list[prop] = TextTrackCueList.prototype[prop];
       }
     }

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -26,7 +26,7 @@ let TextTrackList = function(tracks) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackList.prototype) {
-      if(prop!='constructor'){
+      if(prop!=='constructor'){
         list[prop] = TextTrackList.prototype[prop];
       }
     }

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -26,7 +26,9 @@ let TextTrackList = function(tracks) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackList.prototype) {
-      list[prop] = TextTrackList.prototype[prop];
+      if(prop!='constructor'){
+        list[prop] = TextTrackList.prototype[prop];
+      }
     }
   }
 

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -26,7 +26,7 @@ let TextTrackList = function(tracks) {
     list = document.createElement('custom');
 
     for (let prop in TextTrackList.prototype) {
-      if(prop!=='constructor'){
+      if (prop !== 'constructor') {
         list[prop] = TextTrackList.prototype[prop];
       }
     }


### PR DESCRIPTION
there have some question in my projects, when I run video.js on  IE8.
throw the exception "SCRIPT3: 找不到成员。"

I'll google a lot of information, I finally found this
https://developer.mozilla.org/en-US/docs/ECMAScript_DontEnum_attribute#JScript_DontEnum_Bug

Reproducing  this bug:[run context:ie8]

 var testEle=document.createElement('custom');
 testEle['constructor']=function(){} ;//or testEle.constructor=function(){}

solution:avoid all of the pitfalls 

