### PR TITLE
Sass variable might be defined globally

### DIFF
--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -1,7 +1,7 @@
 @import "variables";
 @import "utilities";
 
-$icon-font-path: 'font';
+$icon-font-path: 'font' !default;
 @import "../../node_modules/videojs-font/scss/icons";
 
 @import "components/layout";


### PR DESCRIPTION
Variables should be defined with `!default` syntax in case someone want to define customize it:
http://stackoverflow.com/questions/32253344/gulp-dependency-looking-in-wrong-folder/32475297

Similar Sass projects like `bootstrap` always use this syntax.