### PR TITLE
Make background color have opacity instead of everything.

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -2,7 +2,7 @@
   position: relative;
   top: 1em;
   background-color: $primary-bg;
-  opacity: 0.75;
+  background-color: rgba($primary-bg, 0.75);
   color: $primary-text;
   margin: 0 auto;
   padding: 0.5em;


### PR DESCRIPTION
This is because otherwise, it could be hard to read the dropdowns and labels for the captions settings dialog.
`rgba()` is a sass function that takes a color and an opacity and outputs the rgba value for.
I kept the old background-color directive as a fallback for browsers that don't support rgba