### PR TITLE
Removed the loadedalldata event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ CHANGELOG
 * @gkatsev added a mouse-hover time display to the progress bar ([view](https://github.com/videojs/video.js/pull/2569))
 * @heff added an attributes argument to createEl() ([view](https://github.com/videojs/video.js/pull/2589))
 * @heff made tech related functions private in the player ([view](https://github.com/videojs/video.js/pull/2590))
+* @heff removed the loadedalldata event ([view](https://github.com/videojs/video.js/pull/2591))
 
 --------------------
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -856,11 +856,6 @@ class Player extends Component {
    */
   handleTechProgress_() {
     this.trigger('progress');
-
-    // Add custom event for when source is finished downloading.
-    if (this.bufferedPercent() === 1) {
-      this.trigger('loadedalldata');
-    }
   }
 
   /**
@@ -2570,13 +2565,6 @@ Player.prototype.handleLoadedMetaData_;
  * @event loadeddata
  */
 Player.prototype.handleLoadedData_;
-
-/**
- * Fired when the player has finished downloading the source data
- *
- * @event loadedalldata
- */
-Player.prototype.handleLoadedAllData;
 
 /**
  * Fired when the user is active, e.g. moves the mouse over the player


### PR DESCRIPTION
Want to get this out before 5.0. Reasoning from #1676. 

> I think we need to deprecate the loadedalldata event for 5.0. It's a made up event (not from the video element) that has less use these days for a few reasons:
- For most cases, you should use the canplaythrough event instead of loadedalldata.
- Browsers manage their buffer more carefully now, they don't just load the whole video at once
- It doesn't apply to live events