### PR TITLE
Extend createTimeRange to enable creation of TimeRanges with multiple ranges

### DIFF
--- a/src/js/utils/time-ranges.js
+++ b/src/js/utils/time-ranges.js
@@ -1,3 +1,5 @@
+import log from './log.js';
+
 /**
  * @file time-ranges.js
  *
@@ -43,6 +45,7 @@ function createTimeRangesObj(ranges){
 
 function getRange(fnName, valueIndex, ranges, rangeIndex){
   if (rangeIndex === undefined) {
+    log.warn(`DEPRECATED: Function '${fnName}' on 'TimeRanges' called without an index argument.`);
     rangeIndex = 0;
   }
   rangeCheck(fnName, rangeIndex, ranges.length - 1);

--- a/src/js/utils/time-ranges.js
+++ b/src/js/utils/time-ranges.js
@@ -6,14 +6,24 @@
  * return the start and end times for a range
  * TimeRanges are returned by the buffered() method
  *
- * @param  {Number} start Start time in seconds
- * @param  {Number} end   End time in seconds
- * @return {Object}       Fake TimeRange object
+ * @param  {(Number|Array)} Start of a single range or an array of ranges
+ * @param  {Number} End of a single range
  * @private
- * @method createTimeRange
+ * @method createTimeRanges
  */
-export function createTimeRange(start, end){
-  if (start === undefined && end === undefined) {
+export function createTimeRanges(start, end){
+  if (Array.isArray(start)) {
+    return createTimeRangesObj(start);
+  } else if (start === undefined || end === undefined) {
+    return createTimeRangesObj();
+  }
+  return createTimeRangesObj([[start, end]]);
+}
+
+export { createTimeRanges as createTimeRange };
+
+function createTimeRangesObj(ranges){
+  if (ranges === undefined || ranges.length === 0) {
     return {
       length: 0,
       start: function() {
@@ -25,8 +35,22 @@ export function createTimeRange(start, end){
     };
   }
   return {
-    length: 1,
-    start: function() { return start; },
-    end: function() { return end; }
+    length: ranges.length,
+    start: getRange.bind(null, 'start', 0, ranges),
+    end: getRange.bind(null, 'end', 1, ranges)
   };
+}
+
+function getRange(fnName, valueIndex, ranges, rangeIndex){
+  if (rangeIndex === undefined) {
+    rangeIndex = 0;
+  }
+  rangeCheck(fnName, rangeIndex, ranges.length - 1);
+  return ranges[rangeIndex][valueIndex];
+}
+
+function rangeCheck(fnName, index, maxIndex){
+  if (index < 0 || index > maxIndex) {
+    throw new Error(`Failed to execute '${fnName}' on 'TimeRanges': The index provided (${index}) is greater than or equal to the maximum bound (${maxIndex}).`);
+  }
 }

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -13,7 +13,7 @@ import mergeOptions from '../../src/js/utils/merge-options.js';
 import * as Fn from './utils/fn.js';
 
 import assign from 'object.assign';
-import { createTimeRange } from './utils/time-ranges.js';
+import { createTimeRanges } from './utils/time-ranges.js';
 import formatTime from './utils/format-time.js';
 import log from './utils/log.js';
 import * as Dom from './utils/dom.js';
@@ -374,12 +374,12 @@ videojs.log = log;
 /**
  * Creates an emulated TimeRange object.
  *
- * @param  {Number} start Start time in seconds
+ * @param  {Number|Array} start Start time in seconds or an array of ranges
  * @param  {Number} end   End time in seconds
  * @return {Object}       Fake TimeRange object
  * @method createTimeRange
  */
-videojs.createTimeRange = createTimeRange;
+videojs.createTimeRange = videojs.createTimeRanges = createTimeRanges;
 
 /**
  * Format seconds as a time string, H:MM:SS or M:SS

--- a/test/unit/utils/time-ranges.test.js
+++ b/test/unit/utils/time-ranges.test.js
@@ -1,9 +1,34 @@
-import { createTimeRange } from '../../../src/js/utils/time-ranges.js';
+import { createTimeRanges, createTimeRange } from '../../../src/js/utils/time-ranges.js';
 
 q.module('time-ranges');
 
-test('should create a fake timerange', function(){
-  var tr = createTimeRange(0, 10);
-  ok(tr.start() === 0);
-  ok(tr.end() === 10);
+test('should export the deprecated createTimeRange function', function(){
+  equal(createTimeRange, createTimeRanges, 'createTimeRange is an alias to createTimeRanges');
+});
+
+test('should create a fake single timerange', function(assert){
+  var tr = createTimeRanges(0, 10);
+
+  equal(tr.length, 1, 'length should be 1');
+  equal(tr.start(), 0, 'works if start is called with no arguments');
+  equal(tr.end(), 10, 'works if end is called with no arguments');
+  equal(tr.start(0), 0, 'works if start is called with valid index');
+  equal(tr.end(0), 10, 'works if end is called with with valid index');
+  assert.throws(()=>tr.start(1), /Failed to execute 'start'/, 'fails if start is called with an invalid index');
+  assert.throws(()=>tr.end(1), /Failed to execute 'end'/, 'fails if end is called with with an invalid index');
+});
+
+test('should create a fake multiple timerange', function(assert){
+  var tr = createTimeRanges([
+    [0, 10],
+    [11, 20]
+  ]);
+
+  equal(tr.length, 2, 'length should equal 2');
+  equal(tr.start(), 0, 'works if start is called with no arguments');
+  equal(tr.end(), 10, 'works if end is called with no arguments');
+  equal(tr.start(1), 11, 'works if start is called with valid index');
+  equal(tr.end(1), 20, 'works if end is called with with valid index');
+  assert.throws(()=>tr.start(-1), /Failed to execute 'start'/, 'fails if start is called with an invalid index');
+  assert.throws(()=>tr.end(-1), /Failed to execute 'end'/, 'fails if end is called with with an invalid index');
 });


### PR DESCRIPTION
No checks are performed to ensure that the resulting TimeRanges-like object is "normalized" as the spec requires.

Supports not passing an argument to `start` and `end` and returns the first range for backward  compatibility.

Throws an error with Chrome's error message if `start` or `end` is passed an index that is outside the supported ranges.