### PR TITLE
Remove phantomjs dependency

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -146,7 +146,6 @@ module.exports = function(grunt) {
       firefox:      { browsers: ['Firefox'] },
       safari:       { browsers: ['Safari'] },
       ie:           { browsers: ['IE'] },
-      phantomjs:    { browsers: ['PhantomJS'] },
 
       // this only runs on PRs from the mainrepo on BrowserStack
       browserstack: { browsers: ['chrome_bs'] },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-ie-launcher": "^0.1.5",
     "karma-opera-launcher": "~0.1.0",
-    "karma-phantomjs-launcher": "^0.1.4",
     "karma-qunit": "^0.1.2",
     "karma-safari-launcher": "^0.1.1",
     "karma-sinon": "^1.0.3",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -43,7 +43,6 @@ module.exports = function(config) {
       'karma-firefox-launcher',
       'karma-ie-launcher',
       'karma-opera-launcher',
-      'karma-phantomjs-launcher',
       'karma-safari-launcher',
       'karma-browserstack-launcher',
       'karma-browserify',


### PR DESCRIPTION
This PR is to remove phantomjs as a dependency for testing because I believe that it is rarely used. Pull Requests test against Firefox on Travis or BrowserStack browsers and local tests use Chrome by default.