### PR TITLE
Rename `extends` to `extend`

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1258,7 +1258,7 @@ class Component {
   static extend(props) {
     props = props || {};
 
-    log.warn('Component.extend({}) has been deprecated, use videojs.extends(Component, {}) instead');
+    log.warn('Component.extend({}) has been deprecated, use videojs.extend(Component, {}) instead');
 
     // Set up the constructor using the supplied init method
     // or using the init of the parent object

--- a/src/js/extend.js
+++ b/src/js/extend.js
@@ -1,7 +1,7 @@
 import log from './utils/log';
 
 /*
- * @file extends.js
+ * @file extend.js
  *
  * A combination of node inherits and babel's inherits (after transpile).
  * Both work the same but node adds `super_` to the subClass
@@ -34,7 +34,7 @@ const _inherits = function (subClass, superClass) {
  * var Button = videojs.getComponent('Button');
  * ```
  * ```js
- * var MyButton = videojs.extends(Button, {
+ * var MyButton = videojs.extend(Button, {
  *   constructor: function(player, options) {
  *     Button.call(this, player, options);
  *   },
@@ -44,7 +44,7 @@ const _inherits = function (subClass, superClass) {
  * });
  * ```
  */
-const extendsFn = function(superClass, subClassMethods={}) {
+const extendFn = function(superClass, subClassMethods={}) {
   let subClass = function() {
     superClass.apply(this, arguments);
   };
@@ -75,4 +75,4 @@ const extendsFn = function(superClass, subClassMethods={}) {
   return subClass;
 };
 
-export default extendsFn;
+export default extendFn;

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -19,7 +19,7 @@ import log from './utils/log.js';
 import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
 import * as Url from './utils/url.js';
-import extendsFn from './extends.js';
+import extendFn from './extend.js';
 import merge from 'lodash-compat/object/merge';
 import createDeprecationProxy from './utils/create-deprecation-proxy.js';
 import xhr from 'xhr';
@@ -180,8 +180,8 @@ videojs.getComponent = Component.getComponent;
  * ```js
  *     // Get a component to subclass
  *     var VjsButton = videojs.getComponent('Button');
- *     // Subclass the component (see 'extends' doc for more info)
- *     var MySpecialButton = videojs.extends(VjsButton, {});
+ *     // Subclass the component (see 'extend' doc for more info)
+ *     var MySpecialButton = videojs.extend(VjsButton, {});
  *     // Register the new component
  *     VjsButton.registerComponent('MySepcialButton', MySepcialButton);
  *     // (optionally) add the new component as a default player child
@@ -218,7 +218,7 @@ videojs.TOUCH_ENABLED = browser.TOUCH_ENABLED;
 
 /**
  * Subclass an existing class
- * Mimics ES6 subclassing with the `extends` keyword
+ * Mimics ES6 subclassing with the `extend` keyword
  * ```js
  *     // Create a basic javascript 'class'
  *     function MyClass(name){
@@ -231,7 +231,7 @@ videojs.TOUCH_ENABLED = browser.TOUCH_ENABLED;
  *     };
  *     // Subclass the exisitng class and change the name
  *     // when initializing
- *     var MySubClass = videojs.extends(MyClass, {
+ *     var MySubClass = videojs.extend(MyClass, {
  *       constructor: function(name) {
  *         // Call the super class constructor for the subclass
  *         MyClass.call(this, name)
@@ -247,9 +247,9 @@ videojs.TOUCH_ENABLED = browser.TOUCH_ENABLED;
  *                   Optionally including a `constructor` function
  * @return {Function} The newly created subclass
  * @mixes videojs
- * @method extends
+ * @method extend
  */
-videojs.extends = extendsFn;
+videojs.extend = extendFn;
 
 /**
  * Merge two options objects recursively

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -228,7 +228,7 @@ test('component can be subclassed externally', function(){
   var Component = videojs.getComponent('Component');
   var ControlBar = videojs.getComponent('ControlBar');
 
-  var player = new (videojs.extends(Component, {
+  var player = new (videojs.extend(Component, {
     reportUserActivity: function(){},
     textTracks: function(){ return {
         addEventListener: Function.prototype,
@@ -252,7 +252,7 @@ function testHelperMakeTag(){
 
 test('should extend Component', function(){
   var Component = videojs.getComponent('Component');
-  var MyComponent = videojs.extends(Component, {
+  var MyComponent = videojs.extend(Component, {
     constructor: function() {
       this.bar = true;
     },
@@ -267,7 +267,7 @@ test('should extend Component', function(){
   ok(myComponent.bar, 'the constructor function is used');
   ok(myComponent.foo(), 'instance methods are applied');
 
-  var NoMethods = videojs.extends(Component);
+  var NoMethods = videojs.extend(Component);
   var noMethods = new NoMethods({});
   ok(noMethods.on, 'should extend component with no methods or constructor');
 });

--- a/test/unit/extend.test.js
+++ b/test/unit/extend.test.js
@@ -1,13 +1,13 @@
-import extendsFn from '../../src/js/extends.js';
+import extendFn from '../../src/js/extend.js';
 
-q.module('extends.js');
+q.module('extend.js');
 
 test('should add implicit parent constructor call', function(){
   var superCalled = false;
   var Parent = function() {
     superCalled = true;
   };
-  var Child = extendsFn(Parent, {
+  var Child = extendFn(Parent, {
       foo: 'bar'
   });
   var child = new Child();

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -2,7 +2,7 @@ var noop = function() {}, clock, oldTextTracks;
 
 import Tech from '../../../src/js/tech/tech.js';
 import { createTimeRange } from '../../../src/js/utils/time-ranges.js';
-import extendsFn from '../../../src/js/extends.js';
+import extendFn from '../../../src/js/extend.js';
 import MediaError from '../../../src/js/media-error.js';
 
 q.module('Media Tech', {
@@ -105,7 +105,7 @@ test('should add the source handler interface to a tech', function(){
   var sourceB = { src: 'no-support', type: 'no-support' };
 
   // Define a new tech class
-  var MyTech = extendsFn(Tech);
+  var MyTech = extendFn(Tech);
 
   // Extend Tech with source handlers
   Tech.withSourceHandlers(MyTech);
@@ -181,7 +181,7 @@ test('should add the source handler interface to a tech', function(){
 
 test('should handle unsupported sources with the source handler API', function(){
   // Define a new tech class
-  var MyTech = extendsFn(Tech);
+  var MyTech = extendFn(Tech);
   // Extend Tech with source handlers
   Tech.withSourceHandlers(MyTech);
   // Create an instance of Tech
@@ -223,7 +223,7 @@ test('should track whether a video has played', function() {
 });
 
 test('delegates seekable to the source handler', function(){
-  let MyTech = extendsFn(Tech, {
+  let MyTech = extendFn(Tech, {
     seekable: function() {
       throw new Error('You should not be calling me!');
     }


### PR DESCRIPTION
This is a consequence of IE8 choking on the unquoted property name, "extends."

Fixes #2620.

Also updated the wiki page.