### PR TITLE
Removed timeranges no-index tests because they are invalid now

### DIFF
--- a/test/unit/utils/time-ranges.test.js
+++ b/test/unit/utils/time-ranges.test.js
@@ -10,8 +10,6 @@ test('should create a fake single timerange', function(assert){
   var tr = createTimeRanges(0, 10);
 
   equal(tr.length, 1, 'length should be 1');
-  equal(tr.start(), 0, 'works if start is called with no arguments');
-  equal(tr.end(), 10, 'works if end is called with no arguments');
   equal(tr.start(0), 0, 'works if start is called with valid index');
   equal(tr.end(0), 10, 'works if end is called with with valid index');
   assert.throws(()=>tr.start(1), /Failed to execute 'start'/, 'fails if start is called with an invalid index');
@@ -25,8 +23,6 @@ test('should create a fake multiple timerange', function(assert){
   ]);
 
   equal(tr.length, 2, 'length should equal 2');
-  equal(tr.start(), 0, 'works if start is called with no arguments');
-  equal(tr.end(), 10, 'works if end is called with no arguments');
   equal(tr.start(1), 11, 'works if start is called with valid index');
   equal(tr.end(1), 20, 'works if end is called with with valid index');
   assert.throws(()=>tr.start(-1), /Failed to execute 'start'/, 'fails if start is called with an invalid index');


### PR DESCRIPTION
They were throwing deprecation warnings in the test logs.

<img width="704" alt="screen shot 2015-09-22 at 11 32 52 am" src="https://cloud.githubusercontent.com/assets/166/10023440/3684e95c-6120-11e5-90fc-5e8f06e25ba5.png">
