### PR TITLE
Use button state for icon

### DIFF
--- a/src/css/components/_play-pause.scss
+++ b/src/css/components/_play-pause.scss
@@ -5,6 +5,6 @@
 .video-js .vjs-play-control {
   @extend .vjs-icon-play;
 }
-.video-js.vjs-playing .vjs-play-control {
+.video-js .vjs-play-control.vjs-playing {
   @extend .vjs-icon-pause;
 }


### PR DESCRIPTION
Instead of using the player state to decide which icon a play control should display, this keeps that state in the button. This allows videojs-contrib-ads to keep working.

Fixes an internal Brightcove issue.