### PR TITLE
This adds touch and move listeners to the parent of volumeBar.

### DIFF
--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -22,7 +22,6 @@ class VolumeBar extends Slider {
     super(player, options);
     this.on(player, 'volumechange', this.updateARIAAttributes);
     player.ready(Fn.bind(this, this.updateARIAAttributes));
-    player.ready(() => this.on(this.el().parentNode, ['mousedown', 'touchdown'], this.handleMouseDown));
   }
 
   /**
@@ -50,19 +49,6 @@ class VolumeBar extends Slider {
     }
 
     this.player_.volume(this.calculateDistance(event));
-  }
-
-  handleMouseDown(event) {
-    super.handleMouseDown(event);
-
-    this.on(this.el().parentNode, ['mousemove', 'touchmove'], this.handleMouseMove);
-    this.on(this.el().parentNode, ['mouseup', 'touchend'], this.handleMouseUp);
-  }
-
-  handleMouseUp(event) {
-    super.handleMouseUp(event);
-
-    this.off(this.el().parentNode, ['mousemove', 'touchmove'], this.handleMouseMove);
   }
 
   /**

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -22,6 +22,7 @@ class VolumeBar extends Slider {
     super(player, options);
     this.on(player, 'volumechange', this.updateARIAAttributes);
     player.ready(Fn.bind(this, this.updateARIAAttributes));
+    player.ready(() => this.on(this.el().parentNode, ['mousedown', 'touchdown'], this.handleMouseDown));
   }
 
   /**
@@ -49,6 +50,19 @@ class VolumeBar extends Slider {
     }
 
     this.player_.volume(this.calculateDistance(event));
+  }
+
+  handleMouseDown(event) {
+    super.handleMouseDown(event);
+
+    this.on(this.el().parentNode, ['mousemove', 'touchmove'], this.handleMouseMove);
+    this.on(this.el().parentNode, ['mouseup', 'touchend'], this.handleMouseUp);
+  }
+
+  handleMouseUp(event) {
+    super.handleMouseUp(event);
+
+    this.off(this.el().parentNode, ['mousemove', 'touchmove'], this.handleMouseMove);
   }
 
   /**

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -8,6 +8,7 @@ import Menu from '../menu/menu.js';
 import MenuButton from '../menu/menu-button.js';
 import MuteToggle from './mute-toggle.js';
 import VolumeBar from './volume-control/volume-bar.js';
+import document from 'global/document';
 
 /**
  * Button for volume menu
@@ -123,7 +124,7 @@ class VolumeMenuButton extends MenuButton {
 
   handleMouseDown(event) {
     this.on(['mousemove', 'touchmove'], Fn.bind(this.volumeBar, this.volumeBar.handleMouseMove));
-    this.on(['mouseup', 'touchend'], this.handleMouseUp);
+    this.on(document, ['mouseup', 'touchend'], this.handleMouseUp);
   }
 
   handleMouseUp(event) {

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -67,12 +67,6 @@ class VolumeMenuButton extends MenuButton {
     this.on(this.volumeBar, ['sliderinactive', 'blur'], function(){
       this.removeClass('vjs-slider-active');
     });
-
-    // we show the volumeBar on focus for keyboard accessibility
-    // when using the mouse, you don't want it to stay up, so, we blur it manually
-    this.on('mouseout', function() {
-      this.el().blur();
-    });
   }
 
   /**

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -67,6 +67,12 @@ class VolumeMenuButton extends MenuButton {
     this.on(this.volumeBar, ['sliderinactive', 'blur'], function(){
       this.removeClass('vjs-slider-active');
     });
+
+    // we show the volumeBar on focus for keyboard accessibility
+    // when using the mouse, you don't want it to stay up, so, we blur it manually
+    this.on('mouseout', function() {
+      this.el().blur();
+    });
   }
 
   /**

--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -2,6 +2,7 @@
  * @file volume-menu-button.js
  */
 import Button from '../button.js';
+import * as Fn from '../utils/fn.js';
 import Component from '../component.js';
 import Menu from '../menu/menu.js';
 import MenuButton from '../menu/menu-button.js';
@@ -100,6 +101,9 @@ class VolumeMenuButton extends MenuButton {
     menu.addChild(vb);
 
     this.volumeBar = vb;
+
+    this.attachVolumeBarEvents();
+
     return menu;
   }
 
@@ -113,6 +117,18 @@ class VolumeMenuButton extends MenuButton {
     super.handleClick();
   }
 
+  attachVolumeBarEvents() {
+    this.on(['mousedown', 'touchdown'], this.handleMouseDown);
+  }
+
+  handleMouseDown(event) {
+    this.on(['mousemove', 'touchmove'], Fn.bind(this.volumeBar, this.volumeBar.handleMouseMove));
+    this.on(['mouseup', 'touchend'], this.handleMouseUp);
+  }
+
+  handleMouseUp(event) {
+    this.off(['mousemove', 'touchmove'], Fn.bind(this.volumeBar, this.volumeBar.handleMouseMove));
+  }
 }
 
 VolumeMenuButton.prototype.volumeUpdate = MuteToggle.prototype.update;


### PR DESCRIPTION
This is useful because it allows us to more easily be able to interact with the volume bar. Instead of just being able to click or touch on the 4 pixel high bar, we can click or touch on the whole height of the container where the bar is located in.