### PR TITLE
Remove z-index on big play button

### DIFF
--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -4,7 +4,6 @@
   height: $big-play-button--height;
   width: $big-play-button--width; // Firefox bug: For some reason without width the icon wouldn't show up. Switched to using width and removed padding.
   display: block;
-  z-index: 2;
   position: absolute;
   top: 10px;
   left: 10px;


### PR DESCRIPTION
This was interfering with some internal BCOV plugins and doesn't seem to be necessary in video.js proper.