### PR TITLE
Fix node.js 4.1 build failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "grunt-fastly": "^0.1.3",
     "grunt-github-releaser": "^0.1.17",
     "grunt-karma": "^0.8.3",
-    "grunt-sass": "^0.18.1",
+    "grunt-sass": "^1.0.0",
     "grunt-version": "~0.3.0",
     "grunt-videojs-languages": "0.0.4",
     "grunt-zip": "0.10.2",


### PR DESCRIPTION
Update node-sass to 1.0.0 , resolved #2643