### PR TITLE
Fix `Player.prototype.techCall_` to not throw an error if `player.tec…

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1143,7 +1143,7 @@ class Player extends Component {
     // Otherwise call method now
     } else {
       try {
-        this.tech_[method](arg);
+        this.tech_ && this.tech_[method](arg);
       } catch(e) {
         log(e);
         throw e;


### PR DESCRIPTION
Fix `Player.prototype.techCall_` to not throw an error if `player.tech_` is falsy

- Fixes issue #2665