### PR TITLE
Players know which plugins they're using

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -152,6 +152,9 @@ class Player extends Component {
     // an infinite loop.
     let playerOptionsCopy = mergeOptions(this.options_);
 
+    // Create an object to track which plugins are active on a player
+    this.plugins_ = {};
+
     // Load plugins
     if (options.plugins) {
       let plugins = options.plugins;
@@ -2477,6 +2480,16 @@ class Player extends Component {
     }
 
     return options;
+  }
+
+  /**
+   * Whether or not this player is using a given plugin.
+   *
+   * @param  {String} name The name of a plugin
+   * @return {Boolean}
+   */
+  usingPlugin(name) {
+    return !!this.plugins_[name];
   }
 
   /**

--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -11,7 +11,10 @@ import Player from './player.js';
  * @method plugin
  */
 var plugin = function(name, init){
-  Player.prototype[name] = init;
+  Player.prototype[name] = function() {
+    this.plugins_[name] = true;
+    init.apply(this, arguments);
+  };
 };
 
 export default plugin;

--- a/test/unit/plugins.test.js
+++ b/test/unit/plugins.test.js
@@ -198,3 +198,19 @@ test('Plugin that does not exist logs an error', function() {
   error.restore();
   window['console'] = origConsole;
 });
+
+test('Plugin use can be detected on the player', function() {
+  expect(2);
+
+  registerPlugin('foo', function(){});
+
+  var player = TestHelpers.makePlayer({});
+
+  ok(!player.usingPlugin('foo'), 'plugin not in use yet');
+
+  player.foo();
+
+  ok(player.usingPlugin('foo'), 'plugin in use');
+
+  player.dispose();
+});

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -70,8 +70,8 @@ test('should expose plugin registry function', function() {
 
   player = TestHelpers.makePlayer();
 
-  ok(player.foo, 'should exist');
-  equal(player.foo, pluginFunction, 'should be equal');
+  ok(player[pluginName], 'should exist');
+  equal(typeof player[pluginName], 'function', 'should be equal');
 });
 
 test('should expose options and players properties for backward-compatibility', function() {


### PR DESCRIPTION
It seems like it would be useful for players to know which plugins they're using.

My only concern with this approach is that the `Player.prototype[name]` function is no longer a direct reference to the `init` function passed to `videojs.plugin`. This required one assertion to be changed. This may or may not qualify as a backward incompatibility; seems debatable.