### PR TITLE
URL to player API docs 404s

### DIFF
--- a/docs/guides/api.md
+++ b/docs/guides/api.md
@@ -41,4 +41,4 @@ myPlayer.currentTime(120);
 
 ```
 
-The full list of player API methods and events can be found in the [player API docs](../api/vjs.Player.md).
+The full list of player API methods and events can be found in the [player API docs](http://docs.videojs.com/docs/api/index.html).


### PR DESCRIPTION
I made a change to point towards the correct API. At least I believe this is what you were looking to direct developers to.