### PR TITLE
Wait until the tech's element has been added to the DOM before calling emulateTextTracks

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -58,7 +58,7 @@ class Tech extends Component {
     }
 
     if (!this.featuresNativeTextTracks) {
-      this.emulateTextTracks();
+      this.on('ready', this.emulateTextTracks);
     }
 
     this.initTextTrackListeners();


### PR DESCRIPTION
When we create a new tech, we can create an element - `Tech.el_` (in Flash an `object` element and in html5 a `video` element) - that is initially *detached* from the DOM. `Tech.el_` is a child of a dummy-`div`. Later, after the tech's constructor has run, the Component system will append `Tech.el_` to the DOM.

Calling `emulateTextTracks` in the Tech's constructor creates a `script` element in the *parentNode* of the `Tech.el_`. In the case of a detached node, we create a script tag that is never inserted into the DOM (since it'll be added as a child of the empty `div` that is thrown away.)

Instead of calling `emulateTextTracks` immediately, we should wait until the Component system signals that the Tech is ready - at which point it is part of the DOM.