### PR TITLE
Wait until the tech's element has been added to the DOM before calling emulateTextTracks

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -58,7 +58,7 @@ class Tech extends Component {
     }
 
     if (!this.featuresNativeTextTracks) {
-      this.emulateTextTracks();
+      this.on('ready', this.emulateTextTracks);
     }
 
     this.initTextTrackListeners();


### PR DESCRIPTION
This is the same change in #2690 rebased onto the stable branch.