### PR TITLE
Fix captions sticking to bottom for webkit browsers.

### DIFF
--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -3,6 +3,14 @@
   background-color: rgba($color, $alpha);
 }
 
+@mixin transform($transform) {
+  -moz-transform: $transform;
+  -ms-transform: $transform;
+  -o-transform: $transform;
+  -webkit-transform: $transform;
+  transform: $transform;
+}
+
 @mixin transition($string: $transition--default) {
   -webkit-transition: $string;
   -moz-transition: $string;

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -1,3 +1,4 @@
+/* Emulated tracks */
 .vjs-text-track-display {
   position: absolute;
   bottom: 3em;
@@ -25,6 +26,12 @@
 .vjs-captions { color: #fc6 /* Captions are yellow */; }
 .vjs-tt-cue { display: block; }
 
+/* Native tracks */
 video::-webkit-media-text-track-display {
-  @include transform(translateY(-45px));
+  @include transform(translateY(-3em));
+}
+
+/* Move captions down when controls aren't being shown */
+.video-js.vjs-user-inactive.vjs-playing video::-webkit-media-text-track-display {
+  @include transform(translateY(-1.5em));
 }

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -24,3 +24,7 @@
 .vjs-subtitles { color: #fff /* Subtitles are white */; }
 .vjs-captions { color: #fc6 /* Captions are yellow */; }
 .vjs-tt-cue { display: block; }
+
+video::-webkit-media-text-track-display {
+  @include transform(translateY(-45px));
+}


### PR DESCRIPTION
This PR is to start a conversation about addressing https://github.com/videojs/video.js/issues/2193.

![screen shot 2015-10-14 at 7 15 54 pm](https://cloud.githubusercontent.com/assets/549319/10503709/a1fe5ac6-72ad-11e5-8526-3fda53160c7c.png)

![screen shot 2015-10-14 at 7 57 50 pm](https://cloud.githubusercontent.com/assets/549319/10503742/f051b66e-72ad-11e5-8ed5-8be1449a7bc0.png)

Native (Chrome):

![screen shot 2015-10-14 at 7 17 16 pm](https://cloud.githubusercontent.com/assets/549319/10503694/7b25ffa8-72ad-11e5-895d-6803ac1b632a.png)

![screen shot 2015-10-14 at 7 17 02 pm](https://cloud.githubusercontent.com/assets/549319/10503693/7b253a46-72ad-11e5-8430-96f45fcdbf65.png)

Resources:
- http://www.samdutton.com/track/shadowDOM.html
- http://advprog.blogspot.co.uk/2013/07/styling-html-media-inner-workings.html
- Did not check webkit/videojs implementation yet

Browsers:
- Tested in OSX Chrome, Safari (Works), FF, IE (Not so much—to varying degrees)

Compatibility:
- http://caniuse.com/#feat=transforms2d

---

Evaluations:

1. `px`, `rem`, `em`?
1. `bottom`, `top`, `translateY`?
1. `-webkit-media-text-track-container`, `-webkit-media-text-track-display`?

---

#### 1. px

`px` must be used to keep interface consistency. However, this doesn't follow the em standard that is currently used in the player.

```css
/* will make controls larger due to em usage */
.video-js
{
  font-size: 20px;
}
```

The problem with using `em` is that the *browser?* will dynamically modify the `font-size` on the `-webkit-media-text-track-container`, based on player's width.  The larger the width, the larger the `font-size`, the larger the `bottom` offset will be.

```css
/* will look fine on large screens, but poor/poorer on smaller screens */
video::-webkit-media-text-track-container {
  bottom: 0.75em;
}
```

As mentioned https://github.com/videojs/video.js/issues/2193#issuecomment-105519643.

#### 2. & 3. translateY

`bottom` can only be used on the `-webkit-media-text-track-container` since it conflicts with styles found in `-webkit-media-text-track-display` [WebVTT implementation of `line` (WebVTT) modifies `top` (css)]. However, this will cause placement issues if you want to utilize `line` (WebVTT), as they both will stack/conflict.

`translateY` seems to be the best option. `translateY` gives the most predictable offset and it doesn't conflict with any other embedded styles.

The best part about it is that, IF, `line` (WebVTT) is configured, it will override any `translateY` styles set on `-webkit-media-text-track-display`.

```js
WEBVTT

00:00.700 --> 00:04.110
Captions describe all relevant audio for the hearing impaired.
[ Heroic music playing for a seagull ]
```

```css
/* will offset the text 45px from the bottom of the player */
video::-webkit-media-text-track-display {
    transform: transateY(-45px);
}
```

```js
WEBVTT

00:00.700 --> 00:04.110 line:50%
Captions describe all relevant audio for the hearing impaired.
[ Heroic music playing for a seagull ]
```

```css
/* will be ignored and overridden by `-webkit-media-text-track-display`'s `top`' to force the captions to be vertically centered */
video::-webkit-media-text-track-display {
    transform: transateY(-45px);
}
```

This will allow users to benefit from both.

---

Other stuff:

- Positioning captions based on user activity or inactivity is possible (Control bar visibility).
- No idea where the CSS belongs.
- `@mixin` can be removed if `npm i compass-mixins` was favored.