### PR TITLE
Use all installed browsers for unit tests

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -133,7 +133,7 @@ module.exports = function(grunt) {
 
       defaults: {
         detectBrowsers: {
-          enabled: true,
+          enabled: !process.env.TRAVIS,
           usePhantomJS: false
         }
       },

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -131,7 +131,12 @@ module.exports = function(grunt) {
         configFile: 'test/karma.conf.js'
       },
 
-      defaults: {},
+      defaults: {
+        detectBrowsers: {
+          enabled: true,
+          usePhantomJS: false
+        }
+      },
 
       watch: {
         autoWatch: true,

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "karma-browserstack-launcher": "^0.1.4",
     "karma-chrome-launcher": "^0.1.3",
     "karma-coverage": "^0.4.0",
+    "karma-detect-browsers": "^2.0.2",
     "karma-firefox-launcher": "^0.1.3",
     "karma-ie-launcher": "^0.1.5",
     "karma-opera-launcher": "~0.1.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -107,6 +107,8 @@ module.exports = function(config) {
         'android_bs',
         'ios_bs'
       ];
+    } else {
+      settings.browsers = ['Firefox'];
     }
   }
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,10 +3,9 @@ module.exports = function(config) {
   var settings = {
     basePath: '',
 
-    frameworks: ['browserify', 'qunit'],
+    frameworks: ['browserify', 'qunit', 'detectBrowsers'],
     autoWatch: false,
     singleRun: true,
-    browsers: ['Chrome'],
 
     // Compling tests here
     files: [
@@ -46,8 +45,14 @@ module.exports = function(config) {
       'karma-safari-launcher',
       'karma-browserstack-launcher',
       'karma-browserify',
-      'karma-coverage'
+      'karma-coverage',
+      'karma-detect-browsers',
     ],
+
+    detectBrowsers: {
+      enabled: false,
+      usePhantomJS: false
+    },
 
     reporters: ['dots'],
 
@@ -102,8 +107,6 @@ module.exports = function(config) {
         'android_bs',
         'ios_bs'
       ];
-    } else {
-      settings.browsers = ['Firefox'];
     }
   }
 


### PR DESCRIPTION
This PR uses the karma-detect-browsers to launch all available browsers when using the karma:defaults task on a local environment.