### PR TITLE
Add canPlayType method to player

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1650,7 +1650,7 @@ class Player extends Component {
     let can;
 
     // Loop through each playback technology in the options order
-    for (var i=0,j=this.options_.techOrder;i<j.length;i++) {
+    for (let i = 0, j = this.options_.techOrder; i < j.length; i++) {
       let techName = toTitleCase(j[i]);
       let tech = Component.getComponent(techName);
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1640,6 +1640,40 @@ class Player extends Component {
   }
 
   /**
+   * Check whether the player can play a given mimetype
+   *
+   * @param {String} type The mimetype to check
+   * @return {String} 'probably', 'maybe', or '' (empty string)
+   * @method canPlayType
+   */
+  canPlayType(type) {
+    let can;
+
+    // Loop through each playback technology in the options order
+    for (var i=0,j=this.options_.techOrder;i<j.length;i++) {
+      let techName = toTitleCase(j[i]);
+      let tech = Component.getComponent(techName);
+
+      // Check if the current tech is defined before continuing
+      if (!tech) {
+	log.error(`The "${techName}" tech is undefined. Skipped browser support check for that tech.`);
+	continue;
+      }
+
+      // Check if the browser supports this technology
+      if (tech.isSupported()) {
+	can = tech.canPlayType(type);
+
+	if (can) {
+	  return can;
+	}
+      }
+    }
+
+    return '';
+  }
+
+  /**
    * Select source based on tech order
    *
    * @param {Array} sources The sources for a media asset

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1656,17 +1656,17 @@ class Player extends Component {
 
       // Check if the current tech is defined before continuing
       if (!tech) {
-	log.error(`The "${techName}" tech is undefined. Skipped browser support check for that tech.`);
-	continue;
+        log.error(`The "${techName}" tech is undefined. Skipped browser support check for that tech.`);
+        continue;
       }
 
       // Check if the browser supports this technology
       if (tech.isSupported()) {
-	can = tech.canPlayType(type);
+        can = tech.canPlayType(type);
 
-	if (can) {
-	  return can;
-	}
+        if (can) {
+          return can;
+        }
       }
     }
 

--- a/src/js/tech/flash-rtmp.js
+++ b/src/js/tech/flash-rtmp.js
@@ -60,12 +60,31 @@ function FlashRtmpDecorator(Flash) {
   Flash.rtmpSourceHandler = {};
 
   /**
-   * Check Flash can handle the source natively
+   * Check if Flash can play the given videotype
+   * @param  {String} type    The mimetype to check
+   * @return {String}         'probably', 'maybe', or '' (empty string)
+   */
+  Flash.rtmpSourceHandler.canPlayType = function(type){
+    if (Flash.isStreamingType(type)) {
+      return 'maybe';
+    }
+
+    return '';
+  };
+
+  /**
+   * Check if Flash can handle the source natively
    * @param  {Object} source  The source object
    * @return {String}         'probably', 'maybe', or '' (empty string)
    */
   Flash.rtmpSourceHandler.canHandleSource = function(source){
-    if (Flash.isStreamingType(source.type) || Flash.isStreamingSrc(source.src)) {
+    let can = Flash.rtmpSourceHandler.canPlayType(source.type);
+
+    if (can) {
+      return can;
+    }
+
+    if (Flash.isStreamingSrc(source.src)) {
       return 'maybe';
     }
 

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -352,6 +352,19 @@ Tech.withSourceHandlers(Flash);
  */
 Flash.nativeSourceHandler = {};
 
+/**
+ * Check if Flash can play the given videotype
+ * @param  {String} type    The mimetype to check
+ * @return {String}         'probably', 'maybe', or '' (empty string)
+ */
+Flash.nativeSourceHandler.canPlayType = function(type){
+  if (type in Flash.formats) {
+    return 'maybe';
+  }
+
+  return '';
+};
+
 /*
  * Check Flash can handle the source natively
  *
@@ -376,11 +389,7 @@ Flash.nativeSourceHandler.canHandleSource = function(source){
     type = source.type.replace(/;.*/, '').toLowerCase();
   }
 
-  if (type in Flash.formats) {
-    return 'maybe';
-  }
-
-  return '';
+  return Flash.nativeSourceHandler.canPlayType(type);
 };
 
 /*

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -829,6 +829,22 @@ Tech.withSourceHandlers(Html5);
 Html5.nativeSourceHandler = {};
 
 /*
+ * Check if the video element can play the given videotype
+ *
+ * @param  {String} type    The mimetype to check
+ * @return {String}         'probably', 'maybe', or '' (empty string)
+ */
+Html5.nativeSourceHandler.canPlayType = function(type){
+  // IE9 on Windows 7 without MediaPlayer throws an error here
+  // https://github.com/videojs/video.js/issues/519
+  try {
+    return Html5.TEST_VID.canPlayType(type);
+  } catch(e) {
+    return '';
+  }
+};
+
+/*
  * Check if the video element can handle the source natively
  *
  * @param  {Object} source  The source object
@@ -837,24 +853,14 @@ Html5.nativeSourceHandler = {};
 Html5.nativeSourceHandler.canHandleSource = function(source){
   var match, ext;
 
-  function canPlayType(type){
-    // IE9 on Windows 7 without MediaPlayer throws an error here
-    // https://github.com/videojs/video.js/issues/519
-    try {
-      return Html5.TEST_VID.canPlayType(type);
-    } catch(e) {
-      return '';
-    }
-  }
-
   // If a type was provided we should rely on that
   if (source.type) {
-    return canPlayType(source.type);
+    return Html5.nativeSourceHandler.canPlayType(source.type);
   } else if (source.src) {
     // If no type, fall back to checking 'video/[EXTENSION]'
     ext = Url.getFileExtension(source.src);
 
-    return canPlayType(`video/${ext}`);
+    return Html5.nativeSourceHandler.canPlayType(`video/${ext}`);
   }
 
   return '';

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -424,6 +424,19 @@ class Tech extends Component {
    */
   setPoster() {}
 
+  /*
+   * Check if the tech can support the given type
+   *
+   * The base tech does not support any type, but source handlers might
+   * overwrite this.
+   *
+   * @param  {String} type    The mimetype to check
+   * @return {String}         'probably', 'maybe', or '' (empty string)
+   */
+  canPlayType() {
+    return '';
+  }
+
 }
 
 /*

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -498,6 +498,26 @@ Tech.withSourceHandlers = function(_Tech){
     handlers.splice(index, 0, handler);
   };
 
+  /*
+   * Check if the tech can support the given type
+   * @param  {String} type    The mimetype to check
+   * @return {String}         'probably', 'maybe', or '' (empty string)
+   */
+  _Tech.canPlayType = function(type){
+    let handlers = _Tech.sourceHandlers || [];
+    let can;
+
+    for (let i = 0; i < handlers.length; i++) {
+      can = handlers[i].canPlayType(type);
+
+      if (can) {
+	return can;
+      }
+    }
+
+    return '';
+  };
+
    /*
     * Return the first source handler that supports the source
     * TODO: Answer question: should 'probably' be prioritized over 'maybe'

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -524,7 +524,7 @@ Tech.withSourceHandlers = function(_Tech){
       can = handlers[i].canPlayType(type);
 
       if (can) {
-	return can;
+        return can;
       }
     }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -824,3 +824,19 @@ expect(3);
   player.language('en-GB');
   strictEqual(player.localize('Good'), 'Brilliant', 'Ignored case');
 });
+
+test('should return correct values for canPlayType', function(){
+  var tag = TestHelpers.makeTag();
+  var container = document.createElement('div');
+  var fixture = document.getElementById('qunit-fixture');
+
+  container.appendChild(tag);
+  fixture.appendChild(container);
+
+  var player = new Player(tag, { techOrder: ['techFaker'] });
+
+  ok(player.canPlayType('video/mp4') === 'maybe', 'player can play mp4 files');
+  ok(player.canPlayType('video/unsupported-format') === '', 'player can not play unsupported files');
+
+  player.dispose();
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -826,17 +826,10 @@ expect(3);
 });
 
 test('should return correct values for canPlayType', function(){
-  var tag = TestHelpers.makeTag();
-  var container = document.createElement('div');
-  var fixture = document.getElementById('qunit-fixture');
+  var player = TestHelpers.makePlayer();
 
-  container.appendChild(tag);
-  fixture.appendChild(container);
-
-  var player = new Player(tag, { techOrder: ['techFaker'] });
-
-  ok(player.canPlayType('video/mp4') === 'maybe', 'player can play mp4 files');
-  ok(player.canPlayType('video/unsupported-format') === '', 'player can not play unsupported files');
+  equal(player.canPlayType('video/mp4'), 'maybe', 'player can play mp4 files');
+  equal(player.canPlayType('video/unsupported-format'), '', 'player can not play unsupported files');
 
   player.dispose();
 });

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -135,6 +135,16 @@ test('should have the source handler interface', function() {
   ok(Flash.registerSourceHandler, 'has the registerSourceHandler function');
 });
 
+test('canPlayType should select the correct types to play', function () {
+  let canPlayType = Flash.nativeSourceHandler.canPlayType;
+
+  equal('maybe', canPlayType('video/flv'), 'should be able to play FLV files');
+  equal('maybe', canPlayType('video/x-flv'), 'should be able to play x-FLV files');
+  equal('maybe', canPlayType('video/mp4'), 'should be able to play MP4 files');
+  equal('maybe', canPlayType('video/m4v'), 'should be able to play M4V files');
+  equal('', canPlayType('video/ogg'), 'should return empty string if it can not play the video');
+});
+
 test('canHandleSource should be able to work with src objects without a type', function () {
   let canHandleSource = Flash.nativeSourceHandler.canHandleSource;
 

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -138,11 +138,11 @@ test('should have the source handler interface', function() {
 test('canPlayType should select the correct types to play', function () {
   let canPlayType = Flash.nativeSourceHandler.canPlayType;
 
-  equal('maybe', canPlayType('video/flv'), 'should be able to play FLV files');
-  equal('maybe', canPlayType('video/x-flv'), 'should be able to play x-FLV files');
-  equal('maybe', canPlayType('video/mp4'), 'should be able to play MP4 files');
-  equal('maybe', canPlayType('video/m4v'), 'should be able to play M4V files');
-  equal('', canPlayType('video/ogg'), 'should return empty string if it can not play the video');
+  equal(canPlayType('video/flv'), 'maybe', 'should be able to play FLV files');
+  equal(canPlayType('video/x-flv'), 'maybe', 'should be able to play x-FLV files');
+  equal(canPlayType('video/mp4'), 'maybe', 'should be able to play MP4 files');
+  equal(canPlayType('video/m4v'), 'maybe', 'should be able to play M4V files');
+  equal(canPlayType('video/ogg'), '', 'should return empty string if it can not play the video');
 });
 
 test('canHandleSource should be able to work with src objects without a type', function () {

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -155,6 +155,27 @@ test('should have the source handler interface', function() {
   ok(Html5.registerSourceHandler, 'has the registerSourceHandler function');
 });
 
+test('native source handler canPlayType', function(){
+  var result;
+
+  // Stub the test video canPlayType (used in canPlayType) to control results
+  var origCPT = Html5.TEST_VID.canPlayType;
+  Html5.TEST_VID.canPlayType = function(type){
+    if (type === 'video/mp4') {
+      return 'maybe';
+    }
+    return '';
+  };
+
+  var canPlayType = Html5.nativeSourceHandler.canPlayType;
+
+  equal(canPlayType('video/mp4'), 'maybe', 'Native source handler reported type support');
+  equal(canPlayType('foo'), '', 'Native source handler handled bad type');
+
+  // Reset test video canPlayType
+  Html5.TEST_VID.canPlayType = origCPT;
+});
+
 test('native source handler canHandleSource', function(){
   var result;
 

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -50,6 +50,7 @@ class TechFaker extends Tech {
 
   // Support everything except for "video/unsupported-format"
   static isSupported() { return true; }
+  static canPlayType(type) { return (type !== 'video/unsupported-format' ? 'maybe' : ''); }
   static canPlaySource(srcObj) { return srcObj.type !== 'video/unsupported-format'; }
 }
 

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -134,7 +134,7 @@ test('should add the source handler interface to a tech', function(){
   var handlerOne = {
     canPlayType: function(type){
       if (type !=='no-support') {
-	return 'probably';
+        return 'probably';
       }
       return '';
     },

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -132,6 +132,12 @@ test('should add the source handler interface to a tech', function(){
 
   // Create source handlers
   var handlerOne = {
+    canPlayType: function(type){
+      if (type !=='no-support') {
+	return 'probably';
+      }
+      return '';
+    },
     canHandleSource: function(source){
       if (source.type !=='no-support') {
         return 'probably';
@@ -146,6 +152,9 @@ test('should add the source handler interface to a tech', function(){
   };
 
   var handlerTwo = {
+    canPlayType: function(type){
+      return ''; // no support
+    },
     canHandleSource: function(source){
       return ''; // no support
     },
@@ -163,6 +172,10 @@ test('should add the source handler interface to a tech', function(){
   // Test handler selection
   strictEqual(MyTech.selectSourceHandler(sourceA), handlerOne, 'handlerOne was selected to handle the valid source');
   strictEqual(MyTech.selectSourceHandler(sourceB), null, 'no handler was selected to handle the invalid source');
+
+  // Test canPlayType return values
+  strictEqual(MyTech.canPlayType(sourceA.type), 'probably', 'the Tech returned probably for the valid source');
+  strictEqual(MyTech.canPlayType(sourceB.type), '', 'the Tech returned an empty string for the invalid source');
 
   // Test canPlaySource return values
   strictEqual(MyTech.canPlaySource(sourceA), 'probably', 'the Tech returned probably for the valid source');
@@ -239,6 +252,9 @@ test('delegates seekable to the source handler', function(){
   };
 
   MyTech.registerSourceHandler({
+    canPlayType: function() {
+      return true;
+    },
     canHandleSource: function() {
       return true;
     },


### PR DESCRIPTION
This should be the code for #2701 including some tests.

I'm not sure this is what is wanted exactly, but I'm of course open to comments. For example, does it make more sense to let `player.canPlayType` return a boolean? I had that at first but then decided that returning the maybe / probably thingy isn't any more work and maybe more helpful?

For testing, there is only one small test for `player.canPlayType`, but I couldn't find any tests for things link `selectSource` so I did not really have anything to base my tests upon.