### PR TITLE
Fixed argument names in API docs

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -282,9 +282,9 @@ videojs.extend = extendFn;
  *     // result.bar.b = [4,5,6];
  * ```
  *
- * @param {Object} The options object whose values will be overriden
- * @param {Object} The options object with values to override the first
- * @param {Object} Any number of additional options objects
+ * @param {Object} defaults  The options object whose values will be overriden
+ * @param {Object} overrides The options object with values to override the first
+ * @param {Object} etc       Any number of additional options objects
  *
  * @return {Object} a new object with the merged values
  * @mixes videojs

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -349,8 +349,8 @@ videojs.bind = Fn.bind;
  *     // --> Should alert 'Plugin added later!'
  * ```
  *
- * @param {String} The plugin name
- * @param {Function} The plugin function that will be called with options
+ * @param {String}   name The plugin name
+ * @param {Function} fn   The plugin function that will be called with options
  * @mixes videojs
  * @method plugin
  */

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -349,8 +349,8 @@ videojs.bind = Fn.bind;
  *     // --> Should alert 'Plugin added later!'
  * ```
  *
- * @param {String}   name The plugin name
- * @param {Function} fn   The plugin function that will be called with options
+ * @param {String} name The plugin name
+ * @param {Function} fn The plugin function that will be called with options
  * @mixes videojs
  * @method plugin
  */


### PR DESCRIPTION
Some jsdoc arguments were missing names.

Fixes https://github.com/videojs/video.js/issues/2711