### PR TITLE
Remove unhelpful isCrossOrigin test.

### DIFF
--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -105,8 +105,8 @@ export const getFileExtension = function(path) {
  * @method isCrossOrigin
  */
 export const isCrossOrigin = function(url) {
-  let urlInfo = parseUrl(url);
   let winLoc = window.location;
+  let urlInfo = parseUrl(url);
 
   // IE8 protocol relative urls will return ':' for protocol
   let srcProtocol = urlInfo.protocol === ':' ? winLoc.protocol : urlInfo.protocol;

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -93,7 +93,6 @@ test('isCrossOrigin can identify cross origin urls', function() {
   win.location.protocol = 'https:';
   win.location.host = 'google.com';
   ok(Url.isCrossOrigin('http://google.com/example.vtt'), 'http://google.com from https://google.com is cross origin');
-  ok(Url.isCrossOrigin('//google.com/example.vtt'), '//google.com from https://google.com is cross origin');
   ok(Url.isCrossOrigin('http://example.com/example.vtt'), 'http://example.com from https://google.com is cross origin');
   ok(Url.isCrossOrigin('https://example.com/example.vtt'), 'https://example.com from https://google.com is cross origin');
   ok(Url.isCrossOrigin('//example.com/example.vtt'), '//example.com from https://google.com is cross origin');

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -79,8 +79,6 @@ test('isCrossOrigin can identify cross origin urls', function() {
     'global/window': win
   });
 
-  ok(Url.isCrossOrigin, 'we export a isCrossOrigin function');
-
   win.location.protocol = window.location.protocol;
   win.location.host = window.location.host;
   ok(!Url.isCrossOrigin(`http://${win.location.host}/example.vtt`), 'http://google.com from http://google.com is not cross origin');

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -79,6 +79,8 @@ test('isCrossOrigin can identify cross origin urls', function() {
     'global/window': win
   });
 
+  ok(Url.isCrossOrigin, 'we export a isCrossOrigin function');
+
   win.location.protocol = window.location.protocol;
   win.location.host = window.location.host;
   ok(!Url.isCrossOrigin(`http://${win.location.host}/example.vtt`), 'http://google.com from http://google.com is not cross origin');


### PR DESCRIPTION
This test was checking that an "https:" page could load
protocol-relative urls as non-cross origin. However, IE and chrome
handled the parsing of the urls differently. In IE, the url was parsed
to have a protocol of ':' which we chould then backfill to be 'https:'.
But chrome parsed it to have a protocol of 'http:' because our test page
was loaded over http. Having this test is causing more issues than is
worth having it.