### PR TITLE
Add browserify:dist Target

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -317,7 +317,7 @@ module.exports = function(grunt) {
           transform: [
             ['browserify-versionify', {
               placeholder: '../node_modules/vtt.js/dist/vtt.js',
-              version: 'https://raw.githubusercontent.com/gkatsev/vtt.js/vjs-v0.12.1/dist/vtt.min.js'
+              version: 'https://cdn.rawgit.com/gkatsev/vtt.js/vjs-v0.12.1/dist/vtt.min.js'
             }],
           ]
         }),


### PR DESCRIPTION
This adds functions for generating browserify configs to avoid any copy/pasting.

The `browserify:dist` target specifically replaces the `node_modules` version of `vtt.js` with a raw GitHub URL to address multiple reports of 404ing requests for `vtt.js`. The `node_modules` version is maintained for the normal `browserify:build` target (i.e. for local development).

This builds on some of the work introduced in #2426