### PR TITLE
Flash Player Events Data

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tsml": "1.0.1",
     "videojs-font": "2.0.0",
     "videojs-ie8": "1.1.2",
-    "videojs-swf": "5.0.1",
+    "videojs-swf": "5.1.0",
     "videojs-vtt.js": "0.12.1",
     "xhr": "2.2.0"
   },

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -624,6 +624,7 @@ class Player extends Component {
     this.on(this.tech_, 'texttrackchange', this.handleTechTextTrackChange_);
     this.on(this.tech_, 'loadedmetadata', this.updateStyleEl_);
     this.on(this.tech_, 'posterchange', this.handleTechPosterChange_);
+    this.on(this.tech_, 'textdata', this.handleTechTextData_);
 
     this.usingNativeControls(this.techGet_('controls'));
 
@@ -1158,6 +1159,14 @@ class Player extends Component {
    */
   handleTechLoadedMetaData_() {
     this.trigger('loadedmetadata');
+  }
+
+  handleTechTextData_() {
+    var data = null;
+    if (arguments.length > 1) {
+      data = arguments[1];
+    }
+    this.trigger('textdata', data);
   }
 
   /**
@@ -2875,6 +2884,8 @@ Player.prototype.handleTechLoadStart_;
  * @event loadedmetadata
  */
 Player.prototype.handleLoadedMetaData_;
+
+Player.prototype.handleTextData_;
 
 /**
  * Fired when the player has downloaded data at the current playback position

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2885,6 +2885,11 @@ Player.prototype.handleTechLoadStart_;
  */
 Player.prototype.handleLoadedMetaData_;
 
+/**
+ * Fired when the player receives text data
+ *
+ * @event textdata
+ */
 Player.prototype.handleTextData_;
 
 /**

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -457,7 +457,7 @@ Flash.checkReady = function(tech){
 // Trigger events from the swf on the player
 Flash.onEvent = function(swfID, eventName){
   let tech = Dom.getEl(swfID).tech;
-  tech.trigger(eventName);
+  tech.trigger(eventName, Array.prototype.slice.call(arguments, 2));
 };
 
 // Log errors from the swf


### PR DESCRIPTION
These changes add the `textdata` event emitted from the Flash module (PR: https://github.com/videojs/video-js-swf/pull/188). In order for this event to receive the text data from the SWF, this change also passes all additional parameters from the triggered event into the handler in the JS.