### PR TITLE
Use '/' as branch-name separator in contrib.json

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -408,10 +408,10 @@
         [ "git commit -a --author='{{prCommits.[0].commit.author.name}} <{{prCommits.[0].commit.author.email}}>' -m '{{line}}. closes #{{prNum}}'", "Commit the changes" ],
         { "prompt": "confirm",                                         "desc": "Does everything look ok?" },
         [ "git checkout {{pr.base.ref}}",                                      "Check out the base branch" ],
-        [ "git merge {{pr.user.login}}-{{pr.head.ref}}",                       "Merge the changes" ],
+        [ "git merge {{pr.user.login}}/{{pr.head.ref}}",                       "Merge the changes" ],
         [ "git push origin {{pr.base.ref}}",                                   "Push the changes to your remote copy of the project" ],
         [ "git push upstream {{pr.base.ref}}",                                 "Push the changes to the main project" ],
-        [ "git branch -D {{pr.user.login}}-{{pr.head.ref}}",                   "Delete the local branch used for merging" ]
+        [ "git branch -D {{pr.user.login}}/{{pr.head.ref}}",                   "Delete the local branch used for merging" ]
       ]
     }
   }


### PR DESCRIPTION
This is in addition to change that sneaked into the latest commit: https://github.com/videojs/video.js/commit/0da23c1d8d7c922f4e9e0a60b98126c697ce4997#diff-7e451665c8c6834ff419e918026455cdR401
Using the previous `-` was causing issues trying to merge PRs that had `-` in their branch names.