### PR TITLE
Emulate HTMLTrackElement to enable load event.

### DIFF
--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -77,21 +77,13 @@ class ChaptersButton extends TextTrackButton {
     let chaptersTrack;
     let items = this.items = [];
 
-    for (let i = 0, l = tracks.length; i < l; i++) {
+    for (let i = 0, length = tracks.length; i < length; i++) {
       let track = tracks[i];
+
       if (track['kind'] === this.kind_) {
-        if (!track.cues) {
-          track['mode'] = 'hidden';
-          /* jshint loopfunc:true */
-          // TODO see if we can figure out a better way of doing this https://github.com/videojs/video.js/issues/1864
-          window.setTimeout(Fn.bind(this, function() {
-            this.createMenu();
-          }), 100);
-          /* jshint loopfunc:false */
-        } else {
-          chaptersTrack = track;
-          break;
-        }
+        chaptersTrack = track;
+
+        break;
       }
     }
 
@@ -105,7 +97,19 @@ class ChaptersButton extends TextTrackButton {
       }));
     }
 
-    if (chaptersTrack) {
+    if (chaptersTrack && !chaptersTrack.cues) {
+      chaptersTrack['mode'] = 'hidden';
+
+      let remoteTextTrackEl = this.player_.remoteTextTrackEls().getTrackElementByTrack_(chaptersTrack);
+
+      if (remoteTextTrackEl) {
+        remoteTextTrackEl.addEventListener('load', (event) => {
+          this.update();
+        });
+      }
+    }
+
+    if (chaptersTrack && chaptersTrack.cues && chaptersTrack.cues.length > 0) {
       let cues = chaptersTrack['cues'], cue;
 
       for (let i = 0, l = cues.length; i < l; i++) {
@@ -120,6 +124,7 @@ class ChaptersButton extends TextTrackButton {
 
         menu.addChild(mi);
       }
+
       this.addChild(menu);
     }
 

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -103,9 +103,7 @@ class ChaptersButton extends TextTrackButton {
       let remoteTextTrackEl = this.player_.remoteTextTrackEls().getTrackElementByTrack_(chaptersTrack);
 
       if (remoteTextTrackEl) {
-        remoteTextTrackEl.addEventListener('load', (event) => {
-          this.update();
-        });
+        remoteTextTrackEl.addEventListener('load', (event) => this.update());
       }
     }
 

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -97,7 +97,7 @@ class ChaptersButton extends TextTrackButton {
       }));
     }
 
-    if (chaptersTrack && !chaptersTrack.cues) {
+    if (chaptersTrack && chaptersTrack.cues == null) {
       chaptersTrack['mode'] = 'hidden';
 
       let remoteTextTrackEl = this.player_.remoteTextTrackEls().getTrackElementByTrack_(chaptersTrack);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2493,6 +2493,16 @@ class Player extends Component {
   }
 
   /**
+   * Get an array of remote html track elements
+   *
+   * @return {HTMLTrackElement[]}
+   * @method remoteTextTrackEls
+   */
+  remoteTextTrackEls() {
+    return this.tech_ && this.tech_['remoteTextTrackEls']();
+  }
+
+  /**
    * Add a text track
    * In addition to the W3C settings we allow adding additional info through options.
    * http://www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#dom-media-addtexttrack

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -769,8 +769,6 @@ class Html5 extends Tech {
     this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
     this.remoteTextTracks().addTrack_(htmlTrackElement.track);
 
-    // TODO: need to verify that we should be returning htmlTrackElement
-    // https://github.com/videojs/video.js/issues/2799
     return htmlTrackElement;
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -731,11 +731,11 @@ class Html5 extends Tech {
   }
 
   /**
-   * Creates and returns a remote text track object
+   * Creates a remote text track object and returns a html track element
    *
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
-   * @return {TextTrackObject}
+   * @return {HTMLTrackElement}
    * @method addRemoteTextTrack
    */
   addRemoteTextTrack(options={}) {
@@ -743,32 +743,35 @@ class Html5 extends Tech {
       return super.addRemoteTextTrack(options);
     }
 
-    var track = document.createElement('track');
+    var htmlTrackElement = document.createElement('track');
 
     if (options['kind']) {
-      track['kind'] = options['kind'];
+      htmlTrackElement['kind'] = options['kind'];
     }
     if (options['label']) {
-      track['label'] = options['label'];
+      htmlTrackElement['label'] = options['label'];
     }
     if (options['language'] || options['srclang']) {
-      track['srclang'] = options['language'] || options['srclang'];
+      htmlTrackElement['srclang'] = options['language'] || options['srclang'];
     }
     if (options['default']) {
-      track['default'] = options['default'];
+      htmlTrackElement['default'] = options['default'];
     }
     if (options['id']) {
-      track['id'] = options['id'];
+      htmlTrackElement['id'] = options['id'];
     }
     if (options['src']) {
-      track['src'] = options['src'];
+      htmlTrackElement['src'] = options['src'];
     }
 
-    this.el().appendChild(track);
+    this.el().appendChild(htmlTrackElement);
 
-    this.remoteTextTracks().addTrack_(track.track);
+    this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
+    this.remoteTextTracks().addTrack_(htmlTrackElement.track);
 
-    return track;
+    // TODO: need to verify that we should be returning htmlTrackElement
+    // https://github.com/videojs/video.js/issues/2799
+    return htmlTrackElement;
   }
 
   /**
@@ -782,7 +785,11 @@ class Html5 extends Tech {
       return super.removeRemoteTextTrack(track);
     }
 
-    var tracks, i;
+    let tracks, i;
+
+    // TODO: track can be html text element due to addRemoteTextTrack—consider refactoring
+    let trackElement = this.remoteTextTrackEls().getTrackElementByTrack_(track);
+    this.remoteTextTrackEls().removeTrackElement_(trackElement);
 
     this.remoteTextTracks().removeTrack_(track);
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -49,6 +49,7 @@ class Html5 extends Tech {
       while (nodesLength--) {
         let node = nodes[nodesLength];
         let nodeName = node.nodeName.toLowerCase();
+
         if (nodeName === 'track') {
           if (!this.featuresNativeTextTracks) {
             // Empty video tag tracks so the built-in player doesn't use them also.
@@ -57,6 +58,8 @@ class Html5 extends Tech {
             // captions and subtitles. videoElement.textTracks
             removeNodes.push(node);
           } else {
+            // store HTMLTrackElement and TextTrack to remote list
+            this.remoteTextTrackEls().addTrackElement_(node);
             this.remoteTextTracks().addTrack_(node.track);
           }
         }
@@ -766,6 +769,7 @@ class Html5 extends Tech {
 
     this.el().appendChild(htmlTrackElement);
 
+    // store HTMLTrackElement and TextTrack to remote list
     this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
     this.remoteTextTracks().addTrack_(htmlTrackElement.track);
 
@@ -785,10 +789,10 @@ class Html5 extends Tech {
 
     let tracks, i;
 
-    // TODO: track can be html text element due to addRemoteTextTrack—consider refactoring
     let trackElement = this.remoteTextTrackEls().getTrackElementByTrack_(track);
-    this.remoteTextTrackEls().removeTrackElement_(trackElement);
 
+    // remove HTMLTrackElement and TextTrack from remote list
+    this.remoteTextTrackEls().removeTrackElement_(trackElement);
     this.remoteTextTracks().removeTrack_(track);
 
     tracks = this.$$('track');

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -743,25 +743,25 @@ class Html5 extends Tech {
       return super.addRemoteTextTrack(options);
     }
 
-    var htmlTrackElement = document.createElement('track');
+    let htmlTrackElement = document.createElement('track');
 
-    if (options['kind']) {
-      htmlTrackElement['kind'] = options['kind'];
+    if (options.kind) {
+      htmlTrackElement.kind = options.kind;
     }
-    if (options['label']) {
-      htmlTrackElement['label'] = options['label'];
+    if (options.label) {
+      htmlTrackElement.label = options.label;
     }
-    if (options['language'] || options['srclang']) {
-      htmlTrackElement['srclang'] = options['language'] || options['srclang'];
+    if (options.language || options.srclang) {
+      htmlTrackElement.srclang = options.language || options.srclang;
     }
-    if (options['default']) {
-      htmlTrackElement['default'] = options['default'];
+    if (options.default) {
+      htmlTrackElement.default = options.default;
     }
-    if (options['id']) {
-      htmlTrackElement['id'] = options['id'];
+    if (options.id) {
+      htmlTrackElement.id = options.id;
     }
-    if (options['src']) {
-      htmlTrackElement['src'] = options['src'];
+    if (options.src) {
+      htmlTrackElement.src = options.src;
     }
 
     this.el().appendChild(htmlTrackElement);

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -424,10 +424,12 @@ class Tech extends Component {
 
     let htmlTrackElement = new HTMLTrackElement(track);
 
+    // store HTMLTrackElement and TextTrack to remote list
     this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
-
-    this.textTracks().addTrack_(htmlTrackElement.track);
     this.remoteTextTracks().addTrack_(htmlTrackElement.track);
+
+    // must come after remoteTextTracks()
+    this.textTracks().addTrack_(htmlTrackElement.track);
 
     return htmlTrackElement;
   }
@@ -441,10 +443,10 @@ class Tech extends Component {
   removeRemoteTextTrack(track) {
     this.textTracks().removeTrack_(track);
 
-    // TODO: track can be html text element due to addRemoteTextTrack—consider refactoring
     let trackElement = this.remoteTextTrackEls().getTrackElementByTrack_(track);
-    this.remoteTextTrackEls().removeTrackElement_(trackElement);
 
+    // remove HTMLTrackElement and TextTrack from remote list
+    this.remoteTextTrackEls().removeTrackElement_(trackElement);
     this.remoteTextTracks().removeTrack_(track);
   }
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -424,8 +424,6 @@ class Tech extends Component {
     this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
     this.remoteTextTracks().addTrack_(track);
 
-    // TODO: need to verify that we should be returning htmlTrackElement
-    // https://github.com/videojs/video.js/issues/2799
     return htmlTrackElement;
   }
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -5,6 +5,8 @@
  */
 
 import Component from '../component';
+import HTMLTrackElement from '../tracks/html-track-element';
+import HTMLTrackElementList from '../tracks/html-track-element-list';
 import TextTrack from '../tracks/text-track';
 import TextTrackList from '../tracks/text-track-list';
 import * as Fn from '../utils/fn.js';
@@ -378,6 +380,17 @@ class Tech extends Component {
   }
 
   /**
+   * Get remote htmltrackelements
+   *
+   * @returns {HTMLTrackElementList}
+   * @method remoteTextTrackEls
+   */
+  remoteTextTrackEls() {
+    this.remoteTextTrackEls_ = this.remoteTextTrackEls_ || new HTMLTrackElementList();
+    return this.remoteTextTrackEls_;
+  }
+
+  /**
    * Creates and returns a remote text track object
    *
    * @param {String} kind Text track kind (subtitles, captions, descriptions
@@ -396,19 +409,24 @@ class Tech extends Component {
   }
 
   /**
-   * Creates and returns a remote text track object
+   * Creates a remote text track object and returns a emulated html track element
    *
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
-   * @return {TextTrackObject}
+   * @return {HTMLTrackElement}
    * @method addRemoteTextTrack
    */
   addRemoteTextTrack(options) {
     let track = createTrackHelper(this, options.kind, options.label, options.language, options);
+
+    let htmlTrackElement = new HTMLTrackElement(track);
+
+    this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
     this.remoteTextTracks().addTrack_(track);
-    return {
-      track: track
-    };
+
+    // TODO: need to verify that we should be returning htmlTrackElement
+    // https://github.com/videojs/video.js/issues/2799
+    return htmlTrackElement;
   }
 
   /**
@@ -419,6 +437,11 @@ class Tech extends Component {
    */
   removeRemoteTextTrack(track) {
     this.textTracks().removeTrack_(track);
+
+    // TODO: track can be html text element due to addRemoteTextTrack—consider refactoring
+    let trackElement = this.remoteTextTrackEls().getTrackElementByTrack_(track);
+    this.remoteTextTrackEls().removeTrackElement_(trackElement);
+
     this.remoteTextTracks().removeTrack_(track);
   }
 
@@ -447,7 +470,7 @@ class Tech extends Component {
   /*
    * Return whether the argument is a Tech or not.
    * Can be passed either a Class like `Html5` or a instance like `player.tech_`
-   * 
+   *
    * @param {Object} component An item to check
    * @return {Boolean}         Whether it is a tech or not
    */

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -7,6 +7,7 @@
 import Component from '../component';
 import HTMLTrackElement from '../tracks/html-track-element';
 import HTMLTrackElementList from '../tracks/html-track-element-list';
+import mergeOptions from '../utils/merge-options.js';
 import TextTrack from '../tracks/text-track';
 import TextTrackList from '../tracks/text-track-list';
 import * as Fn from '../utils/fn.js';
@@ -417,12 +418,16 @@ class Tech extends Component {
    * @method addRemoteTextTrack
    */
   addRemoteTextTrack(options) {
-    let track = createTrackHelper(this, options.kind, options.label, options.language, options);
+    let track = mergeOptions(options, {
+      tech: this
+    });
 
     let htmlTrackElement = new HTMLTrackElement(track);
 
     this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
-    this.remoteTextTracks().addTrack_(track);
+
+    this.textTracks().addTrack_(htmlTrackElement.track);
+    this.remoteTextTracks().addTrack_(htmlTrackElement.track);
 
     return htmlTrackElement;
   }

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -42,13 +42,11 @@ class HtmlTrackElementList {
     let trackElement_;
 
     for (let i = 0, length = this.trackElements_.length; i < length; i++) {
-      if (track !== this.trackElements_[i].track) {
-        continue;
+      if (track === this.trackElements_[i].track) {
+        trackElement_ = this.trackElements_[i];
+
+        break;
       }
-
-      trackElement_ = this.trackElements_[i];
-
-      break;
     }
 
     return trackElement_;
@@ -56,13 +54,11 @@ class HtmlTrackElementList {
 
   removeTrackElement_(trackElement) {
     for (let i = 0, length = this.trackElements_.length; i < length; i++) {
-      if (trackElement !== this.trackElements_[i]) {
-        continue;
+      if (trackElement === this.trackElements_[i]) {
+        this.trackElements_.splice(i, 1);
+
+        break;
       }
-
-      this.trackElements_.splice(i, 1);
-
-      break;
     }
   }
 }

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -13,7 +13,9 @@ class HtmlTrackElementList {
       list = document.createElement('custom');
 
       for (let prop in HtmlTrackElementList.prototype) {
-        list[prop] = HtmlTrackElementList.prototype[prop];
+        if (prop !== 'constructor') {
+          list[prop] = HtmlTrackElementList.prototype[prop];
+        }
       }
     }
 

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -1,0 +1,59 @@
+/**
+ * @file html-track-element.js
+ */
+
+import * as browser from '../utils/browser.js';
+
+class HtmlTrackElementList {
+  constructor(trackElements = []) {
+    this.trackElements_ = [];
+
+    Object.defineProperty(this, 'length', {
+      get() {
+        return this.trackElements_.length;
+      }
+    });
+
+    for (let i = 0, length = trackElements.length; i < length; i++) {
+      this.addTrackElement_(trackElements[i]);
+    }
+
+    if (browser.IS_IE8) {
+      return this;
+    }
+  }
+
+  addTrackElement_(trackElement) {
+    this.trackElements_.push(trackElement);
+  }
+
+  getTrackElementByTrack_(track) {
+    let trackElement_;
+
+    for (let i = 0, length = this.trackElements_.length; i < length; i++) {
+      if (track !== this.trackElements_[i].track) {
+        continue;
+      }
+
+      trackElement_ = this.trackElements_[i];
+
+      break;
+    }
+
+    return trackElement_;
+  }
+
+  removeTrackElement_(trackElement) {
+    for (let i = 0, length = this.trackElements_.length; i < length; i++) {
+      if (trackElement !== this.trackElements_[i]) {
+        continue;
+      }
+
+      this.trackElements_.splice(i, 1);
+
+      break;
+    }
+  }
+}
+
+export default HtmlTrackElementList;

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -3,23 +3,34 @@
  */
 
 import * as browser from '../utils/browser.js';
+import document from 'global/document';
 
 class HtmlTrackElementList {
   constructor(trackElements = []) {
-    this.trackElements_ = [];
+    let list = this;
 
-    Object.defineProperty(this, 'length', {
+    if (browser.IS_IE8) {
+      list = document.createElement('custom');
+
+      for (let prop in HtmlTrackElementList.prototype) {
+        list[prop] = HtmlTrackElementList.prototype[prop];
+      }
+    }
+
+    list.trackElements_ = [];
+
+    Object.defineProperty(list, 'length', {
       get() {
         return this.trackElements_.length;
       }
     });
 
     for (let i = 0, length = trackElements.length; i < length; i++) {
-      this.addTrackElement_(trackElements[i]);
+      list.addTrackElement_(trackElements[i]);
     }
 
     if (browser.IS_IE8) {
-      return this;
+      return list;
     }
   }
 

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -2,10 +2,10 @@ import * as browser from '../utils/browser.js';
 import document from 'global/document';
 import EventTarget from '../event-target';
 
-export const NONE = 0;
-export const LOADING = 1;
-export const LOADED = 2;
-export const ERROR = 3;
+const NONE = 0;
+const LOADING = 1;
+const LOADED = 2;
+const ERROR = 3;
 
 /**
  * https://html.spec.whatwg.org/multipage/embedded-content.html#htmltrackelement
@@ -32,7 +32,6 @@ class HTMLTrackElement extends EventTarget {
     super();
 
     let readyState,
-        textTrack,
         trackElement = this;
 
     if (browser.IS_IE8) {
@@ -57,14 +56,13 @@ class HTMLTrackElement extends EventTarget {
 
     Object.defineProperty(trackElement, 'track', {
       get() {
-        return textTrack;
+        return track;
       }
     });
 
     readyState = NONE;
-    textTrack = track;
 
-    textTrack.addEventListener('loadeddata', function() {
+    track.addEventListener('loadeddata', function() {
       readyState = LOADED;
 
       trackElement.trigger({
@@ -82,5 +80,10 @@ class HTMLTrackElement extends EventTarget {
 HTMLTrackElement.prototype.allowedEvents_ = {
   load: 'load'
 };
+
+HTMLTrackElement.NONE = NONE;
+HTMLTrackElement.LOADING = LOADING;
+HTMLTrackElement.LOADED = LOADED;
+HTMLTrackElement.ERROR = ERROR;
 
 export default HTMLTrackElement;

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -1,6 +1,7 @@
 import * as browser from '../utils/browser.js';
 import document from 'global/document';
 import EventTarget from '../event-target';
+import TextTrack from '../tracks/text-track';
 
 const NONE = 0;
 const LOADING = 1;
@@ -25,10 +26,13 @@ const ERROR = 3;
  *
  *   readonly attribute TextTrack track;
  * };
+ *
+ * @param {Object} options TextTrack configuration
+ * @class HTMLTrackElement
  */
 
 class HTMLTrackElement extends EventTarget {
-  constructor(track) {
+  constructor(options = {}) {
     super();
 
     let readyState,
@@ -41,6 +45,8 @@ class HTMLTrackElement extends EventTarget {
         trackElement[prop] = HTMLTrackElement.prototype[prop];
       }
     }
+
+    let track = new TextTrack(options);
 
     trackElement.kind = track.kind;
     trackElement.src = track.src;

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -1,4 +1,5 @@
 import * as browser from '../utils/browser.js';
+import document from 'global/document';
 import EventTarget from '../event-target';
 
 export const NONE = 0;
@@ -35,27 +36,26 @@ class HTMLTrackElement extends EventTarget {
         trackElement = this;
 
     if (browser.IS_IE8) {
-      // TODO: do stuff
+      trackElement = document.createElement('custom');
+
+      for (let prop in HTMLTrackElement.prototype) {
+        trackElement[prop] = HTMLTrackElement.prototype[prop];
+      }
     }
 
-    this.kind = track.kind;
-    this.src = track.src;
-    this.srclang = track.srclang;
-    this.label = track.label;
-    this.default = track.default;
+    trackElement.kind = track.kind;
+    trackElement.src = track.src;
+    trackElement.srclang = track.srclang;
+    trackElement.label = track.label;
+    trackElement.default = track.default;
 
-    const NONE = 0;
-    const LOADING = 1;
-    const LOADED = 2;
-    const ERROR = 3;
-
-    Object.defineProperty(this, 'readyState', {
+    Object.defineProperty(trackElement, 'readyState', {
       get() {
         return readyState;
       }
     });
 
-    Object.defineProperty(this, 'track', {
+    Object.defineProperty(trackElement, 'track', {
       get() {
         return textTrack;
       }
@@ -74,7 +74,7 @@ class HTMLTrackElement extends EventTarget {
     });
 
     if (browser.IS_IE8) {
-      return this;
+      return trackElement;
     }
   }
 }

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -1,6 +1,11 @@
 import * as browser from '../utils/browser.js';
 import EventTarget from '../event-target';
 
+export const NONE = 0;
+export const LOADING = 1;
+export const LOADED = 2;
+export const ERROR = 3;
+
 /**
  * https://html.spec.whatwg.org/multipage/embedded-content.html#htmltrackelement
  *
@@ -25,7 +30,7 @@ class HTMLTrackElement extends EventTarget {
   constructor(track) {
     super();
 
-    var readyState,
+    let readyState,
         textTrack,
         trackElement = this;
 
@@ -59,10 +64,6 @@ class HTMLTrackElement extends EventTarget {
     readyState = NONE;
     textTrack = track;
 
-    this.allowedEvents_ = {
-      load: 'load'
-    };
-
     textTrack.addEventListener('loadeddata', function() {
       readyState = LOADED;
 
@@ -77,5 +78,9 @@ class HTMLTrackElement extends EventTarget {
     }
   }
 }
+
+HTMLTrackElement.prototype.allowedEvents_ = {
+  load: 'load'
+};
 
 export default HTMLTrackElement;

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -1,0 +1,81 @@
+import * as browser from '../utils/browser.js';
+import EventTarget from '../event-target';
+
+/**
+ * https://html.spec.whatwg.org/multipage/embedded-content.html#htmltrackelement
+ *
+ * interface HTMLTrackElement : HTMLElement {
+ *   attribute DOMString kind;
+ *   attribute DOMString src;
+ *   attribute DOMString srclang;
+ *   attribute DOMString label;
+ *   attribute boolean default;
+ *
+ *   const unsigned short NONE = 0;
+ *   const unsigned short LOADING = 1;
+ *   const unsigned short LOADED = 2;
+ *   const unsigned short ERROR = 3;
+ *   readonly attribute unsigned short readyState;
+ *
+ *   readonly attribute TextTrack track;
+ * };
+ */
+
+class HTMLTrackElement extends EventTarget {
+  constructor(track) {
+    super();
+
+    var readyState,
+        textTrack,
+        trackElement = this;
+
+    if (browser.IS_IE8) {
+      // TODO: do stuff
+    }
+
+    this.kind = track.kind;
+    this.src = track.src;
+    this.srclang = track.srclang;
+    this.label = track.label;
+    this.default = track.default;
+
+    const NONE = 0;
+    const LOADING = 1;
+    const LOADED = 2;
+    const ERROR = 3;
+
+    Object.defineProperty(this, 'readyState', {
+      get() {
+        return readyState;
+      }
+    });
+
+    Object.defineProperty(this, 'track', {
+      get() {
+        return textTrack;
+      }
+    });
+
+    readyState = NONE;
+    textTrack = track;
+
+    this.allowedEvents_ = {
+      load: 'load'
+    };
+
+    textTrack.addEventListener('loadeddata', function() {
+      readyState = LOADED;
+
+      trackElement.trigger({
+        type: 'load',
+        target: trackElement
+      });
+    });
+
+    if (browser.IS_IE8) {
+      return this;
+    }
+  }
+}
+
+export default HTMLTrackElement;

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -52,7 +52,7 @@ class HTMLTrackElement extends EventTarget {
 
     trackElement.kind = track.kind;
     trackElement.src = track.src;
-    trackElement.srclang = track.srclang;
+    trackElement.srclang = track.language;
     trackElement.label = track.label;
     trackElement.default = track.default;
 

--- a/src/js/tracks/html-track-element.js
+++ b/src/js/tracks/html-track-element.js
@@ -42,7 +42,9 @@ class HTMLTrackElement extends EventTarget {
       trackElement = document.createElement('custom');
 
       for (let prop in HTMLTrackElement.prototype) {
-        trackElement[prop] = HTMLTrackElement.prototype[prop];
+        if (prop !== 'constructor') {
+          trackElement[prop] = HTMLTrackElement.prototype[prop];
+        }
       }
     }
 

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -69,6 +69,13 @@ for (let event in TextTrackList.prototype.allowedEvents_) {
   TextTrackList.prototype['on' + event] = null;
 }
 
+/**
+ * Add TextTrack from TextTrackList
+ *
+ * @param {TextTrack} track
+ * @method addTrack_
+ * @private
+ */
 TextTrackList.prototype.addTrack_ = function(track) {
   let index = this.tracks_.length;
   if (!(''+index in this)) {
@@ -90,19 +97,25 @@ TextTrackList.prototype.addTrack_ = function(track) {
   });
 };
 
+/**
+ * Remove TextTrack from TextTrackList
+ * NOTE: Be mindful of what is passed in as it may be a HTMLTrackElement
+ *
+ * @param {TextTrack} rtrack
+ * @method removeTrack_
+ * @private
+ */
 TextTrackList.prototype.removeTrack_ = function(rtrack) {
   let track;
 
   for (let i = 0, l = this.length; i < l; i++) {
-    if (this[i] !== rtrack) {
-      continue;
+    if (this[i] === rtrack) {
+      track = this[i];
+
+      this.tracks_.splice(i, 1);
+
+      break;
     }
-
-    track = this[i];
-
-    this.tracks_.splice(i, 1);
-
-    break;
   }
 
   if (track) {

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -91,15 +91,22 @@ TextTrackList.prototype.addTrack_ = function(track) {
 };
 
 TextTrackList.prototype.removeTrack_ = function(rtrack) {
-  let result = null;
   let track;
 
   for (let i = 0, l = this.length; i < l; i++) {
-    track = this[i];
-    if (track === rtrack) {
-      this.tracks_.splice(i, 1);
-      break;
+    if (this[i] !== rtrack) {
+      continue;
     }
+
+    track = this[i];
+
+    this.tracks_.splice(i, 1);
+
+    break;
+  }
+
+  if (track) {
+    return;
   }
 
   this.trigger({

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -118,7 +118,7 @@ TextTrackList.prototype.removeTrack_ = function(rtrack) {
     }
   }
 
-  if (track) {
+  if (!track) {
     return;
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -234,25 +234,25 @@ TextTrack.prototype.removeCue = function(removeCue) {
 * Downloading stuff happens below this point
 */
 var parseCues = function(srcContent, track) {
-  let parser = new window['WebVTT']['Parser'](window, window['vttjs'], window['WebVTT']['StringDecoder']());
+  let parser = new window.WebVTT.Parser(window, window.vttjs, window.WebVTT.StringDecoder());
 
-  parser['oncue'] = function(cue) {
+  parser.oncue = function(cue) {
     track.addCue(cue);
   };
 
-  parser['onparsingerror'] = function(error) {
+  parser.onparsingerror = function(error) {
     log.error(error);
   };
 
-  parser['onflush'] = () => {
+  parser.onflush = function() {
     track.trigger({
       type: 'loadeddata',
       target: track
     });
   };
 
-  parser['parse'](srcContent);
-  parser['flush']();
+  parser.parse(srcContent);
+  parser.flush();
 };
 
 var loadTrack = function(src, track) {
@@ -272,9 +272,9 @@ var loadTrack = function(src, track) {
 
     track.loaded_ = true;
 
-    if (typeof window['WebVTT'] !== 'function') {
-      //try again a bit later
-      return window.setTimeout(function() {
+    // NOTE: this is only used for the alt/video.novtt.js build
+    if (typeof window.WebVTT !== 'function') {
+      window.setTimeout(function() {
         parseCues(responseBody, track);
       }, 100);
     } else {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -45,7 +45,9 @@ let TextTrack = function(options={}) {
     tt = document.createElement('custom');
 
     for (let prop in TextTrack.prototype) {
-      tt[prop] = TextTrack.prototype[prop];
+      if (prop !== 'constructor') {
+        tt[prop] = TextTrack.prototype[prop];
+      }
     }
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -195,8 +195,7 @@ TextTrack.prototype.constructor = TextTrack;
  * cuechange - One or more cues in the track have become active or stopped being active.
  */
 TextTrack.prototype.allowedEvents_ = {
-  'cuechange': 'cuechange',
-  'loadeddata': 'loadeddata'
+  'cuechange': 'cuechange'
 };
 
 TextTrack.prototype.addCue = function(cue) {

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -61,6 +61,7 @@ test('should be able to access expected player API methods', function() {
 
   // TextTrack methods
   ok(player.textTracks, 'textTracks exists');
+  ok(player.remoteTextTrackEls, 'remoteTextTrackEls exists');
   ok(player.remoteTextTracks, 'remoteTextTracks exists');
   ok(player.addTextTrack, 'addTextTrack exists');
   ok(player.addRemoteTextTrack, 'addRemoteTextTrack exists');

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -835,6 +835,39 @@ test('createModal()', function() {
   strictEqual(player.children().indexOf(modal), -1, 'modal was removed from player\'s children');
 });
 
+test('should return correct remote text track values', function () {
+  var fixture = document.getElementById('qunit-fixture');
+
+  var html = '<video id="example_1" class="video-js" autoplay preload="none">';
+      html += '<source src="http://google.com" type="video/mp4">';
+      html += '<track kind="captions" label="label">';
+      html += '</video>';
+
+  fixture.innerHTML += html;
+
+  var tag = document.getElementById('example_1');
+
+  var player = TestHelpers.makePlayer({
+    techOrder: ['html5']
+  }, tag);
+
+  equal(player.remoteTextTracks().length, 1, 'add text track via html');
+  equal(player.remoteTextTrackEls().length, 1, 'add html track element via html');
+
+  let htmlTextTrack = player.addRemoteTextTrack({
+    kind: 'captions',
+    label: 'label'
+  });
+
+  equal(player.remoteTextTracks().length, 2, 'add text track via method');
+  equal(player.remoteTextTrackEls().length, 2, 'add html track element via method');
+
+  player.removeRemoteTextTrack(htmlTextTrack.track);
+
+  equal(player.remoteTextTracks().length, 1, 'remove text track via method');
+  equal(player.remoteTextTrackEls().length, 1, 'remove html track element via method');
+});
+
 test('createModal() options object', function() {
   var player = TestHelpers.makePlayer();
   var modal = player.createModal('foo', {content: 'bar', label: 'boo'});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -835,41 +835,6 @@ test('createModal()', function() {
   strictEqual(player.children().indexOf(modal), -1, 'modal was removed from player\'s children');
 });
 
-test('should return correct remote text track values', function () {
-  var fixture = document.getElementById('qunit-fixture');
-
-  var html = '<video id="example_1" class="video-js" autoplay preload="none">';
-      html += '<source src="http://google.com" type="video/mp4">';
-      html += '<track kind="captions" label="label">';
-      html += '</video>';
-
-  fixture.innerHTML += html;
-
-  var tag = document.getElementById('example_1');
-
-  var player = TestHelpers.makePlayer({
-    techOrder: ['html5']
-  }, tag);
-
-  this.clock.tick(1);
-
-  equal(player.remoteTextTracks().length, 1, 'add text track via html');
-  equal(player.remoteTextTrackEls().length, 1, 'add html track element via html');
-
-  let htmlTextTrack = player.addRemoteTextTrack({
-    kind: 'captions',
-    label: 'label'
-  });
-
-  equal(player.remoteTextTracks().length, 2, 'add text track via method');
-  equal(player.remoteTextTrackEls().length, 2, 'add html track element via method');
-
-  player.removeRemoteTextTrack(htmlTextTrack.track);
-
-  equal(player.remoteTextTracks().length, 1, 'remove text track via method');
-  equal(player.remoteTextTrackEls().length, 1, 'remove html track element via method');
-});
-
 test('createModal() options object', function() {
   var player = TestHelpers.makePlayer();
   var modal = player.createModal('foo', {content: 'bar', label: 'boo'});

--- a/test/unit/tracks/html-track-element-list.test.js
+++ b/test/unit/tracks/html-track-element-list.test.js
@@ -1,0 +1,59 @@
+import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
+import HTMLTrackElementList from '../../../src/js/tracks/html-track-element-list.js';
+import TextTrack from '../../../src/js/tracks/text-track.js';
+
+let noop = Function.prototype;
+let defaultTech = {
+  textTracks: noop,
+  on: noop,
+  off: noop,
+  currentTime: noop
+};
+
+let track1 = new TextTrack({
+  id: 1,
+  tech: defaultTech
+});
+let track2 = new TextTrack({
+  id: 2,
+  tech: defaultTech
+});
+
+var genericHtmlTrackElements = [{
+  kind: 'captions',
+  tech: noop,
+  track: track1
+}, {
+  kind: 'chapters',
+  tech: noop,
+  track: track2
+}];
+
+q.module('HTML Track Element List');
+
+test('HTMLTrackElementList\'s length is set correctly', function() {
+  let htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
+
+  equal(htmlTrackElementList.length, genericHtmlTrackElements.length, `the length is ${genericHtmlTrackElements.length}`);
+});
+
+test('can get html track element by track', function() {
+  let htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
+
+  equal(htmlTrackElementList.getTrackElementByTrack_(track1).kind, 'captions', 'track1 has kind of captions');
+  equal(htmlTrackElementList.getTrackElementByTrack_(track2).kind, 'chapters', 'track2 has kind of captions');
+});
+
+test('length is updated when new tracks are added or removed', function() {
+  let htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
+
+  htmlTrackElementList.addTrackElement_({tech: noop});
+  equal(htmlTrackElementList.length, genericHtmlTrackElements.length + 1, `the length is ${genericHtmlTrackElements.length + 1}`);
+  htmlTrackElementList.addTrackElement_({tech: noop});
+  equal(htmlTrackElementList.length, genericHtmlTrackElements.length + 2, `the length is ${genericHtmlTrackElements.length + 2}`);
+
+  htmlTrackElementList.removeTrackElement_(htmlTrackElementList.getTrackElementByTrack_(track1));
+  equal(htmlTrackElementList.length, genericHtmlTrackElements.length + 1, `the length is ${genericHtmlTrackElements.length + 1}`);
+  htmlTrackElementList.removeTrackElement_(htmlTrackElementList.getTrackElementByTrack_(track2));
+  equal(htmlTrackElementList.length, genericHtmlTrackElements.length, `the length is ${genericHtmlTrackElements.length}`);
+});

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -1,5 +1,4 @@
 import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
-import TestHelpers from '../test-helpers.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import window from 'global/window';
 
@@ -43,7 +42,7 @@ test('can create a html track element with various properties', function() {
   equal(htmlTrackElement.readyState, 0, 'we have a readyState');
   equal(htmlTrackElement.src, src, 'we have a src');
   equal(htmlTrackElement.srclang, language, 'we have a srclang');
-  equal(htmlTrackElement.track instanceof TextTrack, true, 'we have a track');
+  equal(htmlTrackElement.track.cues, null, 'we have a track');
 });
 
 test('defaults when items not provided', function() {
@@ -57,12 +56,11 @@ test('defaults when items not provided', function() {
   equal(htmlTrackElement.readyState, 0, 'we have a readyState');
   equal(htmlTrackElement.src, undefined, 'we have a src');
   equal(htmlTrackElement.srclang, '', 'we have a srclang');
-  equal(htmlTrackElement.track instanceof TextTrack, true, 'we have a track');
+  equal(htmlTrackElement.track.cues.length, 0, 'we have a track');
 });
 
 test('fires loadeddata when track cues become populated', function() {
-  let player = TestHelpers.makePlayer(),
-      changes = 0,
+  let changes = 0,
       loadHandler;
 
   loadHandler = function() {
@@ -70,7 +68,7 @@ test('fires loadeddata when track cues become populated', function() {
   };
 
   let htmlTrackElement = new HTMLTrackElement({
-    tech: player.tech_
+    tech: noop
   });
 
   htmlTrackElement.addEventListener('load', loadHandler);
@@ -80,6 +78,4 @@ test('fires loadeddata when track cues become populated', function() {
 
   equal(changes, 1, 'a loadeddata event trigger addEventListener');
   equal(htmlTrackElement.readyState, 2, 'readyState is loaded');
-
-  player.dispose();
 });

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -1,0 +1,85 @@
+import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
+import TestHelpers from '../test-helpers.js';
+import TextTrack from '../../../src/js/tracks/text-track.js';
+import window from 'global/window';
+
+let noop = Function.prototype;
+let defaultTech = {
+  textTracks: noop,
+  on: noop,
+  off: noop,
+  currentTime: noop
+};
+
+q.module('HTML Track Element');
+
+test('html track element requires a tech', function() {
+  window.throws(
+    function() {
+      new HTMLTrackElement();
+    },
+    new Error('A tech was not provided.'),
+    'a tech is required for html track element'
+  );
+});
+
+test('can create a html track element with various properties', function() {
+  let kind = 'chapters',
+      label = 'English',
+      language = 'en',
+      src = 'http://www.example.com';
+
+  let htmlTrackElement = new  HTMLTrackElement({
+    kind,
+    label,
+    language,
+    src,
+    tech: defaultTech
+  });
+
+  equal(htmlTrackElement.default, undefined, 'we have a default');
+  equal(htmlTrackElement.kind, kind, 'we have a kind');
+  equal(htmlTrackElement.label, label, 'we have a label');
+  equal(htmlTrackElement.readyState, 0, 'we have a readyState');
+  equal(htmlTrackElement.src, src, 'we have a src');
+  equal(htmlTrackElement.srclang, language, 'we have a srclang');
+  equal(htmlTrackElement.track instanceof TextTrack, true, 'we have a track');
+});
+
+test('defaults when items not provided', function() {
+  let htmlTrackElement = new  HTMLTrackElement({
+    tech: defaultTech
+  });
+
+  equal(htmlTrackElement.default, undefined, 'we have a default');
+  equal(htmlTrackElement.kind, 'subtitles', 'we have a kind');
+  equal(htmlTrackElement.label, '', 'we have a label');
+  equal(htmlTrackElement.readyState, 0, 'we have a readyState');
+  equal(htmlTrackElement.src, undefined, 'we have a src');
+  equal(htmlTrackElement.srclang, '', 'we have a srclang');
+  equal(htmlTrackElement.track instanceof TextTrack, true, 'we have a track');
+});
+
+test('fires loadeddata when track cues become populated', function() {
+  let player = TestHelpers.makePlayer(),
+      changes = 0,
+      loadHandler;
+
+  loadHandler = function() {
+    changes++;
+  };
+
+  let htmlTrackElement = new HTMLTrackElement({
+    tech: player.tech_
+  });
+
+  htmlTrackElement.addEventListener('load', loadHandler);
+
+  // trigger loaded cues event
+  htmlTrackElement.track.trigger('loadeddata');
+
+  equal(changes, 1, 'a loadeddata event trigger addEventListener');
+  equal(htmlTrackElement.readyState, 2, 'readyState is loaded');
+
+  player.dispose();
+});

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -166,7 +166,7 @@ test('trigger "change" event when "modechange" is fired on a track', function() 
   equal(changes, 2, 'two change events should have fired');
 });
 
-test('trigger "change" event when mode changes on a TextTracl', function() {
+test('trigger "change" event when mode changes on a TextTrack', function() {
   var tt = new TextTrack({
         tech: {
           on: noop


### PR DESCRIPTION
Figure out when track elements are loaded so we can manipulate cues without having to do setTimeout hacks.

Addresses https://github.com/videojs/video.js/issues/2784.

Also addresses (maybe) https://github.com/videojs/video.js/issues/2799.