### PR TITLE
Do not display negative time

### DIFF
--- a/src/js/utils/format-time.js
+++ b/src/js/utils/format-time.js
@@ -12,6 +12,7 @@
  * @function formatTime
  */
 function formatTime(seconds, guide=seconds) {
+  seconds = seconds < 0 ? 0 : seconds;
   let s = Math.floor(seconds % 60);
   let m = Math.floor(seconds / 60 % 60);
   let h = Math.floor(seconds / 3600);

--- a/test/unit/utils/format-time.test.js
+++ b/test/unit/utils/format-time.test.js
@@ -20,6 +20,10 @@ test('should format time as a string', function(){
   // Don't do extra leading zeros for hours
   ok(formatTime(1,36000) === '0:00:01');
   ok(formatTime(1,360000) === '0:00:01');
+
+  // Do not display negative time
+  ok(formatTime(-1) === '0:00');
+  ok(formatTime(-1,3600) === '0:00:00');
 });
 
 test('should format invalid times as dashes', function(){


### PR DESCRIPTION
Sometimes at the end of an HLS video the remaining time is calculated as -1 (current time is greater than duration by a hundredth of a second, rounded to 1 second) causing the remaining time display to show "--1:0-1"

This PR sets negative seconds to 0 so that only a valid time or dashed time is displayed.