### PR TITLE
Check for text track changes that occurred before tech was listening

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -335,6 +335,7 @@ class Tech extends Component {
       }
     });
 
+    textTracksChanges();
     tracks.addEventListener('change', textTracksChanges);
 
     this.on('dispose', function() {

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -342,3 +342,13 @@ if (Html5.supportsNativeTextTracks()) {
     emulatedTt.on('addtrack', addtrack);
   });
 }
+
+test('should check for text track changes when emulating text tracks', function() {
+  let tech = new Tech();
+  let numTextTrackChanges = 0;
+  tech.on('texttrackchange', function() {
+    numTextTrackChanges++;
+  });
+  tech.emulateTextTracks();
+  equal(numTextTrackChanges, 1, 'we got a texttrackchange event');
+});


### PR DESCRIPTION
If any code sets a track mode during player setup (e.g., `track.mode = 'showing'`) for non native text tracks, there is a race case where the player may not be listening for changes on the track. For instance:

```javascript
var player = videojs('my-video', {
    html5: {
        nativeTextTracks: false
    }
});

var track = player.addTextTrack('captions');
track.mode = 'showing';
```

The caption settings will show the captions as on for the track, but the captions will not show up on the video unless a user switches to fullscreen or changes the caption settings (both will update display appropriately).

This change ensures that before videojs starts listening to change events on tracks, it gets any changes that may have happened between then and the start of setup.