### PR TITLE
This adds 'ended' event documentation for API docs

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2718,6 +2718,13 @@ Player.prototype.handleUserInactive_;
 Player.prototype.handleTimeUpdate_;
 
 /**
+ * Fired when video playback ends
+ *
+ * @event ended
+ */
+Player.prototype.handleTechEnded_;
+
+/**
  * Fired when the volume changes
  *
  * @event volumechange


### PR DESCRIPTION
I have seen some people complaining that no documentation about the 'ended' event seems to exist in the official API docs. As I have needed to implement functionality with it, I decided to add it. Please consider.