### PR TITLE
Fix npm WARN deprecated xhr@2.1.0 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "videojs-ie8": "1.1.0",
     "videojs-swf": "5.0.1",
     "vtt.js": "git+https://github.com/gkatsev/vtt.js.git#vjs-v0.12.1",
-    "xhr": "2.1.0"
+    "xhr": "~2.2.0"
   },
   "devDependencies": {
     "babel": "^5.2.2",


### PR DESCRIPTION
12:30:01 npm WARN deprecated xhr@2.1.0: incomplete release, not a valid succesor to v2.0.5, please update to v2.2.0

https://integration.wikimedia.org/ci/job/npm/38335/console