### PR TITLE
Implement source-first ordering in "selectSource" as an optional over…

### DIFF
--- a/docs/guides/tech.md
+++ b/docs/guides/tech.md
@@ -49,6 +49,40 @@ When adding additional Tech to a video player, make sure to add the supported te
       techOrder: ["html5", "flash", "other supported tech"]
     });
 
+Technology Ordering
+==================
+By default Video.js performs "Tech-first" ordering when it searches for a source/tech combination to play videos. This means that if you have two sources and two techs, video.js will try to play each video with the first tech in the `techOrder` option property before moving on to try the next playback technology.
+
+Tech-first ordering can present a problem if you have a `sourceHandler` that supports both `Html5` and `Flash` techs such as videojs-contrib-hls.
+
+For example, given the following video element:
+
+  <video data-setup='{"techOrder": ["html5", "flash"]}'>
+    <source src="http://your.static.provider.net/path/to/video.m3u8" type="application/x-mpegURL">
+    <source src="http://your.static.provider.net/path/to/video.mp4" type="video/mp4">
+  </video>
+
+There is a good chance that the mp4 source will be selected on platforms that do not have media source extensions. Video.js will try all sources against the first playback technology, in this case `Html5`, and select the first source that can play - in this case MP4.
+
+In "Tech-first" mode, the tests run something like this:
+  Can video.m3u8 play with Html5? No...
+  Can video.mp4 play with Html5? Yes! Use the second source.
+
+Video.js now provides another method of selecting the source - "Source-first" ordering. In this mode, Video.js tries the first source against every tech in `techOrder` before moving onto the next source.
+
+With a player setup as follows:
+
+  <video data-setup='{"techOrder": ["html5", "flash"]}, "sourceOrder": true'>
+    <source src="http://your.static.provider.net/path/to/video.m3u8" type="application/x-mpegURL">
+    <source src="http://your.static.provider.net/path/to/video.mp4" type="video/mp4">
+  </video>
+
+The Flash-based HLS support will be tried before falling back to the MP4 source.
+
+In "Source-first" mode, the tests run something like this:
+  Can video.m3u8 play with Html5? No...
+  Can video.m3u8 play with Flash? Yes! Use the first source.
+
 Flash Technology
 ==================
 The Flash playback tech is a part of the default `techOrder`. You may notice undesirable playback behavior in browsers that are subject to using this playback tech, in particular when scrubbing and seeking within a video. This behavior is a result of Flash's progressive video playback.

--- a/docs/guides/tech.md
+++ b/docs/guides/tech.md
@@ -72,7 +72,7 @@ Video.js now provides another method of selecting the source - "Source-first" or
 
 With a player setup as follows:
 
-  <video data-setup='{"techOrder": ["html5", "flash"]}, "sourceOrder": true'>
+  <video data-setup='{"techOrder": ["html5", "flash"], "sourceOrder": true}'>
     <source src="http://your.static.provider.net/path/to/video.m3u8" type="application/x-mpegURL">
     <source src="http://your.static.provider.net/path/to/video.mp4" type="video/mp4">
   </video>

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1693,7 +1693,9 @@ class Player extends Component {
   }
 
   /**
-   * Select source based on tech order
+   * Select source based on tech-order or source-order
+   * Uses source-order selection if `options.sourceOrder` is truthy. Otherwise,
+   * defaults to tech-order selection
    *
    * @param {Array} sources The sources for a media asset
    * @return {Object|Boolean} Object of source and tech order, otherwise false

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1713,10 +1713,7 @@ class Player extends Component {
           // Remove once that deprecated behavior is removed.
           return [techName, Tech.getTech(techName) || Component.getComponent(techName)];
         })
-        .filter((techArr) => {
-          let techName = techArr[0];
-          let tech = techArr[1];
-
+        .filter(([techName, tech]) => {
           // Check if the current tech is defined before continuing
           if (tech) {
             // Check if the browser supports this technology
@@ -1748,10 +1745,7 @@ class Player extends Component {
 
     let foundSourceAndTech;
     let flip = (fn) => (a, b) => fn(b, a);
-    let finder = (techArr, source) => {
-      let techName = techArr[0];
-      let tech = techArr[1];
-
+    let finder = ([techName, tech], source) => {
       if (tech.canPlaySource(source)) {
         return {source: source, tech: techName};
       }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -412,8 +412,8 @@ test('make sure that controls listeners do not get added too many times', functi
 
 test('should select the proper tech based on the the sourceOrder option',
   function() {
-    var fixture = document.getElementById('qunit-fixture');
-    var html =
+    let fixture = document.getElementById('qunit-fixture');
+    let html =
         '<video id="example_1">' +
           '<source src="fake.foo1" type="video/unsupported-format">' +
           '<source src="fake.foo2" type="video/foo-format">' +
@@ -433,9 +433,9 @@ test('should select the proper tech based on the the sourceOrder option',
     Tech.registerTech('PlaysUnsupported', PlaysUnsupported);
 
     fixture.innerHTML += html;
-    var tag = document.getElementById('example_1');
+    let tag = document.getElementById('example_1');
 
-    var player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported'], sourceOrder: true });
+    let player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported'], sourceOrder: true });
     equal(player.techName_, 'PlaysUnsupported', 'selected the PlaysUnsupported tech when sourceOrder is truthy');
     player.dispose();
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -7,6 +7,8 @@ import MediaError from '../../src/js/media-error.js';
 import Html5 from '../../src/js/tech/html5.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
+import Tech from '../../src/js/tech/tech.js';
+import TechFaker from './tech/tech-faker.js';
 
 q.module('Player', {
   'setup': function() {
@@ -419,8 +421,6 @@ test('should select the proper tech based on the the sourceOrder option',
 
     // Extend TechFaker to create a tech that plays the only mime-type that TechFaker
     // will not play
-    import Tech from '../../src/js/tech/tech.js';
-    import TechFaker from './tech/tech-faker.js';
     class PlaysUnsupported extends TechFaker {
       constructor(options, handleReady){
         super(options, handleReady);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -408,6 +408,45 @@ test('make sure that controls listeners do not get added too many times', functi
   player.dispose();
 });
 
+test('should select the proper tech based on the the sourceOrder option',
+  function() {
+    var fixture = document.getElementById('qunit-fixture');
+    var html =
+        '<video id="example_1">' +
+          '<source src="fake.foo1" type="video/unsupported-format">' +
+          '<source src="fake.foo2" type="video/foo-format">' +
+        '</video>';
+
+    // Extend TechFaker to create a tech that plays the only mime-type that TechFaker
+    // will not play
+    import Tech from '../../src/js/tech/tech.js';
+    import TechFaker from './tech/tech-faker.js';
+    class PlaysUnsupported extends TechFaker {
+      constructor(options, handleReady){
+        super(options, handleReady);
+      }
+      // Support ONLY "video/unsupported-format"
+      static isSupported() { return true; }
+      static canPlayType(type) { return (type === 'video/unsupported-format' ? 'maybe' : ''); }
+      static canPlaySource(srcObj) { return srcObj.type === 'video/unsupported-format'; }
+    }
+    Tech.registerTech('PlaysUnsupported', PlaysUnsupported);
+
+    fixture.innerHTML += html;
+    var tag = document.getElementById('example_1');
+
+    var player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported'], sourceOrder: true });
+    equal(player.techName_, 'PlaysUnsupported', 'selected the PlaysUnsupported tech when sourceOrder is truthy');
+    player.dispose();
+
+    fixture.innerHTML += html;
+    tag = document.getElementById('example_1');
+
+    player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported']});
+    equal(player.techName_, 'TechFaker', 'selected the TechFaker tech when sourceOrder is falsey');
+    player.dispose();
+});
+
 test('should register players with generated ids', function(){
   var fixture, video, player, id;
   fixture = document.getElementById('qunit-fixture');


### PR DESCRIPTION
…ride to the currently implemented default "tech-first" ordering

Video.js currently uses a tech-first slection algorithm (ie. find the first source that can be decoded by the first tech. if none, try the next tech and repeat.) but the video element does something more like source-first. This commit implements the semantics of an optional source-first selection system in video.js