### PR TITLE
Prevent non native text tracks from leaking cuechange event listeners

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -321,9 +321,8 @@ class Tech extends Component {
       window['WebVTT'] = true;
     }
 
-    let textTracksChanges = Fn.bind(this, function() {
-      let updateDisplay = () => this.trigger('texttrackchange');
-
+    let updateDisplay = () => this.trigger('texttrackchange');
+    let textTracksChanges = () => {
       updateDisplay();
 
       for (let i = 0; i < tracks.length; i++) {
@@ -333,7 +332,7 @@ class Tech extends Component {
           track.addEventListener('cuechange', updateDisplay);
         }
       }
-    });
+    };
 
     tracks.addEventListener('change', textTracksChanges);
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -2,6 +2,7 @@ import ChaptersButton from '../../../src/js/control-bar/text-track-controls/chap
 import SubtitlesButton from '../../../src/js/control-bar/text-track-controls/subtitles-button.js';
 import CaptionsButton from '../../../src/js/control-bar/text-track-controls/captions-button.js';
 
+import TextTrack from '../../../src/js/tracks/text-track.js';
 import TextTrackDisplay from '../../../src/js/tracks/text-track-display.js';
 import Html5 from '../../../src/js/tech/html5.js';
 import Flash from '../../../src/js/tech/flash.js';
@@ -342,3 +343,48 @@ if (Html5.supportsNativeTextTracks()) {
     emulatedTt.on('addtrack', addtrack);
   });
 }
+
+test('removes cuechange event when text track is hidden for emulated tracks', function() {
+  let player = TestHelpers.makePlayer();
+  let tt = new TextTrack({
+    tech: player.tech_,
+    mode: 'showing'
+  });
+  tt.addCue({
+    id: '1',
+    startTime: 2,
+    endTime: 5
+  });
+  player.tech_.textTracks().addTrack_(tt);
+  player.tech_.emulateTextTracks();
+
+  let numTextTrackChanges = 0;
+  player.tech_.on('texttrackchange', function() {
+    numTextTrackChanges++;
+  });
+
+  tt.mode = 'showing';
+  equal(numTextTrackChanges, 1,
+    'texttrackchange should be called once for mode change');
+  tt.mode = 'showing';
+  equal(numTextTrackChanges, 2,
+    'texttrackchange should be called once for mode change');
+
+  player.tech_.currentTime = function() {
+    return 3;
+  };
+  player.tech_.trigger('timeupdate');
+  equal(numTextTrackChanges, 3,
+    'texttrackchange should be triggered once for the cuechange');
+
+  tt.mode = 'hidden';
+  equal(numTextTrackChanges, 4,
+    'texttrackchange should be called once for the mode change');
+
+  player.tech_.currentTime = function() {
+    return 7;
+  };
+  player.tech_.trigger('timeupdate');
+  equal(numTextTrackChanges, 4,
+    'texttrackchange should be not be called since mode is hidden');
+});


### PR DESCRIPTION
Due to a new updateDisplay function being generated on each invocation of the textTracksChanges function within emulateTextTracks of Tech, the cuechange event listener which called updateDisplay was not getting removed when looping through text tracks. This created a leak where updateDisplay could be called many times on a single track cuechange event.

An example of this can be seen by running the following:

```javascript
var player = videojs('my-video', {
  html5: {
    nativeTextTracks: false
  }
});

player.on(‘ready’, function() {  
  var track = player.addTextTrack('captions');
  track.addCue(new VTTCue(1, 2, 'Test'));
  track.mode = 'showing';
  track.mode = 'showing';
  track.mode = 'showing';
  player.tech_.on('texttrackchange', function() { console.log('Text track change'); });
  player.play();
});
```

When a cuechange is reached (the first being at 1 second), texttrackchange will be triggered 3 times (one for each set of track.mode).

This change moves the updateDisplay function outside of the textTracksChanges function, so that it will not be regenerated on each call of textTracksChanges.