### PR TITLE
Added `display: -moz-box` to display-flex mixin

### DIFF
--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -46,6 +46,7 @@
 
 @mixin display-flex($alignment: '', $justification: '') {
   display: -webkit-box;
+  display: -moz-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;


### PR DESCRIPTION
Added `display: -moz-box` to display-flex mixin to support Firefox 19- (buggy but mostly works)
Refs: https://css-tricks.com/using-flexbox/