### PR TITLE
videojs-ie8 to 1.1.1

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -9,7 +9,7 @@ Step 1: Include the Video.js Javascript and CSS files in the head of your page.
 You can download the Video.js source and host it on your own servers, or use the free CDN hosted version. As of Video.js 5.0, the source is [transpiled from ES2015](http://babeljs.io/) (formerly known as ES6) to [ES5](https://es5.github.io/), but IE8 only supports ES3. In order to continue to support IE8, we've bundled an [ES5 shim and sham](https://github.com/es-shims/es5-shim) together and hosted it on the CDN.
 
 ```html
-<script src="//vjs.zencdn.net/ie8/1.1.0/videojs-ie8.min.js"></script>
+<script src="//vjs.zencdn.net/ie8/1.1.1/videojs-ie8.min.js"></script>
 ```
 
 ### CDN Version ###

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "safe-json-parse": "^4.0.0",
     "tsml": "1.0.1",
     "videojs-font": "1.4.0",
-    "videojs-ie8": "1.1.0",
+    "videojs-ie8": "1.1.1",
     "videojs-swf": "5.0.1",
     "vtt.js": "git+https://github.com/gkatsev/vtt.js.git#vjs-v0.12.1",
     "xhr": "~2.2.0"


### PR DESCRIPTION
Pretty self-explanatory. Brings in updates/bugfixes for the IE8 script's dependency, es5-shim.