### PR TITLE
Add Player#reset function.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1924,13 +1924,14 @@ class Player extends Component {
   }
 
   /**
-   * Reset the player. Removes all sources, loads the Html tech, and calls `load`.
+   * Reset the player. Loads the first tech in the techOrder,
+   * and calls `reset` on the tech`.
    *
    * @return {Player} Returns the player
    * @method reset
    */
   reset() {
-    this.loadTech_('Html5', null);
+    this.loadTech_(toTitleCase(this.options_.techOrder[0]), null);
     this.techCall_('reset');
     return this;
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1924,6 +1924,18 @@ class Player extends Component {
   }
 
   /**
+   * Reset the player. Removes all sources, loads the Html tech, and calls `load`.
+   *
+   * @return {Player} Returns the player
+   * @method reset
+   */
+  reset() {
+    this.loadTech_('Html5', null);
+    this.techCall_('reset');
+    return this;
+  }
+
+  /**
    * Returns the fully qualified URL of the current source value e.g. http://mysite.com/video.mp4
    * Can be used in conjuction with `currentType` to assist in rebuilding the current source object.
    *

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -86,9 +86,6 @@ class Html5 extends Tech {
 
     this.triggerReady();
   }
-  clearMedia() {
-    Html5.clearMediaElement(this.el());
-  }
 
   /**
    * Dispose of html5 media element

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1123,7 +1123,7 @@ Html5.resetMediaElement = function(el){
       try {
         el.load();
       } catch (e) {}
-    })()
+    })();
   }
 };
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -86,6 +86,9 @@ class Html5 extends Tech {
 
     this.triggerReady();
   }
+  clearMedia() {
+    Html5.clearMediaElement(this.el());
+  }
 
   /**
    * Dispose of html5 media element
@@ -484,6 +487,15 @@ class Html5 extends Tech {
    */
   load(){
     this.el_.load();
+  }
+
+  /**
+   * Reset the tech. Removes all sources and calls `load`.
+   *
+   * @method reset
+   */
+  reset() {
+    Html5.resetMediaElement(this.el_);
   }
 
   /**
@@ -1089,6 +1101,29 @@ Html5.disposeMediaElement = function(el){
         // not supported
       }
     })();
+  }
+};
+
+Html5.resetMediaElement = function(el){
+  if (!el) { return; }
+
+  let sources = el.querySelectorAll('source');
+  let i = sources.length;
+  while (i--) {
+    el.removeChild(sources[i]);
+  }
+
+  // remove any src reference.
+  // not setting `src=''` because that throws an error
+  el.removeAttribute('src');
+
+  if (typeof el.load === 'function') {
+    // wrapping in an iife so it's not deoptimized (#1060#discussion_r10324473)
+    (function() {
+      try {
+        el.load();
+      } catch (e) {}
+    })()
   }
 };
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -234,6 +234,13 @@ class Tech extends Component {
   }
 
   /**
+   * Reset the tech. Removes all sources and resets readyState.
+   *
+   * @method reset
+   */
+  reset() {}
+
+  /**
    * When invoked without an argument, returns a MediaError object
    * representing the current error state of the player or null if
    * there is no error. When invoked with an argument, set the current

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -891,6 +891,9 @@ test('player#reset loads the Html5 tech and then techCalls reset', function() {
   let techCallMethod;
 
   let testPlayer = {
+    options_: {
+      techOrder: ['html5', 'flash'],
+    },
     loadTech_(tech, source) {
       loadedTech = tech;
       loadedSource = source;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -884,3 +884,25 @@ test('Player#tech alerts and throws without the appropriate input', function() {
   ok(alertCalled, 'we called an alert');
   window.alert = oldAlert;
 });
+
+test('player#reset loads the Html5 tech and then techCalls reset', function() {
+  let loadedTech;
+  let loadedSource;
+  let techCallMethod;
+
+  let testPlayer = {
+    loadTech_(tech, source) {
+      loadedTech = tech;
+      loadedSource = source;
+    },
+    techCall_(method) {
+      techCallMethod = method;
+    }
+  }
+
+  Player.prototype.reset.call(testPlayer);
+
+  equal(loadedTech, 'Html5', 'we loaded the html5 tech');
+  equal(loadedSource, null, 'with a null source');
+  equal(techCallMethod, 'reset', 'we then reset the tech');
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -909,3 +909,28 @@ test('player#reset loads the Html5 tech and then techCalls reset', function() {
   equal(loadedSource, null, 'with a null source');
   equal(techCallMethod, 'reset', 'we then reset the tech');
 });
+
+test('player#reset loads the first item in the techOrder and then techCalls reset', function() {
+  let loadedTech;
+  let loadedSource;
+  let techCallMethod;
+
+  let testPlayer = {
+    options_: {
+      techOrder: ['flash', 'html5'],
+    },
+    loadTech_(tech, source) {
+      loadedTech = tech;
+      loadedSource = source;
+    },
+    techCall_(method) {
+      techCallMethod = method;
+    }
+  };
+
+  Player.prototype.reset.call(testPlayer);
+
+  equal(loadedTech, 'Flash', 'we loaded the Flash tech');
+  equal(loadedSource, null, 'with a null source');
+  equal(techCallMethod, 'reset', 'we then reset the tech');
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -898,7 +898,7 @@ test('player#reset loads the Html5 tech and then techCalls reset', function() {
     techCall_(method) {
       techCallMethod = method;
     }
-  }
+  };
 
   Player.prototype.reset.call(testPlayer);
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -337,3 +337,17 @@ test('Html5.resetMediaElement should remove sources and call load', function() {
   equal(removedAttribute, 'src', 'we removed the src attribute');
   ok(loaded, 'we called load on the element');
 });
+
+test('Html5#reset calls Html5.resetMediaElement when called', function() {
+  let oldResetMedia = Html5.resetMediaElement;
+  let resetEl;
+
+  Html5.resetMediaElement = (el) => resetEl = el;
+
+  let el = {};
+  Html5.prototype.reset.call({el_: el});
+
+  equal(resetEl, el, 'we called resetMediaElement with the tech\'s el');
+
+  Html5.resetMediaElement = oldResetMedia;
+});

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -304,3 +304,36 @@ test('should fire makeup events when a video tag is initialized late', function(
   testStates({ networkState: 1, readyState: 3 }, ['loadstart', 'loadedmetadata', 'loadeddata', 'canplay']);
   testStates({ networkState: 1, readyState: 4 }, ['loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough']);
 });
+
+test('Html5.resetMediaElement should remove sources and call load', function() {
+  let selector;
+  let removedChildren = [];
+  let removedAttribute;
+  let loaded;
+
+  let children = ['source1', 'source2', 'source3'];
+  let testEl = {
+    querySelectorAll(input) {
+      selector = input;
+      return children;
+    },
+
+    removeChild(child) {
+      removedChildren.push(child);
+    },
+
+    removeAttribute(attr) {
+      removedAttribute = attr;
+    },
+
+    load() {
+      loaded = true;
+    }
+  };
+
+  Html5.resetMediaElement(testEl);
+  equal(selector, 'source', 'we got the source elements from the test el');
+  deepEqual(removedChildren, children.reverse(), 'we removed the children that were present');
+  equal(removedAttribute, 'src', 'we removed the src attribute');
+  ok(loaded, 'we called load on the element');
+});


### PR DESCRIPTION
Reset loads in the html5 tech and then resets the media element via a
tech call.
A techCall was used so that other techs could implement reset
functionality as well and we could theoretically not switch to the Html5
tech on reset.
Fixes https://github.com/videojs/video.js/issues/2852