### PR TITLE
Consistent width for fullscreen button and time-control

### DIFF
--- a/src/css/components/_fullscreen.scss
+++ b/src/css/components/_fullscreen.scss
@@ -1,5 +1,4 @@
 .video-js .vjs-fullscreen-control {
-  width: 3.8em;
   cursor: pointer;
   @include flex(none);
 }

--- a/src/css/components/_time.scss
+++ b/src/css/components/_time.scss
@@ -2,7 +2,7 @@
   @include flex(none);
   font-size: 1em;
   line-height: 3em;
-  min-width: 4em;
+  min-width: 2em;
   width: auto;
   padding-left: 1em;
   padding-right: 1em;

--- a/src/css/components/_time.scss
+++ b/src/css/components/_time.scss
@@ -2,6 +2,10 @@
   @include flex(none);
   font-size: 1em;
   line-height: 3em;
+  min-width: 4em;
+  width: auto;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 .vjs-live .vjs-time-control {


### PR DESCRIPTION
This changes the width of the fullscreen button to 4em. For some
reason it was 3.8, but that doesn't make much sense and is not in line
with the other controls.

It also sets the textual time-control's width to auto with a 1em
padding to the left and right. Again this is more in line with the
behavior of the other controls.

I do find the entire interface slightly too wide to my liking, but that is exactly why it should be consistent, so that if required, it would be easier for me to override.