### PR TITLE
added ability to release as @next from master

### DIFF
--- a/contrib.json
+++ b/contrib.json
@@ -253,9 +253,8 @@
     "prerelease": {
       "release_type": "prerelease",
       "steps": [
-        [ "git checkout master",                       "Checkout the developmet branch" ],
-        [ "git pull upstream master",                  "Update the developmet branch" ],
         { "include": "branch check" },
+        { "include": "update local master" },
         [ "git checkout -b temp-release-branch master","Create a temporary branch for the dist" ],
         [ "grunt version:{{release_type}}",            "Bump package versions" ],
         [ "./build/bin/version",                       "Return the current VJS Version from the package.json file", "version" ],

--- a/contrib.json
+++ b/contrib.json
@@ -250,8 +250,30 @@
       ]
     },
 
+    "next": {
+      "patch": {
+        "description": "Create a patch release and tag it @next on npm",
+        "release_type": "patch",
+        "steps": [{ "include": "release run_next" }]
+      },
+      "minor": {
+        "description": "Create a minor release and tag it @next on npm",
+        "release_type": "minor",
+        "steps": [{ "include": "release run_next" }]
+      },
+      "major": {
+        "description": "Create a major release and tag it @next on npm",
+        "release_type": "major",
+        "steps": [{ "include": "release run_next" }]
+      }
+    },
+
     "prerelease": {
       "release_type": "prerelease",
+      "steps": [{ "include": "release run_next" }]
+    },
+
+    "run_next": {
       "steps": [
         { "include": "branch check" },
         { "include": "update local master" },
@@ -273,6 +295,7 @@
         [ "git branch -D temp-release-branch",         "Delete the temp release branch" ]
       ]
     },
+
     "run": {
       "steps": [
         { "include": "branch check" },


### PR DESCRIPTION
Here's the output of `contrib release next minor`:
```sh
$ contrib release next minor --dry-run

DRY RUN OF release next minor

STEP 1. Ensure there&#x27;s no unadded changes
$ git diff --exit-code

STEP 2. Ensure there&#x27;s no uncommitted changes
$ git diff --cached --exit-code

STEP 3. Switch to the development branch
$ git checkout master

STEP 4. Get any changes to master in the main project
$ git pull upstream master

STEP 5. Create a temporary branch for the dist
$ git checkout -b temp-release-branch master

STEP 6. Bump package versions
$ grunt version:{{release_type}}

STEP 7 (ID: version). Return the current VJS Version from the package.json file
$ ./build/bin/version

STEP 8. Add and commit the package changes
$ git commit -am 'v{{version}}'

STEP 9. Checkout the developmet branch
$ git checkout master

STEP 10. Merge package changes into the dev brach
$ git merge temp-release-branch

STEP 11. Push the dev branch changes to the repo
$ git push upstream master

STEP 12. Checkout the temp branch again
$ git checkout temp-release-branch

STEP 13. Build the dist
$ grunt dist

STEP 14. Add the (otherwise ignored) release files
$ git add dist --force

STEP 15. Commit the dist changes
$ git commit -m 'v{{version}} dist'

STEP 16. Tag the release
$ git tag -a v{{version}} -m 'v{{version}}'

STEP 17. Push the new tag to the repo
$ git push upstream --tags

STEP 18. Publish to npm as &#x27;next&#x27;
$ npm publish --tag next

STEP 19. Checkout the developmet branch
$ git checkout master

STEP 20. Delete the temp release branch
$ git branch -D temp-release-branch


IT'S OVER!
```

Fixes #2868