### PR TITLE
Fix menu keyboard access and ARIA labeling for screen readers (Fixes #2155 and #2769)

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -39,8 +39,7 @@ class Button extends Component {
    */
   createEl(tag='button', props={}, attributes={}) {
     props = assign({
-      className: this.buildCSSClass(),
-      tabIndex: 0
+      className: this.buildCSSClass()
     }, props);
 
     if (tag === 'button') {
@@ -52,6 +51,11 @@ class Button extends Component {
       }, attributes);
     } else {
       this.isButtonElement_ = false;
+
+      // If the element isn't a button, it needs tabIndex=0 to allow keyboard focus
+      props = assign({
+        tabIndex: 0
+      }, props);
 
       // Add ARIA attributes for clickable non-button element
       attributes = assign({

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -43,10 +43,24 @@ class Button extends Component {
       tabIndex: 0
     }, props);
 
-    // Add standard Aria info
+    if (tag === 'button') {
+      this.isButtonElement_ = true;
+
+      // Add attributes for button element
+      attributes = assign({
+        type: 'button' // Necessary since the default button type is "submit"
+      }, attributes);
+    } else {
+      this.isButtonElement_ = false;
+
+      // Add ARIA attributes for clickable non-button element
+      attributes = assign({
+        role: 'button'
+      }, attributes);
+    }
+
+    // Add common ARIA attributes
     attributes = assign({
-      role: 'button',
-      type: 'button', // Necessary since the default button type is "submit"
       'aria-live': 'polite' // let the screen reader user know that the text of the button may change
     }, attributes);
 
@@ -111,10 +125,13 @@ class Button extends Component {
    * @method handleKeyPress
    */
   handleKeyPress(event) {
-    // Check for space bar (32) or enter (13) keys
-    if (event.which === 32 || event.which === 13) {
-      event.preventDefault();
-      this.handleClick(event);
+    // A button element already handles Space or Enter key to fire a click event
+    if (!this.isButtonElement_) {
+      // Check for space bar (32) or enter (13) keys
+      if (event.which === 32 || event.which === 13) {
+        event.preventDefault();
+        this.handleClick(event);
+      }
     }
   }
 

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -38,6 +38,8 @@ class ControlBar extends Component {
   createEl() {
     return super.createEl('div', {
       className: 'vjs-control-bar'
+    }, {
+      'role': 'group' // The control bar is a group, so it can contain menuitems
     });
   }
 }

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -29,6 +29,7 @@ import Component from '../../component.js';
 
     super(player, options);
     this.addClass('vjs-texttrack-settings');
+    this.controlText(', opens ' + options['kind'] + ' settings dialog');
   }
 
   /**

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -19,9 +19,13 @@ import Component from '../../component.js';
       'kind': options['kind'],
       'player': player,
       'label': options['kind'] + ' settings',
+      'selectable': false,
       'default': false,
       mode: 'disabled'
     };
+
+    // CaptionSettingsMenuItem has no concept of 'selected'
+    options['selectable'] = false;
 
     super(player, options);
     this.addClass('vjs-texttrack-settings');
@@ -34,6 +38,7 @@ import Component from '../../component.js';
    */
   handleClick() {
     this.player().getChild('textTrackSettings').show();
+    this.player().getChild('textTrackSettings').el_.focus();
   }
 
 }

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -25,6 +25,9 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
       'mode': 'disabled'
     };
 
+    // MenuItem is selectable
+    options['selectable'] = true;
+
     super(player, options);
     this.selected(true);
   }

--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -57,6 +57,8 @@ class TextTrackButton extends MenuButton {
       // only add tracks that are of the appropriate kind and have a label
       if (track['kind'] === this.kind_) {
         items.push(new TextTrackMenuItem(this.player_, {
+          // MenuItem is selectable
+          'selectable': true,
           'track': track
         }));
       }

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -24,6 +24,7 @@ class TextTrackMenuItem extends MenuItem {
     // Modify options for parent MenuItem class's init.
     options['label'] = track['label'] || track['language'] || 'Unknown';
     options['selected'] = track['default'] || track['mode'] === 'showing';
+
     super(player, options);
 
     this.track = track;

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -24,7 +24,7 @@ class MenuButton extends Button {
     this.update();
 
     this.el_.setAttribute('aria-haspopup', true);
-    this.el_.setAttribute('role', 'menu');
+    this.el_.setAttribute('role', 'menuitem');
     this.on('keydown', this.handleSubmenuKeyPress);
   }
 

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -25,7 +25,7 @@ class MenuButton extends Button {
 
     this.on('keydown', this.handleKeyPress);
     this.el_.setAttribute('aria-haspopup', true);
-    this.el_.setAttribute('role', 'button');
+    this.el_.setAttribute('role', 'menu');
   }
 
   /**
@@ -201,7 +201,7 @@ class MenuButton extends Button {
   pressButton() {
     this.buttonPressed_ = true;
     this.menu.lockShowing();
-    this.el_.setAttribute('aria-pressed', true);
+    this.el_.setAttribute('aria-expanded', true);
     if (this.items && this.items.length > 0) {
       this.items[0].el().focus(); // set the focus to the title of the submenu
     }
@@ -215,7 +215,7 @@ class MenuButton extends Button {
   unpressButton() {
     this.buttonPressed_ = false;
     this.menu.unlockShowing();
-    this.el_.setAttribute('aria-pressed', false);
+    this.el_.setAttribute('aria-expanded', false);
   }
 }
 

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -23,9 +23,9 @@ class MenuButton extends Button {
 
     this.update();
 
-    this.on('keydown', this.handleKeyPress);
     this.el_.setAttribute('aria-haspopup', true);
     this.el_.setAttribute('role', 'menu');
+    this.on('keydown', this.handleSubmenuKeyPress);
   }
 
   /**
@@ -50,6 +50,7 @@ class MenuButton extends Button {
      * @private
      */
     this.buttonPressed_ = false;
+    this.el_.setAttribute('aria-expanded', false);
 
     if (this.items && this.items.length === 0) {
       this.hide();
@@ -127,27 +128,6 @@ class MenuButton extends Button {
   }
 
   /**
-   * Focus - Add keyboard functionality to element
-   * This function is not needed anymore. Instead, the
-   * keyboard functionality is handled by
-   * treating the button as triggering a submenu.
-   * When the button is pressed, the submenu
-   * appears. Pressing the button again makes
-   * the submenu disappear.
-   *
-   * @method handleFocus
-   */
-  handleFocus() {}
-
-  /**
-   * Can't turn off list display that we turned
-   * on with focus, because list would go away.
-   *
-   * @method handleBlur
-   */
-  handleBlur() {}
-
-  /**
    * When you click the button it adds focus, which
    * will show the menu indefinitely.
    * So we'll remove focus when the mouse leaves the button.
@@ -171,25 +151,48 @@ class MenuButton extends Button {
   /**
    * Handle key press on menu
    *
-   * @param {Object} Key press event
+   * @param {Object} event Key press event
    * @method handleKeyPress
    */
   handleKeyPress(event) {
 
-    // Check for space bar (32) or enter (13) keys
-    if (event.which === 32 || event.which === 13) {
-      if (this.buttonPressed_){
+    // Escape (27) key or Tab (9) key unpress the 'button'
+    if (event.which === 27 || event.which === 9) {
+      if (this.buttonPressed_) {
         this.unpressButton();
-      } else {
+      }
+      // Don't preventDefault for Tab key - we still want to lose focus
+      if (event.which !== 9) {
+        event.preventDefault();
+      }
+    // Up (38) key or Down (40) key press the 'button'
+    } else if (event.which === 38 || event.which === 40) {
+      if (!this.buttonPressed_) {
         this.pressButton();
+        event.preventDefault();
       }
-      event.preventDefault();
-    // Check for escape (27) key
-    } else if (event.which === 27){
+    } else {
+      super.handleKeyPress(event);
+    }
+  }
+
+  /**
+   * Handle key press on submenu
+   *
+   * @param {Object} event Key press event
+   * @method handleSubmenuKeyPress
+   */
+  handleSubmenuKeyPress(event) {
+
+    // Escape (27) key or Tab (9) key unpress the 'button'
+    if (event.which === 27 || event.which === 9){
       if (this.buttonPressed_){
         this.unpressButton();
       }
-      event.preventDefault();
+      // Don't preventDefault for Tab key - we still want to lose focus
+      if (event.which !== 9) {
+        event.preventDefault();
+      }
     }
   }
 
@@ -202,9 +205,7 @@ class MenuButton extends Button {
     this.buttonPressed_ = true;
     this.menu.lockShowing();
     this.el_.setAttribute('aria-expanded', true);
-    if (this.items && this.items.length > 0) {
-      this.items[0].el().focus(); // set the focus to the title of the submenu
-    }
+    this.menu.focus(); // set the focus into the submenu
   }
 
   /**
@@ -216,6 +217,7 @@ class MenuButton extends Button {
     this.buttonPressed_ = false;
     this.menu.unlockShowing();
     this.el_.setAttribute('aria-expanded', false);
+    this.el_.focus(); // Set focus back to this menu button
   }
 }
 

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -42,7 +42,8 @@ class MenuItem extends Button {
   createEl(type, props, attrs) {
     return super.createEl('li', assign({
       className: 'vjs-menu-item',
-      innerHTML: this.localize(this.options_['label'])
+      innerHTML: this.localize(this.options_['label']),
+      tabIndex: -1
     }, props), attrs);
   }
 

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -17,7 +17,18 @@ class MenuItem extends Button {
 
   constructor(player, options) {
     super(player, options);
+
+    this.selectable = options['selectable'];
+
     this.selected(options['selected']);
+
+    if (this.selectable) {
+      // TODO: May need to be either menuitemcheckbox or menuitemradio,
+      //       and may need logical grouping of menu items.
+      this.el_.setAttribute('role', 'menuitemcheckbox');
+    } else {
+      this.el_.setAttribute('role', 'menuitem');
+    }
   }
 
   /**
@@ -51,12 +62,14 @@ class MenuItem extends Button {
    * @method selected
    */
   selected(selected) {
-    if (selected) {
-      this.addClass('vjs-selected');
-      this.el_.setAttribute('aria-selected',true);
-    } else {
-      this.removeClass('vjs-selected');
-      this.el_.setAttribute('aria-selected',false);
+    if (this.selectable) {
+      if (selected) {
+        this.addClass('vjs-selected');
+        this.el_.setAttribute('aria-checked',true);
+      } else {
+        this.removeClass('vjs-selected');
+        this.el_.setAttribute('aria-checked',false);
+      }
     }
   }
 

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -67,13 +67,18 @@ class MenuItem extends Button {
       if (selected) {
         this.addClass('vjs-selected');
         this.el_.setAttribute('aria-checked',true);
+        // aria-checked isn't fully supported by browsers/screen readers,
+        // so indicate selected state to screen reader in the control text.
+        this.controlText(', selected');
       } else {
         this.removeClass('vjs-selected');
         this.el_.setAttribute('aria-checked',false);
+        // Indicate un-selected state to screen reader
+        // Note that a space clears out the selected state text
+        this.controlText(' ');
       }
     }
   }
-
 }
 
 Component.registerComponent('MenuItem', MenuItem);

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -48,7 +48,7 @@ class Menu extends Component {
     this.contentEl_ = Dom.createEl(contentElType, {
       className: 'vjs-menu-content'
     });
-    this.contentEl_.setAttribute('role', 'presentation');
+    this.contentEl_.setAttribute('role', 'menu');
     var el = super.createEl('div', {
       append: this.contentEl_,
       className: 'vjs-menu'

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -15,6 +15,14 @@ import * as Events from '../utils/events.js';
  */
 class Menu extends Component {
 
+  constructor (player, options) {
+    super(player, options);
+
+    this.focusedChild_ = -1;
+
+    this.on('keydown', this.handleKeyPress);
+  }
+
   /**
    * Add a menu item to the menu
    *
@@ -25,6 +33,7 @@ class Menu extends Component {
     this.addChild(component);
     component.on('click', Fn.bind(this, function(){
       this.unlockShowing();
+      //TODO: Need to set keyboard focus back to the menuButton
     }));
   }
 
@@ -39,10 +48,12 @@ class Menu extends Component {
     this.contentEl_ = Dom.createEl(contentElType, {
       className: 'vjs-menu-content'
     });
+    this.contentEl_.setAttribute('role', 'presentation');
     var el = super.createEl('div', {
       append: this.contentEl_,
       className: 'vjs-menu'
     });
+    el.setAttribute('role', 'presentation');
     el.appendChild(this.contentEl_);
 
     // Prevent clicks from bubbling up. Needed for Menu Buttons,
@@ -53,6 +64,72 @@ class Menu extends Component {
     });
 
     return el;
+  }
+
+  /**
+   * Handle key press for menu
+   *
+   * @param {Object} event Event object
+   * @method handleKeyPress
+   */
+  handleKeyPress (event) {
+    if (event.which === 37 || event.which === 40) { // Left and Down Arrows
+      event.preventDefault();
+      this.stepForward();
+    } else if (event.which === 38 || event.which === 39) { // Up and Right Arrows
+      event.preventDefault();
+      this.stepBack();
+    }
+  }
+
+  /**
+   * Move to next (lower) menu item for keyboard users
+   *
+   * @method stepForward
+   */
+   stepForward () {
+     let stepChild = 0;
+
+     if (this.focusedChild_ !== undefined) {
+       stepChild = this.focusedChild_ + 1;
+     }
+     this.focus(stepChild);
+   }
+
+   /**
+    * Move to previous (higher) menu item for keyboard users
+    *
+    * @method stepBack
+    */
+  stepBack () {
+    let stepChild = 0;
+
+    if (this.focusedChild_ !== undefined) {
+      stepChild = this.focusedChild_ - 1;
+    }
+    this.focus(stepChild);
+  }
+
+  /**
+   * Set focus on a menu item in the menu
+   *
+   * @param {Object|String} item Index of child item set focus on
+   * @method focus
+   */
+  focus (item = 0) {
+    let children = this.children();
+
+    if (children.length > 0) {
+      if (item < 0) {
+        item = 0;
+      } else if (item >= children.length) {
+        item = children.length - 1;
+      }
+
+      this.focusedChild_ = item;
+
+      children[item].el_.focus();
+    }
   }
 }
 


### PR DESCRIPTION
Implement ARIA-specified keyboard access to control bar menus (as in http://www.w3.org/TR/wai-aria-practices-1.1/#menu), and ARIA markup to indicate menu role and state to screen readers.

This also fixes #1446 / #1447, which seemed to have come back (or was never actually resolved) as an issue for keyboard access of menus.

This fix depends on #2889.