### PR TITLE
Set a min-width for the progress slider of 4em

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -15,6 +15,7 @@
 .video-js .vjs-progress-control {
   @include flex(auto);
   @include display-flex(center);
+  min-width: 4em;
 }
 
 .vjs-live .vjs-progress-control {


### PR DESCRIPTION
This is in line with the width of other controls. And at the default
size of the player, anything under 4em is rather unusable actually.