### PR TITLE
Fixing #2831

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -59,14 +59,14 @@ var autoSetup = function(){
 
       // If getAttribute isn't defined, we need to wait for the DOM.
       } else {
-        autoSetupTimeout(1);
+        setTimeout(autoSetup, 1);
         break;
       }
     }
 
   // No videos were found, so keep looping unless page is finished loading.
   } else if (!_windowLoaded) {
-    autoSetupTimeout(1);
+    setTimeout(autoSetup, 1);
   }
 };
 


### PR DESCRIPTION
Fixing #2831. Not setting videojs to undefined when the window is not loaded.