### PR TITLE
Correct adaptive layout selectors to match their intent

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -5,10 +5,10 @@
   .vjs-custom-control-spacer { @include flex(auto); }
   &.vjs-no-flex .vjs-custom-control-spacer { width: auto; }
 
-  .vjs-current-time, .vjs-captions-button, .vjs-time-divider,
-  .vjs-progress-control, .vjs-duration, .vjs-remaining-time, .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control, .vjs-chapters-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-volume-menu-button { display: none; }
+  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
+  .vjs-playback-rate, .vjs-progress-control,
+  .vjs-mute-control, .vjs-volume-control, .vjs-volume-menu-button,
+  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
 }
 
 // When the player is x-small, display nothing but:
@@ -16,10 +16,10 @@
 // - Progress bar
 // - Fullscreen Button
 .video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
-  .vjs-current-time, .vjs-captions-button, .vjs-time-divider,
-  .vjs-duration, .vjs-remaining-time, .vjs-playback-rate, .vjs-captions-button,
-  .vjs-mute-control, .vjs-volume-control, .vjs-chapters-button,
-  .vjs-subtitles-button, .vjs-volume-button, .vjs-fullscreen-control { display: none; }
+  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
+  .vjs-playback-rate,
+  .vjs-mute-control, .vjs-volume-control, .vjs-volume-menu-button,
+  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
 }
 
 
@@ -30,8 +30,8 @@
 // - Captions Button
 // - Fullscreen button
 .video-js.vjs-layout-small:not(.vjs-fullscreen) {
-  .vjs-current-time, .vjs-captions-button, .vjs-time-divider,
-  .vjs-duration, .vjs-remaining-time, .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control, .vjs-chapters-button,
-  .vjs-subtitles-button { display: none; }
+  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
+  .vjs-playback-rate,
+  .vjs-mute-control, .vjs-volume-control,
+  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
 }


### PR DESCRIPTION
There were a few problems
1: The fullscreen button was hidden in vjs-layout-x-small, unlike its
comments claimed and not matching with tiny, where it is visible.
2: The vjs-captions-control was hidden twice for tiny and x-small
3: The vjs-captions-control was hidden in small, even though the
intent was (per comments) for it to be visible
4: The vjs-volume-menu-button was present on x-small, because it was
incorrectly specified as .vjs-volume-button

All of this was partly because the lines for each layout were
different and thus 'hard' to compare between the layouts. I have now
split them in 4 groups/lines. Time controls, rate/progress, volume,
metadata. This will hopefully prevent similar problems in the future.