### PR TITLE
Replace single quotes with double quotes, remove horizontal tables in Tracks page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ can include any Video.js option plus potential [plugin](https://github.com/video
 <video id="really-cool-video" class="video-js vjs-default-skin" controls
  preload="auto" width="640" height="264" poster="really-cool-video-poster.jpg"
  data-setup='{}'>
-  <source src="really-cool-video.mp4" type='video/mp4'>
-  <source src="really-cool-video.webm" type='video/webm'>
+  <source src="really-cool-video.mp4" type="video/mp4">
+  <source src="really-cool-video.webm" type="video/webm">
   <p class="vjs-no-js">
     To view this video please enable JavaScript, and consider upgrading to a web browser
     that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -70,9 +70,9 @@ Otherwise include/exclude attributes, settings, sources, and tracks exactly as y
   controls preload="auto" width="640" height="264"
   poster="http://video-js.zencoder.com/oceans-clip.png"
   data-setup='{"example_option":true}'>
- <source src="http://video-js.zencoder.com/oceans-clip.mp4" type='video/mp4' />
- <source src="http://video-js.zencoder.com/oceans-clip.webm" type='video/webm' />
- <source src="http://video-js.zencoder.com/oceans-clip.ogv" type='video/ogg' />
+ <source src="http://video-js.zencoder.com/oceans-clip.mp4" type="video/mp4" />
+ <source src="http://video-js.zencoder.com/oceans-clip.webm" type="video/webm" />
+ <source src="http://video-js.zencoder.com/oceans-clip.ogv" type="video/ogg" />
  <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
 </video>
 ```

--- a/docs/guides/tracks.md
+++ b/docs/guides/tracks.md
@@ -56,7 +56,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
 
 <table border="0" cellspacing="5" cellpadding="5">
   <tr>
-    <td>
       <table>
         <tr><th>ab<th><td>Abkhazian</td></tr>
         <tr><th>aa<th><td>Afar</td></tr>
@@ -95,10 +94,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>fa<th><td>Farsi</td></tr>
         <tr><th>fj<th><td>Fiji</td></tr>
         <tr><th>fi<th><td>Finnish</td></tr>
-      </table>
-    </td>
-    <td>
-      <table>
         <tr><th>fr<th><td>French</td></tr>
         <tr><th>fy<th><td>Frisian</td></tr>
         <tr><th>gl<th><td>Galician</td></tr>
@@ -136,10 +131,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>ku<th><td>Kurdish</td></tr>
         <tr><th>lo<th><td>Laothian</td></tr>
         <tr><th>la<th><td>Latin</td></tr>
-      </table>
-    </td>
-    <td>
-      <table>
         <tr><th>lv<th><td>Latvian (Lettish)</td></tr>
         <tr><th>li<th><td>Limburgish ( Limburger)</td></tr>
         <tr><th>ln<th><td>Lingala</td></tr>
@@ -177,10 +168,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>sn<th><td>Shona</td></tr>
         <tr><th>ii<th><td>Sichuan Yi</td></tr>
         <tr><th>sd<th><td>Sindhi</td></tr>
-      </table>
-    </td>
-    <td>
-      <table>
         <tr><th>si<th><td>Sinhalese</td></tr>
         <tr><th>ss<th><td>Siswati</td></tr>
         <tr><th>sk<th><td>Slovak</td></tr>
@@ -217,6 +204,5 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>yo<th><td>Yoruba</td></tr>
         <tr><th>zu<th><td>Zulu</td></tr>
       </table>
-    </td>
   </tr>
 </table>

--- a/docs/guides/tracks.md
+++ b/docs/guides/tracks.md
@@ -57,7 +57,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
 <table border="0" cellspacing="5" cellpadding="5">
   <tr>
     <td>
-
       <table>
         <tr><th>ab<th><td>Abkhazian</td></tr>
         <tr><th>aa<th><td>Afar</td></tr>
@@ -97,10 +96,8 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>fj<th><td>Fiji</td></tr>
         <tr><th>fi<th><td>Finnish</td></tr>
       </table>
-
     </td>
     <td>
-
       <table>
         <tr><th>fr<th><td>French</td></tr>
         <tr><th>fy<th><td>Frisian</td></tr>
@@ -140,10 +137,8 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>lo<th><td>Laothian</td></tr>
         <tr><th>la<th><td>Latin</td></tr>
       </table>
-
     </td>
     <td>
-
       <table>
         <tr><th>lv<th><td>Latvian (Lettish)</td></tr>
         <tr><th>li<th><td>Limburgish ( Limburger)</td></tr>
@@ -183,10 +178,8 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>ii<th><td>Sichuan Yi</td></tr>
         <tr><th>sd<th><td>Sindhi</td></tr>
       </table>
-
     </td>
     <td>
-
       <table>
         <tr><th>si<th><td>Sinhalese</td></tr>
         <tr><th>ss<th><td>Siswati</td></tr>
@@ -224,7 +217,6 @@ The two-letter code (valid BCP 47 language tag) for the language of the text tra
         <tr><th>yo<th><td>Yoruba</td></tr>
         <tr><th>zu<th><td>Zulu</td></tr>
       </table>
-
     </td>
   </tr>
 </table>

--- a/docs/guides/tracks.md
+++ b/docs/guides/tracks.md
@@ -23,9 +23,9 @@ Once you have your WebVTT file created, you can add it to Video.js using the tra
 <video id="example_video_1" class="video-js vjs-default-skin"
   controls preload="auto" width="640" height="264"
   data-setup='{"example_option":true}'>
- <source src="http://video-js.zencoder.com/oceans-clip.mp4" type='video/mp4' />
- <source src="http://video-js.zencoder.com/oceans-clip.webm" type='video/webm' />
- <source src="http://video-js.zencoder.com/oceans-clip.ogv" type='video/ogg' />
+ <source src="http://video-js.zencoder.com/oceans-clip.mp4" type="video/mp4" />
+ <source src="http://video-js.zencoder.com/oceans-clip.webm" type="video/webm" />
+ <source src="http://video-js.zencoder.com/oceans-clip.ogv" type="video/ogg" />
 
  <track kind="captions" src="http://example.com/path/to/captions.vtt" srclang="en" label="English" default>
 

--- a/sandbox/index.html.example
+++ b/sandbox/index.html.example
@@ -29,9 +29,9 @@
   <video id="vid1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="264"
       poster="http://vjs.zencdn.net/v/oceans.png"
       data-setup='{}'>
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <track kind="captions" src="../docs/examples/shared/example-captions.vtt" srclang="en" label="English"></track><!-- Tracks need an ending tag thanks to IE9 -->
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>

--- a/sandbox/plugin.html.example
+++ b/sandbox/plugin.html.example
@@ -21,9 +21,9 @@
   <p style="background-color:#eee; border: 1px solid #777; padding: 10px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">This page shows you how to create, register and initialize a Video.js plugin.</p>
 
   <video id="vid1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="264" poster="http://vjs.zencdn.net/v/oceans.png">
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <p>Video Playback Not Supported</p>
   </video>
 


### PR DESCRIPTION
The horizontal tables breaks and turns into regular code as seen on the site http://docs.videojs.com/docs/guides/tracks.html  So removed the tables in the tables so it's just one big long vertical table so maybe it won't break like this.

Many parts of the docs still mentioned using the `<source>`'s  `type` attribute with single quotes.  This still works fine with double quotes, and to make sure some people don't get confused, I changed it to double quotes so it matches with every other HTML attribute.  Some parts of the docs already use it with double quotes anyway.