### PR TITLE
New simple dev server

### DIFF
--- a/build/bin/dev
+++ b/build/bin/dev
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+var path = require('path');
+var sh = require('shelljs');
+var nodeCli = require('shelljs-nodecli');
+var budo = require('budo');
+var minimist = require('minimist');
+var pkg = require('../../package.json');
+var version = pkg.version.split('.');
+var argv = minimist(process.argv, {
+  boolean: ['l', 'o'],
+  alias: {
+    l: 'live',
+    o: 'open'
+  },
+  default: {
+    o: false,
+    l: false
+  }
+});
+
+version = {
+  full: pkg.version,
+  major: version[0],
+  minor: version[1],
+  patch: version[2],
+  majorMinor: version[0] + version[1]
+};
+
+var b = budo(process.cwd() + '/src/js/video.js', {
+  // log to stdout
+  stream: process.stdout,
+  // open up the server the browser
+  open: argv.open,
+  port: 9999,
+  verbose: true,
+  live: argv.live,
+  dir: process.cwd(),
+  serve: 'video.js',
+  browserify: {
+    standalone: 'videojs',
+    transform: [
+      require('babelify').configure({
+        sourceMapRelative: process.cwd(),
+        loose: ['all']
+      }),
+      ['browserify-versionify', {
+        placeholder: '__VERSION__',
+        version: pkg.version
+      }],
+      ['browserify-versionify', {
+        placeholder: '__VERSION_NO_PATCH__',
+        version: version.majorMinor
+      }],
+      ['browserify-versionify', {
+        placeholder: '__SWF_VERSION__',
+        version: pkg.dependencies['videojs-swf']
+      }]
+    ]
+  }
+});
+
+b.watch('src/css/**/*.scss').on('watch', function(type, file) {
+  if (path.extname(file) === '.scss') {
+    nodeCli.exec('node-sass', 'src/css/video-js.scss', 'build/temp/video-js.css');
+    b.reload('build/temp/video-js.css');
+  } else {
+    b.reload(file);
+  }
+});

--- a/build/bin/dev
+++ b/build/bin/dev
@@ -59,11 +59,13 @@ var b = budo(process.cwd() + '/src/js/video.js', {
   }
 });
 
-b.watch('src/css/**/*.scss').on('watch', function(type, file) {
-  if (path.extname(file) === '.scss') {
-    nodeCli.exec('node-sass', 'src/css/video-js.scss', 'build/temp/video-js.css');
-    b.reload('build/temp/video-js.css');
-  } else {
-    b.reload(file);
-  }
-});
+if (argv.live) {
+  b.watch('src/css/**/*.scss').on('watch', function(type, file) {
+    if (path.extname(file) === '.scss') {
+      nodeCli.exec('node-sass', 'src/css/video-js.scss', 'build/temp/video-js.css');
+      b.reload('build/temp/video-js.css');
+    } else {
+      b.reload(file);
+    }
+  });
+}

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -14,6 +14,10 @@ module.exports = function(grunt) {
     patch: verParts[2]
   };
 
+  version.majorMinor = `${version.major}.${version.minor}`;
+  grunt.vjsVersion = version;
+
+
   const browserifyGruntDefaults = {
     browserifyOptions: {
       debug: true,
@@ -103,9 +107,6 @@ module.exports = function(grunt) {
       });
     };
   }
-
-  version.majorMinor = `${version.major}.${version.minor}`;
-  grunt.vjsVersion = version;
 
   // Project configuration.
   grunt.initConfig({

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Sandbox</title>
+  <!--<script src='node_modules/es6-shim/es6-shim.js'></script>-->
+
+  <!-- Add in the videojs-ie8 shim automatically if we're in IE8 -->
+  <!--[if IE 8]>
+    <script src="node_modules/videojs-ie8/dist/videojs-ie8.js"></script>
+  <![endif]-->
+
+  <link href="build/temp/video-js.css" rel="stylesheet" type="text/css">
+
+  <script src="video.js"></script>
+
+  <!-- Set the location of the flash SWF -->
+  <script>
+    //videojs.options.flash.swf = 'build/temp/video-js.swf';
+  </script>
+
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started make a copy of index.html.example and rename it to index.html.</p>
+    <pre>cp sandbox/index.html.example index.html</pre>
+    <pre>grunt watch</pre>
+    <pre>grunt connect</pre>
+    <pre>open http://localhost:9999/sandbox/index.html</pre>
+  </div>
+
+  <video id="vid1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="264"
+      poster="http://vjs.zencdn.net/v/oceans.png"
+      >
+    <source src="http://vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
+    <source src="http://vjs.zencdn.net/v/oceans.webm" type='video/webm'>
+    <source src="http://vjs.zencdn.net/v/oceans.ogv" type='video/ogg'>
+    <track kind="captions" src="docs/examples/shared/example-captions.vtt" srclang="en" label="English"></track>
+    <track kind="captions" src="docs/examples/shared/example-captions.vtt" srclang="fr" label="Another"></track>
+    <track kind="chapters" src="docs/examples/shared/example-captions.vtt" srclang="en" label="Subs"></track>
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video>
+
+  <script>
+    var vid = document.getElementById("vid1");
+    var player = videojs(vid, {
+      controlBar: {
+        volumeMenuButton: {
+          inline: false
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "homepage": "http://videojs.com",
   "author": "Steve Heffernan",
   "scripts": {
+    "budo": "budo",
+    "start": "./build/bin/dev",
     "test": "grunt test && if [ '$TRAVIS' ]; then grunt coveralls; fi;"
   },
   "repository": {
@@ -41,6 +43,7 @@
     "browserify-derequire": "^0.9.4",
     "browserify-istanbul": "^0.2.1",
     "browserify-versionify": "^1.0.4",
+    "budo": "^7.1.0",
     "chg": "^0.3.2",
     "css": "^2.2.0",
     "es5-shim": "^4.1.3",
@@ -83,6 +86,7 @@
     "load-grunt-tasks": "^3.1.0",
     "proxyquireify": "^3.0.0",
     "qunitjs": "^1.18.0",
+    "shelljs": "^0.5.3",
     "sinon": "^1.16.1",
     "time-grunt": "^1.1.1",
     "uglify-js": "~2.3.6",


### PR DESCRIPTION
I decided to add a new super simple dev server that also supports live reload. I also plan to try and figure out whether I can add in [`browserify-hmr`](https://www.npmjs.com/package/browserify-hmr) to this setup.
To get started with this is as easy as just running

``` sh
$ npm start
```

It will start up browserify using watchify and then open up the `index.html` file in your default browser. You can change this behavior via options.

``` sh
$ npm start -- --no-open
```

The initial `--` is a unix convention to know when to stop parsing options for the original command, in this case npm, and then pass it to the subscript. So, the option is `--no-open`. Or `--no-o` for short. This last command won't open a new browser window.
You can also add a `--live` option so that it'll do live-reload.

``` sh
$ npm start -- --live --no-open
```

This enables live reload which will reload the page if the javascript changes and watchify rebuilds the bundle.
When set, it'll also watch the sass files and recompile it and then also reload the page.

One of the main reasons for this is to use [budo](https://www.npmjs.com/package/budo) which is a browserify dev server that would actually delay the response of the things being browseried until the bundle finishes bundling.
The main downside currently is the doubling of the browserify options, though, they're unlikely to change soon.
