### PR TITLE
clear out currentSource on loadstart

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -477,6 +477,11 @@ class Html5 extends Tech {
    * @method setSrc
    */
   setSrc(src) {
+    let loadstartlistener = () => this.currentSource_ = null;
+
+    this.off(this.el_, 'loadstart', loadstartlistener);
+    this.one(this.el_, 'loadstart', () => this.one(this.el_, 'loadstart', loadstartlistener));
+
     this.el_.src = src;
   }
 


### PR DESCRIPTION
Starting with [v5.2.2](https://github.com/videojs/video.js/blob/master/CHANGELOG.md#522-2015-11-23) we've been returning the [cached src](https://github.com/videojs/video.js/pull/2833) for source handlers. This is important for techs that end up using MSE so that we return an the original source rather than the blob url that gets set.
However, there are cases when, in the html5 tech, the underlying video element could get a new video set, bypassing the videojs API. We want to actually pick up this change to return the new sources.