### PR TITLE
Fix for opening errorDisplay more than once

### DIFF
--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -52,6 +52,7 @@ class ErrorDisplay extends ModalDialog {
 
 ErrorDisplay.prototype.options_ = mergeOptions(ModalDialog.prototype.options_, {
   fillAlways: true,
+  temporary: false,
   uncloseable: true
 });
 


### PR DESCRIPTION
Error display can be closed with error(null) therefore it should not be disposed on close.

This fix is related to #2850 