### PR TITLE
Do not autoplay if there is no source

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -720,7 +720,7 @@ class Player extends Component {
     // In Safari (5.1.1), when we move the video element into the container div, autoplay doesn't work.
     // In Chrome (15), if you have autoplay + a poster + no controls, the video gets hidden (but audio plays)
     // This fixes both issues. Need to wait for API, so it updates displays correctly
-    if (this.tag && this.options_.autoplay && this.paused()) {
+    if (this.src() && this.tag && this.options_.autoplay && this.paused()) {
       delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
       this.play();
     }


### PR DESCRIPTION
This PR prevents the player from calling play() with autoplay and no source. In Firefox this would fire a 'play' event (See http://jsbin.com/vubugev/edit?html,console,output). For some reason this doesn't happen in Chrome.