### PR TITLE
Update CDN URL in setup guide

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -14,8 +14,8 @@ You can download the Video.js source and host it on your own servers, or use the
 
 ### CDN Version ###
 ```html
-<link href="//vjs.zencdn.net/4.12/video-js.min.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/4.12/video.min.js"></script>
+<link href="//vjs.zencdn.net/5.4.6/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/5.4.6/video.min.js"></script>
 ```
 
 We include a stripped down Google Analytics pixel that tracks a random percentage (currently 1%) of players loaded from the CDN. This allows us to see (roughly) what browsers are in use in the wild, along with other useful metrics such as OS and device. If you'd like to disable analytics, you can simply include the following global **before** including Video.js:


### PR DESCRIPTION
The setup guide has broken links to non-existent 4.12 files. This updates the URL to 5.4.6.

Longer term, what's the best way to keep the markdown docs updated?