### PR TITLE
Change manual timeUpdate event timing function to be fired more often

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -193,10 +193,28 @@ class Tech extends Component {
    * @method trackCurrentTime
    */
   trackCurrentTime() {
-    if (this.currentTimeInterval) { this.stopTrackingCurrentTime(); }
-    this.currentTimeInterval = this.setInterval(function(){
-      this.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
-    }, 250); // 42 = 24 fps // 250 is what Webkit uses // FF uses 15
+    this.manualTimeUpdatesActive = true;
+    this.manualTimeUpdateTicker();
+  }
+
+  /**
+   * Trigger timeupdate event if not supported by browser
+   *
+   * @method manualTimeUpdateTicker
+   */
+  manualTimeUpdateTicker() {
+    let requestAnimationFrame =
+        window.requestAnimationFrame ||
+        window.webkitRequestAnimationFrame ||
+        window.mozRequestAnimationFrame ||
+        function(timingFn) {
+          setTimeout(timingFn, 16);
+        };
+
+    this.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
+    if(this.manualTimeUpdatesActive){
+      requestAnimationFrame(Fn.bind(this, this.manualTimeUpdateTicker));
+    }
   }
 
   /**
@@ -205,11 +223,7 @@ class Tech extends Component {
    * @method stopTrackingCurrentTime
    */
   stopTrackingCurrentTime() {
-    this.clearInterval(this.currentTimeInterval);
-
-    // #1002 - if the video ends right before the next timeupdate would happen,
-    // the progress bar won't make it all the way to the end
-    this.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
+    this.manualTimeUpdatesActive = false;
   }
 
   /**

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -193,16 +193,16 @@ class Tech extends Component {
    * @method trackCurrentTime
    */
   trackCurrentTime() {
-    this.manualTimeUpdatesActive = true;
-    this.manualTimeUpdateTicker();
+    this.manualTimeUpdatesActive_ = true;
+    this.manualTimeUpdateTicker_();
   }
 
   /**
    * Trigger timeupdate event if not supported by browser
    *
-   * @method manualTimeUpdateTicker
+   * @method manualTimeUpdateTicker_
    */
-  manualTimeUpdateTicker() {
+  manualTimeUpdateTicker_() {
     let requestAnimationFrame =
         window.requestAnimationFrame ||
         window.webkitRequestAnimationFrame ||
@@ -212,8 +212,8 @@ class Tech extends Component {
         };
 
     this.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
-    if(this.manualTimeUpdatesActive){
-      requestAnimationFrame(Fn.bind(this, this.manualTimeUpdateTicker));
+    if(this.manualTimeUpdatesActive_) {
+      requestAnimationFrame(Fn.bind(this, this.manualTimeUpdateTicker_));
     }
   }
 
@@ -223,7 +223,7 @@ class Tech extends Component {
    * @method stopTrackingCurrentTime
    */
   stopTrackingCurrentTime() {
-    this.manualTimeUpdatesActive = false;
+    this.manualTimeUpdatesActive_ = false;
   }
 
   /**


### PR DESCRIPTION
Timeupdate event now use requestAnimationFrame with fallback to setTimeout to get call more often and to permit subtitles to have a better synchronization.

Fix #2979