### PR TITLE
When options are passed via HTML booleans are strings

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -517,8 +517,8 @@ class Component {
         }
 
         // Allow for disabling default components
-        // e.g. options['children']['posterImage'] = false
-        if (opts === false) {
+        // e.g. options['children']['posterImage'] = false or "false" (if set via HTML)
+        if ((opts === false) || (opts === "false")) {
           return;
         }
 


### PR DESCRIPTION
This is how I am invoking the Video Player

```HTML
<div class="video-background">
    <video id="main-video-player" data-setup='{ "controlBar":"false", "bigPlayButton": "false" }'>
      <source src="/media/{{video.videoLocation}}" type="video/mp4">
    </video>
</div>
```

```js
$(function () {
    videojs('main-video-player', {}, function () {
    ...
    })
})
```

But I get a couple of errors. A quick breakpoint in Chrome Dev tools reveal:

![videojs](https://cloud.githubusercontent.com/assets/1716462/12220315/3f47c1fc-b794-11e5-9092-2ce031d6b10c.PNG)

Based on http://stackoverflow.com/questions/263965/how-can-i-convert-a-string-to-boolean-in-javascript I thought this would be the best way to check for `"false"` as well. 

Let me know if this is good, or there's a better way to *parse* this `"false"`. I have a feeling there may be more such issues across the VideoJS code. Especially where we are setting options via HTML attributes and not JS.
