### PR TITLE
Optimize active cues lookup time for HTML track fallback

### DIFF
--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -14,8 +14,9 @@ import document from 'global/document';
  * };
  */
 
-let TextTrackCueList = function(cues) {
+let TextTrackCueList = function(cues, optimized) {
   let list = this;
+  this.optimized_ = optimized || false;
 
   if (browser.IS_IE8) {
     list = document.createElement('custom');
@@ -41,12 +42,45 @@ let TextTrackCueList = function(cues) {
 };
 
 TextTrackCueList.prototype.setCues_ = function(cues) {
-  let oldLength = this.length || 0;
   let i = 0;
   let l = cues.length;
 
-  this.cues_ = cues;
-  this.length_ = cues.length;
+  this.cues_ = [];
+  this.length_ = 0;
+  if (this.optimized_) {
+    this.quickCues_ = [];
+  }
+
+  for(i; i < l; i++){
+    this.addCue_(cues[i]);
+  }
+
+  this.length_ = this.cues_.length;
+};
+
+TextTrackCueList.prototype.optimizeAllCues_ = function() {
+  let cues = this.cues_;
+  this.quickCues_ = [];
+
+  for (let i = 0; i < cues.length; i++) {
+    this.optimizeCue_(cues[i]);
+  }
+};
+
+TextTrackCueList.prototype.optimizeCue_ = function(cue){
+  if(this.optimized_){
+    for (let j = cue['startTime']; j < cue['endTime'] + 100; j += 100) {
+      this.quickCues_[j / 100 | 0] = this.quickCues_[j / 100 | 0] || [];
+      this.quickCues_[j / 100 | 0].push(cue);
+    }
+  }
+};
+
+TextTrackCueList.prototype.addCue_ = function(cue) {
+  this.cues_.push(cue);
+  if(this.optimized_) {
+    this.optimizeCue_(cue);
+  }
 
   let defineProp = function(i) {
     if (!(''+i in this)) {
@@ -57,14 +91,47 @@ TextTrackCueList.prototype.setCues_ = function(cues) {
       });
     }
   };
+  defineProp.call(this, this.cues_.length-1);
+  this.length_ = this.cues_.length;
+};
 
-  if (oldLength < l) {
-    i = oldLength;
+TextTrackCueList.prototype.removeCue_ = function(removeCue) {
+  let removed = false;
 
-    for(; i < l; i++) {
-      defineProp.call(this, i);
+  for (let i = 0, l = this.cues_.length; i < l; i++) {
+    let cue = this.cues_[i];
+    if (cue === removeCue) {
+      this.cues_.splice(i, 1);
+      removed = true;
     }
   }
+
+  if (removed) {
+    this.length_ = this.cues_.length;
+    if(this.optimized_){
+      this.optimizeAllCues_();
+    }
+  }
+};
+
+TextTrackCueList.prototype.getActiveCuesByTime = function(time) {
+  let cues = this.quickCues_[time/100|0]||[];
+  let active = [];
+
+  for (let i = 0, l = cues.length; i < l; i++) {
+    let cue = cues[i];
+    if (cue['startTime'] <= time && cue['endTime'] >= time) {
+      active.push(cue);
+    } else if (cue['startTime'] === cue['endTime'] && cue['startTime'] <= time && cue['startTime'] + 0.5 >= time) {
+      active.push(cue);
+    }
+
+    if (cue['startTime'] > time){
+      break;
+    }
+  }
+
+  return active;
 };
 
 TextTrackCueList.prototype.getCueById = function(id) {

--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -118,6 +118,7 @@ TextTrackCueList.prototype.removeCue_ = function(removeCue) {
     if (cue === removeCue) {
       this.cues_.splice(i, 1);
       removed = true;
+      break;
     }
   }
 
@@ -129,20 +130,26 @@ TextTrackCueList.prototype.removeCue_ = function(removeCue) {
   }
 };
 
-TextTrackCueList.prototype.getActiveCuesByTime = function(time) {
-  let cues = this.quickCues_[time/100|0]||[];
+/**
+ * Return array of active cues at given time from optimized storage of cues.
+ * @param time
+ * @returns {Array}
+ * @private
+ */
+TextTrackCueList.prototype.getActiveCuesByTime_ = function(time) {
+  let group = time/100|0;
+  // Doesn't check for every cues but only the ones appearing around time
+  let cues = this.quickCues_[group]||[];
   let active = [];
 
   for (let i = 0, l = cues.length; i < l; i++) {
     let cue = cues[i];
+    // Accept standard cues that are visible at given time
+    // Also accept malformed cue with same startTime and endTime
     if (cue['startTime'] <= time && cue['endTime'] >= time) {
       active.push(cue);
     } else if (cue['startTime'] === cue['endTime'] && cue['startTime'] <= time && cue['startTime'] + 0.5 >= time) {
       active.push(cue);
-    }
-
-    if (cue['startTime'] > time) {
-      break;
     }
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -66,7 +66,7 @@ let TextTrack = function(options={}) {
   tt.cues_ = [];
   tt.activeCues_ = [];
 
-  let cues = new TextTrackCueList(tt.cues_);
+  let cues = new TextTrackCueList(tt.cues_, true);
   let activeCues = new TextTrackCueList(tt.activeCues_);
 
   let changed = false;
@@ -147,16 +147,7 @@ let TextTrack = function(options={}) {
       }
 
       let ct = this.tech_.currentTime();
-      let active = [];
-
-      for (let i = 0, l = this['cues'].length; i < l; i++) {
-        let cue = this['cues'][i];
-        if (cue['startTime'] <= ct && cue['endTime'] >= ct) {
-          active.push(cue);
-        } else if (cue['startTime'] === cue['endTime'] && cue['startTime'] <= ct && cue['startTime'] + 0.5 >= ct) {
-          active.push(cue);
-        }
-      }
+      let active = this.cues.getActiveCuesByTime(ct);
 
       changed = false;
 
@@ -210,25 +201,11 @@ TextTrack.prototype.addCue = function(cue) {
       }
     }
   }
-
-  this.cues_.push(cue);
-  this['cues'].setCues_(this.cues_);
+  this['cues'].addCue_(cue);
 };
 
 TextTrack.prototype.removeCue = function(removeCue) {
-  let removed = false;
-
-  for (let i = 0, l = this.cues_.length; i < l; i++) {
-    let cue = this.cues_[i];
-    if (cue === removeCue) {
-      this.cues_.splice(i, 1);
-      removed = true;
-    }
-  }
-
-  if (removed) {
-    this.cues.setCues_(this.cues_);
-  }
+  this['cues'].removeCue_(removeCue);
 };
 
 /*

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -147,7 +147,7 @@ let TextTrack = function(options={}) {
       }
 
       let ct = this.tech_.currentTime();
-      let active = this.cues.getActiveCuesByTime(ct);
+      let active = this.cues.getActiveCuesByTime_(ct);
 
       changed = false;
 

--- a/test/unit/tracks/text-track-cue-list.test.js
+++ b/test/unit/tracks/text-track-cue-list.test.js
@@ -14,7 +14,9 @@ q.module('Text Track Cue List');
 
 test('TextTrackCueList\'s length is set correctly', function() {
   var ttcl = new TextTrackCueList(genericTracks);
+  equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 
+  ttcl = new TextTrackCueList(genericTracks, true);
   equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
@@ -25,9 +27,18 @@ test('can get cues by id', function() {
   equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
   equal(ttcl.getCueById('3').id, 3, 'id "3" has id of "3"');
   ok(!ttcl.getCueById(1), 'there isn\'t an item with "numeric" id of `1`');
+
+  ttcl = new TextTrackCueList(genericTracks, true);
+
+  equal(ttcl.getCueById('1').id, 1, 'id "1" has id of "1"');
+  equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
+  equal(ttcl.getCueById('3').id, 3, 'id "3" has id of "3"');
+  ok(!ttcl.getCueById(1), 'there isn\'t an item with "numeric" id of `1`');
 });
 
 test('length is updated when new tracks are added or removed', function() {
+  var newCue = {id: '100'};
+
   var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
@@ -39,17 +50,43 @@ test('length is updated when new tracks are added or removed', function() {
   equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
   ttcl.setCues_(genericTracks);
   equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
+
+
+  ttcl.addCue_(newCue);
+  equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
+  ttcl.removeCue_(newCue);
+  equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
+
+  ttcl = new TextTrackCueList(genericTracks, true);
+
+  ttcl.setCues_(genericTracks.concat([{id: '100'}]));
+  equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
+  ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
+  equal(ttcl.length, genericTracks.length + 2, 'the length is ' + (genericTracks.length + 2));
+
+  ttcl.setCues_(genericTracks.concat([{id: '100'}]));
+  equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
+  ttcl.setCues_(genericTracks);
+  equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
+
+
+  ttcl.addCue_(newCue);
+  equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
+  ttcl.removeCue_(newCue);
+  equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
 test('can access items by index', function() {
   var ttcl = new TextTrackCueList(genericTracks),
+      ttcl2 = new TextTrackCueList(genericTracks, true),
       i = 0,
       length = ttcl.length;
 
-  expect(length);
+  expect(length*2);
 
   for (; i < length; i++) {
     equal(ttcl[i].id, String(i + 1), 'the id of a track matches the index + 1');
+    equal(ttcl2[i].id, String(i + 1), 'the id of a track matches the index + 1');
   }
 });
 
@@ -57,7 +94,13 @@ test('can access new items by index', function() {
   var ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
+  equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+  ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
+  equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
 
+  ttcl = new TextTrackCueList(genericTracks, true);
+
+  ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
   equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
@@ -71,13 +114,33 @@ test('cannot access removed items by index', function() {
   equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
 
   ttcl.setCues_(genericTracks);
+  ok(!ttcl[3], 'nothing at index 3');
+  ok(!ttcl[4], 'nothing at index 4');
 
+  ttcl = new TextTrackCueList(genericTracks, true);
+
+  ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
+  equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+  equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
+
+  ttcl.setCues_(genericTracks);
   ok(!ttcl[3], 'nothing at index 3');
   ok(!ttcl[4], 'nothing at index 4');
 });
 
 test('new item available at old index', function() {
   var ttcl = new TextTrackCueList(genericTracks);
+
+  ttcl.setCues_(genericTracks.concat([{id: '100'}]));
+  equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+
+  ttcl.setCues_(genericTracks);
+  ok(!ttcl[3], 'nothing at index 3');
+
+  ttcl.setCues_(genericTracks.concat([{id: '101'}]));
+  equal(ttcl[3].id, '101', 'id of new item at index 3 is now 101');
+
+  ttcl = new TextTrackCueList(genericTracks, true);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');


### PR DESCRIPTION
Add an optimisation option to cue list. This optimisation permit a 90% performance increase when looking up for new cues to display on a large file.

Amended test for optimize version.

I did some test with a 2049 cues track file on my configuration.
With old method, each active cues lookup took a total more than 4 ms.
With this method, lookup take less than 0.5ms.

Here is a comparison of performances on Edge using both method. New method is obviously on the left, old method on the right.
![image](https://cloud.githubusercontent.com/assets/150214/12232034/1f8f1950-b85c-11e5-8348-bd9a2a3a32af.png)

Optimized version is a flag on object creation to avoid performances issue on startup and when creating activeCues list.
