### PR TITLE
Remove unused tracks from track list when changing source

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -140,9 +140,9 @@ class Html5 extends Tech {
         tl.removeEventListener('removetrack', this[`handle${capitalType}TrackRemove_`]);
       }
       
-      // Stop removing old tracks
-      if (tl) {
-        this.off('loadstart', this[`removeOld${capitalType}Tracks_`]);
+      // Stop removing old text tracks
+      if (type === 'text' && tl) {
+        this.off('loadstart', this.removeOldTextTracks_);
       }
     });
 
@@ -368,20 +368,25 @@ class Html5 extends Tech {
     // This will loop over the texttracks and check if they are still used
     // If not, they will be removed from the emulated list
     let removeTracks = [];
+    const techTracks = this.textTracks();
+    const elTracks = this.el().textTracks;
+    if (!elTracks) {
+      return;
+    }
 
-    for (let i = 0; i < this.textTracks().length; i++) {
-      let techTrack = this.textTracks()[i];
+    for (let i = 0; i < techTracks.length; i++) {
+      let techTrack = techTracks[i];
 
       let found = false;
-      for (let j = 0; j < this.el().textTracks.length; j++) {
-	if (this.el().textTracks[j] === techTrack) {
-	  found = true;
-	  break;
-	}
+      for (let j = 0; j < elTracks.length; j++) {
+        if (elTracks[j] === techTrack) {
+          found = true;
+          break;
+        }
       }
 
       if (!found) {
-	removeTracks.push(techTrack);
+        removeTracks.push(techTrack);
       }
     }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -302,10 +302,8 @@ class Html5 extends Tech {
         tt.addEventListener('addtrack', this.handleTextTrackAdd_);
         tt.addEventListener('removetrack', this.handleTextTrackRemove_);
       }
-    }
-
-    // Remove (native) texttracks that are not used anymore
-    if (tt) {
+    
+      // Remove (native) texttracks that are not used anymore
       this.on('loadstart', this.removeOldTextTracks_);
     }
   }


### PR DESCRIPTION
This should fix #3000 . When using native text tracks it removes unused ones on `loadstart`.

@gkatsev suggested using `inbandmetadatatrack` but that seems to be `""` for my HLS subtitle tracks so I guess we can not use it.