### PR TITLE
return already created player when given an element

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -269,6 +269,7 @@ class Player extends Component {
     // Update tag id/class for use as HTML5 playback tech
     // Might think we should do this after embedding in container so .vjs-tech class
     // doesn't flash 100% width/height, but class only applies with .video-js parent
+    tag.playerId = tag.id;
     tag.id += '_html5_api';
     tag.className = 'vjs-tech';
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -52,8 +52,8 @@ if (typeof HTMLVideoElement === 'undefined') {
  * @mixes videojs
  * @method videojs
  */
-var videojs = function(id, options, ready){
-  var tag; // Element of ID
+let videojs = function(id, options, ready){
+  let tag; // Element of ID
 
   // Allow for element or ID to be passed in
   // String ID

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -95,7 +95,7 @@ let videojs = function(id, options, ready){
 
   // Element may have a player attr referring to an already created player instance.
   // If not, set up a new player and return the instance.
-  return tag['player'] || new Player(tag, options, ready);
+  return tag['player'] || Player.players[tag.playerId] || new Player(tag, options, ready);
 };
 
 // Add default styles

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -37,13 +37,13 @@ test('should return a video player instance', function(){
   ok(player2.id() === 'test_vid_id2', 'created player from element');
 });
 
-test('should return a video player instance from el', function() {
+test('should return a video player instance from el html5 tech', function() {
   var fixture = document.getElementById('qunit-fixture');
   fixture.innerHTML += '<video id="test_vid_id"></video><video id="test_vid_id2"></video>';
 
   var vid = document.querySelector('#test_vid_id');
 
-  var player = videojs(vid, { techOrder: ['techFaker'] });
+  var player = videojs(vid);
   ok(player, 'created player from tag');
   ok(player.id() === 'test_vid_id');
   ok(videojs.getPlayers()['test_vid_id'] === player, 'added player to global reference');
@@ -56,8 +56,28 @@ test('should return a video player instance from el', function() {
   var tag2 = document.getElementById('test_vid_id2');
   var player2 = videojs(tag2, { techOrder: ['techFaker'] });
   ok(player2.id() === 'test_vid_id2', 'created player from element');
+});
 
-})
+test('should return a video player instance from el techfaker', function() {
+  var fixture = document.getElementById('qunit-fixture');
+  fixture.innerHTML += '<video id="test_vid_id"></video><video id="test_vid_id2"></video>';
+
+  var vid = document.querySelector('#test_vid_id');
+
+  var player = videojs(vid, {techOrder: ['techFaker']});
+  ok(player, 'created player from tag');
+  ok(player.id() === 'test_vid_id');
+  ok(videojs.getPlayers()['test_vid_id'] === player, 'added player to global reference');
+
+  var playerAgain = videojs(vid);
+  ok(player === playerAgain, 'did not create a second player from same tag');
+
+  equal(player, playerAgain, 'we did not make a new player');
+
+  var tag2 = document.getElementById('test_vid_id2');
+  var player2 = videojs(tag2, { techOrder: ['techFaker'] });
+  ok(player2.id() === 'test_vid_id2', 'created player from element');
+});
 
 test('should add the value to the languages object', function() {
   var code, data, result;

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -30,10 +30,34 @@ test('should return a video player instance', function(){
   var playerAgain = videojs('test_vid_id');
   ok(player === playerAgain, 'did not create a second player from same tag');
 
+  equal(player, playerAgain, 'we did not make a new player');
+
   var tag2 = document.getElementById('test_vid_id2');
   var player2 = videojs(tag2, { techOrder: ['techFaker'] });
   ok(player2.id() === 'test_vid_id2', 'created player from element');
 });
+
+test('should return a video player instance from el', function() {
+  var fixture = document.getElementById('qunit-fixture');
+  fixture.innerHTML += '<video id="test_vid_id"></video><video id="test_vid_id2"></video>';
+
+  var vid = document.querySelector('#test_vid_id');
+
+  var player = videojs(vid, { techOrder: ['techFaker'] });
+  ok(player, 'created player from tag');
+  ok(player.id() === 'test_vid_id');
+  ok(videojs.getPlayers()['test_vid_id'] === player, 'added player to global reference');
+
+  var playerAgain = videojs(vid);
+  ok(player === playerAgain, 'did not create a second player from same tag');
+
+  equal(player, playerAgain, 'we did not make a new player');
+
+  var tag2 = document.getElementById('test_vid_id2');
+  var player2 = videojs(tag2, { techOrder: ['techFaker'] });
+  ok(player2.id() === 'test_vid_id2', 'created player from element');
+
+})
 
 test('should add the value to the languages object', function() {
   var code, data, result;


### PR DESCRIPTION
As part of the tech 2.0 work, we decided to remote the player out of the tech. One of the changes in it [nulled out `tag.player`](https://github.com/videojs/video.js/blob/b48797bf1788f4207a2f03e8980c53a1b6a05a55/src/js/player.js#L590-L594). This is an issue because `videojs(el)` uses `tag.player` to see whether we have already created, so, if you try to get the player again with the same `el`, it'll actually create a brand new player for you.
An example:
```js
let el = document.querySelector('#my-video');
console.log(el.id); // "my-video"
let player = videojs(el);
console.log(el.id); // "my-video_html5_api"
let anotherPlayer = videojs(el);
console.log(el.id); // "my-video_html5_api_html5_api"
console.log(player == anotherPlayer); // false
```
The expected result should be something like this:
```js
let el = document.querySelector('#my-video');
console.log(el.id); // "my-video"
let player = videojs(el);
console.log(el.id); // "my-video_html5_api"
let anotherPlayer = videojs(el);
console.log(el.id); // "my-video_html5_api"
console.log(player == anotherPlayer); // true
```
There are two ways I can think off right now to fix this:
1. revert the changes that nulled out `tag.player`
2. when given an element and `tag.player` in null, we would want to parse out the id to remove the stuff like `html5_api` and then return `videojs.players[parsedId(tag.id)]` if it exists, otherwise actually go ahead and create a player

I feel like solution number 2 is more correct but it is also a lot more complicated and more prone to issues. Included below right now are two failing tests for the above usecase.
@videojs/core-committers @dconnolly thoughts?