### PR TITLE
Fix double-localization of the control text of the mute-toggle button.

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -76,9 +76,8 @@ class MuteToggle extends Button {
     // This causes unnecessary and confusing information for screen reader users.
     // This check is needed because this function gets called every time the volume level is changed.
     let toMute = this.player_.muted() ? 'Unmute' : 'Mute';
-    let localizedMute = this.localize(toMute);
-    if (this.controlText() !== localizedMute) {
-      this.controlText(localizedMute);
+    if (this.controlText() !== toMute) {
+      this.controlText(toMute);
     }
 
     /* TODO improve muted icon classes */


### PR DESCRIPTION
Since control text localization is entirely hidden inside the `controlText` method, the check for whether the mute button's control text has changed does not need to do localization.