### PR TITLE
added "auto" attribute value support in width or height of the player

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -341,10 +341,19 @@ class Player extends Component {
     let privDimension = dimension + '_';
 
     if (value === undefined) {
-      return this[privDimension] || 0;
+      // if attr of width or height is "auto",
+      // return computed width or height for responsiveness
+      let computedWidthOrHeight;
+      if (dimension === 'width') {
+        computedWidthOrHeight = this.el_.offsetWidth;
+      } else {
+        computedWidthOrHeight = this.el_.offsetHeight;
+      }
+
+      return this[privDimension] || computedWidthOrHeight || 0;
     }
 
-    if (value === '') {
+    if (value === '' || value === 'auto') {
       // If an empty string is given, reset the dimension to be automatic
       this[privDimension] = undefined;
     } else {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -196,6 +196,26 @@ test('should use an class name that begins with an alpha character', function(){
   ok(/\s*\.dimensions-1numeric\s*\{/.test(getStyleText(numericPlayer.styleEl_)), 'prepends dimensions- to a numeric player ID');
 });
 
+test('should be able to set auto value to width or height for responsiveness', function(){
+  var tag = TestHelpers.makeTag();
+  var fixture = document.getElementById('qunit-fixture');
+  fixture.appendChild(tag);
+
+  tag.style.width = '100%';
+  tag.style.height = '100%';
+  tag.setAttribute('width', 'auto');
+  tag.setAttribute('height', 'auto');
+
+  var player = TestHelpers.makePlayer({}, tag);
+  var tagWidth = TestHelpers.getComputedStyle(fixture, 'width');
+  var tagHeight = TestHelpers.getComputedStyle(fixture, 'height');
+
+  equal(player.width() + 'px', tagWidth, 'the width property should equal the tag width');
+  equal(player.height() + 'px', tagHeight, 'the height property should equal the tag height');
+
+  player.dispose();
+});
+
 test('should wrap the original tag in the player div', function(){
   var tag = TestHelpers.makeTag();
   var container = document.createElement('div');


### PR DESCRIPTION
Currently player width or height getter (player.prototype.width()) is return 0 unless width or height attribute hasn't set as "auto" at video tag or hasn't at all. 

But some plugins ex. google ima uses width getter, so if user is using responsive design result will be false positive.