### PR TITLE
When removing a track also remove listeners

### DIFF
--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -111,7 +111,9 @@ TextTrackList.prototype.removeTrack_ = function(rtrack) {
   for (let i = 0, l = this.length; i < l; i++) {
     if (this[i] === rtrack) {
       track = this[i];
-      track.off();
+      if (track.off) {
+        track.off();
+      }
 
       this.tracks_.splice(i, 1);
 

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -111,6 +111,7 @@ TextTrackList.prototype.removeTrack_ = function(rtrack) {
   for (let i = 0, l = this.length; i < l; i++) {
     if (this[i] === rtrack) {
       track = this[i];
+      track.off();
 
       this.tracks_.splice(i, 1);
 

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -6,13 +6,16 @@ var noop = Function.prototype;
 var genericTracks = [
   {
     id: '1',
-    addEventListener: noop
+    addEventListener: noop,
+    off: noop
   }, {
     id: '2',
-    addEventListener: noop
+    addEventListener: noop,
+    off: noop
   }, {
     id: '3',
-    addEventListener: noop
+    addEventListener: noop,
+    off: noop
   }
 ];
 
@@ -36,9 +39,9 @@ test('can get text tracks by id', function() {
 test('length is updated when new tracks are added or removed', function() {
   var ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop});
+  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
   equal(ttl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
-  ttl.addTrack_({id: '101', addEventListener: noop});
+  ttl.addTrack_({id: '101', addEventListener: noop, off: noop});
   equal(ttl.length, genericTracks.length + 2, 'the length is ' + (genericTracks.length + 2));
 
   ttl.removeTrack_(ttl.getTrackById('101'));
@@ -71,8 +74,8 @@ test('can access new items by index', function() {
 test('cannot access removed items by index', function() {
   var ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop});
-  ttl.addTrack_({id: '101', addEventListener: noop});
+  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
+  ttl.addTrack_({id: '101', addEventListener: noop, off: noop});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
   equal(ttl[4].id, '101', 'id of item at index 4 is 101');
 
@@ -86,7 +89,7 @@ test('cannot access removed items by index', function() {
 test('new item available at old index', function() {
   var ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop});
+  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
 
   ttl.removeTrack_(ttl.getTrackById('100'));


### PR DESCRIPTION
This PR is to remove event listeners from removed text tracks. This would be useful for a plugin like videojs-playlist.