### PR TITLE
Fix iPhone detection

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -15,8 +15,12 @@ const appleWebkitVersion = webkitVersionMap ? parseFloat(webkitVersionMap.pop())
  * @constant
  * @private
  */
-export const IS_IPHONE = (/iPhone/i).test(USER_AGENT);
 export const IS_IPAD = (/iPad/i).test(USER_AGENT);
+
+// The Facebook app's UIWebView identifies as both an iPhone and iPad, so
+// to identify iPhones, we need to exclude iPads.
+// http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
+export const IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
 export const IS_IPOD = (/iPod/i).test(USER_AGENT);
 export const IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
 


### PR DESCRIPTION
Because the Facebook iOS app's UIWebView identifies itself as both an iPad _and_ an iPhone, we need to exclude iPads from detection of iPhones.