### PR TITLE
fixed reference to videojs-vtt dependency

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -396,7 +396,7 @@ module.exports = function(grunt) {
         options: {
           separator: '\n',
         },
-        src: ['build/temp/video.js', 'node_modules/vtt.js/dist/vtt.js'],
+        src: ['build/temp/video.js', 'node_modules/videojs-vtt.js/dist/vtt.js'],
         dest: 'build/temp/video.js',
       },
     },


### PR DESCRIPTION
The dependency for the VTT package has not been updated to reflect what is in `package.json`. Building the project then leaves out the VTT code.