### PR TITLE
Android live display fix for HLS VOD

### DIFF
--- a/src/css/components/_live.scss
+++ b/src/css/components/_live.scss
@@ -1,10 +1,14 @@
 // We are assuming there is no progress bar and using the live display
 // to fill in the middle space. Live+DVR will need to adjust this.
 .video-js .vjs-live-control {
-  @include display-flex(flex-start);
-  @include flex(auto);
+  display: none;
   font-size: 1em;
   line-height: 3em;
+}
+
+.video-js.vjs-live .vjs-live-control {
+  @include display-flex(flex-start);
+  @include flex(auto);
 }
 
 .vjs-no-flex .vjs-live-control {

--- a/src/css/components/_live.scss
+++ b/src/css/components/_live.scss
@@ -1,14 +1,10 @@
 // We are assuming there is no progress bar and using the live display
 // to fill in the middle space. Live+DVR will need to adjust this.
 .video-js .vjs-live-control {
-  display: none;
-  font-size: 1em;
-  line-height: 3em;
-}
-
-.video-js.vjs-live .vjs-live-control {
   @include display-flex(flex-start);
   @include flex(auto);
+  font-size: 1em;
+  line-height: 3em;
 }
 
 .vjs-no-flex .vjs-live-control {

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -3,6 +3,7 @@
  */
 import Component from '../component';
 import * as Dom from '../utils/dom.js';
+import * as browser from '../utils/browser.js';
 
 /**
  * Displays the live indicator
@@ -12,6 +13,13 @@ import * as Dom from '../utils/dom.js';
  * @class LiveDisplay
  */
 class LiveDisplay extends Component {
+
+  constructor(player, options) {
+    super(player, options);
+
+    this.updateShowing();
+    this.on(this.player(), 'durationchange', this.updateShowing);
+  }
 
   /**
    * Create the component's DOM element
@@ -33,6 +41,31 @@ class LiveDisplay extends Component {
 
     el.appendChild(this.contentEl_);
     return el;
+  }
+
+  updateShowing() {
+    if (this.player().duration() === Infinity) {
+      // On Android Chrome, duration of VOD HLS remains Infinity until
+      // after playback has begun (and after hasStarted()).
+      if (browser.IS_ANDROID && browser.IS_CHROME) {
+        let checkDuration = function () {
+          if (this.player().currentTime() > 0) {
+            if (this.player().duration() === Infinity) {
+              this.show();
+            } else {
+              this.hide();
+            }
+            this.off(this.player(), 'timeupdate', checkDuration);
+          }
+        };
+
+        this.on(this.player(), 'timeupdate', checkDuration);
+      } else {
+        this.show();
+      }
+    } else {
+      this.hide();
+    }
   }
 
 }

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -13,13 +13,6 @@ import * as Dom from '../utils/dom.js';
  */
 class LiveDisplay extends Component {
 
-  constructor(player, options) {
-    super(player, options);
-
-    this.updateShowing();
-    this.on(this.player(), 'durationchange', this.updateShowing);
-  }
-
   /**
    * Create the component's DOM element
    *
@@ -40,14 +33,6 @@ class LiveDisplay extends Component {
 
     el.appendChild(this.contentEl_);
     return el;
-  }
-
-  updateShowing() {
-    if (this.player().duration() === Infinity) {
-      this.show();
-    } else {
-      this.hide();
-    }
   }
 
 }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1400,7 +1400,24 @@ class Player extends Component {
       this.cache_.duration = seconds;
 
       if (seconds === Infinity) {
-        this.addClass('vjs-live');
+        // On Android Chrome, duration of VOD HLS remains Infinity until
+        // after playback has begun (and after hasStarted()).
+        if (browser.IS_ANDROID && browser.IS_CHROME) {
+          let checkDuration = function () {
+            if (this.currentTime() > 0) {
+              if (this.duration() === Infinity) {
+                this.addClass('vjs-live');
+              } else {
+                this.removeClass('vjs-live');
+              }
+              this.off('timeupdate', checkDuration);
+            }
+          };
+
+          this.on('timeupdate', checkDuration);
+        } else {
+          this.addClass('vjs-live');
+        }
       } else {
         this.removeClass('vjs-live');
       }


### PR DESCRIPTION
This fixes #3079 where Android Chrome shows the live display initially for VOD HLS videos. With this change the live display will not be added until after the video has progressed past 0 and the duration is still `Infinity`.

A couple of caveats:

- It uses user agent tests `browser.IS_ANDROID` and `browser.IS_CHROME` which probably isn't ideal
- For live HLS videos, the non-live controls will now be shown until playback starts. So the opposite issue, but I do think this is much less annoying than the flash of "LIVE" on a non-live video.

This also removes the LiveDisplay component's own duration checks to show/hide itself, and just uses CSS. This brings it into line with other components and avoids making the other changes in two places.