### PR TITLE
Buffer time-display component values to avoid refreshing HTML too often

### DIFF
--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -55,7 +55,7 @@ class CurrentTimeDisplay extends Component {
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
     let localizedText = this.localize('Current Time');
     let formattedTime = formatTime(time, this.player_.duration());
-    if(formattedTime !== this.formattedTime_){
+    if (formattedTime !== this.formattedTime_) {
       this.formattedTime_ = formattedTime;
       this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> ${formattedTime}`;
     }

--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -55,7 +55,10 @@ class CurrentTimeDisplay extends Component {
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
     let localizedText = this.localize('Current Time');
     let formattedTime = formatTime(time, this.player_.duration());
-    this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> ${formattedTime}`;
+    if(formattedTime !== this.formattedTime_){
+      this.formattedTime_ = formattedTime;
+      this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> ${formattedTime}`;
+    }
   }
 
 }

--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -58,7 +58,8 @@ class DurationDisplay extends Component {
    */
   updateContent() {
     let duration = this.player_.duration();
-    if (duration) {
+    if (duration && this.duration_ !== duration) {
+      this.duration_ = duration;
       let localizedText = this.localize('Duration Time');
       let formattedTime = formatTime(duration);
       this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> ${formattedTime}`; // label the duration time for screen reader users

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -54,7 +54,7 @@ class RemainingTimeDisplay extends Component {
     if (this.player_.duration()) {
       const localizedText = this.localize('Remaining Time');
       const formattedTime = formatTime(this.player_.remainingTime());
-      if(formattedTime !== this.formattedTime_){
+      if (formattedTime !== this.formattedTime_) {
         this.formattedTime_ = formattedTime;
         this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> -${formattedTime}`;
       }

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -54,7 +54,10 @@ class RemainingTimeDisplay extends Component {
     if (this.player_.duration()) {
       const localizedText = this.localize('Remaining Time');
       const formattedTime = formatTime(this.player_.remainingTime());
-      this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> -${formattedTime}`;
+      if(formattedTime !== this.formattedTime_){
+        this.formattedTime_ = formattedTime;
+        this.contentEl_.innerHTML = `<span class="vjs-control-text">${localizedText}</span> -${formattedTime}`;
+      }
     }
 
     // Allows for smooth scrubbing, when player can't keep up.


### PR DESCRIPTION
HTML reparsing is a costly action for the browser and these components need to be updated only once per second. To avoid getting updating too often the HTML, the HTML will only update if the input data change.