### PR TITLE
fix minified videojs in ie8

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -149,6 +149,10 @@ module.exports = function(grunt) {
     },
     dist: {},
     watch: {
+      minify: {
+        files: ['build/temp/video.js'],
+        tasks: ['uglify']
+      },
       skin: {
         files: ['src/css/**/*'],
         tasks: ['sass', 'wrapcodepoints']

--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -14,7 +14,7 @@ import document from 'global/document';
  * };
  */
 
-let TextTrackCueList = function(cues) {
+function TextTrackCueList (cues) {
   let list = this;
 
   if (browser.IS_IE8) {

--- a/src/js/tracks/text-track-cue-list.js
+++ b/src/js/tracks/text-track-cue-list.js
@@ -38,7 +38,7 @@ function TextTrackCueList (cues) {
   if (browser.IS_IE8) {
     return list;
   }
-};
+}
 
 TextTrackCueList.prototype.setCues_ = function(cues) {
   let oldLength = this.length || 0;

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -48,7 +48,7 @@ function TextTrackList (tracks) {
   if (browser.IS_IE8) {
     return list;
   }
-};
+}
 
 TextTrackList.prototype = Object.create(EventTarget.prototype);
 TextTrackList.prototype.constructor = TextTrackList;

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -19,7 +19,7 @@ import document from 'global/document';
  *   attribute EventHandler onremovetrack;
  * };
  */
-let TextTrackList = function(tracks) {
+function TextTrackList (tracks) {
   let list = this;
 
   if (browser.IS_IE8) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -35,7 +35,7 @@ import XHR from 'xhr';
  *   attribute EventHandler oncuechange;
  * };
  */
-let TextTrack = function(options={}) {
+function TextTrack (options={}) {
   if (!options.tech) {
     throw new Error('A tech was not provided.');
   }

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -188,7 +188,7 @@ function TextTrack (options={}) {
   if (browser.IS_IE8) {
     return tt;
   }
-};
+}
 
 TextTrack.prototype = Object.create(EventTarget.prototype);
 TextTrack.prototype.constructor = TextTrack;


### PR DESCRIPTION
The issue here is that babel was turning function expressions like `let Foo = function() {}`
in names function expressions like `var Foo = function Foo() {}`. Afterwards, the minifier came through and cause these two variables to diverge causing issues in IE8. The fix is to switch to function statements.
Fixes #3064 and #3070.