### PR TITLE
Add alternate CSS as video-js-cdn.css

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -192,7 +192,7 @@ module.exports = function(grunt) {
       minify: {
         expand: true,
         cwd: 'build/temp/',
-        src: ['video-js.css'],
+        src: ['video-js.css', 'alt/video-js-cdn.css'],
         dest: 'build/temp/',
         ext: '.min.css'
       }
@@ -200,7 +200,8 @@ module.exports = function(grunt) {
     sass: {
       build: {
         files: {
-          'build/temp/video-js.css': 'src/css/vjs.scss'
+          'build/temp/video-js.css': 'src/css/vjs.scss',
+          'build/temp/alt/video-js-cdn.css': 'src/css/vjs-cdn.scss'
         }
       }
     },

--- a/src/css/vjs-cdn.scss
+++ b/src/css/vjs-cdn.scss
@@ -1,0 +1,3 @@
+$icon-font-path: '//vjs.zencdn.net/font/1.5.1';
+
+@import 'video-js';


### PR DESCRIPTION
This stylesheet will automatically load the VideoJS EOT font from CDN for browsers that need it (old IE).