### PR TITLE
Don't break when local storage is disabled

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -166,7 +166,9 @@ class TextTrackSettings extends Component {
       if (err) {
         log.error(err);
       }
-    } catch (e) { }
+    } catch (e) {
+      log.warn(e);
+    }
 
     if (values) {
       this.setValues(values);
@@ -190,7 +192,9 @@ class TextTrackSettings extends Component {
       } else {
         window.localStorage.removeItem('vjs-text-track-settings');
       }
-    } catch (e) {}
+    } catch (e) {
+      log.warn(e);
+    }
   }
 
   /**

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -158,11 +158,15 @@ class TextTrackSettings extends Component {
    * @method restoreSettings
    */
   restoreSettings() {
-    let [err, values] = safeParseTuple(window.localStorage.getItem('vjs-text-track-settings'));
+    let err, values;
 
-    if (err) {
-      log.error(err);
-    }
+    try {
+      [err, values] = safeParseTuple(window.localStorage.getItem('vjs-text-track-settings'));
+
+      if (err) {
+        log.error(err);
+      }
+    } catch (e) { }
 
     if (values) {
       this.setValues(values);


### PR DESCRIPTION
This PR is to fix an issue where attempting to restore caption settings when localstorage is disabled causes an error. 