### PR TITLE
Flash tech duration getter returns Infinity instead of negative value

### DIFF
--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -230,6 +230,16 @@ class Flash extends Tech {
   }
 
   /**
+   * Get media duration
+   *
+   * @returns {Number} Media duration
+   */
+  duration() {
+    var duration = this.el_.vjs_getProperty('duration');
+    return duration >= 0 ? duration : Infinity;
+  }
+
+  /**
    * Load media into player
    *
    * @method load
@@ -312,7 +322,7 @@ class Flash extends Tech {
 // Create setters and getters for attributes
 const _api = Flash.prototype;
 const _readWrite = 'rtmpConnection,rtmpStream,preload,defaultPlaybackRate,playbackRate,autoplay,loop,mediaGroup,controller,controls,volume,muted,defaultMuted'.split(',');
-const _readOnly = 'networkState,readyState,initialTime,duration,startOffsetTime,paused,ended,videoWidth,videoHeight'.split(',');
+const _readOnly = 'networkState,readyState,initialTime,startOffsetTime,paused,ended,videoWidth,videoHeight'.split(',');
 
 function _createSetter(attr){
   var attrUpper = attr.charAt(0).toUpperCase() + attr.slice(1);

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -235,8 +235,12 @@ class Flash extends Tech {
    * @returns {Number} Media duration
    */
   duration() {
-    var duration = this.el_.vjs_getProperty('duration');
-    return duration >= 0 ? duration : Infinity;
+    if (this.readyState() === 0) {
+      return NaN;
+    } else {
+      let duration = this.el_.vjs_getProperty('duration');
+      return duration >= 0 ? duration : Infinity;
+    }
   }
 
   /**

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -197,6 +197,33 @@ test('play after ended seeks to the beginning', function() {
   equal(seeks[0], 0, 'seeked to the beginning');
 });
 
+test('duration returns NaN, Infinity or duration according to the HTML standard', function() {
+  let duration = Flash.prototype.duration;
+  let mockedDuration = -1;
+  let mockedReadyState = 0;
+  let result;
+  let mockFlash = {
+    el_: {
+      vjs_getProperty() {
+        return mockedDuration;
+      }
+    },
+    readyState: function() {
+      return mockedReadyState;
+    }
+  };
+  result = duration.call(mockFlash);
+  ok(Number.isNaN(result), 'duration returns NaN when readyState equals 0');
+
+  mockedReadyState = 1;
+  result = duration.call(mockFlash);
+  ok(!Number.isFinite(result), 'duration returns Infinity when duration property is less then 0');
+
+  mockedDuration = 1;
+  result = duration.call(mockFlash);
+  equal(result, 1, 'duration returns duration property when readeyState and duration property are both higher than 0');
+});
+
 // fake out the <object> interaction but leave all the other logic intact
 class MockFlash extends Flash {
   constructor() {


### PR DESCRIPTION
## Description
Flash tech `duration` getter should return Infinity instead of negative values (which some players do return) as stated in [HTML standard](https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-duration).

This situation is solved in upper layer [Player object](https://github.com/vit-koumar/video.js/blob/master/src/js/player.js#L1353), but sometimes `duration` getter is called from inside the Flash tech for example [here](https://github.com/vit-koumar/video.js/blob/master/src/js/tech/flash.js#L274) which situation ends for example in inability of setting `currentTime` when duration is negative.

## Specific Changes proposed
Explicit `duration()` function defined in [js/tech/flash.js](https://github.com/vit-koumar/video.js/blob/master/src/js/tech/flash.js#L237) which returns Infinity instead of negative Number.

## Requirements Checklist
I will adapt the rest of project in case this change will be approved.

