### PR TITLE
Listen to timeupdate on waiting

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -812,6 +812,7 @@ class Player extends Component {
   handleTechWaiting_() {
     this.addClass('vjs-waiting');
     this.trigger('waiting');
+    this.one('timeupdate', () => this.removeClass('vjs-waiting'));
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -943,3 +943,11 @@ test('player#reset loads the first item in the techOrder and then techCalls rese
   equal(loadedSource, null, 'with a null source');
   equal(techCallMethod, 'reset', 'we then reset the tech');
 });
+
+test('Remove waiting class on timeupdate after tech waiting', function() {
+  let player = TestHelpers.makePlayer();
+  player.tech_.trigger('waiting');
+  ok(/vjs-waiting/.test(player.el().className), 'vjs-waiting is added to the player el on tech waiting');
+  player.trigger('timeupdate');
+  ok(!/vjs-waiting/.test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
+});


### PR DESCRIPTION
## Description
This is to workaround a bug currently present in IE11 and potentially in
other cases where we get the waiting event and set the vjs-waiting
class on the player which shows the spinner but then we don't get any
of the events that we use to remove the spinner.
This fixes #3124.


## Specific Changes proposed
Inside of `handleTechWaiting_`, listen to the first `timeupdate` event to clear the `vjs-waiting` class from the player.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by One Core Contributors