### PR TITLE
Add `player.currentWidth` and `player.currentHeight`* methods for getting computed style

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1098,27 +1098,24 @@ class Component {
    * @method currentDimension
    */
   currentDimension(widthOrHeight) {
-    let computedWidthOrHeight;
+    let computedWidthOrHeight = 0;
 
     if (widthOrHeight !== 'width' && widthOrHeight !== 'height') {
-      log.warn('currentDimension only accepts width or height value');
-      return false;
+      throw new Error('currentDimension only accepts width or height value');
     }
 
-    if (typeof window.getComputedStyle !== 'undefined') {
-      const computedStyle = window.getComputedStyle(this.el_, null);
+    if (typeof window.getComputedStyle === 'function') {
+      const computedStyle = window.getComputedStyle(this.el_);
       computedWidthOrHeight = computedStyle.getPropertyValue(widthOrHeight) || computedStyle[ widthOrHeight ];
-    }
-
-    if (this.el_.currentStyle) {
+    } else if (this.el_.currentStyle) {
       // ie 8 doesn't support computed style, shim it
       // return clientWidth or clientHeight instead for better accuracy
-      const rule = 'client' + widthOrHeight.substr(0, 1).toUpperCase() + widthOrHeight.substr(1);
+      const rule = `offset${toTitleCase(widthOrHeight)}`;
       computedWidthOrHeight = this.el_[rule];
     }
 
     // remove 'px' from variable and parse as integer
-    computedWidthOrHeight = parseInt(computedWidthOrHeight, 10);
+    computedWidthOrHeight = parseFloat(computedWidthOrHeight);
     return computedWidthOrHeight;
   }
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1092,6 +1092,67 @@ class Component {
   }
 
   /**
+   * Get width or height of computed style
+   * @param  {String} widthOrHeight  'width' or 'height'
+   * @return {Number|Boolean} The bolean false if nothing was set
+   * @method currentDimension
+   */
+  currentDimension(widthOrHeight) {
+    let computedWidthOrHeight;
+
+    if (widthOrHeight !== 'width' && widthOrHeight !== 'height') {
+      log.warn('currentDimension only accepts width or height value');
+      return false;
+    }
+
+    if (typeof window.getComputedStyle !== 'undefined') {
+      const computedStyle = window.getComputedStyle(this.el_, null);
+      computedWidthOrHeight = computedStyle.getPropertyValue(widthOrHeight) || computedStyle[ widthOrHeight ];
+    }
+
+    if (this.el_.currentStyle) {
+      // ie 8 doesn't support computed style, shim it
+      // return clientWidth or clientHeight instead for better accuracy
+      const rule = 'client' + widthOrHeight.substr(0, 1).toUpperCase() + widthOrHeight.substr(1);
+      computedWidthOrHeight = this.el_[rule];
+    }
+
+    // remove 'px' from variable and parse as integer
+    computedWidthOrHeight = parseInt(computedWidthOrHeight, 10);
+    return computedWidthOrHeight;
+  }
+
+  /**
+   * Get an object which contains width and height values of computed style
+   * @return {Object} The dimensions of element
+   * @method currentDimensions
+   */
+  currentDimensions() {
+    return {
+      width: this.currentDimension('width'),
+      height: this.currentDimension('height')
+    };
+  }
+
+  /**
+   * Get width of computed style
+   * @return {Integer}
+   * @method currentWidth
+   */
+  currentWidth() {
+    return this.currentDimension('width');
+  }
+
+  /**
+   * Get height of computed style
+   * @return {Integer}
+   * @method currentHeight
+   */
+  currentHeight() {
+    return this.currentDimension('height');
+  }
+
+  /**
    * Emit 'tap' events when touch events are supported
    * This is used to support toggling the controls through a tap on the video.
    * We're requiring them to be enabled because otherwise every component would

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -573,10 +573,13 @@ test('should change the width and height of a component', function(){
 });
 
 test('should get the computed dimensions', function(){
-  var container = document.createElement('div');
-  var comp = new Component(getFakePlayer(), {});
-  var el = comp.el();
-  var fixture = document.getElementById('qunit-fixture');
+  const container = document.createElement('div');
+  const comp = new Component(getFakePlayer(), {});
+  const el = comp.el();
+  const fixture = document.getElementById('qunit-fixture');
+
+  const computedWidth = '500px';
+  const computedHeight = '500px';
 
   fixture.appendChild(container);
   container.appendChild(el);
@@ -587,17 +590,14 @@ test('should get the computed dimensions', function(){
   comp.width('50%');
   comp.height('50%');
 
-  var computedWidth = TestHelpers.getComputedStyle(el, 'width');
-  var computedHeight = TestHelpers.getComputedStyle(el, 'height');
+  equal(comp.currentWidth() + 'px', computedWidth, 'matches computed width');
+  equal(comp.currentHeight() + 'px', computedHeight, 'matches computed height');
 
-  ok(computedWidth === comp.currentWidth() + 'px', 'matches computed width');
-  ok(computedHeight === comp.currentHeight() + 'px', 'matches computed height');
+  equal(comp.currentDimension('width') + 'px', computedWidth, 'matches computed width');
+  equal(comp.currentDimension('height') + 'px', computedHeight, 'matches computed height');
 
-  ok(computedWidth === comp.currentDimension('width') + 'px', 'matches computed width');
-  ok(computedHeight === comp.currentDimension('height') + 'px', 'matches computed height');
-
-  ok(computedWidth === comp.currentDimensions()['width'] + 'px', 'matches computed width');
-  ok(computedHeight === comp.currentDimensions()['height'] + 'px', 'matches computed width');
+  equal(comp.currentDimensions()['width'] + 'px', computedWidth, 'matches computed width');
+  equal(comp.currentDimensions()['height'] + 'px', computedHeight, 'matches computed width');
 
 });
 

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -572,6 +572,34 @@ test('should change the width and height of a component', function(){
   ok(comp.height() === 0, 'forced height was removed');
 });
 
+test('should get the computed dimensions', function(){
+  var container = document.createElement('div');
+  var comp = new Component(getFakePlayer(), {});
+  var el = comp.el();
+  var fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(container);
+  container.appendChild(el);
+  // Container of el needs dimensions or the component won't have dimensions
+  container.style.width = '1000px';
+  container.style.height = '1000px';
+
+  comp.width('50%');
+  comp.height('50%');
+
+  var computedWidth = TestHelpers.getComputedStyle(el, 'width');
+  var computedHeight = TestHelpers.getComputedStyle(el, 'height');
+
+  ok(computedWidth === comp.currentWidth() + 'px', 'matches computed width');
+  ok(computedHeight === comp.currentHeight() + 'px', 'matches computed height');
+
+  ok(computedWidth === comp.currentDimension('width') + 'px', 'matches computed width');
+  ok(computedHeight === comp.currentDimension('height') + 'px', 'matches computed height');
+
+  ok(computedWidth === comp.currentDimensions()['width'] + 'px', 'matches computed width');
+  ok(computedHeight === comp.currentDimensions()['height'] + 'px', 'matches computed width');
+
+});
 
 test('should use a defined content el for appending children', function(){
   class CompWithContent extends Component {}


### PR DESCRIPTION
## Description
Add `player.currentWidth` and `player.currentHeight`* methods for getting computed style

## Specific Changes proposed
API methods:
Component
Component.prototype.currentDimension(widthOrHeight) -> Number - It takes a string value of either width or height to return back the appropriate value
Component.prototype.currentDimensions() -> Object{width: Number, height: Number} - Returns an object with width and height properties
Component.prototype.currentHeight() -> Number - Delegates to Component#currentDimension to get back the height value
Component.prototype.currentWidth() -> Number - Delegates to Component#currentDimension to get back the width value
Player - We probably don't need to make any changes in the player because it extends from component and will inherit the functionality from it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors