### PR TITLE
updated text track unit tests to use full es6 syntax

### DIFF
--- a/test/unit/tracks/html-track-element-list.test.js
+++ b/test/unit/tracks/html-track-element-list.test.js
@@ -2,30 +2,29 @@ import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
 import HTMLTrackElementList from '../../../src/js/tracks/html-track-element-list.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 
-let noop = Function.prototype;
-let defaultTech = {
-  textTracks: noop,
-  on: noop,
-  off: noop,
-  currentTime: noop
+const defaultTech = {
+  textTracks() {},
+  on() {},
+  off() {},
+  currentTime() {}
 };
 
-let track1 = new TextTrack({
+const track1 = new TextTrack({
   id: 1,
   tech: defaultTech
 });
-let track2 = new TextTrack({
+const track2 = new TextTrack({
   id: 2,
   tech: defaultTech
 });
 
-var genericHtmlTrackElements = [{
+const genericHtmlTrackElements = [{
+  tech() {},
   kind: 'captions',
-  tech: noop,
   track: track1
 }, {
+  tech() {},
   kind: 'chapters',
-  tech: noop,
   track: track2
 }];
 
@@ -47,9 +46,9 @@ test('can get html track element by track', function() {
 test('length is updated when new tracks are added or removed', function() {
   let htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
-  htmlTrackElementList.addTrackElement_({tech: noop});
+  htmlTrackElementList.addTrackElement_({tech() {}});
   equal(htmlTrackElementList.length, genericHtmlTrackElements.length + 1, `the length is ${genericHtmlTrackElements.length + 1}`);
-  htmlTrackElementList.addTrackElement_({tech: noop});
+  htmlTrackElementList.addTrackElement_({tech() {}});
   equal(htmlTrackElementList.length, genericHtmlTrackElements.length + 2, `the length is ${genericHtmlTrackElements.length + 2}`);
 
   htmlTrackElementList.removeTrackElement_(htmlTrackElementList.getTrackElementByTrack_(track1));

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -2,12 +2,11 @@ import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import window from 'global/window';
 
-let noop = Function.prototype;
-let defaultTech = {
-  textTracks: noop,
-  on: noop,
-  off: noop,
-  currentTime: noop
+const defaultTech = {
+  textTracks() {},
+  on() {},
+  off() {},
+  currentTime() {}
 };
 
 q.module('HTML Track Element');
@@ -23,12 +22,12 @@ test('html track element requires a tech', function() {
 });
 
 test('can create a html track element with various properties', function() {
-  let kind = 'chapters',
-      label = 'English',
-      language = 'en',
-      src = 'http://www.example.com';
+  let kind = 'chapters';
+  let label = 'English';
+  let language = 'en';
+  let src = 'http://www.example.com';
 
-  let htmlTrackElement = new  HTMLTrackElement({
+  let htmlTrackElement = new HTMLTrackElement({
     kind,
     label,
     language,
@@ -36,7 +35,7 @@ test('can create a html track element with various properties', function() {
     tech: defaultTech
   });
 
-  equal(htmlTrackElement.default, undefined, 'we have a default');
+  equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
   equal(htmlTrackElement.kind, kind, 'we have a kind');
   equal(htmlTrackElement.label, label, 'we have a label');
   equal(htmlTrackElement.readyState, 0, 'we have a readyState');
@@ -46,29 +45,29 @@ test('can create a html track element with various properties', function() {
 });
 
 test('defaults when items not provided', function() {
-  let htmlTrackElement = new  HTMLTrackElement({
+  let htmlTrackElement = new HTMLTrackElement({
     tech: defaultTech
   });
 
-  equal(htmlTrackElement.default, undefined, 'we have a default');
+  equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
   equal(htmlTrackElement.kind, 'subtitles', 'we have a kind');
   equal(htmlTrackElement.label, '', 'we have a label');
   equal(htmlTrackElement.readyState, 0, 'we have a readyState');
-  equal(htmlTrackElement.src, undefined, 'we have a src');
+  equal(typeof htmlTrackElement.src, 'undefined', 'we have a src');
   equal(htmlTrackElement.srclang, '', 'we have a srclang');
   equal(htmlTrackElement.track.cues.length, 0, 'we have a track');
 });
 
 test('fires loadeddata when track cues become populated', function() {
-  let changes = 0,
-      loadHandler;
+  let changes = 0;
+  let loadHandler;
 
   loadHandler = function() {
     changes++;
   };
 
   let htmlTrackElement = new HTMLTrackElement({
-    tech: noop
+    tech() {}
   });
 
   htmlTrackElement.addEventListener('load', loadHandler);

--- a/test/unit/tracks/text-track-controls.test.js
+++ b/test/unit/tracks/text-track-controls.test.js
@@ -3,15 +3,15 @@ import TestHelpers from '../test-helpers.js';
 import * as browser from '../../../src/js/utils/browser.js';
 
 q.module('Text Track Controls', {
-  'setup': function() {
+  setup() {
     this.clock = sinon.useFakeTimers();
   },
-  'teardown': function() {
+  teardown() {
     this.clock.restore();
   }
 });
 
-var track = {
+const track = {
   kind: 'captions',
   label: 'test'
 };
@@ -30,7 +30,7 @@ test('should be displayed when text tracks list is not empty', function() {
 });
 
 test('should be displayed when a text track is added to an empty track list', function() {
-  var player = TestHelpers.makePlayer();
+  let player = TestHelpers.makePlayer();
 
   player.addRemoteTextTrack(track);
 
@@ -41,7 +41,7 @@ test('should be displayed when a text track is added to an empty track list', fu
 });
 
 test('should not be displayed when text tracks list is empty', function() {
-  var player = TestHelpers.makePlayer();
+  let player = TestHelpers.makePlayer();
 
   ok(player.controlBar.captionsButton.hasClass('vjs-hidden'), 'control is not displayed');
   equal(player.textTracks().length, 0, 'textTracks is empty');
@@ -50,7 +50,7 @@ test('should not be displayed when text tracks list is empty', function() {
 });
 
 test('should not be displayed when last text track is removed', function() {
-  var player = TestHelpers.makePlayer({
+  let player = TestHelpers.makePlayer({
     tracks: [track]
   });
 
@@ -63,10 +63,10 @@ test('should not be displayed when last text track is removed', function() {
 });
 
 test('menu should contain "Settings", "Off" and one track', function() {
-  var player = TestHelpers.makePlayer({
-      tracks: [track]
-    }),
-    menuItems;
+  let player = TestHelpers.makePlayer({
+    tracks: [track]
+  });
+  let menuItems;
 
   this.clock.tick(1000);
 
@@ -81,7 +81,7 @@ test('menu should contain "Settings", "Off" and one track', function() {
 });
 
 test('menu should update with addRemoteTextTrack', function() {
-  var player = TestHelpers.makePlayer({
+  let player = TestHelpers.makePlayer({
     tracks: [track]
   });
 
@@ -96,7 +96,7 @@ test('menu should update with addRemoteTextTrack', function() {
 });
 
 test('menu should update with removeRemoteTextTrack', function() {
-  var player = TestHelpers.makePlayer({
+  let player = TestHelpers.makePlayer({
     tracks: [track, track]
   });
 
@@ -115,15 +115,15 @@ if (!browser.IS_IE8) {
   // However, this test tests a specific with iOS7 where the TextTrackList doesn't report track mode changes.
   // TODO: figure out why this test doens't work on IE8. https://github.com/videojs/video.js/issues/1861
   test('menu items should polyfill mode change events', function() {
-    var player = TestHelpers.makePlayer({}),
-        changes,
-        trackMenuItem;
+    let player = TestHelpers.makePlayer({});
+    let changes;
+    let trackMenuItem;
 
     // emulate a TextTrackList that doesn't report track mode changes,
     // like iOS7
     player.textTracks().onchange = undefined;
     trackMenuItem = new TextTrackMenuItem(player, {
-      track: track
+      track
     });
 
     player.textTracks().on('change', function() {

--- a/test/unit/tracks/text-track-cue-list.test.js
+++ b/test/unit/tracks/text-track-cue-list.test.js
@@ -1,6 +1,6 @@
 import TextTrackCueList from '../../../src/js/tracks/text-track-cue-list.js';
 
-let genericTracks = [
+const genericTracks = [
   {
     id: '1'
   }, {
@@ -13,13 +13,13 @@ let genericTracks = [
 q.module('Text Track Cue List');
 
 test('TextTrackCueList\'s length is set correctly', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
 test('can get cues by id', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   equal(ttcl.getCueById('1').id, 1, 'id "1" has id of "1"');
   equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
@@ -28,7 +28,7 @@ test('can get cues by id', function() {
 });
 
 test('length is updated when new tracks are added or removed', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
@@ -42,9 +42,9 @@ test('length is updated when new tracks are added or removed', function() {
 });
 
 test('can access items by index', function() {
-  var ttcl = new TextTrackCueList(genericTracks),
-      i = 0,
-      length = ttcl.length;
+  let ttcl = new TextTrackCueList(genericTracks);
+  let i = 0;
+  let length = ttcl.length;
 
   expect(length);
 
@@ -54,7 +54,7 @@ test('can access items by index', function() {
 });
 
 test('can access new items by index', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
 
@@ -64,7 +64,7 @@ test('can access new items by index', function() {
 });
 
 test('cannot access removed items by index', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
@@ -77,7 +77,7 @@ test('cannot access removed items by index', function() {
 });
 
 test('new item available at old index', function() {
-  var ttcl = new TextTrackCueList(genericTracks);
+  let ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
   equal(ttcl[3].id, '100', 'id of item at index 3 is 100');

--- a/test/unit/tracks/text-track-list-converter.test.js
+++ b/test/unit/tracks/text-track-list-converter.test.js
@@ -3,7 +3,6 @@ import TextTrack from '../../../src/js/tracks/text-track.js';
 import TextTrackList from '../../../src/js/tracks/text-track-list.js';
 import Html5 from '../../../src/js/tech/html5.js';
 import document from 'global/document';
-import window from 'global/window';
 
 q.module('Text Track List Converter', {});
 
@@ -26,6 +25,7 @@ let cleanup = (item) => {
 if (Html5.supportsNativeTextTracks()) {
   q.test('trackToJson_ produces correct representation for native track object', function(a) {
     let track = document.createElement('track');
+
     track.src = 'example.com/english.vtt';
     track.kind = 'captions';
     track.srclang = 'en';
@@ -48,11 +48,13 @@ if (Html5.supportsNativeTextTracks()) {
     });
 
     let nativeTrack = document.createElement('track');
+
     nativeTrack.kind = 'captions';
     nativeTrack.srclang = 'es';
     nativeTrack.label = 'Spanish';
 
     let tt = new TextTrackList();
+
     tt.addTrack_(nativeTrack.track);
     tt.addTrack_(emulatedTrack);
 
@@ -96,12 +98,14 @@ if (Html5.supportsNativeTextTracks()) {
     });
 
     let nativeTrack = document.createElement('track');
+
     nativeTrack.src = 'example.com/spanish.vtt';
     nativeTrack.kind = 'captions';
     nativeTrack.srclang = 'es';
     nativeTrack.label = 'Spanish';
 
     let tt = new TextTrackList();
+
     tt.addTrack_(nativeTrack.track);
     tt.addTrack_(emulatedTrack);
 
@@ -171,6 +175,7 @@ q.test('textTracksToJson produces good json output for emulated only', function(
   });
 
   let tt = new TextTrackList();
+
   tt.addTrack_(anotherTrack);
   tt.addTrack_(emulatedTrack);
 
@@ -224,6 +229,7 @@ q.test('jsonToTextTracks calls addRemoteTextTrack on the tech with emulated trac
   });
 
   let tt = new TextTrackList();
+
   tt.addTrack_(anotherTrack);
   tt.addTrack_(emulatedTrack);
 

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -2,33 +2,33 @@ import TextTrackList from '../../../src/js/tracks/text-track-list.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import EventTarget from '../../../src/js/event-target.js';
 
-var noop = Function.prototype;
-var genericTracks = [
+const noop = () => {};
+const genericTracks = [
   {
     id: '1',
-    addEventListener: noop,
-    off: noop
+    addEventListener() {},
+    off() {}
   }, {
     id: '2',
-    addEventListener: noop,
-    off: noop
+    addEventListener() {},
+    off() {}
   }, {
     id: '3',
-    addEventListener: noop,
-    off: noop
+    addEventListener() {},
+    off() {}
   }
 ];
 
 q.module('Text Track List');
 
 test('TextTrackList\'s length is set correctly', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
   equal(ttl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
 test('can get text tracks by id', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
   equal(ttl.getTrackById('1').id, 1, 'id "1" has id of "1"');
   equal(ttl.getTrackById('2').id, 2, 'id "2" has id of "2"');
@@ -37,11 +37,11 @@ test('can get text tracks by id', function() {
 });
 
 test('length is updated when new tracks are added or removed', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
+  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
   equal(ttl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
-  ttl.addTrack_({id: '101', addEventListener: noop, off: noop});
+  ttl.addTrack_({id: '101', addEventListener() {}, off() {}});
   equal(ttl.length, genericTracks.length + 2, 'the length is ' + (genericTracks.length + 2));
 
   ttl.removeTrack_(ttl.getTrackById('101'));
@@ -51,9 +51,9 @@ test('length is updated when new tracks are added or removed', function() {
 });
 
 test('can access items by index', function() {
-  var ttl = new TextTrackList(genericTracks),
-      i = 0,
-      length = ttl.length;
+  let ttl = new TextTrackList(genericTracks);
+  let i = 0;
+  let length = ttl.length;
 
   expect(length);
 
@@ -63,19 +63,19 @@ test('can access items by index', function() {
 });
 
 test('can access new items by index', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop});
+  ttl.addTrack_({id: '100', addEventListener() {}});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
-  ttl.addTrack_({id: '101', addEventListener: noop});
+  ttl.addTrack_({id: '101', addEventListener() {}});
   equal(ttl[4].id, '101', 'id of item at index 4 is 101');
 });
 
 test('cannot access removed items by index', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
-  ttl.addTrack_({id: '101', addEventListener: noop, off: noop});
+  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
+  ttl.addTrack_({id: '101', addEventListener() {}, off() {}});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
   equal(ttl[4].id, '101', 'id of item at index 4 is 101');
 
@@ -87,51 +87,55 @@ test('cannot access removed items by index', function() {
 });
 
 test('new item available at old index', function() {
-  var ttl = new TextTrackList(genericTracks);
+  let ttl = new TextTrackList(genericTracks);
 
-  ttl.addTrack_({id: '100', addEventListener: noop, off: noop});
+  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
   equal(ttl[3].id, '100', 'id of item at index 3 is 100');
 
   ttl.removeTrack_(ttl.getTrackById('100'));
   ok(!ttl[3], 'nothing at index 3');
 
-  ttl.addTrack_({id: '101', addEventListener: noop});
+  ttl.addTrack_({id: '101', addEventListener() {}});
   equal(ttl[3].id, '101', 'id of new item at index 3 is now 101');
 });
 
 test('a "addtrack" event is triggered when new tracks are added', function() {
-  var ttl = new TextTrackList(genericTracks),
-      tracks = 0,
-      adds = 0,
-      addHandler = function(e) {
-        e.track && tracks++;
-        adds++;
-      };
+  let ttl = new TextTrackList(genericTracks);
+  let tracks = 0;
+  let adds = 0;
+  let addHandler = function(e) {
+    if (e.track) {
+      tracks++;
+    }
+    adds++;
+  };
 
   ttl.on('addtrack', addHandler);
 
-  ttl.addTrack_({id: '100', addEventListener: noop});
-  ttl.addTrack_({id: '101', addEventListener: noop});
+  ttl.addTrack_({id: '100', addEventListener() {}});
+  ttl.addTrack_({id: '101', addEventListener() {}});
 
   ttl.off('addtrack', addHandler);
 
   ttl.onaddtrack = addHandler;
 
-  ttl.addTrack_({id: '102', addEventListener: noop});
-  ttl.addTrack_({id: '103', addEventListener: noop});
+  ttl.addTrack_({id: '102', addEventListener() {}});
+  ttl.addTrack_({id: '103', addEventListener() {}});
 
   equal(adds, 4, 'we got ' + adds + ' "addtrack" events');
   equal(tracks, 4, 'we got a track with every event');
 });
 
 test('a "removetrack" event is triggered when tracks are removed', function() {
-  var ttl = new TextTrackList(genericTracks),
-      tracks = 0,
-      rms = 0,
-      rmHandler = function(e) {
-        e.track && tracks++;
-        rms++;
-      };
+  let ttl = new TextTrackList(genericTracks);
+  let tracks = 0;
+  let rms = 0;
+  let rmHandler = function(e) {
+    if (e.track) {
+      tracks++;
+    }
+    rms++;
+  };
 
   ttl.on('removetrack', rmHandler);
 
@@ -149,12 +153,12 @@ test('a "removetrack" event is triggered when tracks are removed', function() {
 });
 
 test('trigger "change" event when "modechange" is fired on a track', function() {
-  var tt = new EventTarget(),
-      ttl = new TextTrackList([tt]),
-      changes = 0,
-      changeHandler = function() {
-        changes++;
-      };
+  let tt = new EventTarget();
+  let ttl = new TextTrackList([tt]);
+  let changes = 0;
+  let changeHandler = function() {
+    changes++;
+  };
 
   ttl.on('change', changeHandler);
 
@@ -170,16 +174,16 @@ test('trigger "change" event when "modechange" is fired on a track', function() 
 });
 
 test('trigger "change" event when mode changes on a TextTrack', function() {
-  var tt = new TextTrack({
-        tech: {
-          on: noop
-        }
-      }),
-      ttl = new TextTrackList([tt]),
-      changes = 0,
-      changeHandler = function() {
-        changes++;
-      };
+  let tt = new TextTrack({
+    tech: {
+      on() {}
+    }
+  });
+  let ttl = new TextTrackList([tt]);
+  let changes = 0;
+  let changeHandler = function() {
+    changes++;
+  };
 
   ttl.on('change', changeHandler);
 

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -2,7 +2,6 @@ import TextTrackList from '../../../src/js/tracks/text-track-list.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import EventTarget from '../../../src/js/event-target.js';
 
-const noop = () => {};
 const genericTracks = [
   {
     id: '1',

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -4,33 +4,33 @@ import * as Events from '../../../src/js/utils/events.js';
 import safeParseTuple from 'safe-json-parse/tuple';
 import window from 'global/window';
 
-var tracks = [{
+const tracks = [{
   kind: 'captions',
   label: 'test'
 }];
 
 q.module('Text Track Settings', {
-  beforeEach: function() {
+  beforeEach() {
     window.localStorage.clear();
   }
 });
 
 test('should update settings', function() {
-  var player = TestHelpers.makePlayer({
-      tracks: tracks,
-      persistTextTrackSettings: true
-    }),
-    newSettings = {
-      'backgroundOpacity': '1',
-      'textOpacity': '1',
-      'windowOpacity': '1',
-      'edgeStyle': 'raised',
-      'fontFamily': 'monospaceSerif',
-      'color': '#FFF',
-      'backgroundColor': '#FFF',
-      'windowColor': '#FFF',
-      'fontPercent': 1.25
-    };
+  let player = TestHelpers.makePlayer({
+    tracks,
+    persistTextTrackSettings: true
+  });
+  let newSettings = {
+    backgroundOpacity: '1',
+    textOpacity: '1',
+    windowOpacity: '1',
+    edgeStyle: 'raised',
+    fontFamily: 'monospaceSerif',
+    color: '#FFF',
+    backgroundColor: '#FFF',
+    windowColor: '#FFF',
+    fontPercent: 1.25
+  };
 
   player.textTrackSettings.setValues(newSettings);
   deepEqual(player.textTrackSettings.getValues(), newSettings, 'values are updated');
@@ -52,8 +52,8 @@ test('should update settings', function() {
 });
 
 test('should restore default settings', function() {
-  var player = TestHelpers.makePlayer({
-    tracks: tracks,
+  let player = TestHelpers.makePlayer({
+    tracks,
     persistTextTrackSettings: true
   });
 
@@ -88,9 +88,10 @@ test('should restore default settings', function() {
 });
 
 test('should open on click', function() {
-  var player = TestHelpers.makePlayer({
-    tracks: tracks
+  let player = TestHelpers.makePlayer({
+    tracks
   });
+
   Events.trigger(player.$('.vjs-texttrack-settings'), 'click');
   ok(!player.textTrackSettings.hasClass('vjs-hidden'), 'settings open');
 
@@ -98,9 +99,10 @@ test('should open on click', function() {
 });
 
 test('should close on done click', function() {
-  var player = TestHelpers.makePlayer({
-    tracks: tracks
+  let player = TestHelpers.makePlayer({
+    tracks
   });
+
   Events.trigger(player.$('.vjs-texttrack-settings'), 'click');
   Events.trigger(player.$('.vjs-done-button'), 'click');
   ok(player.textTrackSettings.hasClass('vjs-hidden'), 'settings closed');
@@ -109,16 +111,16 @@ test('should close on done click', function() {
 });
 
 test('if persist option is set, restore settings on init', function() {
-  var player,
-      oldRestoreSettings = TextTrackSettings.prototype.restoreSettings,
-      restore = 0;
+  let player;
+  let oldRestoreSettings = TextTrackSettings.prototype.restoreSettings;
+  let restore = 0;
 
   TextTrackSettings.prototype.restoreSettings = function() {
     restore++;
   };
 
   player = TestHelpers.makePlayer({
-    tracks: tracks,
+    tracks,
     persistTextTrackSettings: true
   });
 
@@ -130,12 +132,12 @@ test('if persist option is set, restore settings on init', function() {
 });
 
 test('if persist option is set, save settings when "done"', function() {
-  var player = TestHelpers.makePlayer({
-        tracks: tracks,
-        persistTextTrackSettings: true
-      }),
-      oldSaveSettings = TextTrackSettings.prototype.saveSettings,
-      save = 0;
+  let player = TestHelpers.makePlayer({
+    tracks,
+    persistTextTrackSettings: true
+  });
+  let oldSaveSettings = TextTrackSettings.prototype.saveSettings;
+  let save = 0;
 
   TextTrackSettings.prototype.saveSettings = function() {
     save++;
@@ -151,11 +153,11 @@ test('if persist option is set, save settings when "done"', function() {
 });
 
 test('do not try to restore or save settings if persist option is not set', function() {
-  var player,
-      oldRestoreSettings = TextTrackSettings.prototype.restoreSettings,
-      oldSaveSettings = TextTrackSettings.prototype.saveSettings,
-      save = 0,
-      restore = 0;
+  let player;
+  let oldRestoreSettings = TextTrackSettings.prototype.restoreSettings;
+  let oldSaveSettings = TextTrackSettings.prototype.saveSettings;
+  let save = 0;
+  let restore = 0;
 
   TextTrackSettings.prototype.restoreSettings = function() {
     restore++;
@@ -165,7 +167,7 @@ test('do not try to restore or save settings if persist option is not set', func
   };
 
   player = TestHelpers.makePlayer({
-    tracks: tracks,
+    tracks,
     persistTextTrackSettings: false
   });
 
@@ -183,23 +185,23 @@ test('do not try to restore or save settings if persist option is not set', func
 });
 
 test('should restore saved settings', function() {
-  var player,
-    newSettings = {
-      'backgroundOpacity': '1',
-      'textOpacity': '1',
-      'windowOpacity': '1',
-      'edgeStyle': 'raised',
-      'fontFamily': 'monospaceSerif',
-      'color': '#FFF',
-      'backgroundColor': '#FFF',
-      'windowColor': '#FFF',
-      'fontPercent': 1.25
-    };
+  let player;
+  let newSettings = {
+    backgroundOpacity: '1',
+    textOpacity: '1',
+    windowOpacity: '1',
+    edgeStyle: 'raised',
+    fontFamily: 'monospaceSerif',
+    color: '#FFF',
+    backgroundColor: '#FFF',
+    windowColor: '#FFF',
+    fontPercent: 1.25
+  };
 
   window.localStorage.setItem('vjs-text-track-settings', JSON.stringify(newSettings));
 
   player = TestHelpers.makePlayer({
-    tracks: tracks,
+    tracks,
     persistTextTrackSettings: true
   });
 
@@ -209,23 +211,23 @@ test('should restore saved settings', function() {
 });
 
 test('should not restore saved settings', function() {
-  var player,
-    newSettings = {
-      'backgroundOpacity': '1',
-      'textOpacity': '1',
-      'windowOpacity': '1',
-      'edgeStyle': 'raised',
-      'fontFamily': 'monospaceSerif',
-      'color': '#FFF',
-      'backgroundColor': '#FFF',
-      'windowColor': '#FFF',
-      'fontPercent': 1.25
-    };
+  let player;
+  let newSettings = {
+    backgroundOpacity: '1',
+    textOpacity: '1',
+    windowOpacity: '1',
+    edgeStyle: 'raised',
+    fontFamily: 'monospaceSerif',
+    color: '#FFF',
+    backgroundColor: '#FFF',
+    windowColor: '#FFF',
+    fontPercent: 1.25
+  };
 
   window.localStorage.setItem('vjs-text-track-settings', JSON.stringify(newSettings));
 
   player = TestHelpers.makePlayer({
-    tracks: tracks,
+    tracks,
     persistTextTrackSettings: false
   });
 

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -1,39 +1,35 @@
 import TextTrack from '../../../src/js/tracks/text-track.js';
-import window from 'global/window';
 import TestHelpers from '../test-helpers.js';
 
-var noop = Function.prototype;
-var defaultTech = {
-  textTracks: noop,
-  on: noop,
-  off: noop,
-  currentTime: noop
+const defaultTech = {
+  textTracks() {},
+  on() {},
+  off() {},
+  currentTime() {}
 };
 
 q.module('Text Track');
 
 test('text-track requires a tech', function() {
-  window.throws(function() {
-           new TextTrack();
-         },
-         new Error('A tech was not provided.'),
-         'a tech is required for text track');
+  let error = new Error('A tech was not provided.');
+
+  q.throws(() => new TextTrack(), error, 'a tech is required for text track');
 });
 
 test('can create a TextTrack with various properties', function() {
-  var kind = 'captions',
-      label = 'English',
-      language = 'en',
-      id = '1',
-      mode = 'disabled',
-      tt = new TextTrack({
-        tech: defaultTech,
-        kind: kind,
-        label: label,
-        language: language,
-        id: id,
-        mode: mode
-      });
+  let kind = 'captions';
+  let label = 'English';
+  let language = 'en';
+  let id = '1';
+  let mode = 'disabled';
+  let tt = new TextTrack({
+    kind,
+    label,
+    language,
+    id,
+    mode,
+    tech: defaultTech
+  });
 
   equal(tt.kind, kind, 'we have a kind');
   equal(tt.label, label, 'we have a label');
@@ -43,7 +39,7 @@ test('can create a TextTrack with various properties', function() {
 });
 
 test('defaults when items not provided', function() {
-  var tt = new TextTrack({
+  let tt = new TextTrack({
     tech: defaultTech
   });
 
@@ -54,7 +50,7 @@ test('defaults when items not provided', function() {
 });
 
 test('kind can only be one of several options, defaults to subtitles', function() {
-  var tt = new TextTrack({
+  let tt = new TextTrack({
     tech: defaultTech,
     kind: 'foo'
   });
@@ -99,7 +95,7 @@ test('kind can only be one of several options, defaults to subtitles', function(
 });
 
 test('mode can only be one of several options, defaults to disabled', function() {
-  var tt = new TextTrack({
+  let tt = new TextTrack({
     tech: defaultTech,
     mode: 'foo'
   });
@@ -130,19 +126,19 @@ test('mode can only be one of several options, defaults to disabled', function()
 });
 
 test('kind, label, language, id, cue, and activeCues are read only', function() {
-  var kind = 'captions',
-      label = 'English',
-      language = 'en',
-      id = '1',
-      mode = 'disabled',
-      tt = new TextTrack({
-        tech: defaultTech,
-        kind: kind,
-        label: label,
-        language: language,
-        id: id,
-        mode: mode
-      });
+  let kind = 'captions';
+  let label = 'English';
+  let language = 'en';
+  let id = '1';
+  let mode = 'disabled';
+  let tt = new TextTrack({
+    kind,
+    label,
+    language,
+    id,
+    mode,
+    tech: defaultTech
+  });
 
   tt.kind = 'subtitles';
   tt.label = 'Spanish';
@@ -160,8 +156,8 @@ test('kind, label, language, id, cue, and activeCues are read only', function() 
 });
 
 test('mode can only be set to a few options', function() {
-  var tt = new TextTrack({
-    tech: defaultTech,
+  let tt = new TextTrack({
+    tech: defaultTech
   });
 
   tt.mode = 'foo';
@@ -185,8 +181,8 @@ test('mode can only be set to a few options', function() {
 });
 
 test('cues and activeCues return a TextTrackCueList', function() {
-  var tt = new TextTrack({
-    tech: defaultTech,
+  let tt = new TextTrack({
+    tech: defaultTech
   });
 
   ok(tt.cues.getCueById, 'cues are a TextTrackCueList');
@@ -194,13 +190,12 @@ test('cues and activeCues return a TextTrackCueList', function() {
 });
 
 test('cues can be added and removed from a TextTrack', function() {
-  var tt = new TextTrack({
-        tech: defaultTech,
-      }),
-      cues;
+  let tt = new TextTrack({
+    tech: defaultTech
+  });
+  let cues;
 
   cues = tt.cues;
-
 
   equal(cues.length, 0, 'start with zero cues');
 
@@ -220,13 +215,13 @@ test('cues can be added and removed from a TextTrack', function() {
 });
 
 test('fires cuechange when cues become active and inactive', function() {
-  var player = TestHelpers.makePlayer(),
-      changes = 0,
-      cuechangeHandler,
-      tt = new TextTrack({
-        tech: player.tech_,
-        mode: 'showing'
-      });
+  let player = TestHelpers.makePlayer();
+  let changes = 0;
+  let cuechangeHandler;
+  let tt = new TextTrack({
+    tech: player.tech_,
+    mode: 'showing'
+  });
 
   cuechangeHandler = function() {
     changes++;

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -410,16 +410,15 @@ test('removes cuechange event when text track is hidden for emulated tracks', fu
 
 test('should return correct remote text track values', function() {
   let fixture = document.getElementById('qunit-fixture');
-  let html = '';
-
-  html += '<video id="example_1" class="video-js" autoplay preload="none">';
-  html += '<source src="http://google.com" type="video/mp4">';
-  html += '<source src="http://google.com" type="video/webm">';
-  html += '<track kind="captions" label="label">';
-  html += '</video>';
+  let html = `
+    <video id="example_1" class="video-js" autoplay preload="none">
+      <source src="http://google.com" type="video/mp4">
+      <source src="http://google.com" type="video/webm">
+      <track kind="captions" label="label">
+    </video>
+  `;
 
   fixture.innerHTML += html;
-
   let tag = document.getElementById('example_1');
   let player = TestHelpers.makePlayer({}, tag);
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -5,34 +5,32 @@ import CaptionsButton from '../../../src/js/control-bar/text-track-controls/capt
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import TextTrackDisplay from '../../../src/js/tracks/text-track-display.js';
 import Html5 from '../../../src/js/tech/html5.js';
-import Flash from '../../../src/js/tech/flash.js';
 import Tech from '../../../src/js/tech/tech.js';
 import Component from '../../../src/js/component.js';
 
 import * as browser from '../../../src/js/utils/browser.js';
 import TestHelpers from '../test-helpers.js';
 import document from 'global/document';
-import window from 'global/window';
-import TechFaker from '../tech/tech-faker.js';
 
 q.module('Tracks', {
-  'setup': function() {
+  setup() {
     this.clock = sinon.useFakeTimers();
   },
-  'teardown': function() {
+  teardown() {
     this.clock.restore();
   }
 });
 
 test('should place title list item into ul', function() {
-  var player, chaptersButton;
+  let player;
+  let chaptersButton;
 
   player = TestHelpers.makePlayer();
 
   chaptersButton = new ChaptersButton(player);
 
-  var menuContentElement = chaptersButton.el().getElementsByTagName('UL')[0];
-  var titleElement = menuContentElement.children[0];
+  let menuContentElement = chaptersButton.el().getElementsByTagName('UL')[0];
+  let titleElement = menuContentElement.children[0];
 
   ok(titleElement.innerHTML === 'Chapters', 'title element placed in ul');
 
@@ -40,8 +38,8 @@ test('should place title list item into ul', function() {
 });
 
 test('Player track methods call the tech', function() {
-  var player,
-      calls = 0;
+  let player;
+  let calls = 0;
 
   player = TestHelpers.makePlayer();
 
@@ -61,35 +59,34 @@ test('Player track methods call the tech', function() {
 });
 
 test('TextTrackDisplay initializes tracks on player ready', function() {
-  var calls = 0,
-      ttd = new TextTrackDisplay({
-        on: Function.prototype,
-        addTextTracks: function() {
-          calls--;
-        },
-        getChild: function() {
-          calls--;
-        },
-        ready: function() {
-          calls++;
-        }
-      }, {});
+  let calls = 0;
+  let ttd = new TextTrackDisplay({
+    on() {},
+    addTextTracks() {
+      calls--;
+    },
+    getChild() {
+      calls--;
+    },
+    ready() {
+      calls++;
+    }
+  }, {});
 
   equal(calls, 1, 'only a player.ready call was made');
 });
 
 test('listen to remove and add track events in native text tracks', function() {
-  var oldTestVid = Html5.TEST_VID,
-      player,
-      options,
-      oldTextTracks,
-      events = {},
-      html;
+  let oldTestVid = Html5.TEST_VID;
+  let player;
+  let options;
+  let oldTextTracks = Html5.prototype.textTracks;
+  let events = {};
+  let html;
 
-  oldTextTracks = Html5.prototype.textTracks;
   Html5.prototype.textTracks = function() {
     return {
-      addEventListener: function(type, handler) {
+      addEventListener(type, handler) {
         events[type] = true;
       }
     };
@@ -101,17 +98,17 @@ test('listen to remove and add track events in native text tracks', function() {
 
   player = {
     // Function.prototype is a built-in no-op function.
-    controls: Function.prototype,
-    ready: Function.prototype,
-    options: function() {
+    controls() {},
+    ready() {},
+    options() {
       return {};
     },
-    addChild: Function.prototype,
-    id: Function.prototype,
-    el: function() {
+    addChild() {},
+    id() {},
+    el() {
       return {
-        insertBefore: Function.prototype,
-        appendChild: Function.prototype
+        insertBefore() {},
+        appendChild() {}
       };
     }
   };
@@ -120,24 +117,24 @@ test('listen to remove and add track events in native text tracks', function() {
 
   html = new Html5(options);
 
-  ok(events['removetrack'], 'removetrack listener was added');
-  ok(events['addtrack'], 'addtrack listener was added');
+  ok(events.removetrack, 'removetrack listener was added');
+  ok(events.addtrack, 'addtrack listener was added');
 
   Html5.TEST_VID = oldTestVid;
   Html5.prototype.textTracks = oldTextTracks;
 });
 
 test('update texttrack buttons on removetrack or addtrack', function() {
-  var update = 0,
-      i,
-      player,
-      tag,
-      track,
-      oldTextTracks,
-      events = {},
-      oldCaptionsUpdate,
-      oldSubsUpdate,
-      oldChaptersUpdate;
+  let update = 0;
+  let i;
+  let player;
+  let tag;
+  let track;
+  let oldTextTracks;
+  let events = {};
+  let oldCaptionsUpdate;
+  let oldSubsUpdate;
+  let oldChaptersUpdate;
 
   oldCaptionsUpdate = CaptionsButton.prototype.update;
   oldSubsUpdate = SubtitlesButton.prototype.update;
@@ -155,19 +152,19 @@ test('update texttrack buttons on removetrack or addtrack', function() {
     oldChaptersUpdate.call(this);
   };
 
-  Tech.prototype['featuresNativeTextTracks'] = true;
+  Tech.prototype.featuresNativeTextTracks = true;
   oldTextTracks = Tech.prototype.textTracks;
   Tech.prototype.textTracks = function() {
     return {
       length: 0,
-      addEventListener: function(type, handler) {
+      addEventListener(type, handler) {
         if (!events[type]) {
           events[type] = [];
         }
         events[type].push(handler);
       },
       // Requrired in player.dispose()
-      removeEventListener: function(){}
+      removeEventListener() {}
     };
   };
 
@@ -185,26 +182,26 @@ test('update texttrack buttons on removetrack or addtrack', function() {
   track.src = '#es.vtt';
   tag.appendChild(track);
 
-  player =  TestHelpers.makePlayer({}, tag);
+  player = TestHelpers.makePlayer({}, tag);
 
   player.player_ = player;
 
   equal(update, 3, 'update was called on the three buttons during init');
 
-  for (i = 0; i < events['removetrack'].length; i++) {
-    events['removetrack'][i]();
+  for (i = 0; i < events.removetrack.length; i++) {
+    events.removetrack[i]();
   }
 
   equal(update, 6, 'update was called on the three buttons for remove track');
 
-  for (i = 0; i < events['addtrack'].length; i++) {
-    events['addtrack'][i]();
+  for (i = 0; i < events.addtrack.length; i++) {
+    events.addtrack[i]();
   }
 
   equal(update, 9, 'update was called on the three buttons for remove track');
 
   Tech.prototype.textTracks = oldTextTracks;
-  Tech.prototype['featuresNativeTextTracks'] = false;
+  Tech.prototype.featuresNativeTextTracks = false;
   CaptionsButton.prototype.update = oldCaptionsUpdate;
   SubtitlesButton.prototype.update = oldSubsUpdate;
   ChaptersButton.prototype.update = oldChaptersUpdate;
@@ -213,15 +210,13 @@ test('update texttrack buttons on removetrack or addtrack', function() {
 });
 
 test('if native text tracks are not supported, create a texttrackdisplay', function() {
-  var oldTestVid = Html5.TEST_VID,
-      oldIsFirefox = browser.IS_FIREFOX,
-      oldTextTrackDisplay = Component.getComponent('TextTrackDisplay'),
-      called = false,
-      player,
-      tag,
-      track,
-      options,
-      html;
+  let oldTestVid = Html5.TEST_VID;
+  let oldIsFirefox = browser.IS_FIREFOX;
+  let oldTextTrackDisplay = Component.getComponent('TextTrackDisplay');
+  let called = false;
+  let player;
+  let tag;
+  let track;
 
   tag = document.createElement('video');
   track = document.createElement('track');
@@ -258,7 +253,7 @@ test('if native text tracks are not supported, create a texttrackdisplay', funct
 });
 
 test('html5 tech supports native text tracks if the video supports it, unless mode is a number', function() {
-  var oldTestVid = Html5.TEST_VID;
+  let oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {
     textTracks: [{
@@ -272,8 +267,8 @@ test('html5 tech supports native text tracks if the video supports it, unless mo
 });
 
 test('html5 tech supports native text tracks if the video supports it, unless it is firefox', function() {
-  var oldTestVid = Html5.TEST_VID,
-      oldIsFirefox = browser.IS_FIREFOX;
+  let oldTestVid = Html5.TEST_VID;
+  let oldIsFirefox = browser.IS_FIREFOX;
 
   Html5.TEST_VID = {
     textTracks: []
@@ -308,6 +303,7 @@ if (Html5.supportsNativeTextTracks()) {
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();
     let track = document.createElement('track');
+
     el.appendChild(track);
 
     let addtrack = function() {
@@ -317,6 +313,7 @@ if (Html5.supportsNativeTextTracks()) {
       emulatedTt.off('addtrack', addtrack);
       el.removeChild(track);
     };
+
     emulatedTt.on('addtrack', addtrack);
     emulatedTt.on('removetrack', function() {
       equal(emulatedTt.length, tt.length, 'we have matching tracks length');
@@ -333,6 +330,7 @@ if (Html5.supportsNativeTextTracks()) {
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();
     let track = document.createElement('track');
+
     el.appendChild(track);
 
     let addtrack = function() {
@@ -347,6 +345,7 @@ if (Html5.supportsNativeTextTracks()) {
 
       done();
     };
+
     emulatedTt.on('addtrack', addtrack);
   });
 }
@@ -354,6 +353,7 @@ if (Html5.supportsNativeTextTracks()) {
 test('should check for text track changes when emulating text tracks', function() {
   let tech = new Tech();
   let numTextTrackChanges = 0;
+
   tech.on('texttrackchange', function() {
     numTextTrackChanges++;
   });
@@ -367,6 +367,7 @@ test('removes cuechange event when text track is hidden for emulated tracks', fu
     tech: player.tech_,
     mode: 'showing'
   });
+
   tt.addCue({
     id: '1',
     startTime: 2,
@@ -376,6 +377,7 @@ test('removes cuechange event when text track is hidden for emulated tracks', fu
   player.tech_.emulateTextTracks();
 
   let numTextTrackChanges = 0;
+
   player.tech_.on('texttrackchange', function() {
     numTextTrackChanges++;
   });
@@ -406,19 +408,19 @@ test('removes cuechange event when text track is hidden for emulated tracks', fu
     'texttrackchange should be not be called since mode is hidden');
 });
 
-test('should return correct remote text track values', function () {
+test('should return correct remote text track values', function() {
   let fixture = document.getElementById('qunit-fixture');
+  let html = '';
 
-  let html = '<video id="example_1" class="video-js" autoplay preload="none">';
-      html += '<source src="http://google.com" type="video/mp4">';
-      html += '<source src="http://google.com" type="video/webm">';
-      html += '<track kind="captions" label="label">';
-      html += '</video>';
+  html += '<video id="example_1" class="video-js" autoplay preload="none">';
+  html += '<source src="http://google.com" type="video/mp4">';
+  html += '<source src="http://google.com" type="video/webm">';
+  html += '<track kind="captions" label="label">';
+  html += '</video>';
 
   fixture.innerHTML += html;
 
   let tag = document.getElementById('example_1');
-
   let player = TestHelpers.makePlayer({}, tag);
 
   this.clock.tick(1);
@@ -442,9 +444,8 @@ test('should return correct remote text track values', function () {
   player.dispose();
 });
 
-test('should uniformly create html track element when adding text track', function () {
+test('should uniformly create html track element when adding text track', function() {
   let player = TestHelpers.makePlayer();
-
   let track = {
     kind: 'kind',
     src: 'src',


### PR DESCRIPTION
## Description
Currently a few of the unit tests are using partial es6 or no es6 at all. This Pull Request seeks to rectify that.

## Specific Changes proposed
* converted all text-track test files to full es6 syntax
* fixed most issues with `vjsstandard` (where it would not break jshint)

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors