### PR TITLE
Keep tooltips inside

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -496,6 +496,8 @@ module.exports = function(grunt) {
     grunt.file.write(cssPath, css.replace(/(\\f\w+);/g, "'$1';"));
   });
 
+  grunt.registerTask('skin', ['sass', 'wrapcodepoints']);
+
   // Default task - build and test
   grunt.registerTask('default', ['test']);
 

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -41,19 +41,22 @@ Player
     BigPlayButton
     ControlBar
         PlayToggle
-        FullscreenToggle
-        CurrentTimeDisplay
-        TimeDivider
-        DurationDisplay
-        RemainingTimeDisplay
+        VolumeMenuButton
+        CurrentTimeDisplay (Hidden by default)
+        TimeDivider (Hidden by default)
+        DurationDisplay (Hidden by default)
         ProgressControl
             SeekBar
               LoadProgressBar
+              MouseTimeDisplay
               PlayProgressBar
-              SeekHandle
-        VolumeControl
-            VolumeBar
-                VolumeLevel
-                VolumeHandle
-        MuteToggle
+        LiveDisplay (Hidden by default)
+        RemainingTimeDisplay
+        CustomControlsSpacer (No UI)
+        ChaptersButton (Hidden by default)
+        SubtitlesButton (Hidden by default)
+        CaptionsButton (Hidden by default)
+        FullscreenToggle
+    ErrorDisplay
+    TextTrackSettings
 ```

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -60,3 +60,27 @@ Player
     ErrorDisplay
     TextTrackSettings
 ```
+
+## Progress Control
+The progress control is made up of the SeekBar. The seekbar contains the load progress bar
+and the play progress bar. In addition, it contains the Mouse Time Display which
+is used to display the time tooltip that follows the mouse cursor.
+The play progress bar also has a time tooltip that show the current time.
+
+By default, the progress control is sandwiched between the volume menu button and
+the remaining time display inside the control bar, but in some cases, a skin would
+want to move the progress control above the control bar and have it span the full
+width of the player, in those cases, it is less than ideal to have the tooltips
+get cut off or leave the bounds of the player. This can be prevented by setting the
+`keepTooltipsInside` option on the progress control. This also makes the tooltips use 
+a real element instead of pseudo elements so targetting them with css will be different.
+
+```js
+let player = videojs('myplayer', {
+  controlBar: {
+    progressControl: {
+      keepTooltipsInside: true
+    }
+  }
+});
+```

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -42,6 +42,7 @@
 .vjs-progress-control:hover .vjs-time-tooltip,
 .video-js .vjs-progress-control:hover .vjs-mouse-display:after,
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
+  font-family: VideoJS;
   visibility: visible;
   font-size: 0.6em;
 }

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -132,15 +132,11 @@
 }
 
 .vjs-time-tooltip {
+  display: inline-block;
   height: 2.4em;
-  width: 3.8em;
-  top: auto;
-  right: auto;
   position: relative;
-  margin: -3.4em -1.9em auto auto;
-}
-.vjs-mouse-display .vjs-time-tooltip {
-  margin-left: -1.9em;
+  float: right;
+  right: -1.9em;
 }
 
 .vjs-tooltip-progress-bar {

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -41,7 +41,7 @@
 // Also show the current time tooltip
 .video-js .vjs-progress-control:hover .vjs-mouse-display:after,
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
-  display: block;
+  visibility: visible;
   font-size: 0.6em;
 }
 
@@ -85,17 +85,17 @@
 // By default this is hidden and only shown when hovering over the progress control
 .video-js .vjs-mouse-display:after,
 .video-js .vjs-play-progress:after {
-  display: none;
+  visibility: hidden;
+  pointer-events: none;
   position: absolute;
   top: -3.4em;
-  right: -1.5em;
+  right: -1.9em;
   font-size: 0.9em;
   color: #000;
   content: attr(data-current-time);
   padding: 6px 8px 8px 8px;
   @include background-color-with-alpha(#fff, 0.8);
   @include border-radius(0.3em);
-  visibility: visible;
 }
 
 .video-js .vjs-play-progress:before,
@@ -128,8 +128,6 @@
 }
 
 .vjs-tooltip-progress-bar {
-  min-width: 1.5em;
-  max-width: calc(100% - 1.5em);
   visibility: hidden;
 }
 

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -39,7 +39,7 @@
  to avoid a weird hitch when you roll off the hover. */
 
 // Also show the current time tooltip
-.vjs-progress-control:hover .vjs-time-tooltip,
+.video-js .vjs-progress-control:hover .vjs-time-tooltip,
 .video-js .vjs-progress-control:hover .vjs-mouse-display:after,
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
   font-family: VideoJS;
@@ -86,7 +86,7 @@
 
 // Current Time "tooltip"
 // By default this is hidden and only shown when hovering over the progress control
-.vjs-time-tooltip,
+.video-js .vjs-time-tooltip,
 .video-js .vjs-mouse-display:after,
 .video-js .vjs-play-progress:after {
   visibility: hidden;
@@ -102,7 +102,7 @@
   @include border-radius(0.3em);
 }
 
-.vjs-time-tooltip,
+.video-js .vjs-time-tooltip,
 .video-js .vjs-play-progress:before,
 .video-js .vjs-play-progress:after {
   z-index: 1;
@@ -132,7 +132,7 @@
   width: auto;
 }
 
-.vjs-time-tooltip {
+.video-js .vjs-time-tooltip {
   display: inline-block;
   height: 2.4em;
   position: relative;

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -103,7 +103,7 @@
   z-index: 1;
 }
 
-.video-js .vjs-progress-control:hover .vjs-keep-within:after {
+.video-js .vjs-progress-control:hover .vjs-keep-tooltips-inside:after {
   display: none;
 }
 

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -96,9 +96,15 @@
   @include background-color-with-alpha(#fff, 0.8);
   @include border-radius(0.3em);
 }
+
+.vjs-time-tooltip,
 .video-js .vjs-play-progress:before,
 .video-js .vjs-play-progress:after {
   z-index: 1;
+}
+
+.video-js .vjs-progress-control:hover .vjs-keep-within:after {
+  display: none;
 }
 
 .video-js .vjs-load-progress {
@@ -119,6 +125,24 @@
 
 .video-js.vjs-no-flex .vjs-progress-control {
   width: auto;
+}
+
+.vjs-time-tooltip {
+  display: none;
+  height: 2.4em;
+  width: 3.8em;
+  font-size: 0.6em;
+  position: relative;
+  margin: -3.4em -1.5em auto auto;
+  color: #000;
+  content: attr(data-current-time);
+  padding: 6px 8px 8px 8px;
+  @include background-color-with-alpha(#fff, 0.8);
+  @include border-radius(0.3em);
+  background: red;
+}
+.vjs-progress-control:hover .vjs-time-tooltip {
+  display: block;
 }
 
 .video-js .vjs-progress-control .vjs-mouse-display {

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -39,6 +39,7 @@
  to avoid a weird hitch when you roll off the hover. */
 
 // Also show the current time tooltip
+.vjs-progress-control:hover .vjs-time-tooltip,
 .video-js .vjs-progress-control:hover .vjs-mouse-display:after,
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
   visibility: visible;
@@ -48,6 +49,7 @@
 // Progress Bars
 .video-js .vjs-progress-holder .vjs-play-progress,
 .video-js .vjs-progress-holder .vjs-load-progress,
+.video-js .vjs-progress-holder .vjs-tooltip-progress-bar,
 .video-js .vjs-progress-holder .vjs-load-progress div {
   position: absolute;
   display: block;
@@ -83,6 +85,7 @@
 
 // Current Time "tooltip"
 // By default this is hidden and only shown when hovering over the progress control
+.vjs-time-tooltip,
 .video-js .vjs-mouse-display:after,
 .video-js .vjs-play-progress:after {
   visibility: hidden;
@@ -104,7 +107,7 @@
   z-index: 1;
 }
 
-.video-js .vjs-progress-control:hover .vjs-keep-tooltips-inside:after {
+.video-js .vjs-progress-control .vjs-keep-tooltips-inside:after {
   display: none;
 }
 
@@ -129,21 +132,15 @@
 }
 
 .vjs-time-tooltip {
-  display: none;
   height: 2.4em;
   width: 3.8em;
-  font-size: 0.6em;
+  top: auto;
+  right: auto;
   position: relative;
-  margin: -3.4em -1.5em auto auto;
-  color: #000;
-  content: attr(data-current-time);
-  padding: 6px 8px 8px 8px;
-  @include background-color-with-alpha(#fff, 0.8);
-  @include border-radius(0.3em);
-  background: red;
+  margin: -3.4em -1.9em auto auto;
 }
-.vjs-progress-control:hover .vjs-time-tooltip {
-  display: block;
+.vjs-mouse-display .vjs-time-tooltip {
+  margin-left: -1.9em;
 }
 
 .vjs-tooltip-progress-bar {
@@ -175,6 +172,7 @@
 .video-js.vjs-user-inactive.vjs-no-flex .vjs-progress-control .vjs-mouse-display:after {
   display: none;
 }
+.vjs-mouse-display .vjs-time-tooltip,
 .video-js .vjs-progress-control .vjs-mouse-display:after {
   color: #fff;
   @include background-color-with-alpha(#000, 0.8);

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -95,6 +95,7 @@
   padding: 6px 8px 8px 8px;
   @include background-color-with-alpha(#fff, 0.8);
   @include border-radius(0.3em);
+  visibility: visible;
 }
 
 .vjs-time-tooltip,
@@ -143,6 +144,12 @@
 }
 .vjs-progress-control:hover .vjs-time-tooltip {
   display: block;
+}
+
+.vjs-tooltip-progress-bar {
+  min-width: 1.5em;
+  max-width: calc(100% - 1.5em);
+  visibility: hidden;
 }
 
 .video-js .vjs-progress-control .vjs-mouse-display {

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -98,7 +98,6 @@
   visibility: visible;
 }
 
-.vjs-time-tooltip,
 .video-js .vjs-play-progress:before,
 .video-js .vjs-play-progress:after {
   z-index: 1;
@@ -126,24 +125,6 @@
 
 .video-js.vjs-no-flex .vjs-progress-control {
   width: auto;
-}
-
-.vjs-time-tooltip {
-  display: none;
-  height: 2.4em;
-  width: 3.8em;
-  font-size: 0.6em;
-  position: relative;
-  margin: -3.4em -1.5em auto auto;
-  color: #000;
-  content: attr(data-current-time);
-  padding: 6px 8px 8px 8px;
-  @include background-color-with-alpha(#fff, 0.8);
-  @include border-radius(0.3em);
-  background: red;
-}
-.vjs-progress-control:hover .vjs-time-tooltip {
-  display: block;
 }
 
 .vjs-tooltip-progress-bar {

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -98,6 +98,7 @@
   @include border-radius(0.3em);
 }
 
+.vjs-time-tooltip,
 .video-js .vjs-play-progress:before,
 .video-js .vjs-play-progress:after {
   z-index: 1;
@@ -125,6 +126,24 @@
 
 .video-js.vjs-no-flex .vjs-progress-control {
   width: auto;
+}
+
+.vjs-time-tooltip {
+  display: none;
+  height: 2.4em;
+  width: 3.8em;
+  font-size: 0.6em;
+  position: relative;
+  margin: -3.4em -1.5em auto auto;
+  color: #000;
+  content: attr(data-current-time);
+  padding: 6px 8px 8px 8px;
+  @include background-color-with-alpha(#fff, 0.8);
+  @include border-radius(0.3em);
+  background: red;
+}
+.vjs-progress-control:hover .vjs-time-tooltip {
+  display: block;
 }
 
 .vjs-tooltip-progress-bar {

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -51,12 +51,27 @@ class MouseTimeDisplay extends Component {
   update(newTime, position) {
     let time = formatTime(newTime, this.player_.duration());
 
-    this.el().style.left = position + 'px';
+    this.el().style.left = this.clampPosition(position) + 'px';
     this.el().setAttribute('data-current-time', time);
   }
 
   calculateDistance(event) {
     return Dom.getPointerPosition(this.el().parentNode, event).x;
+  }
+
+  clampPosition(position) {
+    let playerWidth = parseFloat(getComputedStyle(this.player().el()).width);
+    let tooltipWidth = parseFloat(getComputedStyle(this.el(), ':after').width);
+    let tooltipWidthHalf = tooltipWidth / 2;
+    let actualPosition = position;
+
+    if (position < tooltipWidthHalf) {
+      actualPosition = Math.ceil(tooltipWidthHalf);
+    } else if (position > (playerWidth - tooltipWidthHalf)) {
+      actualPosition = Math.floor(playerWidth - tooltipWidthHalf);
+    }
+
+    return actualPosition;
   }
 }
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -1,6 +1,7 @@
 /**
  * @file mouse-time-display.js
  */
+import window from 'global/window';
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import * as Fn from '../../utils/fn.js';
@@ -60,8 +61,8 @@ class MouseTimeDisplay extends Component {
   }
 
   clampPosition(position) {
-    let playerWidth = parseFloat(getComputedStyle(this.player().el()).width);
-    let tooltipWidth = parseFloat(getComputedStyle(this.el(), ':after').width);
+    let playerWidth = parseFloat(window.getComputedStyle(this.player().el()).width);
+    let tooltipWidth = parseFloat(window.getComputedStyle(this.el(), ':after').width);
     let tooltipWidthHalf = tooltipWidth / 2;
     let actualPosition = position;
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -30,8 +30,8 @@ class MouseTimeDisplay extends Component {
     }
 
     if (this.keepTooltipsInside) {
-      this.el().innerHTML = `<div class='vjs-time-tooltip'>`;
-      this.tooltip = this.el().querySelector('.vjs-time-tooltip');
+      this.tooltip = Dom.createEl('div', {className: 'vjs-time-tooltip'});
+      this.el().appendChild(this.tooltip);
       this.addClass('vjs-keep-tooltips-inside');
     }
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -29,6 +29,12 @@ class MouseTimeDisplay extends Component {
       this.keepTooltipsInside = options.playerOptions.controlBar.progressControl.keepTooltipsInside;
     }
 
+    if (this.keepTooltipsInside) {
+      this.el().innerHTML = `<div class='vjs-time-tooltip'>`;
+      this.tooltip = this.el().querySelector('.vjs-time-tooltip');
+      this.addClass('vjs-keep-tooltips-inside');
+    }
+
     this.update(0, 0);
 
     player.on('ready', () => {
@@ -61,6 +67,10 @@ class MouseTimeDisplay extends Component {
 
     this.el().style.left = this.clampPosition(position) + 'px';
     this.el().setAttribute('data-current-time', time);
+
+    if (this.keepTooltipsInside) {
+      this.tooltip.innerHTML = time;
+    }
   }
 
   calculateDistance(event) {
@@ -73,7 +83,7 @@ class MouseTimeDisplay extends Component {
     }
 
     let playerWidth = parseFloat(window.getComputedStyle(this.player().el()).width);
-    let tooltipWidth = parseFloat(window.getComputedStyle(this.el(), ':after').width);
+    let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltip).width);
     let tooltipWidthHalf = tooltipWidth / 2;
     let actualPosition = position;
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -25,8 +25,8 @@ class MouseTimeDisplay extends Component {
     if (options.playerOptions &&
         options.playerOptions.controlBar &&
         options.playerOptions.controlBar.progressControl &&
-        options.playerOptions.controlBar.progressControl.keepWithin) {
-      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+        options.playerOptions.controlBar.progressControl.keepTooltipsInside) {
+      this.keepTooltipsInside = options.playerOptions.controlBar.progressControl.keepTooltipsInside;
     }
 
     this.update(0, 0);
@@ -68,7 +68,7 @@ class MouseTimeDisplay extends Component {
   }
 
   clampPosition(position) {
-    if (!this.keepWithin) {
+    if (!this.keepTooltipsInside) {
       return position;
     }
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -22,6 +22,13 @@ class MouseTimeDisplay extends Component {
   constructor(player, options) {
     super(player, options);
 
+    if (options.playerOptions &&
+        options.playerOptions.controlBar &&
+        options.playerOptions.controlBar.progressControl &&
+        options.playerOptions.controlBar.progressControl.keepWithin) {
+      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+    }
+
     this.update(0, 0);
 
     player.on('ready', () => {
@@ -61,6 +68,10 @@ class MouseTimeDisplay extends Component {
   }
 
   clampPosition(position) {
+    if (!this.keepWithin) {
+      return position;
+    }
+
     let playerWidth = parseFloat(window.getComputedStyle(this.player().el()).width);
     let tooltipWidth = parseFloat(window.getComputedStyle(this.el(), ':after').width);
     let tooltipWidthHalf = tooltipWidth / 2;

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -65,14 +65,17 @@ class MouseTimeDisplay extends Component {
   update(newTime, position) {
     let time = formatTime(newTime, this.player_.duration());
 
-    this.el().style.left = this.clampPosition(position) + 'px';
+    this.el().style.left = position + 'px';
     this.el().setAttribute('data-current-time', time);
 
     if (this.keepTooltipsInside) {
+      let clampedPosition = this.clampPosition(position);
+      let difference = position - clampedPosition + 1;
       let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltip).width);
       let tooltipWidthHalf = tooltipWidth / 2;
+
       this.tooltip.innerHTML = time;
-      this.tooltip.style.right = `-${tooltipWidthHalf}px`;
+      this.tooltip.style.right = `-${tooltipWidthHalf - difference}px`;
     }
   }
 

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -69,7 +69,7 @@ class MouseTimeDisplay extends Component {
     this.el().setAttribute('data-current-time', time);
 
     if (this.keepTooltipsInside) {
-      let clampedPosition = this.clampPosition(position);
+      let clampedPosition = this.clampPosition_(position);
       let difference = position - clampedPosition + 1;
       let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltip).width);
       let tooltipWidthHalf = tooltipWidth / 2;
@@ -83,7 +83,17 @@ class MouseTimeDisplay extends Component {
     return Dom.getPointerPosition(this.el().parentNode, event).x;
   }
 
-  clampPosition(position) {
+  /**
+   * This takes in a horizontal position for the bar and returns a clamped position.
+   * Clamped position means that it will keep the position greater than half the width
+   * of the tooltip and smaller than the player width minus half the width o the tooltip.
+   * It will only clamp the position if `keepTooltipsInside` option is set.
+   *
+   * @param {Number} position the position the bar wants to be
+   * @return {Number} newPosition the (potentially) clamped position
+   * @method clampPosition_
+   */
+  clampPosition_(position) {
     if (!this.keepTooltipsInside) {
       return position;
     }

--- a/src/js/control-bar/progress-control/mouse-time-display.js
+++ b/src/js/control-bar/progress-control/mouse-time-display.js
@@ -69,7 +69,10 @@ class MouseTimeDisplay extends Component {
     this.el().setAttribute('data-current-time', time);
 
     if (this.keepTooltipsInside) {
+      let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltip).width);
+      let tooltipWidthHalf = tooltipWidth / 2;
       this.tooltip.innerHTML = time;
+      this.tooltip.style.right = `-${tooltipWidthHalf}px`;
     }
   }
 

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -3,6 +3,7 @@
  */
 import Component from '../../component.js';
 import * as Fn from '../../utils/fn.js';
+import * as Dom from '../../utils/dom.js';
 import formatTime from '../../utils/format-time.js';
 
 /**
@@ -20,6 +21,23 @@ class PlayProgressBar extends Component {
     this.updateDataAttr();
     this.on(player, 'timeupdate', this.updateDataAttr);
     player.ready(Fn.bind(this, this.updateDataAttr));
+
+    if (options.playerOptions &&
+        options.playerOptions.controlBar &&
+        options.playerOptions.controlBar.progressControl &&
+        options.playerOptions.controlBar.progressControl.keepWithin) {
+      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+    }
+
+    if (this.keepWithin) {
+      this.timeTooltip = Dom.createEl('div', {
+        className: 'vjs-play-progress-time vjs-time-tooltip'
+      });
+      this.el().appendChild(this.timeTooltip);
+
+      this.on(player, ['seeked'], this.resetMargin);
+      this.addClass('vjs-keep-within');
+    }
   }
 
   /**
@@ -35,9 +53,30 @@ class PlayProgressBar extends Component {
     });
   }
 
+  resetMargin() {
+    this.timeTooltip.style.marginRight = '-1.5em';
+  }
+
   updateDataAttr() {
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
     this.el_.setAttribute('data-current-time', formatTime(time, this.player_.duration()));
+
+    if (this.keepWithin) {
+      let progressControl = player.controlBar.progressControl;
+      let playerRect = progressControl.el().getBoundingClientRect();
+      let tooltipRect = this.timeTooltip.getBoundingClientRect();
+      let tooltipStyle = getComputedStyle(this.timeTooltip);
+
+      if (tooltipRect.right === 0 && tooltipRect.left === 0) {
+        return;
+      }
+
+      if (playerRect.right < tooltipRect.right) {
+        this.timeTooltip.style.marginRight = (parseInt(tooltipStyle.marginRight, 10) - (playerRect.right - tooltipRect.right)) + 'px';
+      }
+
+      this.timeTooltip.innerHTML = formatTime(time, this.player_.duration());
+    }
   }
 
 }

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -30,12 +30,6 @@ class PlayProgressBar extends Component {
     }
 
     if (this.keepWithin) {
-      this.timeTooltip = Dom.createEl('div', {
-        className: 'vjs-play-progress-time vjs-time-tooltip'
-      });
-      this.el().appendChild(this.timeTooltip);
-
-      this.on(player, ['seeked'], this.resetMargin);
       this.addClass('vjs-keep-within');
     }
   }
@@ -53,30 +47,9 @@ class PlayProgressBar extends Component {
     });
   }
 
-  resetMargin() {
-    this.timeTooltip.style.marginRight = '-1.5em';
-  }
-
   updateDataAttr() {
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
     this.el_.setAttribute('data-current-time', formatTime(time, this.player_.duration()));
-
-    if (this.keepWithin) {
-      let progressControl = player.controlBar.progressControl;
-      let playerRect = progressControl.el().getBoundingClientRect();
-      let tooltipRect = this.timeTooltip.getBoundingClientRect();
-      let tooltipStyle = getComputedStyle(this.timeTooltip);
-
-      if (tooltipRect.right === 0 && tooltipRect.left === 0) {
-        return;
-      }
-
-      if (playerRect.right < tooltipRect.right) {
-        this.timeTooltip.style.marginRight = (parseInt(tooltipStyle.marginRight, 10) - (playerRect.right - tooltipRect.right)) + 'px';
-      }
-
-      this.timeTooltip.innerHTML = formatTime(time, this.player_.duration());
-    }
   }
 
 }

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -25,12 +25,12 @@ class PlayProgressBar extends Component {
     if (options.playerOptions &&
         options.playerOptions.controlBar &&
         options.playerOptions.controlBar.progressControl &&
-        options.playerOptions.controlBar.progressControl.keepWithin) {
-      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+        options.playerOptions.controlBar.progressControl.keepTooltipsInside) {
+      this.keepTooltipsInside = options.playerOptions.controlBar.progressControl.keepTooltipsInside;
     }
 
-    if (this.keepWithin) {
-      this.addClass('vjs-keep-within');
+    if (this.keepTooltipsInside) {
+      this.addClass('vjs-keep-tooltips-inside');
     }
   }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -69,8 +69,8 @@ class SeekBar extends Slider {
       let playerWidth = parseFloat(getComputedStyle(player.el()).width);
       let tooltipWidth = parseFloat(getComputedStyle(this.tooltipProgressBar.el(), ':after').width);
       let tooltipStyle = this.tooltipProgressBar.el().style;
-      tooltipStyle.maxWidth = (playerWidth - (tooltipWidth / 2)) + 'px';
-      tooltipStyle.minWidth = (tooltipWidth / 2) + 'px';
+      tooltipStyle.maxWidth = Math.floor(playerWidth - (tooltipWidth / 2)) + 'px';
+      tooltipStyle.minWidth = Math.ceil(tooltipWidth / 2) + 'px';
     }
   }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -70,6 +70,7 @@ class SeekBar extends Slider {
       let tooltipStyle = this.tooltipProgressBar.el().style;
       tooltipStyle.maxWidth = Math.floor(playerWidth - (tooltipWidth / 2)) + 'px';
       tooltipStyle.minWidth = Math.ceil(tooltipWidth / 2) + 'px';
+      tooltipStyle.right = `-${tooltipWidth / 2}px`;
     }
   }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -23,6 +23,11 @@ class SeekBar extends Slider {
     super(player, options);
     this.on(player, 'timeupdate', this.updateARIAAttributes);
     player.ready(Fn.bind(this, this.updateARIAAttributes));
+
+    this.tooltipProgressBar = this.addChild('PlayProgressBar', {
+      name: 'tooltipProgressBar'
+    });
+    this.tooltipProgressBar.addClass('vjs-tooltip-progress-bar');
   }
 
   /**
@@ -45,10 +50,16 @@ class SeekBar extends Slider {
    * @method updateARIAAttributes
    */
   updateARIAAttributes() {
+    this.updateAttributes(this.el_);
+    this.updateAttributes(this.tooltipProgressBar.el_);
+    this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
+  }
+
+  updateAttributes(el) {
     // Allows for smooth scrubbing, when player can't keep up.
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
-    this.el_.setAttribute('aria-valuenow', (this.getPercent() * 100).toFixed(2)); // machine readable value of progress bar (percentage complete)
-    this.el_.setAttribute('aria-valuetext', formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
+    el.setAttribute('aria-valuenow', (this.getPercent() * 100).toFixed(2)); // machine readable value of progress bar (percentage complete)
+    el.setAttribute('aria-valuetext', formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -45,10 +45,10 @@ class SeekBar extends Slider {
    * @method updateARIAAttributes
    */
   updateARIAAttributes() {
-      // Allows for smooth scrubbing, when player can't keep up.
-      let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
-      this.el_.setAttribute('aria-valuenow', (this.getPercent() * 100).toFixed(2)); // machine readable value of progress bar (percentage complete)
-      this.el_.setAttribute('aria-valuetext', formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
+    // Allows for smooth scrubbing, when player can't keep up.
+    let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
+    this.el_.setAttribute('aria-valuenow', (this.getPercent() * 100).toFixed(2)); // machine readable value of progress bar (percentage complete)
+    this.el_.setAttribute('aria-valuetext', formatTime(time, this.player_.duration())); // human readable value of progress bar (time complete)
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -1,6 +1,7 @@
 /**
  * @file seek-bar.js
  */
+import window from 'global/window';
 import Slider from '../../slider/slider.js';
 import Component from '../../component.js';
 import LoadProgressBar from './load-progress-bar.js';
@@ -66,8 +67,8 @@ class SeekBar extends Slider {
       this.updateAriaAttributes(this.tooltipProgressBar.el_);
       this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
 
-      let playerWidth = parseFloat(getComputedStyle(player.el()).width);
-      let tooltipWidth = parseFloat(getComputedStyle(this.tooltipProgressBar.el(), ':after').width);
+      let playerWidth = parseFloat(window.getComputedStyle(this.player().el()).width);
+      let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltipProgressBar.el(), ':after').width);
       let tooltipStyle = this.tooltipProgressBar.el().style;
       tooltipStyle.maxWidth = Math.floor(playerWidth - (tooltipWidth / 2)) + 'px';
       tooltipStyle.minWidth = Math.ceil(tooltipWidth / 2) + 'px';

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -6,6 +6,7 @@ import Slider from '../../slider/slider.js';
 import Component from '../../component.js';
 import LoadProgressBar from './load-progress-bar.js';
 import PlayProgressBar from './play-progress-bar.js';
+import TooltipProgressBar from './tooltip-progress-bar.js';
 import * as Fn from '../../utils/fn.js';
 import formatTime from '../../utils/format-time.js';
 import assign from 'object.assign';
@@ -34,10 +35,7 @@ class SeekBar extends Slider {
     }
 
     if (this.keepTooltipsInside) {
-      this.tooltipProgressBar = this.addChild('PlayProgressBar', {
-        name: 'tooltipProgressBar'
-      });
-      this.tooltipProgressBar.addClass('vjs-tooltip-progress-bar');
+      this.tooltipProgressBar = this.addChild('TooltipProgressBar');
     }
   }
 
@@ -68,7 +66,7 @@ class SeekBar extends Slider {
       this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
 
       let playerWidth = parseFloat(window.getComputedStyle(this.player().el()).width);
-      let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltipProgressBar.el(), ':after').width);
+      let tooltipWidth = parseFloat(window.getComputedStyle(this.tooltipProgressBar.tooltip).width);
       let tooltipStyle = this.tooltipProgressBar.el().style;
       tooltipStyle.maxWidth = Math.floor(playerWidth - (tooltipWidth / 2)) + 'px';
       tooltipStyle.minWidth = Math.ceil(tooltipWidth / 2) + 'px';

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -21,8 +21,9 @@ class SeekBar extends Slider {
 
   constructor(player, options){
     super(player, options);
-    this.on(player, 'timeupdate', this.updateARIAAttributes);
-    player.ready(Fn.bind(this, this.updateARIAAttributes));
+    this.on(player, 'timeupdate', this.updateProgress);
+    this.on(player, 'ended', this.updateProgress);
+    player.ready(Fn.bind(this, this.updateProgress));
 
     if (options.playerOptions &&
         options.playerOptions.controlBar &&
@@ -58,16 +59,22 @@ class SeekBar extends Slider {
    *
    * @method updateARIAAttributes
    */
-  updateARIAAttributes() {
-    this.updateAttributes(this.el_);
+  updateProgress() {
+    this.updateAriaAttributes(this.el_);
 
     if (this.keepWithin) {
-      this.updateAttributes(this.tooltipProgressBar.el_);
+      this.updateAriaAttributes(this.tooltipProgressBar.el_);
       this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
+
+      let playerWidth = parseFloat(getComputedStyle(player.el()).width);
+      let tooltipWidth = parseFloat(getComputedStyle(this.tooltipProgressBar.el(), ':after').width);
+      let tooltipStyle = this.tooltipProgressBar.el().style;
+      tooltipStyle.maxWidth = (playerWidth - (tooltipWidth / 2)) + 'px';
+      tooltipStyle.minWidth = (tooltipWidth / 2) + 'px';
     }
   }
 
-  updateAttributes(el) {
+  updateAriaAttributes(el) {
     // Allows for smooth scrubbing, when player can't keep up.
     let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
     el.setAttribute('aria-valuenow', (this.getPercent() * 100).toFixed(2)); // machine readable value of progress bar (percentage complete)

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -24,10 +24,19 @@ class SeekBar extends Slider {
     this.on(player, 'timeupdate', this.updateARIAAttributes);
     player.ready(Fn.bind(this, this.updateARIAAttributes));
 
-    this.tooltipProgressBar = this.addChild('PlayProgressBar', {
-      name: 'tooltipProgressBar'
-    });
-    this.tooltipProgressBar.addClass('vjs-tooltip-progress-bar');
+    if (options.playerOptions &&
+        options.playerOptions.controlBar &&
+        options.playerOptions.controlBar.progressControl &&
+        options.playerOptions.controlBar.progressControl.keepWithin) {
+      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+    }
+
+    if (this.keepWithin) {
+      this.tooltipProgressBar = this.addChild('PlayProgressBar', {
+        name: 'tooltipProgressBar'
+      });
+      this.tooltipProgressBar.addClass('vjs-tooltip-progress-bar');
+    }
   }
 
   /**
@@ -51,8 +60,11 @@ class SeekBar extends Slider {
    */
   updateARIAAttributes() {
     this.updateAttributes(this.el_);
-    this.updateAttributes(this.tooltipProgressBar.el_);
-    this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
+
+    if (this.keepWithin) {
+      this.updateAttributes(this.tooltipProgressBar.el_);
+      this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
+    }
   }
 
   updateAttributes(el) {

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -29,11 +29,11 @@ class SeekBar extends Slider {
     if (options.playerOptions &&
         options.playerOptions.controlBar &&
         options.playerOptions.controlBar.progressControl &&
-        options.playerOptions.controlBar.progressControl.keepWithin) {
-      this.keepWithin = options.playerOptions.controlBar.progressControl.keepWithin;
+        options.playerOptions.controlBar.progressControl.keepTooltipsInside) {
+      this.keepTooltipsInside = options.playerOptions.controlBar.progressControl.keepTooltipsInside;
     }
 
-    if (this.keepWithin) {
+    if (this.keepTooltipsInside) {
       this.tooltipProgressBar = this.addChild('PlayProgressBar', {
         name: 'tooltipProgressBar'
       });
@@ -63,7 +63,7 @@ class SeekBar extends Slider {
   updateProgress() {
     this.updateAriaAttributes(this.el_);
 
-    if (this.keepWithin) {
+    if (this.keepTooltipsInside) {
       this.updateAriaAttributes(this.tooltipProgressBar.el_);
       this.tooltipProgressBar.el_.style.width = this.bar.el_.style.width;
 

--- a/src/js/control-bar/progress-control/tooltip-progress-bar.js
+++ b/src/js/control-bar/progress-control/tooltip-progress-bar.js
@@ -1,0 +1,54 @@
+/**
+ * @file play-progress-bar.js
+ */
+import Component from '../../component.js';
+import * as Fn from '../../utils/fn.js';
+import * as Dom from '../../utils/dom.js';
+import formatTime from '../../utils/format-time.js';
+
+/**
+ * Shows play progress
+ *
+ * @param {Player|Object} player
+ * @param {Object=} options
+ * @extends Component
+ * @class PlayProgressBar
+ */
+class TooltipProgressBar extends Component {
+
+  constructor(player, options){
+    super(player, options);
+    this.updateDataAttr();
+    this.on(player, 'timeupdate', this.updateDataAttr);
+    player.ready(Fn.bind(this, this.updateDataAttr));
+  }
+
+  /**
+   * Create the component's DOM element
+   *
+   * @return {Element}
+   * @method createEl
+   */
+  createEl() {
+    let el = super.createEl('div', {
+      className: 'vjs-tooltip-progress-bar vjs-slider-bar',
+      innerHTML: `<div class="vjs-time-tooltip"></div>
+        <span class="vjs-control-text"><span>${this.localize('Progress')}</span>: 0%</span>`
+    });
+
+    this.tooltip = el.querySelector('.vjs-time-tooltip');
+
+    return el;
+  }
+
+  updateDataAttr() {
+    let time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
+    let formattedTime = formatTime(time, this.player_.duration());
+    this.el_.setAttribute('data-current-time', formattedTime);
+    this.tooltip.innerHTML = formattedTime;
+  }
+
+}
+
+Component.registerComponent('TooltipProgressBar', TooltipProgressBar);
+export default TooltipProgressBar;


### PR DESCRIPTION
## Description
Add a new option that makes the tooltips stay inside the bounds of the player.


## Specific Changes proposed
The new option is `keepWithin` and it's part of the `progressControl`. A new option is required because we can't change the defaults and the changes herein would be breaking otherwise.
Basically, we create a new progress control that we use for the tooltip which we bound with `min-width` and `max-width` to be half the width of the tooltip plus player-width minus half the width of the tooltip.
Also, this is an option because the default videojs skin doesn't have the progress bar go edge-to-edge of the player, so, there's no need to do the extra computations then. But if a skin uses an edge-to-edge progress bar and likes the time tooltips, then, this will be beneficial.

This contains the first attempt at doing this as well as part of the first commit.

## Requirements Checklist
- [x] Cleanup, make sure everything looks for the `keepWithin` option
- [x] Rename `keepWithin` to `keepTooltipsInside` or something
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [x] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors
