### PR TITLE
Fix menu closing on iOS, specifically on iPad (Fixes #3087)

### DIFF
--- a/src/css/components/menu/_menu-popup.scss
+++ b/src/css/components/menu/_menu-popup.scss
@@ -19,7 +19,7 @@
   max-height: 15em;
 }
 
-.vjs-menu-button-popup:hover .vjs-menu,
+.vjs-workinghover .vjs-menu-button-popup:hover .vjs-menu,
 .vjs-menu-button-popup .vjs-menu.vjs-lock-showing {
   display: block;
 }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -196,6 +196,11 @@ class Player extends Component {
     //   this.addClass('vjs-touch-enabled');
     // }
 
+    // iOS Safari has broken hover handling
+    if (!browser.IS_IOS) {
+      this.addClass('vjs-workinghover');
+    }
+
     // Make player easily findable by ID
     Player.players[this.id_] = this;
 


### PR DESCRIPTION
## Description
It is now possible to close menus on an iPad; this fixes #3087.

Tracked the problem down to iOS Safari's weird/buggy `:hover` handling (see [this SO post](https://stackoverflow.com/questions/2741816/is-it-possible-to-force-ignore-the-hover-pseudoclass-for-iphone-ipad-users/25837326#25837326)).


## Specific Changes proposed
Add an extra class to the player if it has working hover, and modify the menu CSS to only have the `:hover` handling if hover works. (Note that I didn't change anything for the inline volume menu's hover behavior since that isn't displayed on an iPad).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed - ??
  - [ ] Docs/guides updated - n/a
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output)) - n/a
- [ ] Reviewed by Two Core Contributors