### PR TITLE
Fix chapters menu

### DIFF
--- a/src/css/components/_chapters.scss
+++ b/src/css/components/_chapters.scss
@@ -2,11 +2,6 @@
   @extend .vjs-icon-chapters;
 }
 
-.vjs-chapters-button .vjs-menu {
-  left: -10em; // (Width of vjs-menu - width of vjs-control) / 2
-  width: 0;
-}
-
 .vjs-chapters-button .vjs-menu ul {
   width: 24em;
 }

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -90,11 +90,13 @@ class ChaptersButton extends TextTrackButton {
     let menu = this.menu;
     if (menu === undefined) {
       menu = new Menu(this.player_);
-      menu.contentEl().appendChild(Dom.createEl('li', {
+      let title = Dom.createEl('li', {
         className: 'vjs-menu-title',
         innerHTML: toTitleCase(this.kind_),
         tabIndex: -1
-      }));
+      });
+      menu.children_.unshift(title);
+      Dom.insertElFirst(title, menu.contentEl());
     }
 
     if (chaptersTrack && chaptersTrack.cues == null) {

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -70,11 +70,13 @@ class MenuButton extends ClickableComponent {
 
     // Add a title list item to the top
     if (this.options_.title) {
-      menu.contentEl().appendChild(Dom.createEl('li', {
+      let title = Dom.createEl('li', {
         className: 'vjs-menu-title',
         innerHTML: toTitleCase(this.options_.title),
         tabIndex: -1
       }));
+      menu.children_.unshift(title);
+      Dom.insertElFirst(title, menu.contentEl());
     }
 
     this.items = this['createItems']();

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -74,7 +74,7 @@ class MenuButton extends ClickableComponent {
         className: 'vjs-menu-title',
         innerHTML: toTitleCase(this.options_.title),
         tabIndex: -1
-      }));
+      });
       menu.children_.unshift(title);
       Dom.insertElFirst(title, menu.contentEl());
     }


### PR DESCRIPTION
## Description
Fixes #3062. The `left` and `width` properties for the chapters menu is unnecessary.
Also, we need to make sure that the chapters title gets added in first into the childrens array so that it's always at the top.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by One Core Contributors
