### PR TITLE
Ignore titles in menu, if they exist.

### DIFF
--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -117,7 +117,14 @@ class Menu extends Component {
    * @method focus
    */
   focus (item = 0) {
-    let children = this.children();
+    let children = this.children().slice();
+    let haveTitle = children[0].className &&
+      /vjs-menu-title/.test(children[0].className);
+
+    if (haveTitle) {
+      children.shift();
+    }
+
 
     if (children.length > 0) {
       if (item < 0) {
@@ -126,19 +133,9 @@ class Menu extends Component {
         item = children.length - 1;
       }
 
-      let haveTitle = children[0].className &&
-        /vjs-menu-title/.test(children[0].className);
-
-      if (item === 0 && haveTitle) {
-        item = 1;
-      }
-
       this.focusedChild_ = item;
 
-      let child = children[item];
-      if (child && child.el_) {
-        child.el_.focus();
-      }
+      children[item].el_.focus();
     }
   }
 }

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -126,6 +126,13 @@ class Menu extends Component {
         item = children.length - 1;
       }
 
+      let haveTitle = children[0].className &&
+        /vjs-menu-title/.test(children[0].className);
+
+      if (item === 0 && haveTitle) {
+        item = 1;
+      }
+
       this.focusedChild_ = item;
 
       children[item].el_.focus();

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -135,7 +135,10 @@ class Menu extends Component {
 
       this.focusedChild_ = item;
 
-      children[item].el_.focus();
+      let child = children[item];
+      if (child && child.el_) {
+        child.el_.focus();
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This is because of the change in #3163 where we added the title as an
item in the childrens array so that it is ordered correctly but this
breaks keyboard support because they expect the children to be lined up
correctly and also because they expect the children to be component
objects with an 'el_' property.
Checking to see if the first item is a 'vjs-menu-title' and adding one
to the 'item' allows us to ignore the title element and also select the
actual menu items.
Fixes #3164.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by One Core Contributors