### PR TITLE
Move Common Functionality from TextTrack & TextTrackList into Track & TrackList

### DIFF
--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -1,14 +1,13 @@
 /**
  * @file text-track-list.js
  */
-import EventTarget from '../event-target';
+import TrackList from './track-list';
 import * as Fn from '../utils/fn.js';
-import * as browser from '../utils/browser.js';
-import document from 'global/document';
 
 /**
- * A text track list as defined in:
- * https://html.spec.whatwg.org/multipage/embedded-content.html#texttracklist
+ * A list of possible text tracks. All functionality is in the
+ * base class TrackList. The spec for TextTrackList is located at:
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html#texttracklist
  *
  * interface TextTrackList : EventTarget {
  *   readonly attribute unsigned long length;
@@ -20,144 +19,16 @@ import document from 'global/document';
  *   attribute EventHandler onremovetrack;
  * };
  *
- * @param {Track[]} tracks A list of tracks to initialize the list with
- * @extends EventTarget
+ * @param {TextTrack[]} tracks A list of tracks to initialize the list with
+ * @extends TrackList
  * @class TextTrackList
  */
-
-class TextTrackList extends EventTarget {
-  constructor(tracks = []) {
-    super();
-    let list = this;
-
-    if (browser.IS_IE8) {
-      list = document.createElement('custom');
-
-      for (let prop in TextTrackList.prototype) {
-        if (prop !== 'constructor') {
-          list[prop] = TextTrackList.prototype[prop];
-        }
-      }
-    }
-
-    list.tracks_ = [];
-
-    Object.defineProperty(list, 'length', {
-      get() {
-        return this.tracks_.length;
-      }
-    });
-
-    for (let i = 0; i < tracks.length; i++) {
-      list.addTrack_(tracks[i]);
-    }
-
-    if (browser.IS_IE8) {
-      return list;
-    }
-  }
-
-  /**
-   * Add TextTrack from TextTrackList
-   *
-   * @param {TextTrack} track
-   * @method addTrack_
-   * @private
-   */
+class TextTrackList extends TrackList {
   addTrack_(track) {
-    let index = this.tracks_.length;
-
-    if (!('' + index in this)) {
-      Object.defineProperty(this, index, {
-        get() {
-          return this.tracks_[index];
-        }
-      });
-    }
-
+    super(track);
     track.addEventListener('modechange', Fn.bind(this, function() {
       this.trigger('change');
     }));
-    this.tracks_.push(track);
-
-    this.trigger({
-      track,
-      type: 'addtrack'
-    });
-  }
-
-  /**
-   * Remove TextTrack from TextTrackList
-   * NOTE: Be mindful of what is passed in as it may be a HTMLTrackElement
-   *
-   * @param {TextTrack} rtrack
-   * @method removeTrack_
-   * @private
-   */
-  removeTrack_(rtrack) {
-    let track;
-
-    for (let i = 0, l = this.length; i < l; i++) {
-      if (this[i] === rtrack) {
-        track = this[i];
-        if (track.off) {
-          track.off();
-        }
-
-        this.tracks_.splice(i, 1);
-
-        break;
-      }
-    }
-
-    if (!track) {
-      return;
-    }
-
-    this.trigger({
-      track,
-      type: 'removetrack'
-    });
-  }
-
-  /**
-   * Get a TextTrack from TextTrackList by a tracks id
-   *
-   * @param {String} id - the id of the track to get
-   * @method getTrackById
-   * @return {TextTrack}
-   * @private
-   */
-  getTrackById(id) {
-    let result = null;
-
-    for (let i = 0, l = this.length; i < l; i++) {
-      let track = this[i];
-
-      if (track.id === id) {
-        result = track;
-        break;
-      }
-    }
-
-    return result;
   }
 }
-
-/**
- * change - One or more tracks in the track list have been enabled or disabled.
- * addtrack - A track has been added to the track list.
- * removetrack - A track has been removed from the track list.
- */
-TextTrackList.prototype.allowedEvents_ = {
-  change: 'change',
-  addtrack: 'addtrack',
-  removetrack: 'removetrack'
-};
-
-// emulate attribute EventHandler support to allow for feature detection
-for (let event in TextTrackList.prototype.allowedEvents_) {
-  TextTrackList.prototype['on' + event] = null;
-}
-
 export default TextTrackList;

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -3,13 +3,11 @@
  */
 import TextTrackCueList from './text-track-cue-list';
 import * as Fn from '../utils/fn.js';
-import * as Guid from '../utils/guid.js';
-import * as browser from '../utils/browser.js';
 import * as TextTrackEnum from './text-track-enums';
 import log from '../utils/log.js';
-import EventTarget from '../event-target';
 import document from 'global/document';
 import window from 'global/window';
+import Track from './track.js';
 import { isCrossOrigin } from '../utils/url.js';
 import XHR from 'xhr';
 
@@ -42,7 +40,6 @@ const parseCues = function(srcContent, track) {
   parser.parse(srcContent);
   parser.flush();
 };
-
 
 /**
  * load a track from a  specifed url
@@ -80,7 +77,7 @@ const loadTrack = function(src, track) {
 
 /**
  * A single text track as defined in:
- * https://html.spec.whatwg.org/multipage/embedded-content.html#texttrack
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html#texttrack
  *
  * interface TextTrack : EventTarget {
  *   readonly attribute TextTrackKind kind;
@@ -102,39 +99,22 @@ const loadTrack = function(src, track) {
  * };
  *
  * @param {Object=} options Object of option names and values
- * @extends EventTarget
+ * @extends Track
  * @class TextTrack
  */
-class TextTrack extends EventTarget {
+class TextTrack extends Track {
   constructor(options = {}) {
-    super();
-    if (!options.tech) {
-      throw new Error('A tech was not provided.');
-    }
-
-    let tt = this;
-
-    if (browser.IS_IE8) {
-      tt = document.createElement('custom');
-
-      for (let prop in TextTrack.prototype) {
-        if (prop !== 'constructor') {
-          tt[prop] = TextTrack.prototype[prop];
-        }
-      }
-    }
-
-    tt.tech_ = options.tech;
-
+    options.kind = TextTrackEnum.TextTrackKind[options.kind] || 'subtitles';
+    options.language = options.language || options.srclang || '';
+    options.trackType = 'text';
     let mode = TextTrackEnum.TextTrackMode[options.mode] || 'disabled';
-    let kind = TextTrackEnum.TextTrackKind[options.kind] || 'subtitles';
-    let label = options.label || '';
-    let language = options.language || options.srclang || '';
-    let id = options.id || 'vjs_text_track_' + Guid.newGUID();
 
-    if (kind === 'metadata' || kind === 'chapters') {
+    if (options.kind === 'metadata' || options.kind === 'chapters') {
       mode = 'hidden';
     }
+    // retval will only be defined on IE8, which is when we need it
+    let retval = super(options);
+    let tt = this;
 
     tt.cues_ = [];
     tt.activeCues_ = [];
@@ -153,34 +133,6 @@ class TextTrack extends EventTarget {
     if (mode !== 'disabled') {
       tt.tech_.on('timeupdate', timeupdateHandler);
     }
-
-    Object.defineProperty(tt, 'kind', {
-      get() {
-        return kind;
-      },
-      set() {}
-    });
-
-    Object.defineProperty(tt, 'label', {
-      get() {
-        return label;
-      },
-      set() {}
-    });
-
-    Object.defineProperty(tt, 'language', {
-      get() {
-        return language;
-      },
-      set() {}
-    });
-
-    Object.defineProperty(tt, 'id', {
-      get() {
-        return id;
-      },
-      set() {}
-    });
 
     Object.defineProperty(tt, 'mode', {
       get() {
@@ -262,9 +214,7 @@ class TextTrack extends EventTarget {
       tt.loaded_ = true;
     }
 
-    if (browser.IS_IE8) {
-      return tt;
-    }
+    return retval;
   }
 
   /**

--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -1,0 +1,146 @@
+/**
+ * @file track-list.js
+ */
+import EventTarget from '../event-target';
+import * as Fn from '../utils/fn.js';
+import * as browser from '../utils/browser.js';
+import document from 'global/document';
+
+/**
+ * Common functionaliy between Text, Audio, and Video TrackLists
+ * Interfaces defined in the following spec:
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html
+ *
+ * @param {Track[]} tracks A list of tracks to initialize the list with
+ * @extends EventTarget
+ * @class TrackList
+ */
+class TrackList extends EventTarget {
+  constructor(tracks = []) {
+    super();
+    let list = this;
+
+    if (browser.IS_IE8) {
+      list = document.createElement('custom');
+      for (let prop in TrackList.prototype) {
+        if (prop !== 'constructor') {
+          list[prop] = TrackList.prototype[prop];
+        }
+      }
+    }
+
+    list.tracks_ = [];
+
+    Object.defineProperty(list, 'length', {
+      get() {
+        return this.tracks_.length;
+      }
+    });
+
+    for (let i = 0; i < tracks.length; i++) {
+      list.addTrack_(tracks[i]);
+    }
+
+    if (browser.IS_IE8) {
+      return list;
+    }
+  }
+
+  /**
+   * Add a Track from TrackList
+   *
+   * @param {Mixed} track
+   * @method addTrack_
+   * @private
+   */
+  addTrack_(track) {
+    let index = this.tracks_.length;
+
+    if (!('' + index in this)) {
+      Object.defineProperty(this, index, {
+        get() {
+          return this.tracks_[index];
+        }
+      });
+    }
+
+    this.tracks_.push(track);
+    this.trigger({
+      track,
+      type: 'addtrack'
+    });
+  }
+
+  /**
+   * Remove a Track from TrackList
+   *
+   * @param {Track} rtrack track to be removed
+   * @method removeTrack_
+   * @private
+   */
+  removeTrack_(rtrack) {
+    let track;
+
+    for (let i = 0, l = this.length; i < l; i++) {
+      if (this[i] === rtrack) {
+        track = this[i];
+        if (track.off) {
+          track.off();
+        }
+
+        this.tracks_.splice(i, 1);
+
+        break;
+      }
+    }
+
+    if (!track) {
+      return;
+    }
+
+    this.trigger({
+      track,
+      type: 'removetrack'
+    });
+  }
+
+  /**
+   * Get a Track from the TrackList by a tracks id
+   *
+   * @param {String} id - the id of the track to get
+   * @method getTrackById
+   * @return {Track}
+   * @private
+   */
+  getTrackById(id) {
+    let result = null;
+
+    for (let i = 0, l = this.length; i < l; i++) {
+      let track = this[i];
+      if (track.id === id) {
+        result = track;
+        break;
+      }
+    }
+
+    return result;
+  }
+}
+
+/**
+ * change - One or more tracks in the track list have been enabled or disabled.
+ * addtrack - A track has been added to the track list.
+ * removetrack - A track has been removed from the track list.
+ */
+TrackList.prototype.allowedEvents_ = {
+  change: 'change',
+  addtrack: 'addtrack',
+  removetrack: 'removetrack'
+};
+
+// emulate attribute EventHandler support to allow for feature detection
+for (let event in TrackList.prototype.allowedEvents_) {
+  TrackList.prototype['on' + event] = null;
+}
+
+export default TrackList;

--- a/src/js/tracks/track.js
+++ b/src/js/tracks/track.js
@@ -1,0 +1,68 @@
+/**
+ * @file track.js
+ */
+import * as browser from '../utils/browser.js';
+import document from 'global/document';
+import * as Guid from '../utils/guid.js';
+import EventTarget from '../event-target';
+
+/**
+ * setup the common parts of an audio, video, or text track
+ * @link https://html.spec.whatwg.org/multipage/embedded-content.html
+ *
+ * @param {String} type The type of track we are dealing with audio|video|text
+ * @param {Object=} options Object of option names and values
+ * @extends EventTarget
+ * @class Track
+ */
+class Track extends EventTarget {
+  constructor(options = {}) {
+    super();
+    if (!options.tech) {
+      throw new Error('A tech was not provided.');
+    }
+
+    let track = this;
+    let type = options.trackType || 'generic';
+    if (browser.IS_IE8) {
+      track = document.createElement('custom_' + type);
+
+      for (let prop in track.prototype) {
+        if (prop !== 'constructor') {
+          track[prop] = track.prototype[prop];
+        }
+      }
+    }
+    track.tech_ = options.tech;
+
+    let id = options.id || 'vjs_' + type + '_track_' + Guid.newGUID();
+    let kind = options.kind || '';
+    let label = options.label || '';
+    let language = options.language || '';
+
+    Object.defineProperties(track, {
+      kind: {
+        get() { return kind; },
+        set() {}
+      },
+      label: {
+        get() { return label; },
+        set() {}
+      },
+      language: {
+        get() { return language; },
+        set() {}
+      },
+      id: {
+        get() { return id; },
+        set() {}
+      }
+    });
+
+    if (browser.IS_IE8) {
+      return track;
+    }
+  }
+}
+
+export default Track;

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -2,155 +2,7 @@ import TextTrackList from '../../../src/js/tracks/text-track-list.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import EventTarget from '../../../src/js/event-target.js';
 
-const genericTracks = [
-  {
-    id: '1',
-    addEventListener() {},
-    off() {}
-  }, {
-    id: '2',
-    addEventListener() {},
-    off() {}
-  }, {
-    id: '3',
-    addEventListener() {},
-    off() {}
-  }
-];
-
 q.module('Text Track List');
-
-test('TextTrackList\'s length is set correctly', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  equal(ttl.length, genericTracks.length, 'the length is ' + genericTracks.length);
-});
-
-test('can get text tracks by id', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  equal(ttl.getTrackById('1').id, 1, 'id "1" has id of "1"');
-  equal(ttl.getTrackById('2').id, 2, 'id "2" has id of "2"');
-  equal(ttl.getTrackById('3').id, 3, 'id "3" has id of "3"');
-  ok(!ttl.getTrackById(1), 'there isn\'t an item with "numeric" id of `1`');
-});
-
-test('length is updated when new tracks are added or removed', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
-  equal(ttl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
-  ttl.addTrack_({id: '101', addEventListener() {}, off() {}});
-  equal(ttl.length, genericTracks.length + 2, 'the length is ' + (genericTracks.length + 2));
-
-  ttl.removeTrack_(ttl.getTrackById('101'));
-  equal(ttl.length, genericTracks.length + 1, 'the length is ' + (genericTracks.length + 1));
-  ttl.removeTrack_(ttl.getTrackById('100'));
-  equal(ttl.length, genericTracks.length, 'the length is ' + genericTracks.length);
-});
-
-test('can access items by index', function() {
-  let ttl = new TextTrackList(genericTracks);
-  let i = 0;
-  let length = ttl.length;
-
-  expect(length);
-
-  for (; i < length; i++) {
-    equal(ttl[i].id, String(i + 1), 'the id of a track matches the index + 1');
-  }
-});
-
-test('can access new items by index', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  ttl.addTrack_({id: '100', addEventListener() {}});
-  equal(ttl[3].id, '100', 'id of item at index 3 is 100');
-  ttl.addTrack_({id: '101', addEventListener() {}});
-  equal(ttl[4].id, '101', 'id of item at index 4 is 101');
-});
-
-test('cannot access removed items by index', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
-  ttl.addTrack_({id: '101', addEventListener() {}, off() {}});
-  equal(ttl[3].id, '100', 'id of item at index 3 is 100');
-  equal(ttl[4].id, '101', 'id of item at index 4 is 101');
-
-  ttl.removeTrack_(ttl.getTrackById('101'));
-  ttl.removeTrack_(ttl.getTrackById('100'));
-
-  ok(!ttl[3], 'nothing at index 3');
-  ok(!ttl[4], 'nothing at index 4');
-});
-
-test('new item available at old index', function() {
-  let ttl = new TextTrackList(genericTracks);
-
-  ttl.addTrack_({id: '100', addEventListener() {}, off() {}});
-  equal(ttl[3].id, '100', 'id of item at index 3 is 100');
-
-  ttl.removeTrack_(ttl.getTrackById('100'));
-  ok(!ttl[3], 'nothing at index 3');
-
-  ttl.addTrack_({id: '101', addEventListener() {}});
-  equal(ttl[3].id, '101', 'id of new item at index 3 is now 101');
-});
-
-test('a "addtrack" event is triggered when new tracks are added', function() {
-  let ttl = new TextTrackList(genericTracks);
-  let tracks = 0;
-  let adds = 0;
-  let addHandler = function(e) {
-    if (e.track) {
-      tracks++;
-    }
-    adds++;
-  };
-
-  ttl.on('addtrack', addHandler);
-
-  ttl.addTrack_({id: '100', addEventListener() {}});
-  ttl.addTrack_({id: '101', addEventListener() {}});
-
-  ttl.off('addtrack', addHandler);
-
-  ttl.onaddtrack = addHandler;
-
-  ttl.addTrack_({id: '102', addEventListener() {}});
-  ttl.addTrack_({id: '103', addEventListener() {}});
-
-  equal(adds, 4, 'we got ' + adds + ' "addtrack" events');
-  equal(tracks, 4, 'we got a track with every event');
-});
-
-test('a "removetrack" event is triggered when tracks are removed', function() {
-  let ttl = new TextTrackList(genericTracks);
-  let tracks = 0;
-  let rms = 0;
-  let rmHandler = function(e) {
-    if (e.track) {
-      tracks++;
-    }
-    rms++;
-  };
-
-  ttl.on('removetrack', rmHandler);
-
-  ttl.removeTrack_(ttl.getTrackById('1'));
-  ttl.removeTrack_(ttl.getTrackById('2'));
-
-  ttl.off('removetrack', rmHandler);
-
-  ttl.onremovetrack = rmHandler;
-
-  ttl.removeTrack_(ttl.getTrackById('3'));
-
-  equal(rms, 3, 'we got ' + rms + ' "removetrack" events');
-  equal(tracks, 3, 'we got a track with every event');
-});
-
 test('trigger "change" event when "modechange" is fired on a track', function() {
   let tt = new EventTarget();
   let ttl = new TextTrackList([tt]);
@@ -160,15 +12,12 @@ test('trigger "change" event when "modechange" is fired on a track', function() 
   };
 
   ttl.on('change', changeHandler);
-
   tt.trigger('modechange');
 
   ttl.off('change', changeHandler);
-
   ttl.onchange = changeHandler;
 
   tt.trigger('modechange');
-
   equal(changes, 2, 'two change events should have fired');
 });
 
@@ -185,11 +34,9 @@ test('trigger "change" event when mode changes on a TextTrack', function() {
   };
 
   ttl.on('change', changeHandler);
-
   tt.mode = 'showing';
 
   ttl.off('change', changeHandler);
-
   ttl.onchange = changeHandler;
 
   tt.mode = 'hidden';

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -1,3 +1,5 @@
+import TrackBaseline from './track-baseline';
+import TechFaker from '../tech/tech-faker';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import TestHelpers from '../test-helpers.js';
 
@@ -7,40 +9,31 @@ const defaultTech = {
   off() {},
   currentTime() {}
 };
-
 q.module('Text Track');
 
-test('text-track requires a tech', function() {
-  let error = new Error('A tech was not provided.');
-
-  q.throws(() => new TextTrack(), error, 'a tech is required for text track');
+// do baseline track testing
+TrackBaseline(TextTrack, {
+  id: '1',
+  kind: 'subtitles',
+  mode: 'disabled',
+  label: 'English',
+  language: 'en',
+  tech: defaultTech
 });
 
-test('can create a TextTrack with various properties', function() {
-  let kind = 'captions';
-  let label = 'English';
-  let language = 'en';
-  let id = '1';
+test('can create a TextTrack with a mode property', function() {
   let mode = 'disabled';
   let tt = new TextTrack({
-    kind,
-    label,
-    language,
-    id,
     mode,
     tech: defaultTech
   });
 
-  equal(tt.kind, kind, 'we have a kind');
-  equal(tt.label, label, 'we have a label');
-  equal(tt.language, language, 'we have a language');
-  equal(tt.id, id, 'we have a id');
   equal(tt.mode, mode, 'we have a mode');
 });
 
 test('defaults when items not provided', function() {
   let tt = new TextTrack({
-    tech: defaultTech
+    tech: TechFaker
   });
 
   equal(tt.kind, 'subtitles', 'kind defaulted to subtitles');
@@ -125,32 +118,16 @@ test('mode can only be one of several options, defaults to disabled', function()
   equal(tt.mode, 'showing', 'the mode is set to showing');
 });
 
-test('kind, label, language, id, cue, and activeCues are read only', function() {
-  let kind = 'captions';
-  let label = 'English';
-  let language = 'en';
-  let id = '1';
+test('cue and activeCues are read only', function() {
   let mode = 'disabled';
   let tt = new TextTrack({
-    kind,
-    label,
-    language,
-    id,
     mode,
-    tech: defaultTech
+    tech: defaultTech,
   });
 
-  tt.kind = 'subtitles';
-  tt.label = 'Spanish';
-  tt.language = 'es';
-  tt.id = '2';
   tt.cues = 'foo';
   tt.activeCues = 'bar';
 
-  equal(tt.kind, kind, 'kind is still set to captions');
-  equal(tt.label, label, 'label is still set to English');
-  equal(tt.language, language, 'language is still set to en');
-  equal(tt.id, id, 'id is still set to \'1\'');
   notEqual(tt.cues, 'foo', 'cues is still original value');
   notEqual(tt.activeCues, 'bar', 'activeCues is still original value');
 });

--- a/test/unit/tracks/track-baseline.js
+++ b/test/unit/tracks/track-baseline.js
@@ -1,0 +1,42 @@
+/**
+ * Tests baseline functionality for all tracks
+ *
+ # @param {Track} TrackClass the track class object to use for testing
+ # @param {Object} options the options to setup a track with
+ */
+const TrackBaseline = function(TrackClass, options) {
+  test('requires a tech', function() {
+    let error = new Error('A tech was not provided.');
+
+    q.throws(() => new TrackClass({}), error, 'a tech is required');
+    q.throws(() => new TrackClass({tech: null}), error, 'a tech is required');
+  });
+
+  test('is setup with id, kind, label, and language', function() {
+    let track = new TrackClass(options);
+    equal(track.kind, options.kind, 'we have a kind');
+    equal(track.label, options.label, 'we have a label');
+    equal(track.language, options.language, 'we have a language');
+    equal(track.id, options.id, 'we have a id');
+  });
+
+  test('kind, label, language, id, are read only', function() {
+    let track = new TrackClass(options);
+    track.kind = 'subtitles';
+    track.label = 'Spanish';
+    track.language = 'es';
+    track.id = '2';
+
+    equal(track.kind, options.kind, 'we have a kind');
+    equal(track.label, options.label, 'we have a label');
+    equal(track.language, options.language, 'we have a language');
+    equal(track.id, options.id, 'we have an id');
+  });
+
+  test('returns an instance of of itself on all browsers', function() {
+    let track = new TrackClass(options);
+    ok(track instanceof TrackClass, 'object is returned');
+  });
+};
+
+export default TrackBaseline;

--- a/test/unit/tracks/track-list.test.js
+++ b/test/unit/tracks/track-list.test.js
@@ -1,0 +1,143 @@
+import TrackList from '../../../src/js/tracks/track-list.js';
+import EventTarget from '../../../src/js/event-target.js';
+
+const newTrack = function(id) {
+  return {
+    id,
+    addEventListener() {},
+    off() {},
+  };
+};
+
+q.module('Track List', {
+  beforeEach() {
+    this.tracks = [newTrack('1'), newTrack('2'), newTrack('3')];
+  }
+});
+
+test('TrackList\'s length is set correctly', function() {
+  let trackList = new TrackList(this.tracks);
+
+  equal(trackList.length, this.tracks.length, 'length is ' + this.tracks.length);
+});
+
+test('can get tracks by int and string id', function() {
+  let trackList = new TrackList(this.tracks);
+
+  equal(trackList.getTrackById('1').id, '1', 'id "1" has id of "1"');
+  equal(trackList.getTrackById('2').id, '2', 'id "2" has id of "2"');
+  equal(trackList.getTrackById('3').id, '3', 'id "3" has id of "3"');
+
+});
+
+test('length is updated when new tracks are added or removed', function() {
+  let trackList = new TrackList(this.tracks);
+
+  trackList.addTrack_(newTrack('100'));
+  equal(trackList.length, this.tracks.length + 1, 'the length is ' + (this.tracks.length + 1));
+  trackList.addTrack_(newTrack('101'));
+  equal(trackList.length, this.tracks.length + 2, 'the length is ' + (this.tracks.length + 2));
+
+  trackList.removeTrack_(trackList.getTrackById('101'));
+  equal(trackList.length, this.tracks.length + 1, 'the length is ' + (this.tracks.length + 1));
+  trackList.removeTrack_(trackList.getTrackById('100'));
+  equal(trackList.length, this.tracks.length, 'the length is ' + this.tracks.length);
+});
+
+test('can access items by index', function() {
+  let trackList = new TrackList(this.tracks);
+  let length = trackList.length;
+
+  expect(length);
+
+  for (let i = 0; i < length; i++) {
+    equal(trackList[i].id, String(i + 1), 'the id of a track matches the index + 1');
+  }
+});
+
+test('can access new items by index', function() {
+  let trackList = new TrackList(this.tracks);
+
+  trackList.addTrack_(newTrack('100'));
+  equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+
+  trackList.addTrack_(newTrack('101'));
+  equal(trackList[4].id, '101', 'id of item at index 4 is 101');
+});
+
+test('cannot access removed items by index', function() {
+  let trackList = new TrackList(this.tracks);
+
+  trackList.addTrack_(newTrack('100'));
+  trackList.addTrack_(newTrack('101'));
+  equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+  equal(trackList[4].id, '101', 'id of item at index 4 is 101');
+
+  trackList.removeTrack_(trackList.getTrackById('101'));
+  trackList.removeTrack_(trackList.getTrackById('100'));
+
+  ok(!trackList[3], 'nothing at index 3');
+  ok(!trackList[4], 'nothing at index 4');
+});
+
+test('new item available at old index', function() {
+  let trackList = new TrackList(this.tracks);
+
+  trackList.addTrack_(newTrack('100'));
+  equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+
+  trackList.removeTrack_(trackList.getTrackById('100'));
+  ok(!trackList[3], 'nothing at index 3');
+
+  trackList.addTrack_(newTrack('101'));
+  equal(trackList[3].id, '101', 'id of new item at index 3 is now 101');
+});
+
+test('a "addtrack" event is triggered when new tracks are added', function() {
+  let trackList = new TrackList(this.tracks);
+  let tracks = 0;
+  let adds = 0;
+  let addHandler = (e) => {
+    if(e.track) {
+      tracks++;
+    }
+    adds++;
+  };
+
+  trackList.on('addtrack', addHandler);
+
+  trackList.addTrack_(newTrack('100'));
+  trackList.addTrack_(newTrack('101'));
+
+  trackList.off('addtrack', addHandler);
+  trackList.onaddtrack = addHandler;
+
+  trackList.addTrack_(newTrack('102'));
+  trackList.addTrack_(newTrack('103'));
+
+  equal(adds, 4, 'we got ' + adds + ' "addtrack" events');
+  equal(tracks, 4, 'we got a track with every event');
+});
+
+test('a "removetrack" event is triggered when tracks are removed', function() {
+  let trackList = new TrackList(this.tracks);
+  let tracks = 0;
+  let rms = 0;
+  let rmHandler = (e) => {
+    if(e.track) {
+      tracks++;
+    }
+    rms++;
+  };
+
+  trackList.on('removetrack', rmHandler);
+  trackList.removeTrack_(trackList.getTrackById('1'));
+  trackList.removeTrack_(trackList.getTrackById('2'));
+
+  trackList.off('removetrack', rmHandler);
+  trackList.onremovetrack = rmHandler;
+  trackList.removeTrack_(trackList.getTrackById('3'));
+
+  equal(rms, 3, 'we got ' + rms + ' "removetrack" events');
+  equal(tracks, 3, 'we got a track with every event');
+});

--- a/test/unit/tracks/track.test.js
+++ b/test/unit/tracks/track.test.js
@@ -1,0 +1,69 @@
+import TechFaker from '../tech/tech-faker';
+import TrackBaseline from './track-baseline';
+import Track from '../../../src/js/tracks/track.js';
+import * as browser from '../../../src/js/utils/browser.js';
+
+const defaultTech = {
+  textTracks() {},
+  on() {},
+  off() {},
+  currentTime() {}
+};
+
+// do baseline track testing
+q.module('Track');
+TrackBaseline(Track, {
+  id: '1',
+  kind: 'subtitles',
+  mode: 'disabled',
+  label: 'English',
+  language: 'en',
+  tech: new TechFaker()
+});
+test('defaults when items not provided', function() {
+  let track = new Track({
+    tech: defaultTech
+  });
+
+  equal(track.kind, '', 'kind defaulted to empty string');
+  equal(track.label, '', 'label defaults to empty string');
+  equal(track.language, '', 'language defaults to empty string');
+  ok(track.id.match(/vjs_generic_track_\d{5}/), 'id defaults to vjs_generic_track_GUID');
+});
+
+test('trackType is used in default id, and defaults to generic', function() {
+  let track = new Track({
+    trackType: 'audio',
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_audio_track_\d{5}/), 'id defaults to vjs_audio_track_GUID');
+
+  track = new Track({
+    trackType: 'video',
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_video_track_\d{5}/), 'id defaults to vjs_video_track_GUID');
+
+  track = new Track({
+    trackType: 'text',
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_text_track_\d{5}/), 'id defaults to vjs_text_track_GUID');
+
+  track = new Track({
+    trackType: 'foo',
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_foo_track_\d{5}/), 'id defaults to vjs_foo_track_GUID');
+
+  track = new Track({
+    trackType: null,
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_generic_track_\d{5}/), 'id defaults to vjs_generic_track_GUID');
+
+  track = new Track({
+    tech: defaultTech
+  });
+  ok(track.id.match(/vjs_generic_track_\d{5}/), 'id defaults to vjs_generic_track_GUID');
+});


### PR DESCRIPTION
## Description
We will have lots of common track & track list functionality between Audio, Video, and Text . This Pull Request seeks to take the common functionality and encapsulate it in an easy to share way. 

## Specific Changes proposed
* move common TextTrack functionality into a Track class
* added Track specific unit tests
* added a new file to verify that a track meets baseline criteria
* moved all common functionality from TextTrack unit tests into Track and TrackBaseline
* moved all of common functionality from text-track-list into track-list
* added unit test for track-list

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors