### PR TITLE
move timeout back into parseCues

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -149,6 +149,10 @@ module.exports = function(grunt) {
     },
     dist: {},
     watch: {
+      novtt: {
+        files: ['build/temp/video.js'],
+        tasks: ['concat:novtt']
+      },
       minify: {
         files: ['build/temp/video.js'],
         tasks: ['uglify']

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -327,6 +327,12 @@ class Tech extends Component {
     if (!window['WebVTT'] && this.el().parentNode != null) {
       let script = document.createElement('script');
       script.src = this.options_['vtt.js'] || '../node_modules/videojs-vtt.js/dist/vtt.js';
+      script.onload = () => {
+        this.trigger('vttjsloaded');
+      };
+      script.onerror = () => {
+        this.trigger('vttjsfailed');
+      }
       this.el().parentNode.appendChild(script);
       window['WebVTT'] = true;
     }

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -331,8 +331,8 @@ class Tech extends Component {
         this.trigger('vttjsloaded');
       };
       script.onerror = () => {
-        this.trigger('vttjsfailed');
-      }
+        this.trigger('vttjserror');
+      };
       this.el().parentNode.appendChild(script);
       window['WebVTT'] = true;
     }

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -19,12 +19,22 @@ import XHR from 'xhr';
  * @param {String} srcContent webVTT file contents
  * @param {Track} track track to addcues to
  */
-const parseCues = function(srcContent, track) {
+const parseCues = function(srcContent, track, retryNum) {
   // Make sure that vttjs has loaded, otherwise, wait till it finished loading
   // NOTE: this is only used for the alt/video.novtt.js build
   if (typeof window.WebVTT !== 'function') {
+    let retry;
+
+    if (retryNum === 0) {
+      return log.error(`vttjs did not load, stopping trying to process ${track.src}`);
+    } else if (typeof retryNum !== 'number') {
+      retry = 3;
+    } else {
+      retry = retryNum - 1;
+    }
+
     return window.setTimeout(function() {
-      parseCues(srcContent, track);
+      parseCues(srcContent, track, retry);
     }, 100);
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -71,7 +71,13 @@ const loadTrack = function(src, track) {
     // NOTE: this is only used for the alt/video.novtt.js build
     if (typeof window.WebVTT !== 'function') {
       if (track.tech_) {
-        track.tech_.on('vttjsloaded', () => parseCues(responseBody, track));
+        let loadHandler = () => parseCues(responseBody, track);
+        track.tech_.on('vttjsloaded', loadHandler);
+        track.tech_.on('vttjserror', () => {
+          log.error(`vttjs failed to load, stopping processing ${track.src}`);
+          track.tech_.off('vttjsloaded', loadHandler);
+        });
+
       }
     } else {
       parseCues(responseBody, track);

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -74,7 +74,7 @@ const loadTrack = function(src, track) {
         let loadHandler = () => parseCues(responseBody, track);
         track.tech_.on('vttjsloaded', loadHandler);
         track.tech_.on('vttjserror', () => {
-          log.error(`vttjs failed to load, stopping processing ${track.src}`);
+          log.error(`vttjs failed to load, stopping trying to process ${track.src}`);
           track.tech_.off('vttjsloaded', loadHandler);
         });
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -24,7 +24,7 @@ const parseCues = function(srcContent, track) {
   // NOTE: this is only used for the alt/video.novtt.js build
   if (typeof window.WebVTT !== 'function') {
     window.setTimeout(function() {
-      parseCues(responseBody, track);
+      parseCues(srcContent, track);
     }, 100);
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -20,6 +20,14 @@ import XHR from 'xhr';
  * @param {Track} track track to addcues to
  */
 const parseCues = function(srcContent, track) {
+  // Make sure that vttjs has loaded, otherwise, wait till it finished loading
+  // NOTE: this is only used for the alt/video.novtt.js build
+  if (typeof window.WebVTT !== 'function') {
+    window.setTimeout(function() {
+      parseCues(responseBody, track);
+    }, 100);
+  }
+
   let parser = new window.WebVTT.Parser(window,
                                         window.vttjs,
                                         window.WebVTT.StringDecoder());
@@ -67,14 +75,7 @@ const loadTrack = function(src, track) {
 
     track.loaded_ = true;
 
-    // NOTE: this is only used for the alt/video.novtt.js build
-    if (typeof window.WebVTT !== 'function') {
-      window.setTimeout(function() {
-        parseCues(responseBody, track);
-      }, 100);
-    } else {
-      parseCues(responseBody, track);
-    }
+    parseCues(responseBody, track);
   }));
 };
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -23,7 +23,7 @@ const parseCues = function(srcContent, track) {
   // Make sure that vttjs has loaded, otherwise, wait till it finished loading
   // NOTE: this is only used for the alt/video.novtt.js build
   if (typeof window.WebVTT !== 'function') {
-    window.setTimeout(function() {
+    return window.setTimeout(function() {
       parseCues(srcContent, track);
     }, 100);
   }

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -1,3 +1,4 @@
+import window from 'global/window';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import TestHelpers from '../test-helpers.js';
 
@@ -253,4 +254,38 @@ test('fires cuechange when cues become active and inactive', function() {
   equal(changes, 4, 'a cuechange event trigger addEventListener and oncuechange');
 
   player.dispose();
+});
+
+test('tracks are parsed if vttjs is loaded', function() {
+  const clock = sinon.useFakeTimers();
+  const oldVTT = window.WebVTT;
+  let parserCreated = false;
+
+  window.WebVTT = () => {};
+  window.WebVTT.StringDecoder = () => {}
+  window.WebVTT.Parser = () => {
+    parserCreated = true;
+    return {
+      oncue() {},
+      onparsingerror() {},
+      onflush() {},
+      parse() {},
+      flush() {}
+    };
+  };
+
+  let xhr;
+  window.xhr.onCreate = (newXhr) => xhr = newXhr;
+
+  let tt = new TextTrack({
+    tech: defaultTech,
+    src: 'http://example.com'
+  });
+
+  xhr.respond(200, {}, 'WebVTT\n');
+
+  ok(parserCreated, 'WebVTT is loaded, so we can just parse');
+
+  clock.restore();
+  window.WebVTT = oldVTT;
 });

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -262,7 +262,7 @@ test('tracks are parsed if vttjs is loaded', function() {
   let parserCreated = false;
 
   window.WebVTT = () => {};
-  window.WebVTT.StringDecoder = () => {}
+  window.WebVTT.StringDecoder = () => {};
   window.WebVTT.Parser = () => {
     parserCreated = true;
     return {
@@ -313,7 +313,7 @@ test('tracks are parsed once vttjs is loaded', function() {
   ok(!parserCreated, 'WebVTT still not loaded, do not try to parse yet');
 
   window.WebVTT = () => {};
-  window.WebVTT.StringDecoder = () => {}
+  window.WebVTT.StringDecoder = () => {};
   window.WebVTT.Parser = () => {
     parserCreated = true;
     return {

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -1,4 +1,5 @@
 import window from 'global/window';
+import EventTarget from '../../../src/js/event-target.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import TestHelpers from '../test-helpers.js';
 import log from '../../../src/js/utils/log.js';
@@ -301,8 +302,13 @@ test('tracks are parsed once vttjs is loaded', function() {
   let xhr;
   window.xhr.onCreate = (newXhr) => xhr = newXhr;
 
+  let testTech = new EventTarget();
+  testTech.textTracks = () => {};
+  testTech.currentTime = () => {};
+
+
   let tt = new TextTrack({
-    tech: defaultTech,
+    tech: testTech,
     src: 'http://example.com'
   });
 
@@ -326,7 +332,7 @@ test('tracks are parsed once vttjs is loaded', function() {
     };
   };
 
-  clock.tick(100);
+  testTech.trigger('vttjsloaded');
   ok(parserCreated, 'WebVTT is loaded, so we can parse now');
 
   clock.restore();

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -370,7 +370,7 @@ test('stops processing if vttjs loading errored out', function() {
   let offSpyCall = testTech.off.getCall(0);
 
   ok(errorSpyCall.calledWithMatch('vttjs failed to load, stopping trying to process'),
-     'we logged the correct error after 3 timeouts');
+     'vttjs failed to load, so, we logged an error');
   ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
   ok(offSpyCall, 'tech.off was called');
 


### PR DESCRIPTION
## Description
Make sure that vttjs has finished loading before proceeding with parsing cues.

## Specific Changes proposed
Specifically, move the code that does a setTimeout from `loadTrack` back into `parseCues`. Make `parseCues` into an asynchronous loop waiting till vttjs has loaded.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Reviewed by one Core Contributors

