### PR TITLE
Fix link adding an extra Tab stop (and confusing JAWS) with IE

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -297,6 +297,14 @@ class Player extends Component {
     this.fluid(this.options_.fluid);
     this.aspectRatio(this.options_.aspectRatio);
 
+    // Hide any links within the video/audio tag, because IE doesn't hide them completely.
+    let links = tag.getElementsByTagName('a');
+    for (let i = 0; i < links.length; i++) {
+      let linkEl = links.item(i);
+      Dom.addElClass(linkEl, 'vjs-hidden');
+      linkEl.setAttribute('hidden', 'hidden');
+    }
+
     // insertElFirst seems to cause the networkState to flicker from 3 to 2, so
     // keep track of the original for later so we can know if the source originally failed
     tag.initNetworkState_ = tag.networkState;


### PR DESCRIPTION
## Description
Fix link adding an extra Tab stop (and confusing JAWS) with IE - fixes #3187 and #3121.

## Specific Changes proposed
Actually hide any links within the `<video>` tag, from Javascript, when video.js creates a new player.

## Requirements Checklist
- [x] Bug fixed
- [x] Reviewed by Two Core Contributors
