### PR TITLE
Fix empty menu throws an error when it gets focus 

### DIFF
--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -117,15 +117,15 @@ class Menu extends Component {
    * @method focus
    */
   focus (item = 0) {
+    let children = this.children().slice();
+    let haveTitle = children.length && children[0].className &&
+      /vjs-menu-title/.test(children[0].className);
+
+    if (haveTitle) {
+      children.shift();
+    }
+
     if (children.length > 0) {
-      let children = this.children().slice();
-      let haveTitle = children[0].className &&
-        /vjs-menu-title/.test(children[0].className);
-
-      if (haveTitle) {
-        children.shift();
-      }
-
       if (item < 0) {
         item = 0;
       } else if (item >= children.length) {

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -117,16 +117,15 @@ class Menu extends Component {
    * @method focus
    */
   focus (item = 0) {
-    let children = this.children().slice();
-    let haveTitle = children[0].className &&
-      /vjs-menu-title/.test(children[0].className);
-
-    if (haveTitle) {
-      children.shift();
-    }
-
-
     if (children.length > 0) {
+      let children = this.children().slice();
+      let haveTitle = children[0].className &&
+        /vjs-menu-title/.test(children[0].className);
+
+      if (haveTitle) {
+        children.shift();
+      }
+
       if (item < 0) {
         item = 0;
       } else if (item >= children.length) {

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -4,6 +4,22 @@ import * as Events from '../../src/js/utils/events.js';
 
 q.module('MenuButton');
 
+q.test('should not throw an error when there is no children', function() {
+  expect(0);
+  let player = TestHelpers.makePlayer();
+
+  let menuButton = new MenuButton(player);
+  let el = menuButton.el();
+
+  try {
+    Events.trigger(el, 'click');
+  } catch (error) {
+    ok(!error, 'click should not throw anything');
+  }
+
+  player.dispose();
+});
+
 q.test('should place title list item into ul', function() {
   let player = TestHelpers.makePlayer();
 


### PR DESCRIPTION
## Description
When empty menu get focus without any children cause it throws an error.

## Specific Changes proposed
- Add children checking in menu focus before check the title

## Requirements Checklist

- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
 - [ ] Unit Tests updated or fixed
 - [ ] Docs/guides updated
 - [ ] Example created (starter template on JSBin)
- [ ] Reviewed by Two Core Contributors