### PR TITLE
Fix missing native HTML5 tracks  

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -257,6 +257,12 @@ class Html5 extends Tech {
   proxyNativeTextTracks_() {
     let tt = this.el().textTracks;
 
+    // Add tracks - if player is initialised after DOM loaded, textTracks
+    // will not trigger addtrack
+    for (let i = 0; i < tt.length; i++) {
+      this.textTracks().addTrack_(tt[i]);
+    }
+
     if (tt && tt.addEventListener) {
       tt.addEventListener('change', this.handleTextTrackChange_);
       tt.addEventListener('addtrack', this.handleTextTrackAdd_);
@@ -504,7 +510,7 @@ class Html5 extends Tech {
    * @return {Object}
    * @method currentSrc
    */
-  currentSrc() { 
+  currentSrc() {
     if (this.currentSource_) {
       return this.currentSource_.src;
     } else {

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -78,12 +78,16 @@ class TextTrackList extends EventTarget {
     track.addEventListener('modechange', Fn.bind(this, function() {
       this.trigger('change');
     }));
-    this.tracks_.push(track);
 
-    this.trigger({
-      track,
-      type: 'addtrack'
-    });
+    // Do not add duplicate tracks
+    if (!this.tracks_.includes(track)) {
+      this.tracks_.push(track);
+      this.trigger({
+        track,
+        type: 'addtrack'
+      });
+    }
+
   }
 
   /**

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -80,7 +80,7 @@ class TextTrackList extends EventTarget {
     }));
 
     // Do not add duplicate tracks
-    if (!this.tracks_.includes(track)) {
+    if (this.tracks_.indexOf(track) === -1) {
       this.tracks_.push(track);
       this.trigger({
         track,


### PR DESCRIPTION
## Description

Fixes missing text tracks when using native tracks in Chrome etc, fixes #2689
Tracks are currently added when the native text tracks `addtrack` event is triggered. Depending on how the player is initialised, this does not occur or fires before the event listener has been added.

## Specific Changes proposed

- Adds tracks when the HTML5 tech is initialised.
- Modifies addTrack() to not add a track that already exists. This is to prevent duplication where `addtrack` is triggered.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
