### PR TITLE
Don't use icon font for time tooltips

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -42,7 +42,7 @@
 .video-js .vjs-progress-control:hover .vjs-time-tooltip,
 .video-js .vjs-progress-control:hover .vjs-mouse-display:after,
 .video-js .vjs-progress-control:hover .vjs-play-progress:after {
-  font-family: VideoJS;
+  font-family: $text-font-family;
   visibility: visible;
   font-size: 0.6em;
 }


### PR DESCRIPTION
## Description
Prevents the browser showing time tooltips in a fallback font.
Fixes #3210

## Specific Changes proposed
Uses the regular text font rather than VideoJS for the time tooltips. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

