### PR TITLE
use a brand new tag el for ie8

### DIFF
--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -972,6 +972,7 @@ test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE option
   equal(styles.length, 0, 'we should not get any style elements included in the DOM');
 
   window.VIDEOJS_NO_DYNAMIC_STYLE = false;
+  tag = TestHelpers.makeTag();
   player = TestHelpers.makePlayer({}, tag);
   styles = document.querySelectorAll('style');
   equal(styles.length, 1, 'we should have one style element in the DOM');


### PR DESCRIPTION
Fix the tests on ie8. We need a new tag for IE8 and not reuse it when we create a new player.