### PR TITLE
Reset ltr direction on control bar and spinner

### DIFF
--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -37,7 +37,8 @@ class ControlBar extends Component {
    */
   createEl() {
     return super.createEl('div', {
-      className: 'vjs-control-bar'
+      className: 'vjs-control-bar',
+      dir: 'ltr'
     }, {
       'role': 'group' // The control bar is a group, so it can contain menuitems
     });

--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -20,7 +20,8 @@ class LoadingSpinner extends Component {
    */
   createEl() {
     return super.createEl('div', {
-      className: 'vjs-loading-spinner'
+      className: 'vjs-loading-spinner',
+      dir: 'ltr'
     });
   }
 }


### PR DESCRIPTION
## Description
If the player is inheriting `rtl` directionality, the control bar order reverses as flex box `row` order follows text direction. The loading spinner animation is also broken as the circles are not aligned. This PR resets the direction on those components to `ltr`, allowing the rest of the player, especially dialogs with localised text to inherit `rtl`.

Fixes #3204

## Specific Changes proposed
Adds `dir="ltr"` to the ControlBar and LoadingSpinner components 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

