### PR TITLE
Fixes #3201 Add ARIA region role and ARIA label to player el

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -35,7 +35,7 @@ class SeekBar extends Slider {
     return super.createEl('div', {
       className: 'vjs-progress-holder'
     }, {
-      'aria-label': 'video progress bar'
+      'aria-label': 'progress bar'
     });
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -182,6 +182,14 @@ class Player extends Component {
       this.addClass('vjs-controls-disabled');
     }
 
+    // Set ARIA label and region role depending on player type
+    this.el_.setAttribute('role', 'region');
+    if (this.isAudio()) {
+      this.el_.setAttribute('aria-label', 'audio player');
+    } else {
+      this.el_.setAttribute('aria-label', 'video player');
+    }
+
     if (this.isAudio()) {
       this.addClass('vjs-audio');
     }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -741,6 +741,26 @@ test('should add an audio class if an audio el is used', function() {
   ok(player.el().className.indexOf(audioClass) !== -1, 'added '+ audioClass +' css class');
 });
 
+test('should add a video player region if a video el is used', function() {
+  var video = document.createElement('video'),
+      player = TestHelpers.makePlayer({}, video),
+      role = 'region',
+      label = 'video player';
+
+  ok(player.el().getAttribute('role') === 'region', 'region role is present');
+  ok(player.el().getAttribute('aria-label') === 'video player', 'video player label present');
+});
+
+test('should add an audio player region if an audio el is used', function() {
+  var audio = document.createElement('audio'),
+      player = TestHelpers.makePlayer({}, audio),
+      role = 'region',
+      label = 'audio player';
+
+  ok(player.el().getAttribute('role') === 'region', 'region role is present');
+  ok(player.el().getAttribute('aria-label') === 'audio player', 'audio player label present');
+});
+
 test('should not be scrubbing while not seeking', function(){
   var player = TestHelpers.makePlayer();
   equal(player.scrubbing(), false, 'player is not scrubbing');


### PR DESCRIPTION
Fixes #3201. Fixes bug where JAWS in IE can't access all player controls if a document contains multiple players. Adds `role` of `region` and `aria-label` identifying media player type. Removes "video" from progress slider label.