### PR TITLE
Note videojs-vtt.js required for self-hosting

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -41,10 +41,11 @@ $ bower install --save video.js
 
 ### Self Hosted. ###
 To entirely self-host, you'll need to pull in the font files and let Video.js know where the swf is located. If you simply copy the dist folder or zip file contents into your project everything
-should Just Work™, but the paths can easily be changed by editing the LESS file and re-building, or by modifying the generated CSS file.
+should Just Work™, but the paths can easily be changed by editing the LESS file and re-building, or by modifying the generated CSS file. Additionally include the [videojs-vtt.js](https://www.npmjs.com/package/videojs-vtt.js) source, which adds the `WebVTT` object to the global scope.
 
 ```html
 <link href="//example.com/path/to/video-js.min.css" rel="stylesheet">
+<script src="//example.com/path/to/videojs-vtt.js"></script>
 <script src="//example.com/path/to/video.min.js"></script>
 <script>
   videojs.options.flash.swf = "http://example.com/path/to/video-js.swf"


### PR DESCRIPTION
## Description
Addresses small oversight in self-hosting documentation. See #3183.

## Specific Changes proposed
Small amendment to the docs. However the caveat is that I'm using node+browserify, so I'm not sure if including the source directly in the browser works as I've noted...?

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors