### PR TITLE
Attach handlers to ownerDocument, not document

### DIFF
--- a/src/js/control-bar/volume-menu-button.js
+++ b/src/js/control-bar/volume-menu-button.js
@@ -7,7 +7,6 @@ import Popup from '../popup/popup.js';
 import PopupButton from '../popup/popup-button.js';
 import MuteToggle from './mute-toggle.js';
 import VolumeBar from './volume-control/volume-bar.js';
-import document from 'global/document';
 
 /**
  * Button for volume popup
@@ -131,7 +130,7 @@ class VolumeMenuButton extends PopupButton {
 
   handleMouseDown(event) {
     this.on(['mousemove', 'touchmove'], Fn.bind(this.volumeBar, this.volumeBar.handleMouseMove));
-    this.on(document, ['mouseup', 'touchend'], this.handleMouseUp);
+    this.on(this.el_.ownerDocument, ['mouseup', 'touchend'], this.handleMouseUp);
   }
 
   handleMouseUp(event) {

--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -1,8 +1,6 @@
 /**
  * @file modal-dialog.js
  */
-import document from 'global/document';
-
 import * as Dom from './utils/dom';
 import * as Fn from './utils/fn';
 import log from './utils/log';
@@ -175,7 +173,7 @@ class ModalDialog extends Component {
       }
 
       if (this.closeable()) {
-        this.on(document, 'keydown', Fn.bind(this, this.handleKeyPress));
+        this.on(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
       }
 
       player.controls(false);
@@ -221,7 +219,7 @@ class ModalDialog extends Component {
       }
 
       if (this.closeable()) {
-        this.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
+        this.off(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
       }
 
       player.controls(true);

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -3,7 +3,6 @@
  */
 import Component from '../component.js';
 import * as Dom from '../utils/dom.js';
-import document from 'global/document';
 import assign from 'object.assign';
 
 /**
@@ -68,16 +67,18 @@ class Slider extends Component {
    * @method handleMouseDown
    */
   handleMouseDown(event) {
+    let doc = this.bar.el_.ownerDocument;
+
     event.preventDefault();
     Dom.blockTextSelection();
 
     this.addClass('vjs-sliding');
     this.trigger('slideractive');
 
-    this.on(document, 'mousemove', this.handleMouseMove);
-    this.on(document, 'mouseup', this.handleMouseUp);
-    this.on(document, 'touchmove', this.handleMouseMove);
-    this.on(document, 'touchend', this.handleMouseUp);
+    this.on(doc, 'mousemove', this.handleMouseMove);
+    this.on(doc, 'mouseup', this.handleMouseUp);
+    this.on(doc, 'touchmove', this.handleMouseMove);
+    this.on(doc, 'touchend', this.handleMouseUp);
 
     this.handleMouseMove(event);
   }
@@ -95,15 +96,17 @@ class Slider extends Component {
    * @method handleMouseUp
    */
   handleMouseUp() {
+    let doc = this.bar.el_.ownerDocument;
+
     Dom.unblockTextSelection();
 
     this.removeClass('vjs-sliding');
     this.trigger('sliderinactive');
 
-    this.off(document, 'mousemove', this.handleMouseMove);
-    this.off(document, 'mouseup', this.handleMouseUp);
-    this.off(document, 'touchmove', this.handleMouseMove);
-    this.off(document, 'touchend', this.handleMouseUp);
+    this.off(doc, 'mousemove', this.handleMouseMove);
+    this.off(doc, 'mouseup', this.handleMouseUp);
+    this.off(doc, 'touchmove', this.handleMouseMove);
+    this.off(doc, 'touchend', this.handleMouseUp);
 
     this.update();
   }
@@ -166,7 +169,7 @@ class Slider extends Component {
    * @method handleFocus
    */
   handleFocus() {
-    this.on(document, 'keydown', this.handleKeyPress);
+    this.on(this.bar.el_.ownerDocument, 'keydown', this.handleKeyPress);
   }
 
   /**
@@ -191,7 +194,7 @@ class Slider extends Component {
    * @method handleBlur
    */
   handleBlur() {
-    this.off(document, 'keydown', this.handleKeyPress);
+    this.off(this.bar.el_.ownerDocument, 'keydown', this.handleKeyPress);
   }
 
   /**


### PR DESCRIPTION
## Description
Currently, video.js has problems if the main script is loaded into a window but the player will be rendered into another window (e.g. an iframe).  Everywhere an event handler attaches to `document` assumes the document where the script was loaded, rather than where the player resides.  This is mostly apparent with the Slider component, that attaches _mousemove_ events on _mousedown_ and removes them on _mouseup_.

## Specific Changes proposed
This PR makes some headway towards context independence for the player.  It attaches events for the Slider and volume controls to the `ownerDocument` of the component's element instead of the global document object.

This allows for a use case we have with React components that may or may not render a video in an iframe, saving us from potentially reloading the script many times as the component updates.  A proper test suite for context independence might be required in the future if this is considered to be an important use case.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors