### PR TITLE
add missing tabindex to player controls for keyboard accessibility

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -45,6 +45,7 @@ class Button extends ClickableComponent {
     attributes = assign({
       type: 'button', // Necessary since the default button type is "submit"
       'aria-live': 'polite' // let the screen reader user know that the text of the button may change
+      'tabindex' : 0 // add tabindex for keyboard accessibility to buttons
     }, attributes);
 
     let el = Component.prototype.createEl.call(this, tag, props, attributes);


### PR DESCRIPTION
## Description
Tabbing to buttons implemented as divs requires tabindex for keyboard accessibility
Adds tabindex to three controls implemented as divs
Fixes tabindex and allows user to tab to controls on control bar


## Specific Changes proposed
One line change to add tabindex to attributes of controls

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

