### PR TITLE
Is chrome on edge return true

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -57,7 +57,8 @@ export const IS_OLD_ANDROID = IS_ANDROID && (/webkit/i).test(USER_AGENT) && ANDR
 export const IS_NATIVE_ANDROID = IS_ANDROID && ANDROID_VERSION < 5 && appleWebkitVersion < 537;
 
 export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
-export const IS_CHROME = (/Chrome/i).test(USER_AGENT) && !(/Edge/i).test(USER_AGENT);
+export const IS_EDGE = (/Edge/i).test(USER_AGENT);
+export const IS_CHROME = !IS_EDGE && (/Chrome/i).test(USER_AGENT);
 export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
 
 export const TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -57,7 +57,7 @@ export const IS_OLD_ANDROID = IS_ANDROID && (/webkit/i).test(USER_AGENT) && ANDR
 export const IS_NATIVE_ANDROID = IS_ANDROID && ANDROID_VERSION < 5 && appleWebkitVersion < 537;
 
 export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
-export const IS_CHROME = (/Chrome/i).test(USER_AGENT);
+export const IS_CHROME = (/Chrome/i).test(USER_AGENT) && !(/Edge/i).test(USER_AGENT);
 export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
 
 export const TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);


### PR DESCRIPTION
## Description
Fix videojs.isChrome() on windows 10 edge return true

Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) **Chrome**/42.0.2311.135 Safari/537.36 Edge/12.10136