### PR TITLE
do not reset videojs when autoSetupTimeout called on autoSetup retry

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -72,7 +72,8 @@ var autoSetup = function(){
 
 // Pause to let the DOM keep processing
 var autoSetupTimeout = function(wait, vjs){
-  videojs = vjs;
+  if (vjs)
+    videojs = vjs;
   setTimeout(autoSetup, wait);
 };
 


### PR DESCRIPTION
## Description
When autoSetupTimeout is called as a retry, it resets videojs variable to undefined, failing consequent auto-setup. See autoSetupTimeout in src/js/setup.js:

if (mediaEl && mediaEl.getAttribute) {
// ...
} else {
  autoSetupTimeout(1);
  break;
}

## Solution
Avoid videojs redefinition when autoSetupTimeout called without second argument (on autoSetup retry). It solves issue #2386.


