### PR TITLE
Improve handling of the deprecated use of Button Component

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -39,6 +39,16 @@ class Button extends ClickableComponent {
 
     if (tag !== 'button') {
       log.warn(`Creating a Button with an HTML element of ${tag} is deprecated; use ClickableComponent instead.`);
+
+      // Add properties for clickable element which is not a native HTML button
+      props = assign({
+        tabIndex: 0
+      }, props);
+
+      // Add ARIA attributes for clickable element which is not a native HTML button
+      attributes = assign({
+        role: 'button'
+      }, attributes);
     }
 
     // Add attributes for button element


### PR DESCRIPTION
## Description
Improve handling of the deprecated use of Button Component with a non-button HTML element, for backward compatibility.

## Specific Changes proposed
If an HTML element other than a `<button>` is used in the Button Component, add properties and attributes as ClickableComponent does.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
