### PR TITLE
Fixes #2156 make controls visible

### DIFF
--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -10,15 +10,6 @@
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }
 
-// IE8 is flakey with fonts, and you have to change the actual content to force
-// fonts to show/hide properly.
-// - "\9" IE8 hack didn't work for this
-// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
-$ie8screen: "\\0screen";
-.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
-  @media #{$ie8screen} { content: ""; }
-}
-
 // Video has started playing
 .vjs-has-started .vjs-control-bar {
   @include display-flex;
@@ -28,6 +19,9 @@ $ie8screen: "\\0screen";
   $trans: visibility 0.1s, opacity 0.1s; // Var needed because of comma
   @include transition($trans);
 }
+
+// IE 8 hack for media queries
+$ie8screen: "\\0screen";
 
 // Video has started playing AND user is inactive
 .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
@@ -55,6 +49,15 @@ $ie8screen: "\\0screen";
 .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   opacity: 1;
   visibility: visible;
+}
+
+
+// IE8 is flakey with fonts, and you have to change the actual content to force
+// fonts to show/hide properly.
+// - "\9" IE8 hack didn't work for this
+// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
+.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
+  @media #{$ie8screen} { content: ""; }
 }
 
 // IE 8 + 9 Support

--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -10,6 +10,15 @@
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }
 
+// IE8 is flakey with fonts, and you have to change the actual content to force
+// fonts to show/hide properly.
+// - "\9" IE8 hack didn't work for this
+// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
+$ie8screen: "\\0screen";
+.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
+  @media #{$ie8screen} { content: ""; }
+}
+
 // Video has started playing
 .vjs-has-started .vjs-control-bar {
   @include display-flex;
@@ -22,11 +31,17 @@
 
 // Video has started playing AND user is inactive
 .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-  visibility: hidden;
+  // Remain visible for screen reader and keyboard users
+  visibility: visible;
   opacity: 0;
 
   $trans: visibility 1.0s, opacity 1.0s;
   @include transition($trans);
+
+  // Make controls hidden in IE8 for now
+  @media #{$ie8screen} {
+    visibility: hidden;
+  }
 }
 
 .vjs-controls-disabled .vjs-control-bar,
@@ -40,15 +55,6 @@
 .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   opacity: 1;
   visibility: visible;
-}
-
-// IE8 is flakey with fonts, and you have to change the actual content to force
-// fonts to show/hide properly.
-// - "\9" IE8 hack didn't work for this
-// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
-$ie8screen: "\\0screen";
-.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
-  @media #{$ie8screen} { content: ""; }
 }
 
 // IE 8 + 9 Support


### PR DESCRIPTION
## Description
Fixes the a11y issue in #2156, where keyboard and screen reader users lose control focus when the control bar hides due to inactivity. I set the controls to `visibility: visible` and tested with NVDA and JAWS across all supported browsers.

For IE8, I opted to keep the controls hidden because `-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";` won't make all of the children transparent. More work could be done on the controls for IE8, if someone can make a compelling case for it.