### PR TITLE
Add <style> to player tag instead of head

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -288,9 +288,8 @@ class Player extends Component {
     // video element
     if (window.VIDEOJS_NO_DYNAMIC_STYLE !== true) {
       this.styleEl_ = stylesheet.createStyleElement('vjs-styles-dimensions');
-      let defaultsStyleEl = Dom.$('.vjs-styles-defaults');
-      let head = Dom.$('head');
-      head.insertBefore(this.styleEl_, defaultsStyleEl ? defaultsStyleEl.nextSibling : head.firstChild);
+      this.styleEl_.setAttribute('scoped', '');
+      this.el_.insertBefore(this.styleEl_, this.el_.firstChild);
     }
 
     // Pass in the width/height/aspectRatio options which will update the style el


### PR DESCRIPTION
## Description
Another portability fix (see #3230).  Currently, players moved to or created in a different window from the video.js script will not have the proper dimensions applied.

## Specific Changes proposed
The video dimensions stylesheet is added to the player element instead of `<head>`.  The `scoped` attribute is also set, though only supported by Firefox it also serves as a cosmetic validation for where the element is contained (scoped style elements are [permitted alongside flow content](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element:concept-element-contexts)).

By doing this, the element can be moved to another window or frame without losing these dimensions.  All browsers support `<style>` elements outside of `<head>`, though it is technically invalid without the `scoped` attribute.  Behaviour-wise, nothing has changed so current tests continue to pass and additional unit tests are unnecessary.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

