### PR TITLE
Pass tech options to source handlers

### DIFF
--- a/src/js/tech/flash-rtmp.js
+++ b/src/js/tech/flash-rtmp.js
@@ -95,10 +95,11 @@ function FlashRtmpDecorator(Flash) {
    * Pass the source to the flash object
    * Adaptive source handlers will have more complicated workflows before passing
    * video data to the video element
-   * @param  {Object} source    The source object
-   * @param  {Flash} tech   The instance of the Flash tech
+   * @param  {Object} source   The source object
+   * @param  {Flash}  tech     The instance of the Flash tech
+   * @param  {Object} options  The options to pass to the source
    */
-  Flash.rtmpSourceHandler.handleSource = function(source, tech){
+  Flash.rtmpSourceHandler.handleSource = function(source, tech, options){
     let srcParts = Flash.streamToParts(source.src);
 
     tech['setRtmpConnection'](srcParts.connection);

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -397,10 +397,11 @@ Flash.nativeSourceHandler.canHandleSource = function(source){
  * Adaptive source handlers will have more complicated workflows before passing
  * video data to the video element
  *
- * @param  {Object} source    The source object
- * @param  {Flash} tech   The instance of the Flash tech
+ * @param  {Object} source   The source object
+ * @param  {Flash}  tech     The instance of the Flash tech
+ * @param  {Object} options  The options to pass to the source
  */
-Flash.nativeSourceHandler.handleSource = function(source, tech){
+Flash.nativeSourceHandler.handleSource = function(source, tech, options){
   tech.setSrc(source.src);
 };
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -903,10 +903,11 @@ Html5.nativeSourceHandler.canHandleSource = function(source){
  * Adaptive source handlers will have more complicated workflows before passing
  * video data to the video element
  *
- * @param  {Object} source    The source object
- * @param  {Html5} tech   The instance of the Html5 tech
+ * @param  {Object} source   The source object
+ * @param  {Html5}  tech     The instance of the Html5 tech
+ * @param  {Object} options  The options to pass to the source
  */
-Html5.nativeSourceHandler.handleSource = function(source, tech){
+Html5.nativeSourceHandler.handleSource = function(source, tech, options){
   tech.setSrc(source.src);
 };
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -714,7 +714,7 @@ Tech.withSourceHandlers = function(_Tech){
     this.off('dispose', this.disposeSourceHandler);
 
     this.currentSource_ = source;
-    this.sourceHandler_ = sh.handleSource(source, this);
+    this.sourceHandler_ = sh.handleSource(source, this, this.options_);
     this.on('dispose', this.disposeSourceHandler);
 
     return this;

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -147,9 +147,10 @@ test('should add the source handler interface to a tech', function(){
       }
       return '';
     },
-    handleSource: function(s, t){
+    handleSource: function(s, t, o){
       strictEqual(tech, t, 'the tech instance was passed to the source handler');
       strictEqual(sourceA, s, 'the tech instance was passed to the source handler');
+      strictEqual(tech.options_, o, 'the tech options were passed to the source handler');
       return new handlerInternalState();
     }
   };
@@ -161,7 +162,7 @@ test('should add the source handler interface to a tech', function(){
     canHandleSource: function(source){
       return ''; // no support
     },
-    handleSource: function(source, tech){
+    handleSource: function(source, tech, options){
       ok(false, 'handlerTwo supports nothing and should never be called');
     }
   };
@@ -261,7 +262,7 @@ test('delegates seekable to the source handler', function(){
     canHandleSource: function() {
       return true;
     },
-    handleSource: function(source, tech) {
+    handleSource: function(source, tech, options) {
       return handler;
     }
   });


### PR DESCRIPTION
## Description

This PR passes the whole `tech`'s options to a source handler in `handleSource`, as discussed in #2616. Note that that PR also mentions things about `sourceHandlerOrder` but I think that has nothing to do with passing options, so I did not add that. If desired, I can create a separate PR for this.

As far as my `grep` skills are accurate, I could not find any documentation that explains how source handlers work. If this is somewhere, let me know so I can add it there as well.

## Specific Changes proposed
This just adds the options to `handleSource`. I also cleaned up some documentation and added a test for this. Furthermore I added the options argument to all `handleSource` calls done internally, although it is not used anywhere yet.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by One Other Core Contributors

