### PR TITLE
Blacklist Android Chrome for playback rate support

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -119,9 +119,10 @@ class PlaybackRateMenuButton extends MenuButton {
   }
 
   /**
-   * Get supported playback rates
+   * Get whether playback rates is supported by the tech
+   * and an array of playback rates exists
    *
-   * @return {Array} Supported playback rates
+   * @return {Boolean} Whether changing playback rate is supported
    * @method playbackRateSupported
    */
   playbackRateSupported() {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -935,9 +935,14 @@ Html5.canControlVolume = function(){
 /*
  * Check if playbackRate is supported in this browser/device.
  *
- * @return {Number} [description]
+ * @return {Boolean}
  */
 Html5.canControlPlaybackRate = function(){
+  // Playback rate API is implemented in Android Chrome, but doesn't do anything
+  // https://github.com/videojs/video.js/issues/3180
+  if (browser.IS_ANDROID && browser.IS_CHROME) {
+    return false;
+  }
   var playbackRate = Html5.TEST_VID.playbackRate;
   Html5.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
   return playbackRate !== Html5.TEST_VID.playbackRate;


### PR DESCRIPTION
## Description
Backlists Android Chrome when testing for playback rate change support, as this browser implements the playbackRate API but it is ineffective.
Fixes #3180

## Specific Changes proposed
Blacklist based on UA in `Html5.canControlPlaybackRate()`.
Should be revisited when Chrome implements playback rate control.

Plus some additional doc corrections.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

