### PR TITLE
the first default text tracks will be show by default in emulated tracks

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -76,6 +76,10 @@ class TextTrackDisplay extends Component {
           }
         }
 
+        // We want to show the first default track but captions and subtitles
+        // take precedence over descriptions.
+        // So, display the first default captions or subtitles track
+        // and otherwise the first default descriptions track.
         if (firstCaptions) {
           firstCaptions.mode = 'showing';
         } else if (firstDesc) {

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -62,11 +62,13 @@ class TextTrackDisplay extends Component {
       let modesToShow = {'captions': 1, 'subtitles': 1, 'descriptions': 1};
       let trackList = this.player_.textTracks();
 
-      for (let i = 0; i < trackList.length; i++) {
-        let track = trackList[i];
-        if (track.default && track.kind in modesToShow) {
-          track.mode = 'showing';
-          break;
+      if (trackList) {
+        for (let i = 0; i < trackList.length; i++) {
+          let track = trackList[i];
+          if (track.default && track.kind in modesToShow) {
+            track.mode = 'showing';
+            break;
+          }
         }
       }
     }));

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -58,6 +58,17 @@ class TextTrackDisplay extends Component {
         let track = tracks[i];
         this.player_.addRemoteTextTrack(track);
       }
+
+      let modesToShow = {'captions': 1, 'subtitles': 1, 'descriptions': 1};
+      let trackList = this.player_.textTracks();
+
+      for (let i = 0; i < trackList.length; i++) {
+        let track = trackList[i];
+        if (track.default && track.kind in modesToShow) {
+          track.mode = 'showing';
+          break;
+        }
+      }
     }));
   }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -59,16 +59,27 @@ class TextTrackDisplay extends Component {
         this.player_.addRemoteTextTrack(track);
       }
 
-      let modesToShow = {'captions': 1, 'subtitles': 1, 'descriptions': 1};
+      let modes = {'captions': 1, 'subtitles': 1};
       let trackList = this.player_.textTracks();
+      let firstDesc;
+      let firstCaptions;
 
       if (trackList) {
         for (let i = 0; i < trackList.length; i++) {
           let track = trackList[i];
-          if (track.default && track.kind in modesToShow) {
-            track.mode = 'showing';
-            break;
+          if (track.default) {
+            if (track.kind === 'descriptions' && !firstDesc) {
+              firstDesc = track;
+            } else if (track.kind in modes && !firstCaptions) {
+              firstCaptions = track;
+            }
           }
+        }
+
+        if (firstCaptions) {
+          firstCaptions.mode = 'showing';
+        } else if (firstDesc) {
+          firstDesc.mode = 'showing';
         }
       }
     }));

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -136,6 +136,7 @@ class TextTrack extends EventTarget {
 
     let mode = TextTrackEnum.TextTrackMode[options.mode] || 'disabled';
     let kind = TextTrackEnum.TextTrackKind[options.kind] || 'subtitles';
+    let default_ = options.default;
     let label = options.label || '';
     let language = options.language || options.srclang || '';
     let id = options.id || 'vjs_text_track_' + Guid.newGUID();
@@ -186,6 +187,13 @@ class TextTrack extends EventTarget {
     Object.defineProperty(tt, 'id', {
       get() {
         return id;
+      },
+      set() {}
+    });
+
+    Object.defineProperty(tt, 'default', {
+      get() {
+        return default_;
       },
       set() {}
     });

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -475,3 +475,57 @@ test('should uniformly create html track element when adding text track', functi
 
   player.dispose();
 });
+
+test('default text tracks should show by default', function() {
+  let tag = TestHelpers.makeTag();
+  let capt = document.createElement('track');
+
+  capt.kind = 'captions';
+  capt.setAttribute('default', 'default');
+
+  tag.appendChild(capt);
+
+  let player = TestHelpers.makePlayer({
+    html5: {
+      nativeTextTracks: false
+    }
+  }, tag);
+
+  // native tracks are initialized after the player is ready
+  this.clock.tick(1);
+
+  let tracks = player.textTracks();
+
+  equal(tracks[0].kind, 'captions', 'the captions track is present');
+  equal(tracks[0].mode, 'showing', 'the captions track is showing');
+});
+
+test('default captions take precedence over default descriptions', function() {
+  let tag = TestHelpers.makeTag();
+  let desc = document.createElement('track');
+  let capt = document.createElement('track');
+
+  desc.kind = 'descriptions';
+  desc.setAttribute('default', 'default');
+  capt.kind = 'captions';
+  capt.setAttribute('default', 'default');
+
+  tag.appendChild(desc);
+  tag.appendChild(capt);
+
+  let player = TestHelpers.makePlayer({
+    html5: {
+      nativeTextTracks: false
+    }
+  }, tag);
+
+  // native tracks are initialized after the player is ready
+  this.clock.tick(1);
+
+  let tracks = player.textTracks();
+
+  equal(tracks[0].kind, 'descriptions', 'the descriptions track is first');
+  equal(tracks[0].mode, 'disabled', 'the descriptions track is disabled');
+  equal(tracks[1].kind, 'captions', 'the captions track is second');
+  equal(tracks[1].mode, 'showing', 'the captions track is showing');
+});


### PR DESCRIPTION
## Description
As the title suggests, default emulated text tracks will now be shown by default. It will choose the first one from the list.

## Specific Changes proposed
* Native tracks will still be have the default attribute handled by the browser
* TextTrack objects now have a default property that represents whether they were created with it originally
* the first default emulated text track will be chosen to be shown by default
* Fixes #1914

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
