### PR TITLE
Fix removeRemoteTextTracks not working with return value from addRemoteTextTracks

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2579,7 +2579,9 @@ class Player extends Component {
    * @param {Object} track    Remote text track to remove
    * @method removeRemoteTextTrack
    */
-  removeRemoteTextTrack(track) {
+  // destructure the input into an object with a track argument, defaulting to arguments[0]
+  // default the whole argument to an empty object if nothing was passed in
+  removeRemoteTextTrack({track = arguments[0]} = {}) {
     this.tech_ && this.tech_['removeRemoteTextTrack'](track);
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2581,7 +2581,7 @@ class Player extends Component {
    */
   // destructure the input into an object with a track argument, defaulting to arguments[0]
   // default the whole argument to an empty object if nothing was passed in
-  removeRemoteTextTrack({track = arguments[0]} = {}) {
+  removeRemoteTextTrack({track = arguments[0]} = {}) { // jshint ignore:line
     this.tech_ && this.tech_['removeRemoteTextTrack'](track);
   }
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -475,3 +475,27 @@ test('should uniformly create html track element when adding text track', functi
 
   player.dispose();
 });
+
+test('removeRemoteTextTrack should be able to take both a track and the response from addRemoteTextTrack', function() {
+  let player = TestHelpers.makePlayer();
+  let track = {
+    kind: 'kind',
+    src: 'src',
+    language: 'language',
+    label: 'label',
+    default: 'default'
+  };
+  let htmlTrackElement = player.addRemoteTextTrack(track);
+
+  equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
+
+  player.removeRemoteTextTrack(htmlTrackElement);
+
+  equal(player.remoteTextTrackEls().length, 0, 'the track element was removed correctly');
+
+  htmlTrackElement = player.addRemoteTextTrack(track);
+  equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
+
+  player.removeRemoteTextTrack(htmlTrackElement.track);
+  equal(player.remoteTextTrackEls().length, 0, 'the track element was removed correctly');
+});


### PR DESCRIPTION
## Description
Fix removeRemoteTextTracks not working with return value from addRemoteTextTracks

## Specific Changes proposed
Destructure and default the argument to `removeRemoteTextTrack` so that it accepts either the track itself or an object with a `track` property.
Also, add tests for this.
Fix #2046.
