### PR TITLE
revert 75116d4 adding chrome to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 0.12
 before_install:
-  - export CHROME_BIN=/usr/bin/google-chrome
+  - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 notifications:
@@ -25,8 +25,3 @@ cache:
     - node_modules
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -107,7 +107,7 @@ module.exports = function(config) {
         'ie8_bs'
       ];
     } else {
-      settings.browsers = ['chrome_travis', 'Firefox'];
+      settings.browsers = ['Firefox'];
     }
   }
 
@@ -116,11 +116,6 @@ module.exports = function(config) {
 
 function getCustomLaunchers(){
   return {
-    chrome_travis: {
-      base: 'Chrome',
-      flags: ['--no-sandbox']
-    },
-
     chrome_bs: {
       base: 'BrowserStack',
       browser: 'chrome',


### PR DESCRIPTION
This is because travis is failing to install the correct version of dependencies. We can re-add chrome back in at a later date.