### PR TITLE
Set lang="en" on the <html> tag in HTML files.

### DIFF
--- a/docs/examples/elephantsdream/index.html
+++ b/docs/examples/elephantsdream/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Video.js Text Descriptions, Chapters &amp; Captions Example</title>

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
 

--- a/sandbox/descriptions.html.example
+++ b/sandbox/descriptions.html.example
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Video.js Text Descriptions, Chapters &amp; Captions Example</title>

--- a/sandbox/icons.html.example
+++ b/sandbox/icons.html.example
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Video.js Icons Sandbox</title>

--- a/sandbox/index.html.example
+++ b/sandbox/index.html.example
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Video.js Sandbox</title>

--- a/sandbox/plugin.html.example
+++ b/sandbox/plugin.html.example
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Video.js Plugin Example</title>

--- a/test/index.html
+++ b/test/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>VideoJS Tests</title>


### PR DESCRIPTION
## Description
Set the lang attribute on all <html> tags in HTML files (in /sandbox/ and /test/).

## Specific Changes proposed
 This is required for accessibility compliance, and will prevent these errors being reported by accessibility testing tools.

## Requirements Checklist
- [x] Bug fixed
- [x] Reviewed by Two Core Contributors
