### PR TITLE
Make firefox use native text tracks.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -551,6 +551,7 @@ class Player extends Component {
 
     // Grab tech-specific options from player options and add source and parent element to use.
     var techOptions = assign({
+      'playerOptions': this.options_,
       'nativeControlsForTouch': this.options_.nativeControlsForTouch,
       'source': source,
       'playerId': this.id(),

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -77,7 +77,7 @@ class Html5 extends Tech {
       this.proxyNativeTextTracks_();
 
       if (browser.IS_FIREFOX) {
-        let tracks = options.playerOptions['tracks'] || [];
+        let tracks = (options.playerOptions || {})['tracks'] || [];
         for (let i = 0; i < tracks.length; i++) {
           let track = tracks[i];
           this.addRemoteTextTrack(track);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -75,6 +75,14 @@ class Html5 extends Tech {
       this.handleTextTrackAdd_ = Fn.bind(this, this.handleTextTrackAdd);
       this.handleTextTrackRemove_ = Fn.bind(this, this.handleTextTrackRemove);
       this.proxyNativeTextTracks_();
+
+      if (browser.IS_FIREFOX) {
+        let tracks = options.playerOptions['tracks'] || [];
+        for (let i = 0; i < tracks.length; i++) {
+          let track = tracks[i];
+          this.addRemoteTextTrack(track);
+        }
+      }
     }
 
     // Determine if native controls should be used
@@ -135,6 +143,13 @@ class Html5 extends Tech {
       // If the original tag is still there, clone and remove it.
       if (el) {
         const clone = el.cloneNode(true);
+        if (browser.IS_FIREFOX) {
+          const trackEls = clone.querySelectorAll('track');
+          let i = trackEls.length;
+          while (i--) {
+            clone.removeChild(trackEls[i]);
+          }
+        }
         el.parentNode.insertBefore(clone, el);
         Html5.disposeMediaElement(el);
         el = clone;
@@ -961,9 +976,6 @@ Html5.supportsNativeTextTracks = function() {
   if (supportsTextTracks && Html5.TEST_VID.textTracks.length > 0) {
     supportsTextTracks = typeof Html5.TEST_VID.textTracks[0]['mode'] !== 'number';
   }
-  if (supportsTextTracks && browser.IS_FIREFOX) {
-    supportsTextTracks = false;
-  }
   if (supportsTextTracks && !('onremovetrack' in Html5.TEST_VID.textTracks)) {
     supportsTextTracks = false;
   }
@@ -1022,7 +1034,7 @@ Html5.prototype['featuresPlaybackRate'] = Html5.canControlPlaybackRate();
  *
  * @type {Boolean}
  */
-Html5.prototype['movingMediaElementInDOM'] = !browser.IS_IOS;
+Html5.prototype['movingMediaElementInDOM'] = !browser.IS_IOS && !browser.IS_FIREFOX;
 
 /*
  * Set the the tech's fullscreen resize support status.

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -301,7 +301,7 @@ if (Html5.supportsNativeTextTracks()) {
     let done = assert.async();
 
     let el = document.createElement('video');
-    fixture.appendChild(el);
+    window.fixture.appendChild(el);
     let html = new Html5({el});
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();
@@ -332,7 +332,7 @@ if (Html5.supportsNativeTextTracks()) {
     let done = assert.async();
 
     let el = document.createElement('video');
-    fixture.appendChild(el);
+    window.fixture.appendChild(el);
     let html = new Html5({el});
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -306,12 +306,13 @@ if (Html5.supportsNativeTextTracks()) {
     let done = assert.async();
 
     let el = document.createElement('video');
+    fixture.appendChild(el);
     let html = new Html5({el});
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();
     let track = document.createElement('track');
-
-    el.appendChild(track);
+    track.src = '../docs/examples/elephantsdream/captions.en.vtt';
+    track.kind = 'captions';
 
     let addtrack = function() {
       equal(emulatedTt.length, tt.length, 'we have matching tracks length');
@@ -319,6 +320,7 @@ if (Html5.supportsNativeTextTracks()) {
 
       emulatedTt.off('addtrack', addtrack);
       el.removeChild(track);
+
     };
 
     emulatedTt.on('addtrack', addtrack);
@@ -327,18 +329,21 @@ if (Html5.supportsNativeTextTracks()) {
       equal(emulatedTt.length, 0, 'we have no more text tracks');
       done();
     });
+
+    el.appendChild(track);
   });
 
   test('should have removed tracks on dispose', function(assert) {
     let done = assert.async();
 
     let el = document.createElement('video');
+    fixture.appendChild(el);
     let html = new Html5({el});
     let tt = el.textTracks;
     let emulatedTt = html.textTracks();
     let track = document.createElement('track');
-
-    el.appendChild(track);
+    track.src = '../docs/examples/elephantsdream/captions.en.vtt';
+    track.kind = 'captions';
 
     let addtrack = function() {
       equal(emulatedTt.length, tt.length, 'we have matching tracks length');
@@ -354,6 +359,8 @@ if (Html5.supportsNativeTextTracks()) {
     };
 
     emulatedTt.on('addtrack', addtrack);
+
+    el.appendChild(track);
   });
 }
 

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -12,6 +12,7 @@ import Component from '../../../src/js/component.js';
 import * as browser from '../../../src/js/utils/browser.js';
 import TestHelpers from '../test-helpers.js';
 import document from 'global/document';
+import window from 'global/window';
 
 q.module('Tracks', {
   setup() {

--- a/test/unit/tracks/tracks.test.js
+++ b/test/unit/tracks/tracks.test.js
@@ -273,20 +273,15 @@ test('html5 tech supports native text tracks if the video supports it, unless mo
   Html5.TEST_VID = oldTestVid;
 });
 
-test('html5 tech supports native text tracks if the video supports it, unless it is firefox', function() {
+test('html5 tech supports native text tracks if the video supports it', function() {
   let oldTestVid = Html5.TEST_VID;
-  let oldIsFirefox = browser.IS_FIREFOX;
-
   Html5.TEST_VID = {
     textTracks: []
   };
 
-  browser.IS_FIREFOX = true;
-
   ok(!Html5.supportsNativeTextTracks(), 'if textTracks are available on video element, native text tracks are supported');
 
   Html5.TEST_VID = oldTestVid;
-  browser.IS_FIREFOX = oldIsFirefox;
 });
 
 test('when switching techs, we should not get a new text track', function() {


### PR DESCRIPTION
## Description
Make firefox use native text tracks.
Fixes https://github.com/videojs/video.js/issues/1862.

## Specific Changes proposed
Pass player options to the tech.
Make firefox not allowed to move the element in the DOM and also clear
out the tracks from the element. In the end of the html5 constructor,
re-add the tracks from the player options.
This still causes firefox to print out a "Network Error" because it
aborts the original loading of the tracks.
![screen shot 2016-04-15 at 14 05 54](https://cloud.githubusercontent.com/assets/535884/14570788/0080d1d6-0314-11e6-8bc8-98314240eeeb.png)

It's possible that some work needs to happen so that we dont keep adding more tracks each time we switch from and to the html5 tech but this is the initial work.

Also, the control bar overlays the captions, though, the native control bar *also* overlays the captions.
![screen shot 2016-04-15 at 14 12 00](https://cloud.githubusercontent.com/assets/535884/14570807/190bcf76-0314-11e6-8912-8ff4793f7f73.png)
![screen shot 2016-04-15 at 14 14 03](https://cloud.githubusercontent.com/assets/535884/14570858/5f87fd30-0314-11e6-9465-4782dde5db4f.png)


## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

