### PR TITLE
Fix to handleKeyPress in ClickableComponent

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -87,9 +87,9 @@ class Button extends ClickableComponent {
    * @method handleKeyPress
    */
   handleKeyPress(event) {
+    // If the element is a div acting like a button, use super's handleKeyPress but 
     // Ignore Space (32) or Enter (13) key operation, which is handled by the browser for a button.
-    if (event.which === 32 || event.which === 13) {
-    } else {
+    if ((this.el_.tagName.toUpperCase() === 'DIV') && ((event.which !== 32) || (event.which !== 13))) {
       super.handleKeyPress(event); // Pass keypress handling up for unsupported keys
     }
   }


### PR DESCRIPTION
## Description
Patch ClickableComponent but adding check to see if component is a DIV and not a button to determine if enter and space should be handled.

## Specific Changes proposed
Added condition to check if element is a DIV

## Requirements Checklist
- [x ] Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

