### PR TITLE
Use background-color to cover video still

### DIFF
--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -4,6 +4,7 @@
   background-repeat: no-repeat;
   background-position: 50% 50%;
   background-size: contain;
+  background-color: #000000;
   cursor: pointer;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Description
It looks like #2138 was lost in the 5.0 update. Fixes #1869 again.

## Specific Changes proposed
Use background-color to cover video still.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
