### PR TITLE
Chrome 50 does not set src attr on video element.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -772,7 +772,7 @@ class Player extends Component {
     // In Safari (5.1.1), when we move the video element into the container div, autoplay doesn't work.
     // In Chrome (15), if you have autoplay + a poster + no controls, the video gets hidden (but audio plays)
     // This fixes both issues. Need to wait for API, so it updates displays correctly
-    if (this.src() && this.tag && this.options_.autoplay && this.paused()) {
+    if ((this.src() || this.currentSrc()) && this.tag && this.options_.autoplay && this.paused()) {
       delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
       this.play();
     }


### PR DESCRIPTION
#3071 

## Description
Chrome does not set the src attr and this causes autoplay to never trigger.

## Specific Changes proposed
Check current src, it will hold the current source when multiple source video files are used.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

