### PR TITLE
Add title to all clickable components

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -78,7 +78,7 @@ class ClickableComponent extends Component {
       el.appendChild(this.controlTextEl_);
     }
 
-    this.controlText(this.controlText_);
+    this.controlText(this.controlText_, el);
 
     return this.controlTextEl_;
   }
@@ -86,15 +86,19 @@ class ClickableComponent extends Component {
   /**
    * Controls text - both request and localize
    *
-   * @param {String} text Text for element
+   * @param {String}  text Text for element
+   * @param {Element=} el Element to set the title on
    * @return {String}
    * @method controlText
    */
-  controlText(text) {
+  controlText(text, el=this.el()) {
     if (!text) return this.controlText_ || 'Need Text';
+    
+    const localizedText = this.localize(text);
 
     this.controlText_ = text;
-    this.controlTextEl_.innerHTML = this.localize(this.controlText_);
+    this.controlTextEl_.innerHTML = localizedText;
+    el.setAttribute('title', localizedText);
 
     return this;
   }

--- a/test/unit/button.test.js
+++ b/test/unit/button.test.js
@@ -4,7 +4,7 @@ import TestHelpers from './test-helpers.js';
 q.module('Button');
 
 test('should localize its text', function(){
-  expect(2);
+  expect(3);
 
   var player, testButton, el;
 
@@ -22,5 +22,6 @@ test('should localize its text', function(){
   el = testButton.createEl();
 
   ok(el.nodeName.toLowerCase().match('button'));
-  ok(el.innerHTML.match('Juego'));
+  ok(el.innerHTML.match('vjs-control-text">Juego'));
+  equal(el.getAttribute('title'), 'Juego');
 });


### PR DESCRIPTION
## Description
As discussed on Slack yesterday, this will add a `title` to all clickable components.
I modified the play toggle test to also check for this, as this was the only test that seemed to test for this already.

Because `controlText` is already called in `createEl` I had to pass the element to set the title on to the function.


## Specific Changes proposed
This sets the `title` HTML attribute on all clickable components when setting `controlText_` initially or changing it using `controlText(...)`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors

