### PR TITLE
Add default styling for print

### DIFF
--- a/src/css/_print.scss
+++ b/src/css/_print.scss
@@ -1,5 +1,5 @@
 @media print {
-  .video-js *:not(.vjs-tech):not(.vjs-poster) {
+  .video-js > *:not(.vjs-tech):not(.vjs-poster) {
     visibility:hidden;
   }
 }

--- a/src/css/_print.scss
+++ b/src/css/_print.scss
@@ -1,0 +1,5 @@
+@media print {
+  .video-js *:not(.vjs-tech):not(.vjs-poster) {
+    visibility:hidden;
+  }
+}

--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -1,7 +1,6 @@
 @import "variables";
 @import "private-variables";
 @import "utilities";
-@import "print";
 
 @import "node_modules/videojs-font/scss/icons";
 
@@ -40,3 +39,5 @@
 @import "components/adaptive";
 @import "components/captions-settings";
 @import "components/modal-dialog";
+
+@import "print";

--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -1,6 +1,7 @@
 @import "variables";
 @import "private-variables";
 @import "utilities";
+@import "print";
 
 @import "node_modules/videojs-font/scss/icons";
 


### PR DESCRIPTION
## Description
Printing a page containing video.js currently is a rather messy state.
Controls are partially visible, as many of them are text (videojs-font), yet all images and backgrounds
are usually stripped by the user-agent from the print.

## Specific Changes proposed
Hide all elements other than the poster and/or the tech.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

By default in print, only show either the poster, or the current tech
element. This matches the behavior of the HTML5 video element for most
user agents.

The video-js poster currently uses a background image, which usually gets stripped by browsers,
when printing. I also propose changing the poster element to be an img element instead of a background image.