### PR TITLE
Add descriptions and audio button to adaptive classes

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -8,7 +8,8 @@
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate, .vjs-progress-control,
   .vjs-mute-control, .vjs-volume-control, .vjs-volume-menu-button,
-  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
+  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
+  .vjs-subtitles-button, .vjs-audio-button { display: none; }
 }
 
 // When the player is x-small, display nothing but:
@@ -19,7 +20,8 @@
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
   .vjs-mute-control, .vjs-volume-control, .vjs-volume-menu-button,
-  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
+  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
+  .vjs-subtitles-button, .vjs-audio-button { display: none; }
 }
 
 
@@ -33,5 +35,6 @@
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
   .vjs-mute-control, .vjs-volume-control,
-  .vjs-chapters-button, .vjs-captions-button, .vjs-subtitles-button { display: none; }
+  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
+  .vjs-subtitles-button .vjs-audio-button { display: none; }
 }


### PR DESCRIPTION
## Description
In 5.9, a button for descriptions was added to the control bar and in 5.10 a button for audio tracks. Unlike their chapter, captions, subtitle counterparts these were not hidden by the adaptive classes.

## Specific Changes proposed
Add these new buttons to the list of buttons hidden in smaller form factor layouts.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

This fixes #3308