### PR TITLE
Retain details from tech error.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1102,7 +1102,7 @@ class Player extends Component {
    */
   handleTechError_() {
     let error = this.tech_.error();
-    this.error(error && error.code);
+    this.error(error);
   }
 
   /**


### PR DESCRIPTION
## Description

Extra details on media errors from a `Tech` component are lost when propagated to the `Player` instance. For example, custom error messages are lost and always use the default message based on the error's code.

### Demonstration
[This example on JSBin](http://jsbin.com/jerozuvazu/1/edit?html,output) registers a dummy `MyTech` tech. In its `play()` function, it immediately calls `error()` with a custom error object:
```js
play() {
    this.trigger('play');
    this.error({
        code: MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
        message: 'Custom error message'
    });
}
```
### Expected behavior
The player shows an error with the message: "Custom error message"
### Actual behavior
The player shows an error with the default message for this media error code: "The media could not be loaded, either because the server or network failed or because the format is not supported."

## Specific Changes proposed
`Player.handleTechError_` is changed to pass the whole `error` object to `Player.error`, instead of only passing `error.code`. This ensures that additional details (such as error messages) are retained.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

