### PR TITLE
null out currentSource_ on tech dispose and src change

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -813,6 +813,8 @@ Tech.withSourceHandlers = function(_Tech){
     // than clear all of our current tracks
     if (this.currentSource_) {
       this.clearTracks(['audio', 'video']);
+
+      this.currentSource_ = null;
     }
 
     if (sh !== _Tech.nativeSourceHandler) {
@@ -852,6 +854,7 @@ Tech.withSourceHandlers = function(_Tech){
     if (this.sourceHandler_ && this.sourceHandler_.dispose) {
       this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
       this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
+      this.currentSource_ = null;
       this.sourceHandler_.dispose();
     }
   };

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -854,7 +854,6 @@ Tech.withSourceHandlers = function(_Tech){
     if (this.sourceHandler_ && this.sourceHandler_.dispose) {
       this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
       this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
-      this.currentSource_ = null;
       this.sourceHandler_.dispose();
     }
   };

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -265,7 +265,7 @@ test('should add the source handler interface to a tech', function(){
   // verify that all the tracks were removed as we got a new source
   equal(tech.audioTracks().length, 0, 'should have zero audio tracks');
   equal(tech.videoTracks().length, 0, 'should have zero video tracks');
-  equal(tech.textTracks().length, 2, 'should have two video tracks');
+  equal(tech.textTracks().length, 2, 'should have two text tracks');
   equal(tech.remoteTextTrackEls().length, 2, 'should have two remote text tracks els');
   equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
 


### PR DESCRIPTION
Follow up to https://github.com/videojs/video.js/pull/3285, we need `currentSource_` to be cleared out if we're switching sources on a tech and we're no longer using a source handler. Plus, when the tech is disposed, we should clear out the `currentSource_`.