### PR TITLE
Catch errors on IE with no media support

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -993,9 +993,13 @@ Html5.registerSourceHandler(Html5.nativeSourceHandler);
  * @return {Boolean}
  */
 Html5.canControlVolume = function(){
-  var volume =  Html5.TEST_VID.volume;
-  Html5.TEST_VID.volume = (volume / 2) + 0.1;
-  return volume !== Html5.TEST_VID.volume;
+  try {
+    var volume =  Html5.TEST_VID.volume;
+    Html5.TEST_VID.volume = (volume / 2) + 0.1;
+    return volume !== Html5.TEST_VID.volume;
+  } catch(e) {
+    return false;
+  }
 };
 
 /*
@@ -1009,9 +1013,13 @@ Html5.canControlPlaybackRate = function(){
   if (browser.IS_ANDROID && browser.IS_CHROME) {
     return false;
   }
-  var playbackRate = Html5.TEST_VID.playbackRate;
-  Html5.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
-  return playbackRate !== Html5.TEST_VID.playbackRate;
+  try {
+    var playbackRate = Html5.TEST_VID.playbackRate;
+    Html5.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;
+    return playbackRate !== Html5.TEST_VID.playbackRate;
+  } catch(e) {
+    return false;
+  }
 };
 
 /*

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -993,6 +993,7 @@ Html5.registerSourceHandler(Html5.nativeSourceHandler);
  * @return {Boolean}
  */
 Html5.canControlVolume = function(){
+  // IE will error if Windows Media Player not installed #3315
   try {
     var volume =  Html5.TEST_VID.volume;
     Html5.TEST_VID.volume = (volume / 2) + 0.1;
@@ -1013,6 +1014,7 @@ Html5.canControlPlaybackRate = function(){
   if (browser.IS_ANDROID && browser.IS_CHROME) {
     return false;
   }
+  // IE will error if Windows Media Player not installed #3315
   try {
     var playbackRate = Html5.TEST_VID.playbackRate;
     Html5.TEST_VID.playbackRate = (playbackRate / 2) + 0.1;


### PR DESCRIPTION
## Description
Prevents an error on versions of IE with no media player when testing volume or playback rate support.
Fixes #3315 

## Specific Changes proposed
Try/catches in `canControlVolume()` and `canControlPlaybackRate()`. Tested on Server 2012 with IE 11.

## Requirements Checklist
- [x] Bug fixed
- [ ] Reviewed by Two Core Contributors

