### PR TITLE
Add Tooltip component

### DIFF
--- a/src/css/components/_tooltip.scss
+++ b/src/css/components/_tooltip.scss
@@ -1,0 +1,23 @@
+.video-js .vjs-tooltip {
+  position: absolute;
+  top: -3em;
+  left: 0;
+  z-index: 10;
+
+  display: none;
+  padding: 6px 8px 8px 8px;
+
+  @include border-radius(0.3em);
+  @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
+
+  color: $primary-foreground-color;
+  font-size: 0.9em;
+  font-family: $text-font-family;
+  white-space: nowrap;
+
+  pointer-events: none;
+}
+
+.video-js .vjs-tooltip-active {
+  display: block;
+}

--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -8,6 +8,7 @@
 @import "components/big-play";
 @import "components/button";
 @import "components/close-button";
+@import "components/tooltip";
 
 @import "components/menu/menu";
 @import "components/menu/menu-popup";

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -38,6 +38,18 @@ class BigPlayButton extends Button {
     this.player_.play();
   }
 
+  /**
+   * Return handler for the tooltip
+   *
+   * @return {Object} Dom element to serve as a handler for the tooltip
+   * @method tooltipHandler
+   */
+  tooltipHandler() {
+    if (this.options_.tooltip !== undefined) {
+      return super.tooltipHandler();
+    }
+  }
+
 }
 
 BigPlayButton.prototype.controlText_ = 'Play Video';

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -215,7 +215,6 @@ class ClickableComponent extends Component {
     let tooltipHandler = this.tooltipHandler();
 
     if (tooltipHandler) {
-      console.log(this);
       this.tooltip = new Tooltip(this.player_);
       this.el().appendChild(this.tooltip.el());
       this.tooltip.text(this.controlText_);

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -8,6 +8,7 @@ import * as Fn from './utils/fn.js';
 import log from './utils/log.js';
 import document from 'global/document';
 import assign from 'object.assign';
+import Tooltip from './tooltip';
 
 /**
  * Clickable Component which is clickable or keyboard actionable, but is not a native HTML button
@@ -21,6 +22,8 @@ class ClickableComponent extends Component {
 
   constructor(player, options) {
     super(player, options);
+
+    this.appendTooltip();
 
     this.emitTapEvents();
 
@@ -95,6 +98,12 @@ class ClickableComponent extends Component {
 
     this.controlText_ = text;
     this.controlTextEl_.innerHTML = this.localize(this.controlText_);
+
+    if (this.tooltip) {
+      this.tooltip.text(this.controlText_);
+    } else {
+      this.appendTooltip();
+    }
 
     return this;
   }
@@ -191,6 +200,55 @@ class ClickableComponent extends Component {
    */
   handleBlur() {
     Events.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
+  }
+
+  /**
+   * Append a tooltip to the component
+   *
+   * @method appendTooltip
+   */
+  appendTooltip() {
+    if (this.tooltip || !this.controlText_ || !this.el()) {
+      return;
+    }
+
+    let tooltipHandler = this.tooltipHandler();
+
+    if (tooltipHandler) {
+      console.log(this);
+      this.tooltip = new Tooltip(this.player_);
+      this.el().appendChild(this.tooltip.el());
+      this.tooltip.text(this.controlText_);
+      this.tooltip.handler(tooltipHandler);
+    }
+  }
+
+  /**
+   * Return handler for the tooltip
+   *
+   * @return {Object} Dom element to serve as a handler for the tooltip
+   * @method tooltipHandler
+   */
+  tooltipHandler() {
+    let handler = this.options_.tooltip;
+
+    if (handler === false) {
+      return;
+    }
+
+    if (handler === true || this.player_.options_.tooltips) {
+      return this.el();
+    }
+
+    if (typeof handler === 'string') {
+      return Dom.getEl(handler);
+    }
+
+    if (handler && typeof handler.el === 'function') {
+      return handler.el();
+    }
+
+    return handler;
   }
 }
 

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -236,7 +236,7 @@ class ClickableComponent extends Component {
       return;
     }
 
-    if (handler === true || this.player_.options_.tooltips) {
+    if (handler === true || (this.player_.options_ && this.player_.options_.tooltips)) {
       return this.el();
     }
 

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -65,7 +65,6 @@ class PlayToggle extends Button {
     this.addClass('vjs-paused');
     this.controlText('Play'); // change the button text to "Play"
   }
-
 }
 
 PlayToggle.prototype.controlText_ = 'Play';

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -256,6 +256,17 @@ class MenuButton extends ClickableComponent {
 
     return super.enable();
   }
+
+  /**
+   * Return handler for the tooltip
+   *
+   * @return {Object} Dom element to serve as a handler for the tooltip
+   * @method tooltipHandler
+   */
+  tooltipHandler() {
+    // TODO: Fix menu button to have a real icon element to make it as tooltip handler
+    return;
+  }
 }
 
 Component.registerComponent('MenuButton', MenuButton);

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -79,6 +79,18 @@ class MenuItem extends ClickableComponent {
       }
     }
   }
+
+  /**
+   * Return handler for the tooltip
+   *
+   * @return {Object} Dom element to serve as a handler for the tooltip
+   * @method tooltipHandler
+   */
+  tooltipHandler() {
+    if (this.options_.tooltip !== undefined) {
+      return super.tooltipHandler();
+    }
+  }
 }
 
 Component.registerComponent('MenuItem', MenuItem);

--- a/src/js/popup/popup-button.js
+++ b/src/js/popup/popup-button.js
@@ -85,6 +85,16 @@ class PopupButton extends ClickableComponent {
     return `vjs-menu-button ${menuButtonClass} ${super.buildCSSClass()}`;
   }
 
+  /**
+   * Return handler for the tooltip
+   *
+   * @return {Object} Dom element to serve as a handler for the tooltip
+   * @method tooltipHandler
+   */
+  tooltipHandler() {
+    // TODO: Fix popup button to have a real icon element to make it as tooltip handler
+    return;
+  }
 }
 
 Component.registerComponent('PopupButton', PopupButton);

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -1,0 +1,119 @@
+/**
+ * @file tooltip.js
+ */
+import Component from './component';
+import * as Dom from './utils/dom.js';
+import * as Events from './utils/events.js';
+import * as Fn from './utils/fn.js';
+import document from 'global/document';
+import throttle from 'lodash-compat/function/throttle';
+
+/**
+ * Base class for all tooltips
+ *
+ * @param {Object} player  Main Player
+ * @param {Object=} options Object of option names and values
+ * @extends Component
+ * @class Tooltip
+ */
+class Tooltip extends Component {
+
+  constructor(player, options) {
+    super(player, options);
+
+    this.handleHover_ = throttle(Fn.bind(this, this.handleHover), 25);
+    this.handleLeave_ = throttle(Fn.bind(this, this.handleLeave), 25);
+  }
+
+  createEl() {
+    return super.createEl('div', {
+      className: 'vjs-tooltip'
+    });
+  }
+
+  text(text) {
+    if (!text) return this.text_ || '';
+
+    this.text_ = text;
+    this.el_.innerHTML = this.localize(this.text_);
+
+    this.update();
+
+    return this;
+  }
+
+  handler(handler) {
+    if (!handler) return this.handler;
+
+    if (this.handler_) {
+      this.off(this.handler_, 'mouseover', this.handleHover_);
+      this.off(this.handler_, 'mouseout', this.handleLeave_);
+
+    }
+
+    this.handler_ = handler;
+    this.on(this.handler_, 'mouseover', this.handleHover_);
+    this.on(this.handler_, 'mouseout', this.handleLeave_);
+
+    return this;
+  }
+
+  handleHover() {
+    if (this.timeout) {
+      this.clearTimeout(this.timeout);
+      this.timeout = 0;
+    }
+    this.timeout = this.setTimeout(()=>this.hide(), 5000);
+    this.show();
+  }
+
+  handleLeave() {
+    if (this.timeout) {
+      this.clearTimeout(this.timeout);
+      this.timeout = 0;
+    }
+    this.hide();
+  }
+
+  show() {
+    this.player_.trigger('tooltipShown');
+    this.player_.on('tooltipShown', Fn.bind(this, this.hide));
+
+    this.addClass('vjs-tooltip-active');
+    this.update();
+  }
+
+  hide() {
+    this.removeClass('vjs-tooltip-active');
+
+    this.player_.off('tooltipShown');
+  }
+
+  update() {
+    let width = this.width();
+
+    if (!width) {
+      return this;
+    }
+
+    let parent_ = this.handler_;
+    let parentWidth = parent_ ? parent_.offsetWidth : 0;
+
+    let parentLeft = Dom.findElPosition(parent_).left - Dom.findElPosition(this.player_.el()).left;
+    let skew = parentWidth/2 - width/2;
+
+    let minSkew = -parentLeft;
+    // TODO: player_.width() is not working properly after switch to fullscreen
+    let maxSkew = this.player_.el().offsetWidth - parentLeft - width;
+
+    skew = Math.min(Math.max(minSkew, skew), maxSkew);
+
+    this.el_.style.left = skew + 'px';
+
+    return this;
+  }
+
+}
+
+Component.registerComponent('Tooltip', Tooltip);
+export default Tooltip;


### PR DESCRIPTION
General Tooltip component for any ClickableComponent.

Allows to show properly positioned tooltips for buttons and so on.

By default, it’s disabled.

Could be enabled for all basic buttons with `{"tooltips": true}` option.

Could be enabled for specific control with per-component option 
`{"MyComponent": {"tooltip": true}}`

Allows to set up custom handler element for specific control:
`{"MyComponent": {"tooltip": "#myTooltipHandler"}}`

Not yet working for MenuButton and PopupButton since they’re using pseudo-element for icons.

Disabled for BigPlayButton even with general `{"tooltips": true}` option – but you can enable it with per-component option (will need to add additional styles as well).

Also it's possible to rewrite mouse-display-tooltip with this component.