### PR TITLE
Fix test for tooltips in IE8

### DIFF
--- a/test/unit/button.test.js
+++ b/test/unit/button.test.js
@@ -22,6 +22,6 @@ test('should localize its text', function(){
   el = testButton.createEl();
 
   ok(el.nodeName.toLowerCase().match('button'));
-  ok(el.innerHTML.match('vjs-control-text">Juego'));
+  ok(el.innerHTML.match(/vjs-control-text"?>Juego/));
   equal(el.getAttribute('title'), 'Juego');
 });


### PR DESCRIPTION
This fixes the broken build from merging #3296.

Nothing too excited, but IE8 has no `"` in the class.