### PR TITLE
Add beforesourcechange and sourcechange events

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1903,11 +1903,14 @@ class Player extends Component {
         // the tech loop to check for a compatible technology
         this.sourceList_([source]);
       } else {
-        let previous = this.currentSrc();
+        const previous = {
+          src: this.currentSrc(),
+          type: this.currentType()
+        };
 
         this.trigger('beforesourcechange', {
           current: previous,
-          next: source.src
+          next: source
         });
 
         this.cache_.src = source.src;
@@ -1936,7 +1939,7 @@ class Player extends Component {
 
           this.trigger('sourcechange', {
             previous,
-            current: source.src
+            current: source
           });
 
         // Set the source synchronously if possible (#2326)

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1903,6 +1903,13 @@ class Player extends Component {
         // the tech loop to check for a compatible technology
         this.sourceList_([source]);
       } else {
+        let previous = this.currentSrc();
+
+        this.trigger('beforesourcechange', {
+          current: previous,
+          upcoming: source.src
+        });
+
         this.cache_.src = source.src;
         this.currentType_ = source.type || '';
 
@@ -1926,6 +1933,11 @@ class Player extends Component {
           if (this.options_.autoplay) {
             this.play();
           }
+
+          this.trigger('sourcechange', {
+            previous,
+            current: source.src
+          });
 
         // Set the source synchronously if possible (#2326)
         }, true);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1903,10 +1903,14 @@ class Player extends Component {
         // the tech loop to check for a compatible technology
         this.sourceList_([source]);
       } else {
-        const previous = {
-          src: this.currentSrc(),
-          type: this.currentType()
-        };
+        const previous = {src: this.currentSrc()};
+
+        // We only want to include the type if it exists. This keeps the
+        // objects sent from the sourcechange events similar: `type` will
+        // not be present if it's not known.
+        if (this.currentType_) {
+          previous.type = this.currentType_;
+        }
 
         this.trigger('beforesourcechange', {
           current: previous,
@@ -1937,10 +1941,12 @@ class Player extends Component {
             this.play();
           }
 
-          this.trigger('sourcechange', {
-            previous,
-            current: source
-          });
+          window.setTimeout(() => {
+            this.trigger('sourcechange', {
+              previous,
+              current: source
+            });
+          }, 0);
 
         // Set the source synchronously if possible (#2326)
         }, true);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1907,7 +1907,7 @@ class Player extends Component {
 
         this.trigger('beforesourcechange', {
           current: previous,
-          upcoming: source.src
+          next: source.src
         });
 
         this.cache_.src = source.src;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1051,11 +1051,11 @@ test('Changing the source via the src() method triggers beforesourcechange and s
   let spyData = spy.lastCall.args[1];
 
   strictEqual(beforeSpy.callCount, 1);
-  strictEqual(beforeSpyData.current, 'oceans.mp4');
-  strictEqual(beforeSpyData.next, 'oceans-1.mp4');
+  deepEqual(beforeSpyData.current, {src: 'oceans.mp4', type: 'video/mp4'});
+  deepEqual(beforeSpyData.next, {src: 'oceans-1.mp4', type: 'video/mp4'});
   strictEqual(spy.callCount, 1);
-  strictEqual(spyData.previous, 'oceans.mp4');
-  strictEqual(spyData.current, 'oceans-1.mp4');
+  deepEqual(spyData.previous, {src: 'oceans.mp4', type: 'video/mp4'});
+  deepEqual(spyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'});
 
   player.src({src: 'oceans-2.mp4', type: 'video/mp4'});
 
@@ -1063,11 +1063,11 @@ test('Changing the source via the src() method triggers beforesourcechange and s
   spyData = spy.lastCall.args[1];
 
   strictEqual(beforeSpy.callCount, 2);
-  strictEqual(beforeSpyData.current, 'oceans-1.mp4');
-  strictEqual(beforeSpyData.next, 'oceans-2.mp4');
+  deepEqual(beforeSpyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'});
+  deepEqual(beforeSpyData.next, {src: 'oceans-2.mp4', type: 'video/mp4'});
   strictEqual(spy.callCount, 2);
-  strictEqual(spyData.previous, 'oceans-1.mp4');
-  strictEqual(spyData.current, 'oceans-2.mp4');
+  deepEqual(spyData.previous, {src: 'oceans-1.mp4', type: 'video/mp4'});
+  deepEqual(spyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'});
 
   player.src({src: 'oceans-3.mp4', type: 'video/mp4'});
 
@@ -1075,9 +1075,9 @@ test('Changing the source via the src() method triggers beforesourcechange and s
   spyData = spy.lastCall.args[1];
 
   strictEqual(beforeSpy.callCount, 3);
-  strictEqual(beforeSpyData.current, 'oceans-2.mp4');
-  strictEqual(beforeSpyData.next, 'oceans-3.mp4');
+  deepEqual(beforeSpyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'});
+  deepEqual(beforeSpyData.next, {src: 'oceans-3.mp4', type: 'video/mp4'});
   strictEqual(spy.callCount, 3);
-  strictEqual(spyData.previous, 'oceans-2.mp4');
-  strictEqual(spyData.current, 'oceans-3.mp4');
+  deepEqual(spyData.previous, {src: 'oceans-2.mp4', type: 'video/mp4'});
+  deepEqual(spyData.current, {src: 'oceans-3.mp4', type: 'video/mp4'});
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1052,7 +1052,7 @@ test('Changing the source via the src() method triggers beforesourcechange and s
 
   strictEqual(beforeSpy.callCount, 1);
   strictEqual(beforeSpyData.current, 'oceans.mp4');
-  strictEqual(beforeSpyData.upcoming, 'oceans-1.mp4');
+  strictEqual(beforeSpyData.next, 'oceans-1.mp4');
   strictEqual(spy.callCount, 1);
   strictEqual(spyData.previous, 'oceans.mp4');
   strictEqual(spyData.current, 'oceans-1.mp4');
@@ -1064,7 +1064,7 @@ test('Changing the source via the src() method triggers beforesourcechange and s
 
   strictEqual(beforeSpy.callCount, 2);
   strictEqual(beforeSpyData.current, 'oceans-1.mp4');
-  strictEqual(beforeSpyData.upcoming, 'oceans-2.mp4');
+  strictEqual(beforeSpyData.next, 'oceans-2.mp4');
   strictEqual(spy.callCount, 2);
   strictEqual(spyData.previous, 'oceans-1.mp4');
   strictEqual(spyData.current, 'oceans-2.mp4');
@@ -1076,7 +1076,7 @@ test('Changing the source via the src() method triggers beforesourcechange and s
 
   strictEqual(beforeSpy.callCount, 3);
   strictEqual(beforeSpyData.current, 'oceans-2.mp4');
-  strictEqual(beforeSpyData.upcoming, 'oceans-3.mp4');
+  strictEqual(beforeSpyData.next, 'oceans-3.mp4');
   strictEqual(spy.callCount, 3);
   strictEqual(spyData.previous, 'oceans-2.mp4');
   strictEqual(spyData.current, 'oceans-3.mp4');

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1034,50 +1034,70 @@ test('Changing the source via the src() method triggers beforesourcechange and s
     ]
   });
 
+  // Tick forward to ready the player.
+  this.clock.tick(1);
+
   var beforeSpy = sinon.spy();
   var spy = sinon.spy();
 
   player.on('beforesourcechange', beforeSpy);
   player.on('sourcechange', spy);
 
-  this.clock.tick(1);
-
   player.src([
     {src: 'oceans-1.mp4', type: 'video/mp4'},
     {src: 'oceans-1.webm', type: 'video/webm'}
   ]);
 
+  // We need to tick forward each time we call `src()` because the
+  // `sourcechange` event is asynchronous.
+  this.clock.tick(1);
+
   let beforeSpyData = beforeSpy.lastCall.args[1];
   let spyData = spy.lastCall.args[1];
 
-  strictEqual(beforeSpy.callCount, 1);
-  deepEqual(beforeSpyData.current, {src: 'oceans.mp4', type: 'video/mp4'});
-  deepEqual(beforeSpyData.next, {src: 'oceans-1.mp4', type: 'video/mp4'});
-  strictEqual(spy.callCount, 1);
-  deepEqual(spyData.previous, {src: 'oceans.mp4', type: 'video/mp4'});
-  deepEqual(spyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'});
+  strictEqual(beforeSpy.callCount, 1, 'beforesourechange was triggered once');
+  deepEqual(beforeSpyData.current, {src: 'oceans.mp4', type: 'video/mp4'}, 'the current source has both src and type');
+  deepEqual(beforeSpyData.next, {src: 'oceans-1.mp4', type: 'video/mp4'}, 'the next source has both src and type');
+  strictEqual(spy.callCount, 1, 'sourechange was triggered once');
+  deepEqual(spyData.previous, {src: 'oceans.mp4', type: 'video/mp4'}, 'the previous source has both src and type');
+  deepEqual(spyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'}, 'the (new) current source has both src and type');
 
   player.src({src: 'oceans-2.mp4', type: 'video/mp4'});
+  this.clock.tick(1);
 
   beforeSpyData = beforeSpy.lastCall.args[1];
   spyData = spy.lastCall.args[1];
 
-  strictEqual(beforeSpy.callCount, 2);
-  deepEqual(beforeSpyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'});
-  deepEqual(beforeSpyData.next, {src: 'oceans-2.mp4', type: 'video/mp4'});
-  strictEqual(spy.callCount, 2);
-  deepEqual(spyData.previous, {src: 'oceans-1.mp4', type: 'video/mp4'});
-  deepEqual(spyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'});
+  strictEqual(beforeSpy.callCount, 2, 'beforesourechange was triggered twice');
+  deepEqual(beforeSpyData.current, {src: 'oceans-1.mp4', type: 'video/mp4'}, 'the current source has both src and type');
+  deepEqual(beforeSpyData.next, {src: 'oceans-2.mp4', type: 'video/mp4'}, 'the next source has both src and type');
+  strictEqual(spy.callCount, 2, 'sourechange was triggered twice');
+  deepEqual(spyData.previous, {src: 'oceans-1.mp4', type: 'video/mp4'}, 'the previous source has both src and type');
+  deepEqual(spyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'}, 'the (new) current source has both src and type');
 
-  player.src({src: 'oceans-3.mp4', type: 'video/mp4'});
+  player.src('oceans-3.mp4');
+  this.clock.tick(1);
 
   beforeSpyData = beforeSpy.lastCall.args[1];
   spyData = spy.lastCall.args[1];
 
-  strictEqual(beforeSpy.callCount, 3);
-  deepEqual(beforeSpyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'});
-  deepEqual(beforeSpyData.next, {src: 'oceans-3.mp4', type: 'video/mp4'});
-  strictEqual(spy.callCount, 3);
-  deepEqual(spyData.previous, {src: 'oceans-2.mp4', type: 'video/mp4'});
-  deepEqual(spyData.current, {src: 'oceans-3.mp4', type: 'video/mp4'});
+  strictEqual(beforeSpy.callCount, 3, 'beforesourechange was triggered three times');
+  deepEqual(beforeSpyData.current, {src: 'oceans-2.mp4', type: 'video/mp4'}, 'the current source has both src and type');
+  deepEqual(beforeSpyData.next, {src: 'oceans-3.mp4'}, 'the next source has only src');
+  strictEqual(spy.callCount, 3, 'sourechange was triggered three times');
+  deepEqual(spyData.previous, {src: 'oceans-2.mp4', type: 'video/mp4'}, 'the previous source has both src and type');
+  deepEqual(spyData.current, {src: 'oceans-3.mp4'}, 'the (new) current source has only src');
+
+  player.src({src: 'oceans-4.mp4', type: 'video/mp4'});
+  this.clock.tick(1);
+
+  beforeSpyData = beforeSpy.lastCall.args[1];
+  spyData = spy.lastCall.args[1];
+
+  strictEqual(beforeSpy.callCount, 4, 'beforesourechange was triggered four times');
+  deepEqual(beforeSpyData.current, {src: 'oceans-3.mp4'}, 'the current source has only src');
+  deepEqual(beforeSpyData.next, {src: 'oceans-4.mp4', type: 'video/mp4'}, 'the next source has both src and type');
+  strictEqual(spy.callCount, 4, 'sourechange was triggered four times');
+  deepEqual(spyData.previous, {src: 'oceans-3.mp4'}, 'the previous source has only src');
+  deepEqual(spyData.current, {src: 'oceans-4.mp4', type: 'video/mp4'}, 'the (new) current source has both src and type');
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1026,3 +1026,58 @@ test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the tech el
   equal(player.tech_.el().width, 600, 'the width is equal to 600');
   equal(player.tech_.el().height, 300, 'the height is equal 300');
 });
+
+test('Changing the source via the src() method triggers beforesourcechange and sourcechange events', function() {
+  var player = TestHelpers.makePlayer({
+    sources: [
+      {src: 'oceans.mp4', type: 'video/mp4'}
+    ]
+  });
+
+  var beforeSpy = sinon.spy();
+  var spy = sinon.spy();
+
+  player.on('beforesourcechange', beforeSpy);
+  player.on('sourcechange', spy);
+
+  this.clock.tick(1);
+
+  player.src([
+    {src: 'oceans-1.mp4', type: 'video/mp4'},
+    {src: 'oceans-1.webm', type: 'video/webm'}
+  ]);
+
+  let beforeSpyData = beforeSpy.lastCall.args[1];
+  let spyData = spy.lastCall.args[1];
+
+  strictEqual(beforeSpy.callCount, 1);
+  strictEqual(beforeSpyData.current, 'oceans.mp4');
+  strictEqual(beforeSpyData.upcoming, 'oceans-1.mp4');
+  strictEqual(spy.callCount, 1);
+  strictEqual(spyData.previous, 'oceans.mp4');
+  strictEqual(spyData.current, 'oceans-1.mp4');
+
+  player.src({src: 'oceans-2.mp4', type: 'video/mp4'});
+
+  beforeSpyData = beforeSpy.lastCall.args[1];
+  spyData = spy.lastCall.args[1];
+
+  strictEqual(beforeSpy.callCount, 2);
+  strictEqual(beforeSpyData.current, 'oceans-1.mp4');
+  strictEqual(beforeSpyData.upcoming, 'oceans-2.mp4');
+  strictEqual(spy.callCount, 2);
+  strictEqual(spyData.previous, 'oceans-1.mp4');
+  strictEqual(spyData.current, 'oceans-2.mp4');
+
+  player.src({src: 'oceans-3.mp4', type: 'video/mp4'});
+
+  beforeSpyData = beforeSpy.lastCall.args[1];
+  spyData = spy.lastCall.args[1];
+
+  strictEqual(beforeSpy.callCount, 3);
+  strictEqual(beforeSpyData.current, 'oceans-2.mp4');
+  strictEqual(beforeSpyData.upcoming, 'oceans-3.mp4');
+  strictEqual(spy.callCount, 3);
+  strictEqual(spyData.previous, 'oceans-2.mp4');
+  strictEqual(spyData.current, 'oceans-3.mp4');
+});

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -32,6 +32,7 @@ class TechFaker extends Tech {
 
   setControls(val) {}
 
+  currentSrc() { return ''; }
   currentTime() { return 0; }
   seeking() { return false; }
   src() { return 'movie.mp4'; }


### PR DESCRIPTION
## Description
This adds two new events which are triggered by the `Player#src()` method.

- `"beforesourcechange"` fires before a playable source is set on the player.
- `"sourcechange"` fires after the playable source has been set on the player (including after any tech-readiness and autoplay/preload behavior is triggered).

These are non-standard events, but I'd like to open discussion on adding them. They have a lot of practical application as we've seen at Brightcove and other companies where core contributors work. This may be ultimately more appropriate in a separate project - in order to keep the core more pure, but modifying the `Player` prototype seems out of the scope of plugins to me. An alternative might be coming up with some kind of flag that notes an event as non-standard.

Discuss!

## Requirements Checklist
- [x] Feature implemented
  - [x] Unit Tests updated
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

