### PR TITLE
Fixed unhandled exception on ios 7.1.2

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -773,7 +773,12 @@ class Player extends Component {
     // In Chrome (15), if you have autoplay + a poster + no controls, the video gets hidden (but audio plays)
     // This fixes both issues. Need to wait for API, so it updates displays correctly
     if (this.src() && this.tag && this.options_.autoplay && this.paused()) {
-      delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
+      try {
+        delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
+      }
+      catch (e) {
+        console.log('error on ios7, breaks player', e);
+      }
       this.play();
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -777,7 +777,7 @@ class Player extends Component {
         delete this.tag.poster; // Chrome Fix. Fixed in Chrome v16.
       }
       catch (e) {
-        console.log('error on ios7, breaks player', e);
+        log('deleting tag.poster throws in some browsers', e);
       }
       this.play();
     }


### PR DESCRIPTION
## Description
On iOS 7.1.2 (possible other lower versions as well) videojs throws an unhandled error which breaks the player. (first pull request, so bear with me)


## Specific Changes proposed
Try catch around chrome fix (which breaks in safari on iOS 7.1.2) in handleTechReady_

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

Error: Unable to delete property.

handleTechReady_@....