### PR TITLE
only call source handler dispose once on the same source handler

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -855,6 +855,7 @@ Tech.withSourceHandlers = function(_Tech){
       this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
       this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
       this.sourceHandler_.dispose();
+      this.sourceHandler_ = null;
     }
   };
 


### PR DESCRIPTION
## Description
Currently we will try to dispose of SourceHandlers twice when we call setSource multiple times, this causes videojs to throw an error on the second setSource

## Specific Changes proposed
* Null out sourceHandler_ on the tech when sourceHandler is disposed

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

