### PR TITLE
only call source handler dispose once on the same source handler

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -855,6 +855,7 @@ Tech.withSourceHandlers = function(_Tech){
       this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
       this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
       this.sourceHandler_.dispose();
+      this.sourceHandler_ = null;
     }
   };
 

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -413,3 +413,82 @@ test('Tech#setSource clears currentSource_ after repeated loadstart', function()
   equal(tech.currentSource_, null, 'Current source is still null');
 
 });
+
+test('setSource after tech dispose should dispose source handler once', function(){
+  let MyTech = extendFn(Tech);
+  Tech.withSourceHandlers(MyTech);
+
+  let disposeCount = 0;
+  let handler = {
+    dispose() {
+      disposeCount++;
+    }
+  };
+
+  MyTech.registerSourceHandler({
+    canPlayType: function() {
+      return true;
+    },
+    canHandleSource: function() {
+      return true;
+    },
+    handleSource: function(source, tech, options) {
+      return handler;
+    }
+  });
+
+  let tech = new MyTech();
+  tech.setSource('test');
+
+  equal(disposeCount, 0, 'did not call sourceHandler_ dispose for initial dispose');
+  tech.dispose();
+  ok(!tech.sourceHandler_, 'sourceHandler should be unset');
+  equal(disposeCount, 1, 'called the source handler dispose');
+
+  // this would normally be done above tech on src after dispose
+  tech.el_ = tech.createEl();
+
+  tech.setSource('test');
+  equal(disposeCount, 1, 'did not dispose after initial setSource');
+
+  tech.setSource('test');
+  equal(disposeCount, 2, 'did dispose on second setSource');
+
+});
+
+test('setSource after previous setSource should dispose source handler once', function(){
+  let MyTech = extendFn(Tech);
+  Tech.withSourceHandlers(MyTech);
+
+  let disposeCount = 0;
+  let handler = {
+    dispose() {
+      disposeCount++;
+    }
+  };
+
+  MyTech.registerSourceHandler({
+    canPlayType: function() {
+      return true;
+    },
+    canHandleSource: function() {
+      return true;
+    },
+    handleSource: function(source, tech, options) {
+      return handler;
+    }
+  });
+
+  let tech = new MyTech();
+
+  tech.setSource('test');
+  equal(disposeCount, 0, 'did not call dispose for initial setSource');
+
+  tech.setSource('test');
+  equal(disposeCount, 1, 'did dispose for second setSource');
+
+  tech.setSource('test');
+  equal(disposeCount, 2, 'did dispose for third setSource');
+
+});
+


### PR DESCRIPTION
## Description
Currently we will try to dispose of SourceHandlers twice when we call setSource multiple times, this causes videojs to throw an error on the second setSource

## Specific Changes proposed
* Null out sourceHandler_ on the tech when sourceHandler is disposed

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors