### PR TITLE
Update duration and remaining time displays on durationchange

### DIFF
--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -18,13 +18,7 @@ class DurationDisplay extends Component {
   constructor(player, options){
     super(player, options);
 
-    // this might need to be changed to 'durationchange' instead of 'timeupdate' eventually,
-    // however the durationchange event fires before this.player_.duration() is set,
-    // so the value cannot be written out using this method.
-    // Once the order of durationchange and this.player_.duration() being set is figured out,
-    // this can be updated.
-    this.on(player, 'timeupdate', this.updateContent);
-    this.on(player, 'loadedmetadata', this.updateContent);
+    this.on(player, 'durationchange', this.updateContent);
   }
 
   /**

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -19,6 +19,7 @@ class RemainingTimeDisplay extends Component {
     super(player, options);
 
     this.on(player, 'timeupdate', this.updateContent);
+    this.on(player, 'durationchange', this.updateContent);
   }
 
   /**


### PR DESCRIPTION
## Description
The duration display and remaining time displays do not update when the tech dispatches a `durationchange` event without a `timeupdate` event. This PR ensures that these displays bind to `durationchange` to update their content.

There is a [comment in `DurationDisplay`](https://github.com/videojs/video.js/blob/b9e3e55384447cb8928ad413146d77cc9832e654/src/js/control-bar/time-controls/duration-display.js#L21) saying that this change should be done once a previous bug was resolved with the way `player.duration()` is updated on `durationchange`. I believe this bug was fixed with #2552, so I think it should be safe to do this change now.

## Problem
In the current version, if a `Tech` updates its duration and only fires a `durationchange` event (without firing a `timeupdate` event), the time displays are currently not updated properly.

### Steps to reproduce
1. Create a custom `Tech`, for example based on [`TechFaker`](https://github.com/videojs/video.js/blob/b9e3e55384447cb8928ad413146d77cc9832e654/test/unit/tech/tech-faker.js)
2. Set the tech's `featuresTimeupdateEvents` to `true` (to prevent the player from triggering interval-based `timeupdate` events)
2. Make the tech update its duration and dispatch a `durationchange` event
3. Notice the duration display and remaining time displays

This page demonstrates the issue when you hit the play button: http://jsbin.com/gedoxah/edit?html,output

### Expected results
* The duration display and remaining time display update their content with the new duration.

### Actual results
* The duration display and remaining time display are not updated with the new duration.

## Specific Changes proposed
* Add `durationchange` listeners in `DurationDisplay` and `RemainingTimeDisplay`
* Remove the `timeupdate` and `loadedmetadata` listeners in `DurationDisplay` (since they are no longer needed)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors