### PR TITLE
Improve Logging for IE < 11

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -60,6 +60,9 @@ export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_EDGE = (/Edge/i).test(USER_AGENT);
 export const IS_CHROME = !IS_EDGE && (/Chrome/i).test(USER_AGENT);
 export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
+export const IE_VERSION = (function(result){
+  return result && parseFloat(result[1]);
+})((/MSIE\s(\d+)\.\d/).exec(USER_AGENT));
 
 export const TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);
 export const BACKGROUND_SIZE_SUPPORTED = 'backgroundSize' in document.createElement('video').style;

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -63,6 +63,7 @@ export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
 export const IE_VERSION = (function(result){
   return result && parseFloat(result[1]);
 })((/MSIE\s(\d+)\.\d/).exec(USER_AGENT));
+export const IS_IE_LT_11 = !!IE_VERSION && IE_VERSION < 11;
 
 export const TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);
 export const BACKGROUND_SIZE_SUPPORTED = 'backgroundSize' in document.createElement('video').style;

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -63,7 +63,6 @@ export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
 export const IE_VERSION = (function(result){
   return result && parseFloat(result[1]);
 })((/MSIE\s(\d+)\.\d/).exec(USER_AGENT));
-export const IS_IE_LT_11 = !!IE_VERSION && IE_VERSION < 11;
 
 export const TOUCH_ENABLED = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch);
 export const BACKGROUND_SIZE_SUPPORTED = 'backgroundSize' in document.createElement('video').style;

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -2,78 +2,90 @@
  * @file log.js
  */
 import window from 'global/window';
+import {IE_VERSION} from './browser';
+
+const IS_IE_LT_11 = !!IE_VERSION && IE_VERSION < 11;
 
 /**
- * Log plain debug messages
+ * Log messages to the console and history based on the type of message
+ *
+ * @param  {Object} args The args to be passed to the log
+ * @param  {String} [type='log']
+ * @private
  */
-const log = function(){
-  _logType(null, arguments);
+const _logByType = (args, type = 'log') => {
+
+  // if there's no console then don't try to output messages
+  // they will still be stored in log.history
+  // Was setting these once outside of this function, but containing them
+  // in the function makes it easier to test cases where console doesn't exist
+  const noop = function(){};
+
+  const console = window.console || {
+    log: noop,
+    warn: noop,
+    error: noop
+  };
+
+  const fn = console[type];
+
+  if (type !== 'log') {
+    // add the type to the front of the message
+    args.unshift(type.toUpperCase() + ':');
+  }
+
+  // add to history
+  log.history.push(args);
+
+  // add console prefix after adding to history
+  args.unshift('VIDEOJS:');
+
+  // Old IE versions do not allow .apply() for some/all console method(s). And
+  // IEs previous to 11 log objects uselessly as "[object Object]"; so, JSONify
+  // objects and arrays for those less-capable browsers.
+  if (!fn.apply || IS_IE_LT_11) {
+    fn(args.map(a => {
+      if (a && typeof a === 'object' || Array.isArray(a)) {
+        return JSON.stringify(a);
+      }
+      return a;
+    }).join(' '));
+
+  // Default hanlding for modern consoles.
+  } else {
+    fn(...args);
+  }
 };
 
 /**
+ * Log plain debug messages
+ *
+ * @function log
+ */
+function log(...args) {
+  _logByType(args);
+}
+
+/**
  * Keep a history of log messages
+ *
  * @type {Array}
  */
 log.history = [];
 
 /**
  * Log error messages
+ *
+ * @method error
  */
-log.error = function(){
-  _logType('error', arguments);
-};
+log.error = (...args) => _logByType(args, 'error');
 
 /**
  * Log warning messages
- */
-log.warn = function(){
-  _logType('warn', arguments);
-};
-
-/**
- * Log messages to the console and history based on the type of message
  *
- * @param  {String} type The type of message, or `null` for `log`
- * @param  {Object} args The args to be passed to the log
- * @private
- * @method _logType
+ * @method warn
  */
-function _logType(type, args){
-  // convert args to an array to get array functions
-  let argsArray = Array.prototype.slice.call(args);
-  // if there's no console then don't try to output messages
-  // they will still be stored in log.history
-  // Was setting these once outside of this function, but containing them
-  // in the function makes it easier to test cases where console doesn't exist
-  let noop = function(){};
+log.warn = (...args) => _logByType(args, 'warn');
 
-  let console = window['console'] || {
-    'log': noop,
-    'warn': noop,
-    'error': noop
-  };
-
-  if (type) {
-    // add the type to the front of the message
-    argsArray.unshift(type.toUpperCase()+':');
-  } else {
-    // default to log with no prefix
-    type = 'log';
-  }
-
-  // add to history
-  log.history.push(argsArray);
-
-  // add console prefix after adding to history
-  argsArray.unshift('VIDEOJS:');
-
-  // call appropriate log function
-  if (console[type].apply) {
-    console[type].apply(console, argsArray);
-  } else {
-    // ie8 doesn't allow error.apply, but it will just join() the array anyway
-    console[type](argsArray.join(' '));
-  }
-}
 
 export default log;

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -44,7 +44,9 @@ export const logByType = (type, args, stringify = IS_IE_LT_11) => {
   if (!fn.apply || stringify) {
     fn(args.map(a => {
       if (a && typeof a === 'object' || Array.isArray(a)) {
-        return JSON.stringify(a);
+        try {
+          return JSON.stringify(a);
+        } catch (x) {}
       }
 
       // Cast to string before joining, so we get null and undefined explicitly

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -2,7 +2,7 @@
  * @file log.js
  */
 import window from 'global/window';
-import {IS_IE_LT_11} from './browser';
+import {IE_VERSION} from './browser';
 
 /**
  * Log messages to the console and history based on the type of message
@@ -11,11 +11,11 @@ import {IS_IE_LT_11} from './browser';
  *         The name of the console method to use.
  * @param  {Array} args
  *         The arguments to be passed to the matching console method.
- * @param  {Boolean} [stringify=IS_IE_LT_11]
+ * @param  {Boolean} [stringify]
  *         By default, only old IEs should get console argument stringification,
  *         but this is exposed as a parameter to facilitate testing.
  */
-export const logByType = (type, args, stringify = IS_IE_LT_11) => {
+export const logByType = (type, args, stringify = !!IE_VERSION && IE_VERSION < 11) => {
   const console = window.console;
 
   // If there's no console then don't try to output messages, but they will

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -4,12 +4,13 @@ import window from 'global/window';
 q.module('log');
 
 test('should confirm logging functions work', function() {
-  let origConsole = window['console'];
+  let origConsole = window.console;
+
   // replace the native console for testing
   // in ie8 console.log is apparently not a 'function' so sinon chokes on it
   // https://github.com/cjohansen/Sinon.JS/issues/386
   // instead we'll temporarily replace them with no-op functions
-  let console = window['console'] = {
+  let console = window.console = {
     log: function(){},
     warn: function(){},
     error: function(){}
@@ -52,5 +53,5 @@ test('should confirm logging functions work', function() {
   warnStub.restore();
 
   // restore the native console
-  window['console'] = origConsole;
+  window.console = origConsole;
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -1,57 +1,70 @@
 import log from '../../../src/js/utils/log.js';
+import {logByType} from '../../../src/js/utils/log.js';
 import window from 'global/window';
 
-q.module('log');
+q.module('log', {
 
-test('should confirm logging functions work', function() {
-  let origConsole = window.console;
+  beforeEach() {
 
-  // replace the native console for testing
-  // in ie8 console.log is apparently not a 'function' so sinon chokes on it
-  // https://github.com/cjohansen/Sinon.JS/issues/386
-  // instead we'll temporarily replace them with no-op functions
-  let console = window.console = {
-    log: function(){},
-    warn: function(){},
-    error: function(){}
-  };
+    // Back up the original console.
+    this.originalConsole = window.console;
 
-  // stub the global log functions
-  let logStub = sinon.stub(console, 'log');
-  let errorStub = sinon.stub(console, 'error');
-  let warnStub = sinon.stub(console, 'warn');
+    // Replace the native console for testing. In IE8 `console.log` is not a
+    // 'function' so sinon chokes on it when trying to spy:
+    //   https://github.com/cjohansen/Sinon.JS/issues/386
+    //
+    // Instead we'll temporarily replace them with no-op functions
+    window.console = {
+      log: sinon.spy(),
+      warn: sinon.spy(),
+      error: sinon.spy()
+    };
+  },
 
-  // Reset the log history
-  log.history = [];
+  afterEach() {
 
+    // Restore the native/original console.
+    window.console = this.originalConsole;
+
+    // Empty the logger's history.
+    log.history.length = 0;
+  }
+});
+
+test('logging functions should work', function() {
   log('log1', 'log2');
   log.warn('warn1', 'warn2');
   log.error('error1', 'error2');
 
-  ok(logStub.called, 'log was called');
-  equal(logStub.firstCall.args[0], 'VIDEOJS:');
-  equal(logStub.firstCall.args[1], 'log1');
-  equal(logStub.firstCall.args[2], 'log2');
+  ok(window.console.log.called, 'log was called');
+  deepEqual(window.console.log.firstCall.args,
+            ['VIDEOJS:', 'log1', 'log2']);
 
-  ok(warnStub.called, 'warn was called');
-  equal(warnStub.firstCall.args[0], 'VIDEOJS:');
-  equal(warnStub.firstCall.args[1], 'WARN:');
-  equal(warnStub.firstCall.args[2], 'warn1');
-  equal(warnStub.firstCall.args[3], 'warn2');
+  ok(window.console.warn.called, 'warn was called');
+  deepEqual(window.console.warn.firstCall.args,
+            ['VIDEOJS:', 'WARN:', 'warn1', 'warn2']);
 
-  ok(errorStub.called, 'error was called');
-  equal(errorStub.firstCall.args[0], 'VIDEOJS:');
-  equal(errorStub.firstCall.args[1], 'ERROR:');
-  equal(errorStub.firstCall.args[2], 'error1');
-  equal(errorStub.firstCall.args[3], 'error2');
+  ok(window.console.error.called, 'error was called');
+  deepEqual(window.console.error.firstCall.args,
+            ['VIDEOJS:', 'ERROR:', 'error1', 'error2']);
 
   equal(log.history.length, 3, 'there should be three messages in the log history');
+});
 
-  // tear down sinon
-  logStub.restore();
-  errorStub.restore();
-  warnStub.restore();
+test('in IE pre-11 (or when requested) objects and arrays are stringified', function() {
 
-  // restore the native console
-  window.console = origConsole;
+  // Run a custom log call, explicitly requesting object/array stringification.
+  logByType('log', [
+    'test',
+    {foo: 'bar'},
+    [1, 2, 3],
+    0,
+    false,
+    null,
+    undefined
+  ], true);
+
+  ok(window.console.log.called, 'log was called');
+  deepEqual(window.console.log.firstCall.args,
+            ['VIDEOJS: test {"foo":"bar"} [1,2,3] 0 false null undefined']);
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -32,6 +32,11 @@ q.module('log', {
 });
 
 test('logging functions should work', function() {
+
+  // Need to reset history here because there are extra messages logged
+  // when running via Karma.
+  log.history.length = 0;
+
   log('log1', 'log2');
   log.warn('warn1', 'warn2');
   log.error('error1', 'error2');


### PR DESCRIPTION
## Description
IE11 introduced expandable objects in the console. Previously, everything was `.join()`ed and, therefore, objects came through as `[object Object]`, which is not useful. This improves the ES6-ification of the log module and passes objects and arrays through `JSON.stringify()` before logging them in IE10 and lower.

Some opportunities for ES6 brevity were left out because JSHint does not like them; though, they would pass `videojs-standard`.

## Specific Changes proposed
- Modifications to the existing `utils/log` module.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors