### PR TITLE
Use function statement for videojs

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -55,7 +55,7 @@ if (typeof HTMLVideoElement === 'undefined') {
  * @mixes videojs
  * @method videojs
  */
-let videojs = function(id, options, ready){
+function videojs(id, options, ready){
   let tag; // Element of ID
 
   // Allow for element or ID to be passed in
@@ -99,7 +99,7 @@ let videojs = function(id, options, ready){
   // Element may have a player attr referring to an already created player instance.
   // If not, set up a new player and return the instance.
   return tag['player'] || Player.players[tag.playerId] || new Player(tag, options, ready);
-};
+}
 
 // Add default styles
 if (window.VIDEOJS_NO_DYNAMIC_STYLE !== true) {


### PR DESCRIPTION
## Description
This is a fix for IE8 where the name of a named function
expression is different from the variable that function is
assigned to. This is an issue because our version of babel outputs
functions like that.
Fixes #3064 again.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by One Core Contributors

