### PR TITLE
Remove unused loadEvent property in ControlBar options

### DIFF
--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -48,7 +48,6 @@ class ControlBar extends Component {
 }
 
 ControlBar.prototype.options_ = {
-  loadEvent: 'play',
   children: [
     'playToggle',
     'volumeMenuButton',


### PR DESCRIPTION
## Description
`ControlBar`'s default options currently contains a misleading `loadEvent` property.

Looking through the code (`grep -irl loadEvent --exclude-dir=node_modules *`) shows that this property is not used anywhere.

## Specific Changes proposed
Remove an unused property.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed (**N/A**)
  - [x] Docs/guides updated  (**N/A**)
  - [x] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output)) (**N/A**)
- [ ] Reviewed by Two Core Contributors

