### PR TITLE
rework build to seperate out ie8 specific sass

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -199,13 +199,21 @@ module.exports = function(grunt) {
         src: ['video-js.css', 'alt/video-js-cdn.css'],
         dest: 'build/temp/',
         ext: '.min.css'
+      },
+      ie8: {
+        expand: true,
+        cwd: 'build/temp/ie8/',
+        src: ['videojs-ie8.css'],
+        dest: 'build/temp/ie8/',
+        ext: '.min.css'
       }
     },
     sass: {
       build: {
         files: {
           'build/temp/video-js.css': 'src/css/vjs.scss',
-          'build/temp/alt/video-js-cdn.css': 'src/css/vjs-cdn.scss'
+          'build/temp/alt/video-js-cdn.css': 'src/css/vjs-cdn.scss',
+          'build/temp/ie8/videojs-ie8.css': 'src/css/ie8.scss'
         }
       }
     },
@@ -466,6 +474,7 @@ module.exports = function(grunt) {
     'sass',
     'version:css',
     'cssmin',
+    'cssmin:ie8',
 
     'copy:fonts',
     'copy:swf',

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -194,26 +194,16 @@ module.exports = function(grunt) {
     },
     cssmin: {
       minify: {
-        expand: true,
-        cwd: 'build/temp/',
-        src: ['video-js.css', 'alt/video-js-cdn.css'],
-        dest: 'build/temp/',
-        ext: '.min.css'
-      },
-      ie8: {
-        expand: true,
-        cwd: 'build/temp/ie8/',
-        src: ['videojs-ie8.css'],
-        dest: 'build/temp/ie8/',
-        ext: '.min.css'
+        files: {
+          'build/temp/video-js.min.css': ['build/temp/video-js.css', 'build/temp/alt/video-js-cdn.css', 'src/css/ie8.css']
+        }
       }
     },
     sass: {
       build: {
         files: {
           'build/temp/video-js.css': 'src/css/vjs.scss',
-          'build/temp/alt/video-js-cdn.css': 'src/css/vjs-cdn.scss',
-          'build/temp/ie8/videojs-ie8.css': 'src/css/ie8.scss'
+          'build/temp/alt/video-js-cdn.css': 'src/css/vjs-cdn.scss'
         }
       }
     },
@@ -402,20 +392,17 @@ module.exports = function(grunt) {
       }
     },
     concat: {
+      options: {
+        separator: '\n'
+      },
       novtt: {
-        options: {
-          separator: '\n'
-        },
         src: ['build/temp/video.js'],
         dest: 'build/temp/alt/video.novtt.js'
       },
       vtt: {
-        options: {
-          separator: '\n',
-        },
         src: ['build/temp/video.js', 'node_modules/videojs-vtt.js/dist/vtt.js'],
-        dest: 'build/temp/video.js',
-      },
+        dest: 'build/temp/video.js'
+      }
     },
     concurrent: {
       options: {
@@ -474,7 +461,6 @@ module.exports = function(grunt) {
     'sass',
     'version:css',
     'cssmin',
-    'cssmin:ie8',
 
     'copy:fonts',
     'copy:swf',

--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -20,9 +20,6 @@
   @include transition($trans);
 }
 
-// IE 8 hack for media queries
-$ie8screen: "\\0screen";
-
 // Video has started playing AND user is inactive
 .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   // Remain visible for screen reader and keyboard users
@@ -32,10 +29,6 @@ $ie8screen: "\\0screen";
   $trans: visibility 1.0s, opacity 1.0s;
   @include transition($trans);
 
-  // Make controls hidden in IE8 for now
-  @media #{$ie8screen} {
-    visibility: hidden;
-  }
 }
 
 .vjs-controls-disabled .vjs-control-bar,
@@ -49,15 +42,6 @@ $ie8screen: "\\0screen";
 .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   opacity: 1;
   visibility: visible;
-}
-
-
-// IE8 is flakey with fonts, and you have to change the actual content to force
-// fonts to show/hide properly.
-// - "\9" IE8 hack didn't work for this
-// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
-.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
-  @media #{$ie8screen} { content: ""; }
 }
 
 // IE 8 + 9 Support

--- a/src/css/ie8.css
+++ b/src/css/ie8.css
@@ -1,4 +1,5 @@
-// IE 8 hack for media queries
+/**
+// IE 8 hack for media queries which the sass parser can encounter problems with
 $ie8screen: "\\0screen";
 
 // original home: css/components/_control-bar.scss
@@ -18,3 +19,12 @@ $ie8screen: "\\0screen";
     visibility: hidden;
   }
 }
+*/
+
+@media \0screen {
+  .vjs-user-inactive.vjs-playing .vjs-control-bar :before {
+    content: ""; } }
+
+@media \0screen {
+  .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+    visibility: hidden; } }

--- a/src/css/ie8.scss
+++ b/src/css/ie8.scss
@@ -1,0 +1,20 @@
+// IE 8 hack for media queries
+$ie8screen: "\\0screen";
+
+// original home: css/components/_control-bar.scss
+// IE8 is flakey with fonts, and you have to change the actual content to force
+// fonts to show/hide properly.
+// - "\9" IE8 hack didn't work for this
+// Found in XP IE8 from http://modern.ie. Does not show up in "IE8 mode" in IE9
+.vjs-user-inactive.vjs-playing .vjs-control-bar :before {
+  @media #{$ie8screen} { content: ""; }
+}
+
+// Video has started playing AND user is inactive
+.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+
+  // Make controls hidden in IE8 for now
+  @media #{$ie8screen} {
+    visibility: hidden;
+  }
+}


### PR DESCRIPTION
## Description
* This is in reference to issue #3013 
* Slice out some identified lines of sass specific to `IE8` and create its own separate `.css` file if needed by developers

## Specific Changes proposed
* added `src/css/ie8.scss` to capture all ie8 specific sass.
* moved out some lines from `src/css/components/_control-bar.scss` which were ie8 specific.
* added some necessary modifications to the `grunt build` task to support this.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

