### PR TITLE
Don't use VideoJS font for menu text

### DIFF
--- a/src/css/components/menu/_menu.scss
+++ b/src/css/components/menu/_menu.scss
@@ -16,6 +16,7 @@
   display: block;
   padding: 0; margin: 0;
   overflow: auto;
+  font-family: $text-font-family;
 }
 
 // prevent menus from opening while scrubbing (FF, IE)


### PR DESCRIPTION
## Description
Similar to #3213, the VideoJS font shouldn't be used for menu content as the browser fallback font will be used.

## Specific Changes proposed
Use `$text-font-family` for `.vjs-menu .vjs-menu-content`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [n/a] Unit Tests updated or fixed
  - [n/a] Docs/guides updated
  - [n/a] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

