### PR TITLE
set Player to Live on Number.MAX_VALUE seconds

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1410,7 +1410,7 @@ class Player extends Component {
     seconds = parseFloat(seconds) || 0;
 
     // Standardize on Inifity for signaling video is live
-    if (seconds < 0) {
+    if (seconds < 0 || seconds >= Number.MAX_VALUE) {
       seconds = Infinity;
     }
 


### PR DESCRIPTION
## Description

set the Player to Live controls on Number.MAX_VALUE (used by dash.js player)

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

