### PR TITLE
Remove spurious <head> tags in the simple-embed example

### DIFF
--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -3,13 +3,10 @@
 
 <head>
 
-  <head>
     <title>Video.js | HTML5 Video Player</title>
     <link href="http://vjs.zencdn.net/5.0.2/video-js.css" rel="stylesheet">
     <script src="http://vjs.zencdn.net/ie8/1.1.0/videojs-ie8.min.js"></script>
     <script src="http://vjs.zencdn.net/5.0.2/video.js"></script>
-
-  </head>
 
 </head>
 


### PR DESCRIPTION
## Description
The [simple-embed example HTML file](https://github.com/videojs/video.js/blob/master/docs/examples/simple-embed/index.html) has extra `<head>` and `</head>` tags; I've been looking at adding more automated checking in the build process, and this minor issue cases HTML validation to fail.

## Specific Changes proposed
Delete two lines of HTML, and two blank lines!

## Requirements Checklist
- [x] Bug fixed (Captain Pedantic at your service!)
- [ ] Reviewed by Two Core Contributors


