### PR TITLE
Validate errorDisplay as it can be disabled in options (fixes #3014)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2270,7 +2270,9 @@ class Player extends Component {
     if (err === null) {
       this.error_ = err;
       this.removeClass('vjs-error');
-      this.errorDisplay.close();
+      if (this.errorDisplay) {
+        this.errorDisplay.close();
+      }
       return this;
     }
 


### PR DESCRIPTION
## Description
All UI elements can be disabled in options for example
```javascript
{
  'posterImage': false,
  'textTrackDisplay': false,
  'loadingSpinner': false,
  'bigPlayButton': false,
  'controlBar': false,
  'errorDisplay': false,
  'textTrackSettings': false
}
```

When `errorDisplay` is disabled it does not exist anymore. Thus its existence needs to be validated to avoid crashes. The one fixed occurs immediately after player is initialized.

## Specific Changes proposed
Validate existence of `this.errorDisplay`. This fixes #3014.

## Requirements Checklist
- [x] Bug fixed
- [ ] Reviewed by Two Core Contributors

