### PR TITLE
Prevent coveralls from running locally

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -494,7 +494,8 @@ module.exports = function(grunt) {
   // Default task - build and test
   grunt.registerTask('default', ['test']);
 
-  grunt.registerTask('test', ['build', 'karma:defaults']);
+  // The test script includes coveralls only when the TRAVIS env var is set.
+  grunt.registerTask('test', ['build', 'karma:defaults'].concat(process.env.TRAVIS && 'coveralls').filter(Boolean));
 
   // Run while developing
   grunt.registerTask('dev', ['build', 'connect:dev', 'concurrent:watchSandbox']);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "http://videojs.com",
   "author": "Steve Heffernan",
   "scripts": {
-    "test": "grunt test && if [ '$TRAVIS' ]; then grunt coveralls; fi;"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
The bash condition that previously existed in `package.json` to check for the `TRAVIS` env var was not working properly for everyone, causing `grunt coveralls` to run (and fail) locally.

Additionally, it would fail on Windows, since it was bash.

## Specific Changes proposed
This moves that condition checking for the `TRAVIS` env var to JavaScript, where it now works reliably.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

