### PR TITLE
Correct checks for IEs older than 11 in log tests

### DIFF
--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -48,10 +48,9 @@ export const logByType = (type, args, stringify = !!IE_VERSION && IE_VERSION < 1
         } catch (x) {}
       }
 
-      // Cast to string before joining in order to get consistent results. And
-      // explicitly include a check for undefined because IE8 casts undefined
-      // to an empty string.
-      return a === undefined ? 'undefined' : String(a);
+      // Cast to string before joining, so we get null and undefined explicitly
+      // included in output (as we would in a modern console).
+      return String(a);
     }).join(' ');
   }
 

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -48,9 +48,10 @@ export const logByType = (type, args, stringify = !!IE_VERSION && IE_VERSION < 1
         } catch (x) {}
       }
 
-      // Cast to string before joining, so we get null and undefined explicitly
-      // included in output (as we would in a modern console).
-      return String(a);
+      // Cast to string before joining in order to get consistent results. And
+      // explicitly include a check for undefined because IE8 casts undefined
+      // to an empty string.
+      return a === undefined ? 'undefined' : String(a);
     }).join(' ');
   }
 

--- a/test/unit/plugins.test.js
+++ b/test/unit/plugins.test.js
@@ -1,3 +1,4 @@
+import {IE_VERSION} from '../../src/js/utils/browser';
 import registerPlugin from '../../src/js/plugins.js';
 import Player from '../../src/js/player.js';
 import TestHelpers from './test-helpers.js';
@@ -169,14 +170,18 @@ test('Plugins should not get events after stopImmediatePropagation is called', f
 });
 
 test('Plugin that does not exist logs an error', function() {
+
   // stub the global log functions
   var console, log, error, origConsole;
-  origConsole = window['console'];
-  console = window['console'] = {
+
+  origConsole = window.console;
+
+  console = window.console = {
     log: function(){},
     warn: function(){},
     error: function(){}
   };
+
   log = sinon.stub(console, 'log');
   error = sinon.stub(console, 'error');
 
@@ -190,11 +195,16 @@ test('Plugin that does not exist logs an error', function() {
   });
 
   ok(error.called, 'error was called');
-  equal(error.firstCall.args[2], 'Unable to find plugin:');
-  equal(error.firstCall.args[3], 'nonExistingPlugin');
+
+  if (IE_VERSION && IE_VERSION < 11) {
+    equal(error.firstCall.args[2], 'VIDEOJS: Unable to find plugin: nonExistingPlugin');
+  } else {
+    equal(error.firstCall.args[2], 'Unable to find plugin:');
+    equal(error.firstCall.args[3], 'nonExistingPlugin');
+  }
 
   // tear down logging stubs
   log.restore();
   error.restore();
-  window['console'] = origConsole;
+  window.console = origConsole;
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -75,11 +75,10 @@ test('in IE pre-11 (or when requested) objects and arrays are stringified', func
     [1, 2, 3],
     0,
     false,
-    null,
-    undefined
+    null
   ], true);
 
   ok(window.console.log.called, 'log was called');
   deepEqual(window.console.log.firstCall.args,
-            ['VIDEOJS: test {"foo":"bar"} [1,2,3] 0 false null undefined']);
+            ['VIDEOJS: test {"foo":"bar"} [1,2,3] 0 false null']);
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -1,3 +1,4 @@
+import {IE_VERSION} from '../../../src/js/utils/browser';
 import log from '../../../src/js/utils/log.js';
 import {logByType} from '../../../src/js/utils/log.js';
 import window from 'global/window';
@@ -31,6 +32,9 @@ q.module('log', {
   }
 });
 
+const getConsoleArgs = (...arr) =>
+  IE_VERSION && IE_VERSION < 11 ? [arr.join(' ')] : arr;
+
 test('logging functions should work', function() {
 
   // Need to reset history here because there are extra messages logged
@@ -43,15 +47,15 @@ test('logging functions should work', function() {
 
   ok(window.console.log.called, 'log was called');
   deepEqual(window.console.log.firstCall.args,
-            ['VIDEOJS:', 'log1', 'log2']);
+            getConsoleArgs('VIDEOJS:', 'log1', 'log2'));
 
   ok(window.console.warn.called, 'warn was called');
   deepEqual(window.console.warn.firstCall.args,
-            ['VIDEOJS:', 'WARN:', 'warn1', 'warn2']);
+            getConsoleArgs('VIDEOJS:', 'WARN:', 'warn1', 'warn2'));
 
   ok(window.console.error.called, 'error was called');
   deepEqual(window.console.error.firstCall.args,
-            ['VIDEOJS:', 'ERROR:', 'error1', 'error2']);
+            getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2'));
 
   equal(log.history.length, 3, 'there should be three messages in the log history');
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -46,16 +46,22 @@ test('logging functions should work', function() {
   log.error('error1', 'error2');
 
   ok(window.console.log.called, 'log was called');
-  deepEqual(window.console.log.firstCall.args,
-            getConsoleArgs('VIDEOJS:', 'log1', 'log2'));
+  deepEqual(
+    window.console.log.firstCall.args,
+    getConsoleArgs('VIDEOJS:', 'log1', 'log2')
+  );
 
   ok(window.console.warn.called, 'warn was called');
-  deepEqual(window.console.warn.firstCall.args,
-            getConsoleArgs('VIDEOJS:', 'WARN:', 'warn1', 'warn2'));
+  deepEqual(
+    window.console.warn.firstCall.args,
+    getConsoleArgs('VIDEOJS:', 'WARN:', 'warn1', 'warn2')
+  );
 
   ok(window.console.error.called, 'error was called');
-  deepEqual(window.console.error.firstCall.args,
-            getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2'));
+  deepEqual(
+    window.console.error.firstCall.args,
+    getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2')
+  );
 
   equal(log.history.length, 3, 'there should be three messages in the log history');
 });


### PR DESCRIPTION
## Description
This corrects test assertions for IE versions older than 11 in the tests for the `utils/log` module.

Because those browsers have their arguments `join`ed by default, they were causing some tests to fail when run in Browserstack against IE.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

