### PR TITLE
add es6-shim to tests, fixes the Flash test

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chg": "^0.3.2",
     "css": "^2.2.0",
     "es5-shim": "^4.1.3",
+    "es6-shim": "^0.35.1",
     "gkatsev-grunt-sass": "^1.1.1",
     "grunt": "^0.4.4",
     "grunt-aws-s3": "^0.12.1",

--- a/test/globals-shim.js
+++ b/test/globals-shim.js
@@ -1,3 +1,4 @@
+import 'es6-shim';
 import document from 'global/document';
 import window from 'global/window';
 import sinon from 'sinon';


### PR DESCRIPTION
## Description
Add es6-shim to the tests. This allows us to use newer features in the tests where it's useful. This fixes the test issues we're seeing when https://github.com/videojs/video.js/pull/3128 was merged in.