### PR TITLE
Allow to use custom Player class

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1444,7 +1444,7 @@ class Component {
       const Player = Component.components_[name];
 
       if (Player.players && Object.keys(Player.players).length > 0) {
-        throw new Error(`Can't register ${name} component after Player has been created`);
+        throw new Error('Can not register Player component after player has been created');
       }
     }
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1440,6 +1440,14 @@ class Component {
       Component.components_ = {};
     }
 
+    if (name === 'Player' && Component.components_[name]) {
+      const Player = Component.components_[name];
+
+      if (Player.players && Object.keys(Player.players).length > 0) {
+        throw new Error(`Can't register ${name} component after Player has been created`);
+      }
+    }
+
     Component.components_[name] = comp;
 
     return comp;

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -117,8 +117,9 @@ function videojs(id, options, ready) {
     options = mergeOptions(options, opts);
   });
 
+  const PlayerComponent = Component.getComponent('Player');
   // If not, set up a new player
-  const player = new Player(tag, options, ready);
+  const player = new PlayerComponent(tag, options, ready);
 
   videojs.hooks('setup').forEach((hookFunction) => hookFunction(player));
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -17,7 +17,7 @@ QUnit.module('Player', {
   beforeEach() {
     this.clock = sinon.useFakeTimers();
     // reset players storage
-    for (let playerId in Player.players) {
+    for (const playerId in Player.players) {
       if (Player.players[playerId] !== null) {
         Player.players[playerId].dispose();
       }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1252,3 +1252,15 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   assert.equal(player.tech_.el().height, 300, 'the height is equal 300');
   player.dispose();
 });
+
+test('should allow to use custom player class', function(){
+  class CustomPlayer extends Player {}
+  videojs.registerComponent('Player', CustomPlayer);
+
+  let tag = TestHelpers.makeTag();
+  let player = videojs(tag);
+
+  equal(player instanceof CustomPlayer, true, 'player is custom');
+
+  player.dispose();
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1279,6 +1279,7 @@ QUnit.test('should not allow to register custom player when any player has been 
   try {
     videojs.registerComponent('Player', CustomPlayer);
   } catch (e) {
+    player.dispose();
     return assert.equal(e.message, 'Can not register Player component after player has been created');
   }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1253,14 +1253,13 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   player.dispose();
 });
 
-test('should allow to use custom player class', function(){
+QUnit.test('should allow to use custom player class', function(assert) {
   class CustomPlayer extends Player {}
   videojs.registerComponent('Player', CustomPlayer);
 
-  let tag = TestHelpers.makeTag();
-  let player = videojs(tag);
+  const tag = TestHelpers.makeTag();
+  const player = videojs(tag);
 
-  equal(player instanceof CustomPlayer, true, 'player is custom');
-
+  assert.equal(player instanceof CustomPlayer, true, 'player is custom');
   player.dispose();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1260,7 +1260,7 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   player.dispose();
 });
 
-QUnit.test('should allow to use custom player class', function(assert) {
+QUnit.test('should allow to register custom player when any player has not been created', function(assert) {
   class CustomPlayer extends Player {}
   videojs.registerComponent('Player', CustomPlayer);
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1270,3 +1270,17 @@ QUnit.test('should allow to register custom player when any player has not been 
   assert.equal(player instanceof CustomPlayer, true, 'player is custom');
   player.dispose();
 });
+
+QUnit.test('should not allow to register custom player when any player has been created', function(assert) {
+  const tag = TestHelpers.makeTag();
+  const player = videojs(tag);
+
+  class CustomPlayer extends Player {}
+  try {
+    videojs.registerComponent('Player', CustomPlayer);
+  } catch (e) {
+    return assert.equal(e.message, 'Can not register Player component after player has been created');
+  }
+
+  assert.ok(false, 'It should throw Error when any player has been created');
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -16,6 +16,13 @@ import TechFaker from './tech/tech-faker.js';
 QUnit.module('Player', {
   beforeEach() {
     this.clock = sinon.useFakeTimers();
+    // reset players storage
+    for (let playerId in Player.players) {
+      if (Player.players[playerId] !== null) {
+        Player.players[playerId].dispose();
+      }
+      delete Player.players[playerId];
+    }
   },
   afterEach() {
     this.clock.restore();


### PR DESCRIPTION
## Description

Allow to use custom player class
## Specific Changes proposed

This change will allow to use custom player class. In version 4 new player instance was created from `vjs.Player` https://github.com/videojs/video.js/blob/release/4.2.0/src/js/core.js#L52 so it was possible to override Player witch custom class. Right now it's not possible since player is created directly from `Player` import. Using `Component.getComponent('Player')` will alllow to use custom player class that can be registered via `Component.registerComponent` same as current player is registered right now https://github.com/videojs/video.js/blob/master/src/js/player.js#L2979
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors
