### PR TITLE
Suppress Infinity duration on Android Chrome before playback

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -435,7 +435,7 @@ class Html5 extends Tech {
     if (this.el_.duration === Infinity &&
       browser.IS_ANDROID && browser.IS_CHROME) {
       if (this.el_.currentTime === 0) {
-        let checkProgress = () => {
+        const checkProgress = () => {
           if (this.el_.currentTime > 0) {
             this.trigger('durationchange');
             this.off(this.player_, 'timeupdate', checkProgress);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -435,9 +435,14 @@ class Html5 extends Tech {
     if (this.el_.duration === Infinity &&
       browser.IS_ANDROID && browser.IS_CHROME) {
       if (this.el_.currentTime === 0) {
+        // Wait for the first `timeupdate` with currentTime > 0 - there may be
+        // several with 0
         const checkProgress = () => {
           if (this.el_.currentTime > 0) {
-            this.trigger('durationchange');
+            // Trigger durationchange for genuinely live video
+            if (this.el_.duration === Infinity) {
+              this.trigger('durationchange');
+            }
             this.off(this.player_, 'timeupdate', checkProgress);
           }
         };

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -430,7 +430,7 @@ class Html5 extends Tech {
   duration() {
     // Android Chrome will report duration as Infinity for VOD HLS until after
     // playback has started, which triggers the live display erroneously.
-    // Return 0 if playback has not started and trigger a durationupdate once
+    // Return NaN if playback has not started and trigger a durationupdate once
     // the duration can be reliably known.
     if (this.el_.duration === Infinity &&
       browser.IS_ANDROID && browser.IS_CHROME) {
@@ -442,10 +442,10 @@ class Html5 extends Tech {
           }
         };
         this.on(this.player_, 'timeupdate', checkProgress);
-        return 0;
+        return NaN;
       }
     }
-    return this.el_.duration || 0;
+    return this.el_.duration || NaN;
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -446,6 +446,7 @@ class Html5 extends Tech {
             this.off(this.player_, 'timeupdate', checkProgress);
           }
         };
+
         this.on(this.player_, 'timeupdate', checkProgress);
         return NaN;
       }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1105,20 +1105,3 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   player.dispose();
 });
 
-test('When Android Chrome reports Infinity duration with currentTime 0, return NaN', function() {
-  const oldIsAndroid = browser.IS_ANDROID;
-  const oldIsChrome = browser.IS_CHROME;
-  const player = TestHelpers.makePlayer();
-
-  browser.IS_ANDROID = true;
-  browser.IS_CHROME = true;
-
-  player.tech_.el_ = {
-    duration: Infinity,
-    currentTime: 0
-  };
-  ok(isNaN(player.tech_.duration()), 'returned NaN with currentTime 0');
-
-  browser.IS_ANDROID = oldIsAndroid;
-  browser.IS_CHROME = oldIsChrome;
-});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1104,3 +1104,21 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   assert.equal(player.tech_.el().height, 300, 'the height is equal 300');
   player.dispose();
 });
+
+test('When Android Chrome reports Infinity duration with currentTime 0, return NaN', function() {
+  const oldIsAndroid = browser.IS_ANDROID;
+  const oldIsChrome = browser.IS_CHROME;
+  const player = TestHelpers.makePlayer();
+
+  browser.IS_ANDROID = true;
+  browser.IS_CHROME = true;
+
+  player.tech_.el_ = {
+    duration: Infinity,
+    currentTime: 0
+  };
+  ok(isNaN(player.tech_.duration()), 'returned NaN with currentTime 0');
+
+  browser.IS_ANDROID = oldIsAndroid;
+  browser.IS_CHROME = oldIsChrome;
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1104,4 +1104,3 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   assert.equal(player.tech_.el().height, 300, 'the height is equal 300');
   player.dispose();
 });
-

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -562,3 +562,22 @@ QUnit.test('Exception in play promise should be caught', function() {
 
   tech.el_ = oldEl;
 });
+
+test('When Android Chrome reports Infinity duration with currentTime 0, return NaN', function() {
+  const oldIsAndroid = browser.IS_ANDROID;
+  const oldIsChrome = browser.IS_CHROME;
+  const oldEl = tech.el_;
+
+  browser.IS_ANDROID = true;
+  browser.IS_CHROME = true;
+
+  tech.el_ = {
+    duration: Infinity,
+    currentTime: 0
+  };
+  ok(Number.isNaN(tech.duration()), 'returned NaN with currentTime 0');
+
+  browser.IS_ANDROID = oldIsAndroid;
+  browser.IS_CHROME = oldIsChrome;
+  tech.el_ = oldEl;
+});


### PR DESCRIPTION
## Description

Re issue #3079 and the discussion in #3083. Android Chrome returns `Infinity` for VOD HLS until after playback has started. This causes issues such as an unwanted flash of the live display control.
## Specific Changes proposed

HTML5 tech will return `NaN` instead of `Infinity` if playback has not started. Fires a `durationupdate` event once the reported duration can be believed if the duration is still `Infinity`, so controls can update.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit test updated
- [ ] Reviewed by Two Core Contributors
