### PR TITLE
add initial axe-core check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "xhr": "2.2.0"
   },
   "devDependencies": {
+    "axe-core": "^2.0.5",
     "babel": "^5.2.2",
     "babelify": "^6.0.1",
     "blanket": "^1.1.6",

--- a/test/unit/a11y.js
+++ b/test/unit/a11y.js
@@ -1,0 +1,28 @@
+import axe from 'axe-core';
+import TestHelpers from './test-helpers.js';
+
+q.module('a11y', {});
+
+q.test('should have no a11y issues, using simple defaults', function(assert) {
+  const done = assert.async();
+  const player = TestHelpers.makePlayer({
+    techOrder: ['html5']
+  });
+
+  player.addRemoteTextTrack({
+    kind: 'captions',
+    srclang: 'en',
+    label: 'English'
+  });
+  player.addRemoteTextTrack({
+    kind: 'descriptions',
+    srclang: 'en',
+    label: 'Descriptions'
+  });
+
+  axe.a11yCheck('#qunit-fixture', function(results) {
+    console.log(results);
+    assert.equal(results.violations.length, 0, 'there are no a11y violations');
+    done();
+  });
+});


### PR DESCRIPTION
## Description
Add a11y checks using axe-core. Currently, it's just being done with the default player created by `TestHelpers`.
We need to add a `descriptions` and `captions` track to not get any violations. 
We still should make sure that the control bar gets added and linted by axe or this won't be that helpful to us.