### PR TITLE
Basic accessibility testing with HTML_CodeSniffer in Grunt's test phase

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -443,6 +443,19 @@ module.exports = function(grunt) {
           src: ['build/temp/video.js']
         }
       }
+    },
+    accessibility: {
+      options: {
+        accessibilityLevel: 'WCAG2AA',
+        reportLevels: {
+          notice: false,
+          warning: true,
+          error: true
+        }
+      },
+      test: {
+        src: ['sandbox/index.html']
+      }
     }
   });
 
@@ -451,6 +464,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('videojs-doc-generator');
   grunt.loadNpmTasks('chg');
   grunt.loadNpmTasks('gkatsev-grunt-sass');
+  grunt.loadNpmTasks('grunt-accessibility');
 
   const buildDependents = [
     'clean:build',
@@ -501,6 +515,8 @@ module.exports = function(grunt) {
   grunt.registerTask('dev', ['build', 'connect:dev', 'concurrent:watchSandbox']);
 
   grunt.registerTask('watchAll', ['build', 'connect:dev', 'concurrent:watchAll']);
+
+  grunt.registerTask('test-a11y', ['build', 'accessibility']);
 
   // Pick your testing, or run both in different terminals
   grunt.registerTask('test-ui', ['browserify:tests']);

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -515,14 +515,14 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['test']);
 
   // The test script includes coveralls only when the TRAVIS env var is set.
-  grunt.registerTask('test', ['build', 'karma:defaults'].concat(process.env.TRAVIS && 'coveralls').filter(Boolean));
+  grunt.registerTask('test', ['build', 'karma:defaults', 'test-a11y'].concat(process.env.TRAVIS && 'coveralls').filter(Boolean));
 
   // Run while developing
   grunt.registerTask('dev', ['build', 'connect:dev', 'concurrent:watchSandbox']);
 
   grunt.registerTask('watchAll', ['build', 'connect:dev', 'concurrent:watchAll']);
 
-  grunt.registerTask('test-a11y', ['build', 'copy:a11y', 'accessibility']);
+  grunt.registerTask('test-a11y', ['copy:a11y', 'accessibility']);
 
   // Pick your testing, or run both in different terminals
   grunt.registerTask('test-ui', ['browserify:tests']);

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -451,7 +451,12 @@ module.exports = function(grunt) {
           notice: false,
           warning: true,
           error: true
-        }
+        },
+        ignore: [
+          // Ignore the warning about needing <optgroup> elements
+          'WCAG2AA.Principle1.Guideline1_3.1_3_1.H85.2'
+        ]
+
       },
       test: {
         src: ['sandbox/index.html']

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -190,6 +190,7 @@ module.exports = function(grunt) {
       swf:   { cwd: 'node_modules/videojs-swf/dist/', src: 'video-js.swf', dest: 'build/temp/', expand: true, filter: 'isFile' },
       ie8:   { cwd: 'node_modules/videojs-ie8/dist/', src: ['**/**'], dest: 'build/temp/ie8/', expand: true, filter: 'isFile' },
       dist:  { cwd: 'build/temp/', src: ['**/**', '!test*'], dest: 'dist/', expand: true, filter: 'isFile' },
+      a11y:  { src: 'sandbox/descriptions.html.example', dest: 'sandbox/descriptions.test-a11y.html' }, // Can only test a file with a .html or .htm extension
       examples: { cwd: 'docs/examples/', src: ['**/**'], dest: 'dist/examples/', expand: true, filter: 'isFile' }
     },
     cssmin: {
@@ -459,7 +460,7 @@ module.exports = function(grunt) {
 
       },
       test: {
-        src: ['sandbox/index.html']
+        src: ['sandbox/descriptions.test-a11y.html']
       }
     }
   });
@@ -521,7 +522,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('watchAll', ['build', 'connect:dev', 'concurrent:watchAll']);
 
-  grunt.registerTask('test-a11y', ['build', 'accessibility']);
+  grunt.registerTask('test-a11y', ['build', 'copy:a11y', 'accessibility']);
 
   // Pick your testing, or run both in different terminals
   grunt.registerTask('test-ui', ['browserify:tests']);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "es6-shim": "^0.35.1",
     "gkatsev-grunt-sass": "^1.1.1",
     "grunt": "^0.4.4",
+    "grunt-accessibility": "^4.1.0",
     "grunt-aws-s3": "^0.12.1",
     "grunt-banner": "^0.4.0",
     "grunt-browserify": "3.5.1",


### PR DESCRIPTION
## Description
Add automated accessibility (`a11y`) testing to Grunt's testing. Use HTML_CodeSniffer, which does fairly reliable in-browser testing, to check for any automatically-detectable violations in the video.js player core, using `sandbox/descriptions.html.example` (since that file has a fairly comprehensive set of additional tracks for accessibility).

Note that automated testing can only detect a fraction of potential accessibility issues, since accessibility is inherently a functional issue rather than purely technical - passing these tests should not be considered a thorough test of accessibility, but just a baseline verification. (Note, for example, that it did flag a11y violations with the Captions Settings Dialog before #3281)

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed - **N/A**
  - [ ] Docs/guides updated
  - [x] Example created - **N/A**
  - [ ] Reviewed by Two Core Contributors
