### PR TITLE
Disable HLS hack on Firefox for Android

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1230,7 +1230,7 @@ const mp4RE = /^video\/mp4/i;
 
 Html5.patchCanPlayType = function() {
   // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
-  if (browser.ANDROID_VERSION >= 4.0) {
+  if (browser.ANDROID_VERSION >= 4.0 && !browser.IS_FIREFOX) {
     if (!canPlayType) {
       canPlayType = Html5.TEST_VID.constructor.prototype.canPlayType;
     }


### PR DESCRIPTION
## Description
Chrome reports HLS is not supported when it actually so a hack was added to work around it. Contrastingly Firefox for Android actually doesn't support HLS. This fixes the Firefox compat bug https://bugzilla.mozilla.org/show_bug.cgi?id=1194662 


## Specific Changes proposed
Firefox for Android will use alternative fallbacks if they are available rather than hitting a dead end.

