### PR TITLE
do a nullcheck for navigator. default to null for ios_version

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -574,7 +574,7 @@ class Html5 extends Tech {
    */
   supportsFullScreen() {
     if (typeof this.el_.webkitEnterFullScreen === 'function') {
-      const userAgent = window.navigator.userAgent;
+      const userAgent = window.navigator && window.navigator.userAgent || "";
 
       // Seems to be broken in Chromium/Chrome && Safari in Leopard
       if ((/Android/).test(userAgent) || !(/Chrome|Mac OS X 10.5/).test(userAgent)) {

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -4,7 +4,7 @@
 import document from 'global/document';
 import window from 'global/window';
 
-const USER_AGENT = window.navigator.userAgent;
+const USER_AGENT = window.navigator && window.navigator.userAgent || "";
 const webkitVersionMap = (/AppleWebKit\/([\d.]+)/i).exec(USER_AGENT);
 const appleWebkitVersion = webkitVersionMap ? parseFloat(webkitVersionMap.pop()) : null;
 
@@ -30,6 +30,7 @@ export const IOS_VERSION = (function() {
   if (match && match[1]) {
     return match[1];
   }
+  return null;
 }());
 
 export const IS_ANDROID = (/Android/i).test(USER_AGENT);


### PR DESCRIPTION
This allows us to require videojs in node or tonicdev.com
```js
const browser = require('./browser.js');
console.log(browser);
{ IS_IPAD: false,
  IS_IPHONE: false,
  IS_IPOD: false,
  IS_IOS: false,
  IOS_VERSION: null,
  IS_ANDROID: false,
  ANDROID_VERSION: null,
  IS_OLD_ANDROID: false,
  IS_NATIVE_ANDROID: false,
  IS_FIREFOX: false,
  IS_EDGE: false,
  IS_CHROME: false,
  IS_IE8: false,
  IE_VERSION: null,
  TOUCH_ENABLED: false,
  BACKGROUND_SIZE_SUPPORTED: false }
```

/cc @ljharb