### PR TITLE
Use videojs-standard 5.2 and fix two errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.12
+  - 4.4
 before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -454,6 +454,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('gkatsev-grunt-sass');
 
   const buildDependents = [
+    'shell:lint',
     'clean:build',
 
     'browserify:build',
@@ -482,6 +483,7 @@ module.exports = function(grunt) {
   );
 
   grunt.registerTask('dist', [
+    'shell:lint',
     'clean:dist',
     'build:dist',
     'copy:dist',

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -483,7 +483,6 @@ module.exports = function(grunt) {
   );
 
   grunt.registerTask('dist', [
-    'shell:lint',
     'clean:dist',
     'build:dist',
     'copy:dist',

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "time-grunt": "^1.1.1",
     "uglify-js": "~2.3.6",
     "videojs-doc-generator": "0.0.1",
-    "videojs-standard": "^5.0.0"
+    "videojs-standard": "^5.2.0"
   },
   "vjsstandard": {
     "ignore": [

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -574,7 +574,7 @@ class Html5 extends Tech {
    */
   supportsFullScreen() {
     if (typeof this.el_.webkitEnterFullScreen === 'function') {
-      const userAgent = window.navigator && window.navigator.userAgent || "";
+      const userAgent = window.navigator && window.navigator.userAgent || '';
 
       // Seems to be broken in Chromium/Chrome && Safari in Leopard
       if ((/Android/).test(userAgent) || !(/Chrome|Mac OS X 10.5/).test(userAgent)) {

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -4,7 +4,7 @@
 import document from 'global/document';
 import window from 'global/window';
 
-const USER_AGENT = window.navigator && window.navigator.userAgent || "";
+const USER_AGENT = window.navigator && window.navigator.userAgent || '';
 const webkitVersionMap = (/AppleWebKit\/([\d.]+)/i).exec(USER_AGENT);
 const appleWebkitVersion = webkitVersionMap ? parseFloat(webkitVersionMap.pop()) : null;
 


### PR DESCRIPTION
## Description
This updates to videojs-standard 5.2 or higher and fixes two errors. The benefit of the upgrade is that we get correct exit codes from the videojs-standard CLI tool so the git pre-push hook actually works to prevent invalid pushes.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

