### PR TITLE
Qunit 2 Style

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "karma-sinon": "^1.0.5",
     "load-grunt-tasks": "^3.1.0",
     "proxyquireify": "^3.0.0",
-    "qunitjs": "^1.18.0",
+    "qunitjs": "^2.0.1",
     "sinon": "^1.16.1",
     "time-grunt": "^1.1.1",
     "uglify-js": "~2.3.6",

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -8,75 +8,75 @@ import window from 'global/window';
 const videojs = window.videojs;
 
 QUnit.module('Player API');
-QUnit.test('videojs should exist on the window', function() {
-  QUnit.ok(window.videojs, 'videojs exists on the window');
+QUnit.test('videojs should exist on the window', function(assert) {
+  assert.ok(window.videojs, 'videojs exists on the window');
 });
 
-QUnit.test('should be able to access expected player API methods', function() {
+QUnit.test('should be able to access expected player API methods', function(assert) {
   const player = videojs.getComponent('Player').prototype;
 
   // Native HTML5 Methods
-  QUnit.ok(player.error, 'error exists');
-  QUnit.ok(player.src, 'src exists');
-  QUnit.ok(player.currentSrc, 'currentSrc exists');
-  QUnit.ok(player.buffered, 'buffered exists');
-  QUnit.ok(player.load, 'load exists');
-  QUnit.ok(player.seeking, 'seeking exists');
-  QUnit.ok(player.currentTime, 'currentTime exists');
-  QUnit.ok(player.duration, 'duration exists');
-  QUnit.ok(player.paused, 'paused exists');
-  QUnit.ok(player.ended, 'ended exists');
-  QUnit.ok(player.autoplay, 'autoplay exists');
-  QUnit.ok(player.loop, 'loop exists');
-  QUnit.ok(player.play, 'play exists');
-  QUnit.ok(player.pause, 'pause exists');
-  QUnit.ok(player.controls, 'controls exists');
-  QUnit.ok(player.volume, 'volume exists');
-  QUnit.ok(player.muted, 'muted exists');
-  QUnit.ok(player.width, 'width exists');
-  QUnit.ok(player.height, 'height exists');
-  QUnit.ok(player.poster, 'poster exists');
-  QUnit.ok(player.textTracks, 'textTracks exists');
-  QUnit.ok(player.requestFullscreen, 'requestFullscreen exists');
-  QUnit.ok(player.exitFullscreen, 'exitFullscreen exists');
-  QUnit.ok(player.playbackRate, 'playbackRate exists');
-  QUnit.ok(player.networkState, 'networkState exists');
-  QUnit.ok(player.readyState, 'readyState exists');
+  assert.ok(player.error, 'error exists');
+  assert.ok(player.src, 'src exists');
+  assert.ok(player.currentSrc, 'currentSrc exists');
+  assert.ok(player.buffered, 'buffered exists');
+  assert.ok(player.load, 'load exists');
+  assert.ok(player.seeking, 'seeking exists');
+  assert.ok(player.currentTime, 'currentTime exists');
+  assert.ok(player.duration, 'duration exists');
+  assert.ok(player.paused, 'paused exists');
+  assert.ok(player.ended, 'ended exists');
+  assert.ok(player.autoplay, 'autoplay exists');
+  assert.ok(player.loop, 'loop exists');
+  assert.ok(player.play, 'play exists');
+  assert.ok(player.pause, 'pause exists');
+  assert.ok(player.controls, 'controls exists');
+  assert.ok(player.volume, 'volume exists');
+  assert.ok(player.muted, 'muted exists');
+  assert.ok(player.width, 'width exists');
+  assert.ok(player.height, 'height exists');
+  assert.ok(player.poster, 'poster exists');
+  assert.ok(player.textTracks, 'textTracks exists');
+  assert.ok(player.requestFullscreen, 'requestFullscreen exists');
+  assert.ok(player.exitFullscreen, 'exitFullscreen exists');
+  assert.ok(player.playbackRate, 'playbackRate exists');
+  assert.ok(player.networkState, 'networkState exists');
+  assert.ok(player.readyState, 'readyState exists');
 
   // Unsupported Native HTML5 Methods
-  // QUnit.ok(player.canPlayType, 'canPlayType exists');
-  // QUnit.ok(player.startTime, 'startTime exists');
-  // QUnit.ok(player.defaultPlaybackRate, 'defaultPlaybackRate exists');
-  // QUnit.ok(player.playbackRate, 'playbackRate exists');
-  // QUnit.ok(player.played, 'played exists');
-  // QUnit.ok(player.seekable, 'seekable exists');
-  // QUnit.ok(player.videoWidth, 'videoWidth exists');
-  // QUnit.ok(player.videoHeight, 'videoHeight exists');
+  // assert.ok(player.canPlayType, 'canPlayType exists');
+  // assert.ok(player.startTime, 'startTime exists');
+  // assert.ok(player.defaultPlaybackRate, 'defaultPlaybackRate exists');
+  // assert.ok(player.playbackRate, 'playbackRate exists');
+  // assert.ok(player.played, 'played exists');
+  // assert.ok(player.seekable, 'seekable exists');
+  // assert.ok(player.videoWidth, 'videoWidth exists');
+  // assert.ok(player.videoHeight, 'videoHeight exists');
 
   // Additional player methods
-  QUnit.ok(player.bufferedPercent, 'bufferedPercent exists');
-  QUnit.ok(player.reportUserActivity, 'reportUserActivity exists');
-  QUnit.ok(player.userActive, 'userActive exists');
-  QUnit.ok(player.usingNativeControls, 'usingNativeControls exists');
-  QUnit.ok(player.isFullscreen, 'isFullscreen exists');
+  assert.ok(player.bufferedPercent, 'bufferedPercent exists');
+  assert.ok(player.reportUserActivity, 'reportUserActivity exists');
+  assert.ok(player.userActive, 'userActive exists');
+  assert.ok(player.usingNativeControls, 'usingNativeControls exists');
+  assert.ok(player.isFullscreen, 'isFullscreen exists');
 
   // Track methods
-  QUnit.ok(player.audioTracks, 'audioTracks exists');
-  QUnit.ok(player.videoTracks, 'videoTracks exists');
-  QUnit.ok(player.textTracks, 'textTracks exists');
-  QUnit.ok(player.remoteTextTrackEls, 'remoteTextTrackEls exists');
-  QUnit.ok(player.remoteTextTracks, 'remoteTextTracks exists');
-  QUnit.ok(player.addTextTrack, 'addTextTrack exists');
-  QUnit.ok(player.addRemoteTextTrack, 'addRemoteTextTrack exists');
-  QUnit.ok(player.removeRemoteTextTrack, 'removeRemoteTextTrack exists');
+  assert.ok(player.audioTracks, 'audioTracks exists');
+  assert.ok(player.videoTracks, 'videoTracks exists');
+  assert.ok(player.textTracks, 'textTracks exists');
+  assert.ok(player.remoteTextTrackEls, 'remoteTextTrackEls exists');
+  assert.ok(player.remoteTextTracks, 'remoteTextTracks exists');
+  assert.ok(player.addTextTrack, 'addTextTrack exists');
+  assert.ok(player.addRemoteTextTrack, 'addRemoteTextTrack exists');
+  assert.ok(player.removeRemoteTextTrack, 'removeRemoteTextTrack exists');
 
   // Deprecated methods that should still exist
-  QUnit.ok(player.requestFullScreen, 'requestFullScreen exists');
-  QUnit.ok(player.isFullScreen, 'isFullScreen exists');
-  QUnit.ok(player.cancelFullScreen, 'cancelFullScreen exists');
+  assert.ok(player.requestFullScreen, 'requestFullScreen exists');
+  assert.ok(player.isFullScreen, 'isFullScreen exists');
+  assert.ok(player.cancelFullScreen, 'cancelFullScreen exists');
 });
 
-QUnit.test('should be able to access expected component API methods', function() {
+QUnit.test('should be able to access expected component API methods', function(assert) {
   const Component = videojs.getComponent('Component');
   const comp = new Component({
     id() {
@@ -86,40 +86,40 @@ QUnit.test('should be able to access expected component API methods', function()
   });
 
   // Component methods
-  QUnit.ok(comp.player, 'player exists');
-  QUnit.ok(comp.options, 'options exists');
-  QUnit.ok(comp.init, 'init exists');
-  QUnit.ok(comp.dispose, 'dispose exists');
-  QUnit.ok(comp.createEl, 'createEl exists');
-  QUnit.ok(comp.contentEl, 'contentEl exists');
-  QUnit.ok(comp.el, 'el exists');
-  QUnit.ok(comp.addChild, 'addChild exists');
-  QUnit.ok(comp.getChild, 'getChild exists');
-  QUnit.ok(comp.getChildById, 'getChildById exists');
-  QUnit.ok(comp.children, 'children exists');
-  QUnit.ok(comp.initChildren, 'initChildren exists');
-  QUnit.ok(comp.removeChild, 'removeChild exists');
-  QUnit.ok(comp.on, 'on exists');
-  QUnit.ok(comp.off, 'off exists');
-  QUnit.ok(comp.one, 'one exists');
-  QUnit.ok(comp.trigger, 'trigger exists');
-  QUnit.ok(comp.triggerReady, 'triggerReady exists');
-  QUnit.ok(comp.show, 'show exists');
-  QUnit.ok(comp.hide, 'hide exists');
-  QUnit.ok(comp.width, 'width exists');
-  QUnit.ok(comp.height, 'height exists');
-  QUnit.ok(comp.dimensions, 'dimensions exists');
-  QUnit.ok(comp.ready, 'ready exists');
-  QUnit.ok(comp.addClass, 'addClass exists');
-  QUnit.ok(comp.removeClass, 'removeClass exists');
-  QUnit.ok(comp.buildCSSClass, 'buildCSSClass exists');
-  QUnit.ok(comp.setInterval, 'setInterval exists');
-  QUnit.ok(comp.clearInterval, 'clearInterval exists');
-  QUnit.ok(comp.setTimeout, 'setTimeout exists');
-  QUnit.ok(comp.clearTimeout, 'clearTimeout exists');
+  assert.ok(comp.player, 'player exists');
+  assert.ok(comp.options, 'options exists');
+  assert.ok(comp.init, 'init exists');
+  assert.ok(comp.dispose, 'dispose exists');
+  assert.ok(comp.createEl, 'createEl exists');
+  assert.ok(comp.contentEl, 'contentEl exists');
+  assert.ok(comp.el, 'el exists');
+  assert.ok(comp.addChild, 'addChild exists');
+  assert.ok(comp.getChild, 'getChild exists');
+  assert.ok(comp.getChildById, 'getChildById exists');
+  assert.ok(comp.children, 'children exists');
+  assert.ok(comp.initChildren, 'initChildren exists');
+  assert.ok(comp.removeChild, 'removeChild exists');
+  assert.ok(comp.on, 'on exists');
+  assert.ok(comp.off, 'off exists');
+  assert.ok(comp.one, 'one exists');
+  assert.ok(comp.trigger, 'trigger exists');
+  assert.ok(comp.triggerReady, 'triggerReady exists');
+  assert.ok(comp.show, 'show exists');
+  assert.ok(comp.hide, 'hide exists');
+  assert.ok(comp.width, 'width exists');
+  assert.ok(comp.height, 'height exists');
+  assert.ok(comp.dimensions, 'dimensions exists');
+  assert.ok(comp.ready, 'ready exists');
+  assert.ok(comp.addClass, 'addClass exists');
+  assert.ok(comp.removeClass, 'removeClass exists');
+  assert.ok(comp.buildCSSClass, 'buildCSSClass exists');
+  assert.ok(comp.setInterval, 'setInterval exists');
+  assert.ok(comp.clearInterval, 'clearInterval exists');
+  assert.ok(comp.setTimeout, 'setTimeout exists');
+  assert.ok(comp.clearTimeout, 'clearTimeout exists');
 });
 
-QUnit.test('should be able to access expected MediaTech API methods', function() {
+QUnit.test('should be able to access expected MediaTech API methods', function(assert) {
   const media = videojs.getComponent('Tech');
   const mediaProto = media.prototype;
   const html5 = videojs.getComponent('Html5');
@@ -127,32 +127,32 @@ QUnit.test('should be able to access expected MediaTech API methods', function()
   const flash = videojs.getComponent('Flash');
   const flashProto = flash.prototype;
 
-  QUnit.ok(mediaProto.setPoster, 'setPoster should exist on the Media tech');
-  QUnit.ok(html5Proto.setPoster, 'setPoster should exist on the HTML5 tech');
-  QUnit.ok(flashProto.setPoster, 'setPoster should exist on the Flash tech');
+  assert.ok(mediaProto.setPoster, 'setPoster should exist on the Media tech');
+  assert.ok(html5Proto.setPoster, 'setPoster should exist on the HTML5 tech');
+  assert.ok(flashProto.setPoster, 'setPoster should exist on the Flash tech');
 
-  QUnit.ok(html5.patchCanPlayType, 'patchCanPlayType should exist for HTML5');
-  QUnit.ok(html5.unpatchCanPlayType, 'unpatchCanPlayType should exist for HTML5');
+  assert.ok(html5.patchCanPlayType, 'patchCanPlayType should exist for HTML5');
+  assert.ok(html5.unpatchCanPlayType, 'unpatchCanPlayType should exist for HTML5');
 
   // Source Handler Functions
-  QUnit.ok(media.withSourceHandlers, 'withSourceHandlers should exist for Media Tech');
+  assert.ok(media.withSourceHandlers, 'withSourceHandlers should exist for Media Tech');
 
-  QUnit.ok(html5.canPlaySource, 'canPlaySource should exist for HTML5');
-  QUnit.ok(html5.registerSourceHandler, 'registerSourceHandler should exist for Html5');
-  QUnit.ok(html5.selectSourceHandler, 'selectSourceHandler should exist for Html5');
-  QUnit.ok(html5.prototype.setSource, 'setSource should exist for Html5');
-  QUnit.ok(html5.prototype.disposeSourceHandler,
+  assert.ok(html5.canPlaySource, 'canPlaySource should exist for HTML5');
+  assert.ok(html5.registerSourceHandler, 'registerSourceHandler should exist for Html5');
+  assert.ok(html5.selectSourceHandler, 'selectSourceHandler should exist for Html5');
+  assert.ok(html5.prototype.setSource, 'setSource should exist for Html5');
+  assert.ok(html5.prototype.disposeSourceHandler,
            'disposeSourceHandler should exist for Html5');
 
-  QUnit.ok(flash.canPlaySource, 'canPlaySource should exist for Flash');
-  QUnit.ok(flash.registerSourceHandler, 'registerSourceHandler should exist for Flash');
-  QUnit.ok(flash.selectSourceHandler, 'selectSourceHandler should exist for Flash');
-  QUnit.ok(flash.prototype.setSource, 'setSource should exist for Flash');
-  QUnit.ok(flash.prototype.disposeSourceHandler,
+  assert.ok(flash.canPlaySource, 'canPlaySource should exist for Flash');
+  assert.ok(flash.registerSourceHandler, 'registerSourceHandler should exist for Flash');
+  assert.ok(flash.selectSourceHandler, 'selectSourceHandler should exist for Flash');
+  assert.ok(flash.prototype.setSource, 'setSource should exist for Flash');
+  assert.ok(flash.prototype.disposeSourceHandler,
            'disposeSourceHandler should exist for Flash');
 });
 
-QUnit.test('should export ready api call to public', function() {
+QUnit.test('should export ready api call to public', function(assert) {
   const videoTag = testHelperMakeTag();
   const fixture = document.getElementById('qunit-fixture');
 
@@ -160,62 +160,62 @@ QUnit.test('should export ready api call to public', function() {
 
   const player = videojs('example_1');
 
-  QUnit.ok(player.ready !== undefined, 'ready callback is defined');
+  assert.ok(player.ready !== undefined, 'ready callback is defined');
   player.dispose();
 });
 
-QUnit.test('should export useful components to the public', function() {
-  QUnit.ok(videojs.browser.TOUCH_ENABLED !== undefined,
+QUnit.test('should export useful components to the public', function(assert) {
+  assert.ok(videojs.browser.TOUCH_ENABLED !== undefined,
            'Touch detection should be public');
-  QUnit.ok(videojs.getComponent('ControlBar'), 'ControlBar should be public');
-  QUnit.ok(videojs.getComponent('Button'), 'Button should be public');
-  QUnit.ok(videojs.getComponent('PlayToggle'), 'PlayToggle should be public');
-  QUnit.ok(videojs.getComponent('FullscreenToggle'), 'FullscreenToggle should be public');
-  QUnit.ok(videojs.getComponent('BigPlayButton'), 'BigPlayButton should be public');
-  QUnit.ok(videojs.getComponent('LoadingSpinner'), 'LoadingSpinner should be public');
-  QUnit.ok(videojs.getComponent('CurrentTimeDisplay'),
+  assert.ok(videojs.getComponent('ControlBar'), 'ControlBar should be public');
+  assert.ok(videojs.getComponent('Button'), 'Button should be public');
+  assert.ok(videojs.getComponent('PlayToggle'), 'PlayToggle should be public');
+  assert.ok(videojs.getComponent('FullscreenToggle'), 'FullscreenToggle should be public');
+  assert.ok(videojs.getComponent('BigPlayButton'), 'BigPlayButton should be public');
+  assert.ok(videojs.getComponent('LoadingSpinner'), 'LoadingSpinner should be public');
+  assert.ok(videojs.getComponent('CurrentTimeDisplay'),
            'CurrentTimeDisplay should be public');
-  QUnit.ok(videojs.getComponent('DurationDisplay'), 'DurationDisplay should be public');
-  QUnit.ok(videojs.getComponent('TimeDivider'), 'TimeDivider should be public');
-  QUnit.ok(videojs.getComponent('RemainingTimeDisplay'),
+  assert.ok(videojs.getComponent('DurationDisplay'), 'DurationDisplay should be public');
+  assert.ok(videojs.getComponent('TimeDivider'), 'TimeDivider should be public');
+  assert.ok(videojs.getComponent('RemainingTimeDisplay'),
            'RemainingTimeDisplay should be public');
-  QUnit.ok(videojs.getComponent('Slider'), 'Slider should be public');
-  QUnit.ok(videojs.getComponent('ProgressControl'), 'ProgressControl should be public');
-  QUnit.ok(videojs.getComponent('SeekBar'), 'SeekBar should be public');
-  QUnit.ok(videojs.getComponent('LoadProgressBar'), 'LoadProgressBar should be public');
-  QUnit.ok(videojs.getComponent('PlayProgressBar'), 'PlayProgressBar should be public');
-  QUnit.ok(videojs.getComponent('VolumeControl'), 'VolumeControl should be public');
-  QUnit.ok(videojs.getComponent('VolumeBar'), 'VolumeBar should be public');
-  QUnit.ok(videojs.getComponent('VolumeLevel'), 'VolumeLevel should be public');
-  QUnit.ok(videojs.getComponent('VolumeMenuButton'), 'VolumeMenuButton should be public');
-  QUnit.ok(videojs.getComponent('MuteToggle'), 'MuteToggle should be public');
-  QUnit.ok(videojs.getComponent('PosterImage'), 'PosterImage should be public');
-  QUnit.ok(videojs.getComponent('Menu'), 'Menu should be public');
-  QUnit.ok(videojs.getComponent('MenuItem'), 'MenuItem should be public');
-  QUnit.ok(videojs.getComponent('MenuButton'), 'MenuButton should be public');
-  QUnit.ok(videojs.getComponent('PlaybackRateMenuButton'),
+  assert.ok(videojs.getComponent('Slider'), 'Slider should be public');
+  assert.ok(videojs.getComponent('ProgressControl'), 'ProgressControl should be public');
+  assert.ok(videojs.getComponent('SeekBar'), 'SeekBar should be public');
+  assert.ok(videojs.getComponent('LoadProgressBar'), 'LoadProgressBar should be public');
+  assert.ok(videojs.getComponent('PlayProgressBar'), 'PlayProgressBar should be public');
+  assert.ok(videojs.getComponent('VolumeControl'), 'VolumeControl should be public');
+  assert.ok(videojs.getComponent('VolumeBar'), 'VolumeBar should be public');
+  assert.ok(videojs.getComponent('VolumeLevel'), 'VolumeLevel should be public');
+  assert.ok(videojs.getComponent('VolumeMenuButton'), 'VolumeMenuButton should be public');
+  assert.ok(videojs.getComponent('MuteToggle'), 'MuteToggle should be public');
+  assert.ok(videojs.getComponent('PosterImage'), 'PosterImage should be public');
+  assert.ok(videojs.getComponent('Menu'), 'Menu should be public');
+  assert.ok(videojs.getComponent('MenuItem'), 'MenuItem should be public');
+  assert.ok(videojs.getComponent('MenuButton'), 'MenuButton should be public');
+  assert.ok(videojs.getComponent('PlaybackRateMenuButton'),
            'PlaybackRateMenuButton should be public');
 
-  QUnit.ok(videojs.getComponent('CaptionSettingsMenuItem'),
+  assert.ok(videojs.getComponent('CaptionSettingsMenuItem'),
            'CaptionSettingsMenuItem should be public');
-  QUnit.ok(videojs.getComponent('OffTextTrackMenuItem'),
+  assert.ok(videojs.getComponent('OffTextTrackMenuItem'),
            'OffTextTrackMenuItem should be public');
-  QUnit.ok(videojs.getComponent('TextTrackMenuItem'),
+  assert.ok(videojs.getComponent('TextTrackMenuItem'),
            'TextTrackMenuItem should be public');
-  QUnit.ok(videojs.getComponent('TextTrackDisplay'), 'TextTrackDisplay should be public');
-  QUnit.ok(videojs.getComponent('TextTrackButton'), 'TextTrackButton should be public');
-  QUnit.ok(videojs.getComponent('CaptionsButton'), 'CaptionsButton should be public');
-  QUnit.ok(videojs.getComponent('SubtitlesButton'), 'SubtitlesButton should be public');
-  QUnit.ok(videojs.getComponent('DescriptionsButton'),
+  assert.ok(videojs.getComponent('TextTrackDisplay'), 'TextTrackDisplay should be public');
+  assert.ok(videojs.getComponent('TextTrackButton'), 'TextTrackButton should be public');
+  assert.ok(videojs.getComponent('CaptionsButton'), 'CaptionsButton should be public');
+  assert.ok(videojs.getComponent('SubtitlesButton'), 'SubtitlesButton should be public');
+  assert.ok(videojs.getComponent('DescriptionsButton'),
            'DescriptionsButton should be public');
-  QUnit.ok(videojs.getComponent('ChaptersButton'), 'ChaptersButton should be public');
-  QUnit.ok(videojs.getComponent('ChaptersTrackMenuItem'),
+  assert.ok(videojs.getComponent('ChaptersButton'), 'ChaptersButton should be public');
+  assert.ok(videojs.getComponent('ChaptersTrackMenuItem'),
            'ChaptersTrackMenuItem should be public');
 
-  QUnit.ok(videojs.mergeOptions, 'mergeOptions should be public');
+  assert.ok(videojs.mergeOptions, 'mergeOptions should be public');
 });
 
-QUnit.test('should be able to initialize player twice on the same tag using string reference', function() {
+QUnit.test('should be able to initialize player twice on the same tag using string reference', function(assert) {
   const videoTag = testHelperMakeTag();
   const id = videoTag.id;
   const fixture = document.getElementById('qunit-fixture');
@@ -225,7 +225,7 @@ QUnit.test('should be able to initialize player twice on the same tag using stri
   const player = videojs('example_1');
 
   player.dispose();
-  QUnit.ok(!document.getElementById(id), 'element is removed');
+  assert.ok(!document.getElementById(id), 'element is removed');
 
   videoTag = testHelperMakeTag();
   fixture.appendChild(videoTag);
@@ -234,7 +234,7 @@ QUnit.test('should be able to initialize player twice on the same tag using stri
   player.dispose();
 });
 
-QUnit.test('videojs.getPlayers() should be available after minification', function() {
+QUnit.test('videojs.getPlayers() should be available after minification', function(assert) {
   const videoTag = testHelperMakeTag();
   const id = videoTag.id;
   const fixture = document.getElementById('qunit-fixture');
@@ -243,12 +243,12 @@ QUnit.test('videojs.getPlayers() should be available after minification', functi
 
   const player = videojs(id);
 
-  QUnit.ok(videojs.getPlayers()[id] === player, 'videojs.getPlayers() is available');
+  assert.ok(videojs.getPlayers()[id] === player, 'videojs.getPlayers() is available');
 
   player.dispose();
 });
 
-QUnit.test('component can be subclassed externally', function() {
+QUnit.test('component can be subclassed externally', function(assert) {
   const Component = videojs.getComponent('Component');
   const ControlBar = videojs.getComponent('ControlBar');
 
@@ -265,7 +265,7 @@ QUnit.test('component can be subclassed externally', function() {
     reportUserActivity() {}
   });
 
-  QUnit.ok(new ControlBar(player), 'created a control bar without throwing');
+  assert.ok(new ControlBar(player), 'created a control bar without throwing');
 });
 
 function testHelperMakeTag() {
@@ -276,7 +276,7 @@ function testHelperMakeTag() {
   return videoTag;
 }
 
-QUnit.test('should extend Component', function() {
+QUnit.test('should extend Component', function(assert) {
   const Component = videojs.getComponent('Component');
   const MyComponent = videojs.extend(Component, {
     constructor() {
@@ -289,13 +289,13 @@ QUnit.test('should extend Component', function() {
 
   const myComponent = new MyComponent();
 
-  QUnit.ok(myComponent instanceof Component, 'creates an instance of Component');
-  QUnit.ok(myComponent instanceof MyComponent, 'creates an instance of MyComponent');
-  QUnit.ok(myComponent.bar, 'the constructor function is used');
-  QUnit.ok(myComponent.foo(), 'instance methods are applied');
+  assert.ok(myComponent instanceof Component, 'creates an instance of Component');
+  assert.ok(myComponent instanceof MyComponent, 'creates an instance of MyComponent');
+  assert.ok(myComponent.bar, 'the constructor function is used');
+  assert.ok(myComponent.foo(), 'instance methods are applied');
 
   const NoMethods = videojs.extend(Component);
   const noMethods = new NoMethods({});
 
-  QUnit.ok(noMethods.on, 'should extend component with no methods or constructor');
+  assert.ok(noMethods.on, 'should extend component with no methods or constructor');
 });

--- a/test/unit/button.test.js
+++ b/test/unit/button.test.js
@@ -4,8 +4,8 @@ import TestHelpers from './test-helpers.js';
 
 QUnit.module('Button');
 
-QUnit.test('should localize its text', function() {
-  QUnit.expect(3);
+QUnit.test('should localize its text', function(assert) {
+  assert.expect(3);
 
   const player = TestHelpers.makePlayer({
     language: 'es',
@@ -21,7 +21,7 @@ QUnit.test('should localize its text', function() {
   testButton.controlText_ = 'Play';
   const el = testButton.createEl();
 
-  QUnit.ok(el.nodeName.toLowerCase().match('button'));
-  QUnit.ok(el.innerHTML.match(/vjs-control-text"?>Juego/));
-  QUnit.equal(el.getAttribute('title'), 'Juego');
+  assert.ok(el.nodeName.toLowerCase().match('button'));
+  assert.ok(el.innerHTML.match(/vjs-control-text"?>Juego/));
+  assert.equal(el.getAttribute('title'), 'Juego');
 });

--- a/test/unit/clickable-component.test.js
+++ b/test/unit/clickable-component.test.js
@@ -4,37 +4,37 @@ import TestHelpers from './test-helpers.js';
 
 QUnit.module('ClickableComponent');
 
-QUnit.test('should create a div with role="button"', function() {
-  QUnit.expect(2);
+QUnit.test('should create a div with role="button"', function(assert) {
+  assert.expect(2);
 
   const player = TestHelpers.makePlayer({});
 
   const testClickableComponent = new ClickableComponent(player);
   const el = testClickableComponent.createEl();
 
-  QUnit.equal(el.nodeName.toLowerCase(), 'div', 'the name of the element is "div"');
-  QUnit.equal(el.getAttribute('role').toLowerCase(), 'button', 'the role of the element is "button"');
+  assert.equal(el.nodeName.toLowerCase(), 'div', 'the name of the element is "div"');
+  assert.equal(el.getAttribute('role').toLowerCase(), 'button', 'the role of the element is "button"');
 
   testClickableComponent.dispose();
   player.dispose();
 });
 
-QUnit.test('should be enabled/disabled', function() {
-  QUnit.expect(3);
+QUnit.test('should be enabled/disabled', function(assert) {
+  assert.expect(3);
 
   const player = TestHelpers.makePlayer({});
 
   const testClickableComponent = new ClickableComponent(player);
 
-  QUnit.equal(testClickableComponent.hasClass('vjs-disabled'), false, 'ClickableComponent defaults to enabled');
+  assert.equal(testClickableComponent.hasClass('vjs-disabled'), false, 'ClickableComponent defaults to enabled');
 
   testClickableComponent.disable();
 
-  QUnit.equal(testClickableComponent.hasClass('vjs-disabled'), true, 'ClickableComponent is disabled');
+  assert.equal(testClickableComponent.hasClass('vjs-disabled'), true, 'ClickableComponent is disabled');
 
   testClickableComponent.enable();
 
-  QUnit.equal(testClickableComponent.hasClass('vjs-disabled'), false, 'ClickableComponent is enabled');
+  assert.equal(testClickableComponent.hasClass('vjs-disabled'), false, 'ClickableComponent is enabled');
 
   testClickableComponent.dispose();
   player.dispose();

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -164,8 +164,9 @@ QUnit.test('should do a deep merge of child options', function(assert) {
   assert.strictEqual(children.childThree, false, 'object two levels deep removed');
   assert.ok(children.childFour, 'object two levels deep added');
 
-  assert.strictEqual(Component.prototype.options_.example.childOne.foo, 'bar',
-  'prototype options were not overridden');
+  assert.strictEqual(Component.prototype.options_.example.childOne.foo,
+                     'bar',
+                     'prototype options were not overridden');
 
   // Reset default component options to none
   Component.prototype.options_ = null;

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -23,10 +23,10 @@ Component.registerComponent('TestComponent3', TestComponent3);
 Component.registerComponent('TestComponent4', TestComponent4);
 
 QUnit.module('Component', {
-  setup() {
+  beforeEach() {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach() {
     this.clock.restore();
   }
 });
@@ -41,76 +41,76 @@ const getFakePlayer = function() {
   };
 };
 
-QUnit.test('should create an element', function() {
+QUnit.test('should create an element', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
-  QUnit.ok(comp.el().nodeName);
+  assert.ok(comp.el().nodeName);
 });
 
-QUnit.test('should add a child component', function() {
+QUnit.test('should add a child component', function(assert) {
   const comp = new Component(getFakePlayer());
 
   const child = comp.addChild('component');
 
-  QUnit.ok(comp.children().length === 1);
-  QUnit.ok(comp.children()[0] === child);
-  QUnit.ok(comp.el().childNodes[0] === child.el());
-  QUnit.ok(comp.getChild('component') === child);
-  QUnit.ok(comp.getChildById(child.id()) === child);
+  assert.ok(comp.children().length === 1);
+  assert.ok(comp.children()[0] === child);
+  assert.ok(comp.el().childNodes[0] === child.el());
+  assert.ok(comp.getChild('component') === child);
+  assert.ok(comp.getChildById(child.id()) === child);
 });
 
-QUnit.test('should add a child component to an index', function() {
+QUnit.test('should add a child component to an index', function(assert) {
   const comp = new Component(getFakePlayer());
 
   const child = comp.addChild('component');
 
-  QUnit.ok(comp.children().length === 1);
-  QUnit.ok(comp.children()[0] === child);
+  assert.ok(comp.children().length === 1);
+  assert.ok(comp.children()[0] === child);
 
   const child0 = comp.addChild('component', {}, 0);
 
-  QUnit.ok(comp.children().length === 2);
-  QUnit.ok(comp.children()[0] === child0);
-  QUnit.ok(comp.children()[1] === child);
+  assert.ok(comp.children().length === 2);
+  assert.ok(comp.children()[0] === child0);
+  assert.ok(comp.children()[1] === child);
 
   const child1 = comp.addChild('component', {}, '2');
 
-  QUnit.ok(comp.children().length === 3);
-  QUnit.ok(comp.children()[2] === child1);
+  assert.ok(comp.children().length === 3);
+  assert.ok(comp.children()[2] === child1);
 
   const child2 = comp.addChild('component', {}, undefined);
 
-  QUnit.ok(comp.children().length === 4);
-  QUnit.ok(comp.children()[3] === child2);
+  assert.ok(comp.children().length === 4);
+  assert.ok(comp.children()[3] === child2);
 
   const child3 = comp.addChild('component', {}, -1);
 
-  QUnit.ok(comp.children().length === 5);
-  QUnit.ok(comp.children()[3] === child3);
-  QUnit.ok(comp.children()[4] === child2);
+  assert.ok(comp.children().length === 5);
+  assert.ok(comp.children()[3] === child3);
+  assert.ok(comp.children()[4] === child2);
 });
 
-QUnit.test('addChild should throw if the child does not exist', function() {
+QUnit.test('addChild should throw if the child does not exist', function(assert) {
   const comp = new Component(getFakePlayer());
 
-  throws(function() {
+  assert.throws(function() {
     comp.addChild('non-existent-child');
   }, new Error('Component Non-existent-child does not exist'), 'addChild threw');
 
 });
 
-QUnit.test('should init child components from options', function() {
+QUnit.test('should init child components from options', function(assert) {
   const comp = new Component(getFakePlayer(), {
     children: {
       component: {}
     }
   });
 
-  QUnit.ok(comp.children().length === 1);
-  QUnit.ok(comp.el().childNodes.length === 1);
+  assert.ok(comp.children().length === 1);
+  assert.ok(comp.el().childNodes.length === 1);
 });
 
-QUnit.test('should init child components from simple children array', function() {
+QUnit.test('should init child components from simple children array', function(assert) {
   const comp = new Component(getFakePlayer(), {
     children: [
       'component',
@@ -119,11 +119,11 @@ QUnit.test('should init child components from simple children array', function()
     ]
   });
 
-  QUnit.ok(comp.children().length === 3);
-  QUnit.ok(comp.el().childNodes.length === 3);
+  assert.ok(comp.children().length === 3);
+  assert.ok(comp.el().childNodes.length === 3);
 });
 
-QUnit.test('should init child components from children array of objects', function() {
+QUnit.test('should init child components from children array of objects', function(assert) {
   const comp = new Component(getFakePlayer(), {
     children: [
       { name: 'component' },
@@ -132,11 +132,11 @@ QUnit.test('should init child components from children array of objects', functi
     ]
   });
 
-  QUnit.ok(comp.children().length === 3);
-  QUnit.ok(comp.el().childNodes.length === 3);
+  assert.ok(comp.children().length === 3);
+  assert.ok(comp.el().childNodes.length === 3);
 });
 
-QUnit.test('should do a deep merge of child options', function() {
+QUnit.test('should do a deep merge of child options', function(assert) {
   // Create a default option for component
   Component.prototype.options_ = {
     example: {
@@ -157,31 +157,31 @@ QUnit.test('should do a deep merge of child options', function() {
   const mergedOptions = comp.options_;
   const children = mergedOptions.example;
 
-  QUnit.strictEqual(children.childOne.foo, 'baz', 'value three levels deep overridden');
-  QUnit.strictEqual(children.childOne.asdf, 'fdsa', 'value three levels deep maintained');
-  QUnit.strictEqual(children.childOne.abc, '123', 'value three levels deep added');
-  QUnit.ok(children.childTwo, 'object two levels deep maintained');
-  QUnit.strictEqual(children.childThree, false, 'object two levels deep removed');
-  QUnit.ok(children.childFour, 'object two levels deep added');
+  assert.strictEqual(children.childOne.foo, 'baz', 'value three levels deep overridden');
+  assert.strictEqual(children.childOne.asdf, 'fdsa', 'value three levels deep maintained');
+  assert.strictEqual(children.childOne.abc, '123', 'value three levels deep added');
+  assert.ok(children.childTwo, 'object two levels deep maintained');
+  assert.strictEqual(children.childThree, false, 'object two levels deep removed');
+  assert.ok(children.childFour, 'object two levels deep added');
 
-  QUnit.strictEqual(Component.prototype.options_.example.childOne.foo, 'bar',
+  assert.strictEqual(Component.prototype.options_.example.childOne.foo, 'bar',
   'prototype options were not overridden');
 
   // Reset default component options to none
   Component.prototype.options_ = null;
 });
 
-QUnit.test('should init child components from component options', function() {
+QUnit.test('should init child components from component options', function(assert) {
   const testComp = new TestComponent1(TestHelpers.makePlayer(), {
     testComponent2: false,
     testComponent4: {}
   });
 
-  QUnit.ok(!testComp.childNameIndex_.testComponent2, 'we do not have testComponent2');
-  QUnit.ok(testComp.childNameIndex_.testComponent4, 'we have a testComponent4');
+  assert.ok(!testComp.childNameIndex_.testComponent2, 'we do not have testComponent2');
+  assert.ok(testComp.childNameIndex_.testComponent4, 'we have a testComponent4');
 });
 
-QUnit.test('should allows setting child options at the parent options level', function() {
+QUnit.test('should allows setting child options at the parent options level', function(assert) {
   let parent;
 
   // using children array
@@ -200,10 +200,10 @@ QUnit.test('should allows setting child options at the parent options level', fu
   try {
     parent = new Component(getFakePlayer(), options);
   } catch (err) {
-    QUnit.ok(false, 'Child with `false` option was initialized');
+    assert.ok(false, 'Child with `false` option was initialized');
   }
-  QUnit.equal(parent.children()[0].options_.foo, true, 'child options set when children array is used');
-  QUnit.equal(parent.children().length, 1, 'we should only have one child');
+  assert.equal(parent.children()[0].options_.foo, true, 'child options set when children array is used');
+  assert.equal(parent.children().length, 1, 'we should only have one child');
 
   // using children object
   options = {
@@ -223,19 +223,19 @@ QUnit.test('should allows setting child options at the parent options level', fu
   try {
     parent = new Component(getFakePlayer(), options);
   } catch (err) {
-    QUnit.ok(false, 'Child with `false` option was initialized');
+    assert.ok(false, 'Child with `false` option was initialized');
   }
-  QUnit.equal(parent.children()[0].options_.foo, true, 'child options set when children object is used');
-  QUnit.equal(parent.children().length, 1, 'we should only have one child');
+  assert.equal(parent.children()[0].options_.foo, true, 'child options set when children object is used');
+  assert.equal(parent.children().length, 1, 'we should only have one child');
 });
 
-QUnit.test('should dispose of component and children', function() {
+QUnit.test('should dispose of component and children', function(assert) {
   const comp = new Component(getFakePlayer());
 
   // Add a child
   const child = comp.addChild('Component');
 
-  QUnit.ok(comp.children().length === 1);
+  assert.ok(comp.children().length === 1);
 
   // Add a listener
   comp.on('click', function() {
@@ -254,28 +254,28 @@ QUnit.test('should dispose of component and children', function() {
 
   comp.dispose();
 
-  QUnit.ok(hasDisposed, 'component fired dispose event');
-  QUnit.ok(bubbles === false, 'dispose event does not bubble');
-  QUnit.ok(!comp.children(), 'component children were deleted');
-  QUnit.ok(!comp.el(), 'component element was deleted');
-  QUnit.ok(!child.children(), 'child children were deleted');
-  QUnit.ok(!child.el(), 'child element was deleted');
-  QUnit.ok(!Dom.hasElData(el), 'listener data nulled');
-  QUnit.ok(!Object.getOwnPropertyNames(data).length,
+  assert.ok(hasDisposed, 'component fired dispose event');
+  assert.ok(bubbles === false, 'dispose event does not bubble');
+  assert.ok(!comp.children(), 'component children were deleted');
+  assert.ok(!comp.el(), 'component element was deleted');
+  assert.ok(!child.children(), 'child children were deleted');
+  assert.ok(!child.el(), 'child element was deleted');
+  assert.ok(!Dom.hasElData(el), 'listener data nulled');
+  assert.ok(!Object.getOwnPropertyNames(data).length,
   'original listener data object was emptied');
 });
 
-QUnit.test('should add and remove event listeners to element', function() {
+QUnit.test('should add and remove event listeners to element', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
   // No need to make this async because we're triggering events inline.
   // We're going to trigger the event after removing the listener,
   // So if we get extra asserts that's a problem.
-  QUnit.expect(2);
+  assert.expect(2);
 
   const testListener = function() {
-    QUnit.ok(true, 'fired event once');
-    QUnit.ok(this === comp, 'listener has the component as context');
+    assert.ok(true, 'fired event once');
+    assert.ok(this === comp, 'listener has the component as context');
   };
 
   comp.on('test-event', testListener);
@@ -284,13 +284,13 @@ QUnit.test('should add and remove event listeners to element', function() {
   comp.trigger('test-event');
 });
 
-QUnit.test('should trigger a listener once using one()', function() {
+QUnit.test('should trigger a listener once using one()', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
-  QUnit.expect(1);
+  assert.expect(1);
 
   const testListener = function() {
-    QUnit.ok(true, 'fired event once');
+    assert.ok(true, 'fired event once');
   };
 
   comp.one('test-event', testListener);
@@ -298,17 +298,17 @@ QUnit.test('should trigger a listener once using one()', function() {
   comp.trigger('test-event');
 });
 
-QUnit.test('should be possible to pass data when you trigger an event', function() {
+QUnit.test('should be possible to pass data when you trigger an event', function(assert) {
   const comp = new Component(getFakePlayer(), {});
   const data1 = 'Data1';
   const data2 = {txt: 'Data2'};
 
-  QUnit.expect(3);
+  assert.expect(3);
 
   const testListener = function(evt, hash) {
-    QUnit.ok(true, 'fired event once');
-    deepEqual(hash.d1, data1);
-    deepEqual(hash.d2, data2);
+    assert.ok(true, 'fired event once');
+    assert.deepEqual(hash.d1, data1);
+    assert.deepEqual(hash.d2, data2);
   };
 
   comp.one('test-event', testListener);
@@ -316,47 +316,47 @@ QUnit.test('should be possible to pass data when you trigger an event', function
   comp.trigger('test-event');
 });
 
-QUnit.test('should add listeners to other components and remove them', function() {
+QUnit.test('should add listeners to other components and remove them', function(assert) {
   const player = getFakePlayer();
   const comp1 = new Component(player);
   const comp2 = new Component(player);
   let listenerFired = 0;
 
   const testListener = function() {
-    QUnit.equal(this, comp1, 'listener has the first component as context');
+    assert.equal(this, comp1, 'listener has the first component as context');
     listenerFired++;
   };
 
   comp1.on(comp2, 'test-event', testListener);
   comp2.trigger('test-event');
-  QUnit.equal(listenerFired, 1, 'listener was fired once');
+  assert.equal(listenerFired, 1, 'listener was fired once');
 
   listenerFired = 0;
   comp1.off(comp2, 'test-event', testListener);
   comp2.trigger('test-event');
-  QUnit.equal(listenerFired, 0, 'listener was not fired after being removed');
+  assert.equal(listenerFired, 0, 'listener was not fired after being removed');
 
   // this component is disposed first
   listenerFired = 0;
   comp1.on(comp2, 'test-event', testListener);
   comp1.dispose();
   comp2.trigger('test-event');
-  QUnit.equal(listenerFired, 0, 'listener was removed when this component was disposed first');
+  assert.equal(listenerFired, 0, 'listener was removed when this component was disposed first');
   comp1.off = function() {
     throw new Error('Comp1 off called');
   };
   comp2.dispose();
-  QUnit.ok(true, 'this component removed dispose listeners from other component');
+  assert.ok(true, 'this component removed dispose listeners from other component');
 });
 
-QUnit.test('should add listeners to other components and remove when them other component is disposed', function() {
+QUnit.test('should add listeners to other components and remove when them other component is disposed', function(assert) {
   const player = getFakePlayer();
   const comp1 = new Component(player);
   const comp2 = new Component(player);
   let listenerFired = 0;
 
   const testListener = function() {
-    QUnit.equal(this, comp1, 'listener has the first component as context');
+    assert.equal(this, comp1, 'listener has the first component as context');
     listenerFired++;
   };
 
@@ -366,53 +366,53 @@ QUnit.test('should add listeners to other components and remove when them other 
     throw new Error('Comp2 off called');
   };
   comp1.dispose();
-  QUnit.ok(true, 'this component removed dispose listener from this component that referenced other component');
+  assert.ok(true, 'this component removed dispose listener from this component that referenced other component');
 });
 
-QUnit.test('should add listeners to other components that are fired once', function() {
+QUnit.test('should add listeners to other components that are fired once', function(assert) {
   const player = getFakePlayer();
   const comp1 = new Component(player);
   const comp2 = new Component(player);
   let listenerFired = 0;
 
   const testListener = function() {
-    QUnit.equal(this, comp1, 'listener has the first component as context');
+    assert.equal(this, comp1, 'listener has the first component as context');
     listenerFired++;
   };
 
   comp1.one(comp2, 'test-event', testListener);
   comp2.trigger('test-event');
-  QUnit.equal(listenerFired, 1, 'listener was executed once');
+  assert.equal(listenerFired, 1, 'listener was executed once');
   comp2.trigger('test-event');
-  QUnit.equal(listenerFired, 1, 'listener was executed only once');
+  assert.equal(listenerFired, 1, 'listener was executed only once');
 });
 
-QUnit.test('should add listeners to other element and remove them', function() {
+QUnit.test('should add listeners to other element and remove them', function(assert) {
   const player = getFakePlayer();
   const comp1 = new Component(player);
   const el = document.createElement('div');
   let listenerFired = 0;
 
   const testListener = function() {
-    QUnit.equal(this, comp1, 'listener has the first component as context');
+    assert.equal(this, comp1, 'listener has the first component as context');
     listenerFired++;
   };
 
   comp1.on(el, 'test-event', testListener);
   Events.trigger(el, 'test-event');
-  QUnit.equal(listenerFired, 1, 'listener was fired once');
+  assert.equal(listenerFired, 1, 'listener was fired once');
 
   listenerFired = 0;
   comp1.off(el, 'test-event', testListener);
   Events.trigger(el, 'test-event');
-  QUnit.equal(listenerFired, 0, 'listener was not fired after being removed from other element');
+  assert.equal(listenerFired, 0, 'listener was not fired after being removed from other element');
 
   // this component is disposed first
   listenerFired = 0;
   comp1.on(el, 'test-event', testListener);
   comp1.dispose();
   Events.trigger(el, 'test-event');
-  QUnit.equal(listenerFired, 0, 'listener was removed when this component was disposed first');
+  assert.equal(listenerFired, 0, 'listener was removed when this component was disposed first');
   comp1.off = function() {
     throw new Error('Comp1 off called');
   };
@@ -420,31 +420,31 @@ QUnit.test('should add listeners to other element and remove them', function() {
   try {
     Events.trigger(el, 'dispose');
   } catch (e) {
-    QUnit.ok(false, 'listener was not removed from other element');
+    assert.ok(false, 'listener was not removed from other element');
   }
   Events.trigger(el, 'dispose');
-  QUnit.ok(true, 'this component removed dispose listeners from other element');
+  assert.ok(true, 'this component removed dispose listeners from other element');
 });
 
-QUnit.test('should add listeners to other components that are fired once', function() {
+QUnit.test('should add listeners to other components that are fired once', function(assert) {
   const player = getFakePlayer();
   const comp1 = new Component(player);
   const el = document.createElement('div');
   let listenerFired = 0;
 
   const testListener = function() {
-    QUnit.equal(this, comp1, 'listener has the first component as context');
+    assert.equal(this, comp1, 'listener has the first component as context');
     listenerFired++;
   };
 
   comp1.one(el, 'test-event', testListener);
   Events.trigger(el, 'test-event');
-  QUnit.equal(listenerFired, 1, 'listener was executed once');
+  assert.equal(listenerFired, 1, 'listener was executed once');
   Events.trigger(el, 'test-event');
-  QUnit.equal(listenerFired, 1, 'listener was executed only once');
+  assert.equal(listenerFired, 1, 'listener was executed only once');
 });
 
-QUnit.test('should trigger a listener when ready', function() {
+QUnit.test('should trigger a listener when ready', function(assert) {
   let initListenerFired;
   let methodListenerFired;
   let syncListenerFired;
@@ -463,13 +463,13 @@ QUnit.test('should trigger a listener when ready', function() {
     syncListenerFired = true;
   }, true);
 
-  QUnit.ok(!initListenerFired, 'init listener should NOT fire synchronously');
-  QUnit.ok(!methodListenerFired, 'method listener should NOT fire synchronously');
-  QUnit.ok(syncListenerFired, 'sync listener SHOULD fire synchronously if after ready');
+  assert.ok(!initListenerFired, 'init listener should NOT fire synchronously');
+  assert.ok(!methodListenerFired, 'method listener should NOT fire synchronously');
+  assert.ok(syncListenerFired, 'sync listener SHOULD fire synchronously if after ready');
 
   this.clock.tick(1);
-  QUnit.ok(initListenerFired, 'init listener should fire asynchronously');
-  QUnit.ok(methodListenerFired, 'method listener should fire asynchronously');
+  assert.ok(initListenerFired, 'init listener should fire asynchronously');
+  assert.ok(methodListenerFired, 'method listener should fire asynchronously');
 
   // Listeners should only be fired once and then removed
   initListenerFired = false;
@@ -479,12 +479,12 @@ QUnit.test('should trigger a listener when ready', function() {
   comp.triggerReady();
   this.clock.tick(1);
 
-  QUnit.ok(!initListenerFired, 'init listener should be removed');
-  QUnit.ok(!methodListenerFired, 'method listener should be removed');
-  QUnit.ok(!syncListenerFired, 'sync listener should be removed');
+  assert.ok(!initListenerFired, 'init listener should be removed');
+  assert.ok(!methodListenerFired, 'method listener should be removed');
+  assert.ok(!syncListenerFired, 'sync listener should be removed');
 });
 
-QUnit.test('should not retrigger a listener when the listener calls triggerReady', function() {
+QUnit.test('should not retrigger a listener when the listener calls triggerReady', function(assert) {
   let timesCalled = 0;
   let selfTriggered = false;
   const comp = new Component(getFakePlayer(), {});
@@ -505,32 +505,32 @@ QUnit.test('should not retrigger a listener when the listener calls triggerReady
 
   this.clock.tick(100);
 
-  QUnit.equal(timesCalled, 1, 'triggerReady from inside a ready handler does not result in an infinite loop');
+  assert.equal(timesCalled, 1, 'triggerReady from inside a ready handler does not result in an infinite loop');
 });
 
-QUnit.test('should add and remove a CSS class', function() {
+QUnit.test('should add and remove a CSS class', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
   comp.addClass('test-class');
-  QUnit.ok(comp.el().className.indexOf('test-class') !== -1);
+  assert.ok(comp.el().className.indexOf('test-class') !== -1);
   comp.removeClass('test-class');
-  QUnit.ok(comp.el().className.indexOf('test-class') === -1);
+  assert.ok(comp.el().className.indexOf('test-class') === -1);
   comp.toggleClass('test-class');
-  QUnit.ok(comp.el().className.indexOf('test-class') !== -1);
+  assert.ok(comp.el().className.indexOf('test-class') !== -1);
   comp.toggleClass('test-class');
-  QUnit.ok(comp.el().className.indexOf('test-class') === -1);
+  assert.ok(comp.el().className.indexOf('test-class') === -1);
 });
 
-QUnit.test('should show and hide an element', function() {
+QUnit.test('should show and hide an element', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
   comp.hide();
-  QUnit.ok(comp.hasClass('vjs-hidden') === true);
+  assert.ok(comp.hasClass('vjs-hidden') === true);
   comp.show();
-  QUnit.ok(comp.hasClass('vjs-hidden') === false);
+  assert.ok(comp.hasClass('vjs-hidden') === false);
 });
 
-QUnit.test('dimension() should treat NaN and null as zero', function() {
+QUnit.test('dimension() should treat NaN and null as zero', function(assert) {
   let newWidth;
 
   const width = 300;
@@ -543,23 +543,23 @@ QUnit.test('dimension() should treat NaN and null as zero', function() {
 
   newWidth = comp.dimension('width', null);
 
-  QUnit.notEqual(newWidth, width, 'new width and old width are not the same');
-  QUnit.equal(newWidth, comp, 'we set a value, so, return value is component');
-  QUnit.equal(comp.width(), 0, 'the new width is zero');
+  assert.notEqual(newWidth, width, 'new width and old width are not the same');
+  assert.equal(newWidth, comp, 'we set a value, so, return value is component');
+  assert.equal(comp.width(), 0, 'the new width is zero');
 
   const newHeight = comp.dimension('height', NaN);
 
-  QUnit.notEqual(newHeight, height, 'new height and old height are not the same');
-  QUnit.equal(newHeight, comp, 'we set a value, so, return value is component');
-  QUnit.equal(comp.height(), 0, 'the new height is zero');
+  assert.notEqual(newHeight, height, 'new height and old height are not the same');
+  assert.equal(newHeight, comp, 'we set a value, so, return value is component');
+  assert.equal(comp.height(), 0, 'the new height is zero');
 
   comp.width(width);
   newWidth = comp.dimension('width', undefined);
 
-  QUnit.equal(newWidth, width, 'we did not set the width with undefined');
+  assert.equal(newWidth, width, 'we did not set the width with undefined');
 });
 
-QUnit.test('should change the width and height of a component', function() {
+QUnit.test('should change the width and height of a component', function(assert) {
   const container = document.createElement('div');
   const comp = new Component(getFakePlayer(), {});
   const el = comp.el();
@@ -574,22 +574,22 @@ QUnit.test('should change the width and height of a component', function() {
   comp.width('50%');
   comp.height('123px');
 
-  QUnit.ok(comp.width() === 500, 'percent values working');
+  assert.ok(comp.width() === 500, 'percent values working');
   const compStyle = TestHelpers.getComputedStyle(el, 'width');
 
-  QUnit.ok(compStyle === comp.width() + 'px', 'matches computed style');
-  QUnit.ok(comp.height() === 123, 'px values working');
+  assert.ok(compStyle === comp.width() + 'px', 'matches computed style');
+  assert.ok(comp.height() === 123, 'px values working');
 
   comp.width(321);
-  QUnit.ok(comp.width() === 321, 'integer values working');
+  assert.ok(comp.width() === 321, 'integer values working');
 
   comp.width('auto');
   comp.height('auto');
-  QUnit.ok(comp.width() === 1000, 'forced width was removed');
-  QUnit.ok(comp.height() === 0, 'forced height was removed');
+  assert.ok(comp.width() === 1000, 'forced width was removed');
+  assert.ok(comp.height() === 0, 'forced height was removed');
 });
 
-QUnit.test('should get the computed dimensions', function() {
+QUnit.test('should get the computed dimensions', function(assert) {
   const container = document.createElement('div');
   const comp = new Component(getFakePlayer(), {});
   const el = comp.el();
@@ -607,18 +607,18 @@ QUnit.test('should get the computed dimensions', function() {
   comp.width('50%');
   comp.height('50%');
 
-  QUnit.equal(comp.currentWidth() + 'px', computedWidth, 'matches computed width');
-  QUnit.equal(comp.currentHeight() + 'px', computedHeight, 'matches computed height');
+  assert.equal(comp.currentWidth() + 'px', computedWidth, 'matches computed width');
+  assert.equal(comp.currentHeight() + 'px', computedHeight, 'matches computed height');
 
-  QUnit.equal(comp.currentDimension('width') + 'px', computedWidth, 'matches computed width');
-  QUnit.equal(comp.currentDimension('height') + 'px', computedHeight, 'matches computed height');
+  assert.equal(comp.currentDimension('width') + 'px', computedWidth, 'matches computed width');
+  assert.equal(comp.currentDimension('height') + 'px', computedHeight, 'matches computed height');
 
-  QUnit.equal(comp.currentDimensions().width + 'px', computedWidth, 'matches computed width');
-  QUnit.equal(comp.currentDimensions().height + 'px', computedHeight, 'matches computed width');
+  assert.equal(comp.currentDimensions().width + 'px', computedWidth, 'matches computed width');
+  assert.equal(comp.currentDimensions().height + 'px', computedHeight, 'matches computed width');
 
 });
 
-QUnit.test('should use a defined content el for appending children', function() {
+QUnit.test('should use a defined content el for appending children', function(assert) {
   class CompWithContent extends Component {}
 
   CompWithContent.prototype.createEl = function() {
@@ -634,30 +634,30 @@ QUnit.test('should use a defined content el for appending children', function() 
   const comp = new CompWithContent(getFakePlayer());
   const child = comp.addChild('component');
 
-  QUnit.ok(comp.children().length === 1);
-  QUnit.ok(comp.el().childNodes[0].id === 'contentEl');
-  QUnit.ok(comp.el().childNodes[0].childNodes[0] === child.el());
+  assert.ok(comp.children().length === 1);
+  assert.ok(comp.el().childNodes[0].id === 'contentEl');
+  assert.ok(comp.el().childNodes[0].childNodes[0] === child.el());
 
   comp.removeChild(child);
 
-  QUnit.ok(comp.children().length === 0, 'Length should now be zero');
-  QUnit.ok(comp.el().childNodes[0].id === 'contentEl', 'Content El should still exist');
-  QUnit.ok(comp.el().childNodes[0].childNodes[0] !== child.el(),
+  assert.ok(comp.children().length === 0, 'Length should now be zero');
+  assert.ok(comp.el().childNodes[0].id === 'contentEl', 'Content El should still exist');
+  assert.ok(comp.el().childNodes[0].childNodes[0] !== child.el(),
   'Child el should be removed.');
 });
 
-QUnit.test('should emit a tap event', function() {
+QUnit.test('should emit a tap event', function(assert) {
   const comp = new Component(getFakePlayer());
   let singleTouch = {};
   const origTouch = browser.TOUCH_ENABLED;
 
-  QUnit.expect(3);
+  assert.expect(3);
   // Fake touch support. Real touch support isn't needed for this test.
   browser.TOUCH_ENABLED = true;
 
   comp.emitTapEvents();
   comp.on('tap', function() {
-    QUnit.ok(true, 'Tap event emitted');
+    assert.ok(true, 'Tap event emitted');
   });
 
   // A touchstart followed by touchend should trigger a tap
@@ -704,30 +704,30 @@ QUnit.test('should emit a tap event', function() {
   browser.TOUCH_ENABLED = origTouch;
 });
 
-QUnit.test('should provide timeout methods that automatically get cleared on component disposal', function() {
+QUnit.test('should provide timeout methods that automatically get cleared on component disposal', function(assert) {
   const comp = new Component(getFakePlayer());
   let timeoutsFired = 0;
   const timeoutToClear = comp.setTimeout(function() {
     timeoutsFired++;
-    QUnit.ok(false, 'Timeout should have been manually cleared');
+    assert.ok(false, 'Timeout should have been manually cleared');
   }, 500);
 
-  QUnit.expect(4);
+  assert.expect(4);
 
   comp.setTimeout(function() {
     timeoutsFired++;
-    QUnit.equal(this, comp, 'Timeout fn has the component as its context');
-    QUnit.ok(true, 'Timeout created and fired.');
+    assert.equal(this, comp, 'Timeout fn has the component as its context');
+    assert.ok(true, 'Timeout created and fired.');
   }, 100);
 
   comp.setTimeout(function() {
     timeoutsFired++;
-    QUnit.ok(false, 'Timeout should have been disposed');
+    assert.ok(false, 'Timeout should have been disposed');
   }, 1000);
 
   this.clock.tick(100);
 
-  QUnit.ok(timeoutsFired === 1, 'One timeout should have fired by this point');
+  assert.ok(timeoutsFired === 1, 'One timeout should have fired by this point');
 
   comp.clearTimeout(timeoutToClear);
 
@@ -737,45 +737,45 @@ QUnit.test('should provide timeout methods that automatically get cleared on com
 
   this.clock.tick(1000);
 
-  QUnit.ok(timeoutsFired === 1, 'One timeout should have fired overall');
+  assert.ok(timeoutsFired === 1, 'One timeout should have fired overall');
 });
 
-QUnit.test('should provide interval methods that automatically get cleared on component disposal', function() {
+QUnit.test('should provide interval methods that automatically get cleared on component disposal', function(assert) {
   const comp = new Component(getFakePlayer());
 
   let intervalsFired = 0;
 
   const interval = comp.setInterval(function() {
     intervalsFired++;
-    QUnit.equal(this, comp, 'Interval fn has the component as its context');
-    QUnit.ok(true, 'Interval created and fired.');
+    assert.equal(this, comp, 'Interval fn has the component as its context');
+    assert.ok(true, 'Interval created and fired.');
   }, 100);
 
-  QUnit.expect(13);
+  assert.expect(13);
 
   comp.setInterval(function() {
     intervalsFired++;
-    QUnit.ok(false, 'Interval should have been disposed');
+    assert.ok(false, 'Interval should have been disposed');
   }, 1200);
 
   this.clock.tick(500);
 
-  QUnit.ok(intervalsFired === 5, 'Component interval fired 5 times');
+  assert.ok(intervalsFired === 5, 'Component interval fired 5 times');
 
   comp.clearInterval(interval);
 
   this.clock.tick(600);
 
-  QUnit.ok(intervalsFired === 5, 'Interval was manually cleared');
+  assert.ok(intervalsFired === 5, 'Interval was manually cleared');
 
   comp.dispose();
 
   this.clock.tick(1200);
 
-  QUnit.ok(intervalsFired === 5, 'Interval was cleared when component was disposed');
+  assert.ok(intervalsFired === 5, 'Interval was cleared when component was disposed');
 });
 
-QUnit.test('$ and $$ functions', function() {
+QUnit.test('$ and $$ functions', function(assert) {
   const comp = new Component(getFakePlayer());
   const contentEl = document.createElement('div');
   const children = [
@@ -786,6 +786,6 @@ QUnit.test('$ and $$ functions', function() {
   comp.contentEl_ = contentEl;
   children.forEach(child => contentEl.appendChild(child));
 
-  QUnit.strictEqual(comp.$('div'), children[0], '$ defaults to contentEl as scope');
-  QUnit.strictEqual(comp.$$('div').length, children.length, '$$ defaults to contentEl as scope');
+  assert.strictEqual(comp.$('div'), children[0], '$ defaults to contentEl as scope');
+  assert.strictEqual(comp.$$('div').length, children.length, '$$ defaults to contentEl as scope');
 });

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -8,8 +8,8 @@ import document from 'global/document';
 
 QUnit.module('Controls');
 
-QUnit.test('should hide volume control if it\'s not supported', function() {
-  QUnit.expect(2);
+QUnit.test('should hide volume control if it\'s not supported', function(assert) {
+  assert.expect(2);
   const noop = function() {};
   const player = {
     id: noop,
@@ -26,11 +26,11 @@ QUnit.test('should hide volume control if it\'s not supported', function() {
   const volumeControl = new VolumeControl(player);
   const muteToggle = new MuteToggle(player);
 
-  QUnit.ok(volumeControl.el().className.indexOf('vjs-hidden') >= 0, 'volumeControl is not hidden');
-  QUnit.ok(muteToggle.el().className.indexOf('vjs-hidden') >= 0, 'muteToggle is not hidden');
+  assert.ok(volumeControl.el().className.indexOf('vjs-hidden') >= 0, 'volumeControl is not hidden');
+  assert.ok(muteToggle.el().className.indexOf('vjs-hidden') >= 0, 'muteToggle is not hidden');
 });
 
-QUnit.test('should test and toggle volume control on `loadstart`', function() {
+QUnit.test('should test and toggle volume control on `loadstart`', function(assert) {
   const noop = function() {};
   const listeners = [];
   const player = {
@@ -57,27 +57,27 @@ QUnit.test('should test and toggle volume control on `loadstart`', function() {
   const volumeControl = new VolumeControl(player);
   const muteToggle = new MuteToggle(player);
 
-  QUnit.equal(volumeControl.hasClass('vjs-hidden'), false, 'volumeControl is hidden initially');
-  QUnit.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle is hidden initially');
+  assert.equal(volumeControl.hasClass('vjs-hidden'), false, 'volumeControl is hidden initially');
+  assert.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle is hidden initially');
 
   player.tech_.featuresVolumeControl = false;
   for (let i = 0; i < listeners.length; i++) {
     listeners[i]();
   }
 
-  QUnit.equal(volumeControl.hasClass('vjs-hidden'), true, 'volumeControl does not hide itself');
-  QUnit.equal(muteToggle.hasClass('vjs-hidden'), true, 'muteToggle does not hide itself');
+  assert.equal(volumeControl.hasClass('vjs-hidden'), true, 'volumeControl does not hide itself');
+  assert.equal(muteToggle.hasClass('vjs-hidden'), true, 'muteToggle does not hide itself');
 
   player.tech_.featuresVolumeControl = true;
   for (let i = 0; i < listeners.length; i++) {
     listeners[i]();
   }
 
-  QUnit.equal(volumeControl.hasClass('vjs-hidden'), false, 'volumeControl does not show itself');
-  QUnit.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle does not show itself');
+  assert.equal(volumeControl.hasClass('vjs-hidden'), false, 'volumeControl does not show itself');
+  assert.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle does not show itself');
 });
 
-QUnit.test('calculateDistance should use changedTouches, if available', function() {
+QUnit.test('calculateDistance should use changedTouches, if available', function(assert) {
   const noop = function() {};
   const player = {
     id: noop,
@@ -99,14 +99,14 @@ QUnit.test('calculateDistance should use changedTouches, if available', function
     }]
   };
 
-  QUnit.equal(slider.calculateDistance(event), 0.5, 'we should have touched exactly in the center, so, the ratio should be half');
+  assert.equal(slider.calculateDistance(event), 0.5, 'we should have touched exactly in the center, so, the ratio should be half');
 });
 
-QUnit.test('should hide playback rate control if it\'s not supported', function() {
-  QUnit.expect(1);
+QUnit.test('should hide playback rate control if it\'s not supported', function(assert) {
+  assert.expect(1);
 
   const player = TestHelpers.makePlayer();
   const playbackRate = new PlaybackRateMenuButton(player);
 
-  QUnit.ok(playbackRate.el().className.indexOf('vjs-hidden') >= 0, 'playbackRate is not hidden');
+  assert.ok(playbackRate.el().className.indexOf('vjs-hidden') >= 0, 'playbackRate is not hidden');
 });

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -4,12 +4,12 @@ import document from 'global/document';
 
 QUnit.module('Events');
 
-QUnit.test('should add and remove an event listener to an element', function() {
-  QUnit.expect(1);
+QUnit.test('should add and remove an event listener to an element', function(assert) {
+  assert.expect(1);
 
   const el = document.createElement('div');
   const listener = function() {
-    QUnit.ok(true, 'Click Triggered');
+    assert.ok(true, 'Click Triggered');
   };
 
   Events.on(el, 'click', listener);
@@ -20,12 +20,12 @@ QUnit.test('should add and remove an event listener to an element', function() {
   Events.trigger(el, 'click');
 });
 
-QUnit.test('should add and remove multiple event listeners to an element with a single call', function() {
-  QUnit.expect(6);
+QUnit.test('should add and remove multiple event listeners to an element with a single call', function(assert) {
+  assert.expect(6);
 
   const el = document.createElement('div');
   const listener = function() {
-    QUnit.ok(true, 'Callback triggered');
+    assert.ok(true, 'Callback triggered');
   };
 
   Events.on(el, ['click', 'event1', 'event2'], listener);
@@ -49,16 +49,16 @@ QUnit.test('should add and remove multiple event listeners to an element with a 
   Events.trigger(el, 'event2');
 });
 
-QUnit.test('should be possible to pass data when you trigger an event', function() {
-  QUnit.expect(6);
+QUnit.test('should be possible to pass data when you trigger an event', function(assert) {
+  assert.expect(6);
   const el = document.createElement('div');
   const fakeData1 = 'Fake Data 1';
   const fakeData2 = {txt: 'Fake Data 2'};
 
   const listener = function(evt, hash) {
-    QUnit.ok(true, 'Callback triggered');
-    deepEqual(fakeData1, hash.d1, 'Shoulbe be passed to the handler');
-    deepEqual(fakeData2, hash.d2, 'Shoulbe be passed to the handler');
+    assert.ok(true, 'Callback triggered');
+    assert.deepEqual(fakeData1, hash.d1, 'Shoulbe be passed to the handler');
+    assert.deepEqual(fakeData2, hash.d2, 'Shoulbe be passed to the handler');
   };
 
   Events.on(el, ['event1', 'event2'], listener);
@@ -67,7 +67,7 @@ QUnit.test('should be possible to pass data when you trigger an event', function
 
 });
 
-QUnit.test('should remove all listeners of a type', function() {
+QUnit.test('should remove all listeners of a type', function(assert) {
   const el = document.createElement('div');
   let clicks = 0;
   const listener = function() {
@@ -82,16 +82,16 @@ QUnit.test('should remove all listeners of a type', function() {
     // 2 clicks
   Events.trigger(el, 'click');
 
-  QUnit.ok(clicks === 2, 'both click listeners fired');
+  assert.ok(clicks === 2, 'both click listeners fired');
 
   Events.off(el, 'click');
   // No click should happen.
   Events.trigger(el, 'click');
 
-  QUnit.ok(clicks === 2, 'no click listeners fired');
+  assert.ok(clicks === 2, 'no click listeners fired');
 });
 
-QUnit.test('should remove all listeners of an array of types', function() {
+QUnit.test('should remove all listeners of an array of types', function(assert) {
   const el = document.createElement('div');
   let calls = 0;
   const listener = function() {
@@ -108,7 +108,7 @@ QUnit.test('should remove all listeners of an array of types', function() {
   // 2 calls
   Events.trigger(el, 'event1');
 
-  QUnit.ok(calls === 4, 'both click listeners fired');
+  assert.ok(calls === 4, 'both click listeners fired');
 
   Events.off(el, ['click', 'event1']);
   // No click should happen.
@@ -116,18 +116,18 @@ QUnit.test('should remove all listeners of an array of types', function() {
   // No event1 should happen.
   Events.trigger(el, 'event1');
 
-  QUnit.ok(calls === 4, 'no event listeners fired');
+  assert.ok(calls === 4, 'no event listeners fired');
 });
 
-QUnit.test('should remove all listeners from an element', function() {
-  QUnit.expect(2);
+QUnit.test('should remove all listeners from an element', function(assert) {
+  assert.expect(2);
 
   const el = document.createElement('div');
   const listener = function() {
-    QUnit.ok(true, 'Fake1 Triggered');
+    assert.ok(true, 'Fake1 Triggered');
   };
   const listener2 = function() {
-    QUnit.ok(true, 'Fake2 Triggered');
+    assert.ok(true, 'Fake2 Triggered');
   };
 
   Events.on(el, 'fake1', listener);
@@ -143,12 +143,12 @@ QUnit.test('should remove all listeners from an element', function() {
   Events.trigger(el, 'fake2');
 });
 
-QUnit.test('should listen only once', function() {
-  QUnit.expect(1);
+QUnit.test('should listen only once', function(assert) {
+  assert.expect(1);
 
   const el = document.createElement('div');
   const listener = function() {
-    QUnit.ok(true, 'Click Triggered');
+    assert.ok(true, 'Click Triggered');
   };
 
   Events.one(el, 'click', listener);
@@ -158,12 +158,12 @@ QUnit.test('should listen only once', function() {
   Events.trigger(el, 'click');
 });
 
-QUnit.test('should listen only once in multiple events from a single call', function() {
-  QUnit.expect(3);
+QUnit.test('should listen only once in multiple events from a single call', function(assert) {
+  assert.expect(3);
 
   const el = document.createElement('div');
   const listener = function() {
-    QUnit.ok(true, 'Callback Triggered');
+    assert.ok(true, 'Callback Triggered');
   };
 
   Events.one(el, ['click', 'event1', 'event2'], listener);
@@ -181,80 +181,80 @@ QUnit.test('should listen only once in multiple events from a single call', func
   Events.trigger(el, 'event2');
 });
 
-QUnit.test('should stop immediate propagtion', function() {
-  QUnit.expect(1);
+QUnit.test('should stop immediate propagtion', function(assert) {
+  assert.expect(1);
 
   const el = document.createElement('div');
 
   Events.on(el, 'test', function(e) {
-    QUnit.ok(true, 'First listener fired');
+    assert.ok(true, 'First listener fired');
     e.stopImmediatePropagation();
   });
 
   Events.on(el, 'test', function(e) {
-    QUnit.ok(false, 'Second listener fired');
+    assert.ok(false, 'Second listener fired');
   });
 
   Events.trigger(el, 'test');
 });
 
-QUnit.test('should bubble up DOM unless bubbles == false', function() {
-  QUnit.expect(3);
+QUnit.test('should bubble up DOM unless bubbles == false', function(assert) {
+  assert.expect(3);
 
   const outer = document.createElement('div');
   const inner = outer.appendChild(document.createElement('div'));
 
   // Verify that if bubbles === true, event bubbles up dom.
   Events.on(inner, 'bubbles', function(e) {
-    QUnit.ok(true, 'Inner listener fired');
+    assert.ok(true, 'Inner listener fired');
   });
   Events.on(outer, 'bubbles', function(e) {
-    QUnit.ok(true, 'Outer listener fired');
+    assert.ok(true, 'Outer listener fired');
   });
   Events.trigger(inner, { type: 'bubbles', target: inner, bubbles: true });
 
   // Only change 'bubbles' to false, and verify only inner handler is called.
   Events.on(inner, 'nobub', function(e) {
-    QUnit.ok(true, 'Inner listener fired');
+    assert.ok(true, 'Inner listener fired');
   });
   Events.on(outer, 'nobub', function(e) {
-    QUnit.ok(false, 'Outer listener fired');
+    assert.ok(false, 'Outer listener fired');
   });
   Events.trigger(inner, { type: 'nobub', target: inner, bubbles: false });
 });
 
-QUnit.test('should have a defaultPrevented property on an event that was prevent from doing default action', function() {
-  QUnit.expect(2);
+QUnit.test('should have a defaultPrevented property on an event that was prevent from doing default action', function(assert) {
+  assert.expect(2);
 
   const el = document.createElement('div');
 
   Events.on(el, 'test', function(e) {
-    QUnit.ok(true, 'First listener fired');
+    assert.ok(true, 'First listener fired');
     e.preventDefault();
   });
 
   Events.on(el, 'test', function(e) {
-    QUnit.ok(e.defaultPrevented, 'Should have `defaultPrevented` to signify preventDefault being called');
+    assert.ok(e.defaultPrevented, 'Should have `defaultPrevented` to signify preventDefault being called');
   });
 
   Events.trigger(el, 'test');
 });
 
-QUnit.test('should have relatedTarget correctly set on the event', function() {
-  QUnit.expect(2);
+QUnit.test('should have relatedTarget correctly set on the event', function(assert) {
+  assert.expect(2);
 
   const el1 = document.createElement('div');
   const el2 = document.createElement('div');
   const relatedEl = document.createElement('div');
 
   Events.on(el1, 'click', function(e) {
-    QUnit.equal(e.relatedTarget, relatedEl, 'relatedTarget is set for all browsers when related element is set on the event');
+    assert.equal(e.relatedTarget, relatedEl, 'relatedTarget is set for all browsers when related element is set on the event');
   });
 
   Events.trigger(el1, { type: 'click', relatedTarget: relatedEl });
 
   Events.on(el2, 'click', function(e) {
-    QUnit.equal(e.relatedTarget, null, 'relatedTarget is null when none is provided');
+    assert.equal(e.relatedTarget, null, 'relatedTarget is null when none is provided');
   });
 
   Events.trigger(el2, { type: 'click', relatedTarget: undefined });

--- a/test/unit/extend.test.js
+++ b/test/unit/extend.test.js
@@ -3,7 +3,7 @@ import extendFn from '../../src/js/extend.js';
 
 QUnit.module('extend.js');
 
-QUnit.test('should add implicit parent constructor call', function() {
+QUnit.test('should add implicit parent constructor call', function(assert) {
   let superCalled = false;
   const Parent = function() {
     superCalled = true;
@@ -13,6 +13,6 @@ QUnit.test('should add implicit parent constructor call', function() {
   });
   const child = new Child();
 
-  QUnit.ok(superCalled, 'super constructor called');
-  QUnit.ok(child.foo, 'child properties set');
+  assert.ok(superCalled, 'super constructor called');
+  assert.ok(child.foo, 'child properties set');
 });

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -5,8 +5,8 @@ import * as Events from '../../src/js/utils/events.js';
 
 QUnit.module('MenuButton');
 
-QUnit.test('should not throw an error when there is no children', function() {
-  QUnit.expect(0);
+QUnit.test('should not throw an error when there is no children', function(assert) {
+  assert.expect(0);
   const player = TestHelpers.makePlayer();
 
   const menuButton = new MenuButton(player);
@@ -15,13 +15,13 @@ QUnit.test('should not throw an error when there is no children', function() {
   try {
     Events.trigger(el, 'click');
   } catch (error) {
-    QUnit.ok(!error, 'click should not throw anything');
+    assert.ok(!error, 'click should not throw anything');
   }
 
   player.dispose();
 });
 
-QUnit.test('should place title list item into ul', function() {
+QUnit.test('should place title list item into ul', function(assert) {
   const player = TestHelpers.makePlayer();
 
   const menuButton = new MenuButton(player, {
@@ -31,13 +31,13 @@ QUnit.test('should place title list item into ul', function() {
   const menuContentElement = menuButton.el().getElementsByTagName('UL')[0];
   const titleElement = menuContentElement.children[0];
 
-  QUnit.ok(titleElement.innerHTML === 'TestTitle', 'title element placed in ul');
+  assert.ok(titleElement.innerHTML === 'TestTitle', 'title element placed in ul');
 
   player.dispose();
 });
 
-QUnit.test('clicking should display the menu', function() {
-  QUnit.expect(6);
+QUnit.test('clicking should display the menu', function(assert) {
+  assert.expect(6);
 
   const player = TestHelpers.makePlayer();
 
@@ -47,29 +47,29 @@ QUnit.test('clicking should display the menu', function() {
   });
   const el = menuButton.el();
 
-  QUnit.ok(menuButton.menu !== undefined, 'menu is created');
+  assert.ok(menuButton.menu !== undefined, 'menu is created');
 
-  QUnit.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'menu defaults to hidden');
-
-  Events.trigger(el, 'click');
-
-  QUnit.equal(menuButton.menu.hasClass('vjs-lock-showing'), true, 'clicking on the menu button shows the menu');
+  assert.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'menu defaults to hidden');
 
   Events.trigger(el, 'click');
 
-  QUnit.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'clicking again on the menu button hides the menu');
+  assert.equal(menuButton.menu.hasClass('vjs-lock-showing'), true, 'clicking on the menu button shows the menu');
+
+  Events.trigger(el, 'click');
+
+  assert.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'clicking again on the menu button hides the menu');
 
   menuButton.disable();
 
   Events.trigger(el, 'click');
 
-  QUnit.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'disable() prevents clicking from showing the menu');
+  assert.equal(menuButton.menu.hasClass('vjs-lock-showing'), false, 'disable() prevents clicking from showing the menu');
 
   menuButton.enable();
 
   Events.trigger(el, 'click');
 
-  QUnit.equal(menuButton.menu.hasClass('vjs-lock-showing'), true, 'enable() allows clicking to show the menu');
+  assert.equal(menuButton.menu.hasClass('vjs-lock-showing'), true, 'enable() allows clicking to show the menu');
 
   player.dispose();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -14,38 +14,38 @@ import Tech from '../../src/js/tech/tech.js';
 import TechFaker from './tech/tech-faker.js';
 
 QUnit.module('Player', {
-  setup() {
+  beforeEach() {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach() {
     this.clock.restore();
   }
 });
 
-QUnit.test('should create player instance that inherits from component and dispose it', function() {
+QUnit.test('should create player instance that inherits from component and dispose it', function(assert) {
   const player = TestHelpers.makePlayer();
 
-  QUnit.ok(player.el().nodeName === 'DIV');
-  QUnit.ok(player.on, 'component function exists');
+  assert.ok(player.el().nodeName === 'DIV');
+  assert.ok(player.on, 'component function exists');
 
   player.dispose();
-  QUnit.ok(player.el() === null, 'element disposed');
+  assert.ok(player.el() === null, 'element disposed');
 });
 
-QUnit.test('dispose should not throw if styleEl is missing', function() {
+QUnit.test('dispose should not throw if styleEl is missing', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.styleEl_.parentNode.removeChild(player.styleEl_);
 
   player.dispose();
-  QUnit.ok(player.el() === null, 'element disposed');
+  assert.ok(player.el() === null, 'element disposed');
 });
 
 // technically, all uses of videojs.options should be replaced with
 // Player.prototype.options_ in this file and a equivalent test using
 // videojs.options should be made in video.test.js. Keeping this here
 // until we make that move.
-QUnit.test('should accept options from multiple sources and override in correct order', function() {
+QUnit.test('should accept options from multiple sources and override in correct order', function(assert) {
 
   // Set a global option
   videojs.options.attr = 1;
@@ -53,7 +53,7 @@ QUnit.test('should accept options from multiple sources and override in correct 
   const tag0 = TestHelpers.makeTag();
   const player0 = new Player(tag0, { techOrder: ['techFaker'] });
 
-  QUnit.equal(player0.options_.attr, 1, 'global option was set');
+  assert.equal(player0.options_.attr, 1, 'global option was set');
   player0.dispose();
 
   // Set a tag level option
@@ -64,7 +64,7 @@ QUnit.test('should accept options from multiple sources and override in correct 
 
   const player2 = new Player(tag2, { techOrder: ['techFaker'] });
 
-  QUnit.equal(player2.options_.attr, 'asdf', 'Tag options overrode global options');
+  assert.equal(player2.options_.attr, 'asdf', 'Tag options overrode global options');
   player2.dispose();
 
   // Set a tag level option
@@ -74,11 +74,11 @@ QUnit.test('should accept options from multiple sources and override in correct 
 
   const player3 = new Player(tag3, { techOrder: ['techFaker'], attr: 'fdsa' });
 
-  QUnit.equal(player3.options_.attr, 'fdsa', 'Init options overrode tag and global options');
+  assert.equal(player3.options_.attr, 'fdsa', 'Init options overrode tag and global options');
   player3.dispose();
 });
 
-QUnit.test('should get tag, source, and track settings', function() {
+QUnit.test('should get tag, source, and track settings', function(assert) {
   // Partially tested in lib->getElAttributes
 
   const fixture = document.getElementById('qunit-fixture');
@@ -95,33 +95,33 @@ QUnit.test('should get tag, source, and track settings', function() {
   const tag = document.getElementById('example_1');
   const player = TestHelpers.makePlayer({}, tag);
 
-  QUnit.equal(player.options_.autoplay, true, 'autoplay is set to true');
-  QUnit.equal(player.options_.preload, 'none', 'preload is set to none');
-  QUnit.equal(player.options_.id, 'example_1', 'id is set to example_1');
-  QUnit.equal(player.options_.sources.length, 2, 'we have two sources');
-  QUnit.equal(player.options_.sources[0].src, 'http://google.com', 'first source is google.com');
-  QUnit.equal(player.options_.sources[0].type, 'video/mp4', 'first time is video/mp4');
-  QUnit.equal(player.options_.sources[1].type, 'video/webm', 'second type is video/webm');
-  QUnit.equal(player.options_.tracks.length, 1, 'we have one text track');
-  QUnit.equal(player.options_.tracks[0].kind, 'captions', 'the text track is a captions file');
-  QUnit.equal(player.options_.tracks[0].attrtest, '', 'we have an empty attribute called attrtest');
+  assert.equal(player.options_.autoplay, true, 'autoplay is set to true');
+  assert.equal(player.options_.preload, 'none', 'preload is set to none');
+  assert.equal(player.options_.id, 'example_1', 'id is set to example_1');
+  assert.equal(player.options_.sources.length, 2, 'we have two sources');
+  assert.equal(player.options_.sources[0].src, 'http://google.com', 'first source is google.com');
+  assert.equal(player.options_.sources[0].type, 'video/mp4', 'first time is video/mp4');
+  assert.equal(player.options_.sources[1].type, 'video/webm', 'second type is video/webm');
+  assert.equal(player.options_.tracks.length, 1, 'we have one text track');
+  assert.equal(player.options_.tracks[0].kind, 'captions', 'the text track is a captions file');
+  assert.equal(player.options_.tracks[0].attrtest, '', 'we have an empty attribute called attrtest');
 
-  QUnit.notEqual(player.el().className.indexOf('video-js'), -1, 'transferred class from tag to player div');
-  QUnit.equal(player.el().id, 'example_1', 'transferred id from tag to player div');
+  assert.notEqual(player.el().className.indexOf('video-js'), -1, 'transferred class from tag to player div');
+  assert.equal(player.el().id, 'example_1', 'transferred id from tag to player div');
 
-  QUnit.equal(Player.players[player.id()], player, 'player referenceable from global list');
-  QUnit.notEqual(tag.id, player.id, 'tag ID no longer is the same as player ID');
-  QUnit.notEqual(tag.className, player.el().className, 'tag classname updated');
+  assert.equal(Player.players[player.id()], player, 'player referenceable from global list');
+  assert.notEqual(tag.id, player.id, 'tag ID no longer is the same as player ID');
+  assert.notEqual(tag.className, player.el().className, 'tag classname updated');
 
   player.dispose();
 
-  QUnit.notEqual(tag.player, player, 'tag player ref killed');
-  QUnit.ok(!Player.players.example_1, 'global player ref killed');
-  QUnit.equal(player.el(), null, 'player el killed');
+  assert.notEqual(tag.player, player, 'tag player ref killed');
+  assert.ok(!Player.players.example_1, 'global player ref killed');
+  assert.equal(player.el(), null, 'player el killed');
 });
 
-QUnit.test('should asynchronously fire error events during source selection', function() {
-  QUnit.expect(2);
+QUnit.test('should asynchronously fire error events during source selection', function(assert) {
+  assert.expect(2);
 
   sinon.stub(log, 'error');
 
@@ -132,10 +132,10 @@ QUnit.test('should asynchronously fire error events during source selection', fu
     ]
   });
 
-  QUnit.ok(player.options_.techOrder[0] === 'foo', 'Foo listed as the only tech');
+  assert.ok(player.options_.techOrder[0] === 'foo', 'Foo listed as the only tech');
 
   player.on('error', function(e) {
-    QUnit.ok(player.error().code === 4, 'Source could not be played error thrown');
+    assert.ok(player.error().code === 4, 'Source could not be played error thrown');
   });
 
   this.clock.tick(1);
@@ -144,7 +144,7 @@ QUnit.test('should asynchronously fire error events during source selection', fu
   log.error.restore();
 });
 
-QUnit.test('should set the width, height, and aspect ratio via a css class', function() {
+QUnit.test('should set the width, height, and aspect ratio via a css class', function(assert) {
   const player = TestHelpers.makePlayer();
   const getStyleText = function(styleEl) {
     return (styleEl.styleSheet && styleEl.styleSheet.cssText) || styleEl.innerHTML;
@@ -163,34 +163,34 @@ QUnit.test('should set the width, height, and aspect ratio via a css class', fun
   };
 
   // Initial state
-  QUnit.ok(!getStyleText(player.styleEl_), 'style element should be empty when the player is given no dimensions');
+  assert.ok(!getStyleText(player.styleEl_), 'style element should be empty when the player is given no dimensions');
 
   // Set only the width
   player.width(100);
-  QUnit.ok(confirmSetting('width', '100px'), 'style width should equal the supplied width in pixels');
-  QUnit.ok(confirmSetting('height', '56.25px'), 'style height should match the default aspect ratio of the width');
+  assert.ok(confirmSetting('width', '100px'), 'style width should equal the supplied width in pixels');
+  assert.ok(confirmSetting('height', '56.25px'), 'style height should match the default aspect ratio of the width');
 
   // Set the height
   player.height(200);
-  QUnit.ok(confirmSetting('height', '200px'), 'style height should match the supplied height in pixels');
+  assert.ok(confirmSetting('height', '200px'), 'style height should match the supplied height in pixels');
 
   // Reset the width and height to defaults
   player.width('');
   player.height('');
-  QUnit.ok(confirmSetting('width', '300px'), 'supplying an empty string should reset the width');
-  QUnit.ok(confirmSetting('height', '168.75px'), 'supplying an empty string should reset the height');
+  assert.ok(confirmSetting('width', '300px'), 'supplying an empty string should reset the width');
+  assert.ok(confirmSetting('height', '168.75px'), 'supplying an empty string should reset the height');
 
   // Switch to fluid mode
   player.fluid(true);
-  QUnit.ok(player.hasClass('vjs-fluid'), 'the vjs-fluid class should be added to the player');
-  QUnit.ok(confirmSetting('padding-top', '56.25%'), 'fluid aspect ratio should match the default aspect ratio');
+  assert.ok(player.hasClass('vjs-fluid'), 'the vjs-fluid class should be added to the player');
+  assert.ok(confirmSetting('padding-top', '56.25%'), 'fluid aspect ratio should match the default aspect ratio');
 
   // Change the aspect ratio
   player.aspectRatio('4:1');
-  QUnit.ok(confirmSetting('padding-top', '25%'), 'aspect ratio percent should match the newly set aspect ratio');
+  assert.ok(confirmSetting('padding-top', '25%'), 'aspect ratio percent should match the newly set aspect ratio');
 });
 
-QUnit.test('should use an class name that begins with an alpha character', function() {
+QUnit.test('should use an class name that begins with an alpha character', function(assert) {
   const alphaPlayer = TestHelpers.makePlayer({ id: 'alpha1' });
   const numericPlayer = TestHelpers.makePlayer({ id: '1numeric' });
 
@@ -201,11 +201,11 @@ QUnit.test('should use an class name that begins with an alpha character', funct
   alphaPlayer.width(100);
   numericPlayer.width(100);
 
-  QUnit.ok(/\s*\.alpha1-dimensions\s*\{/.test(getStyleText(alphaPlayer.styleEl_)), 'appends -dimensions to an alpha player ID');
-  QUnit.ok(/\s*\.dimensions-1numeric\s*\{/.test(getStyleText(numericPlayer.styleEl_)), 'prepends dimensions- to a numeric player ID');
+  assert.ok(/\s*\.alpha1-dimensions\s*\{/.test(getStyleText(alphaPlayer.styleEl_)), 'appends -dimensions to an alpha player ID');
+  assert.ok(/\s*\.dimensions-1numeric\s*\{/.test(getStyleText(numericPlayer.styleEl_)), 'prepends dimensions- to a numeric player ID');
 });
 
-QUnit.test('should wrap the original tag in the player div', function() {
+QUnit.test('should wrap the original tag in the player div', function(assert) {
   const tag = TestHelpers.makeTag();
   const container = document.createElement('div');
   const fixture = document.getElementById('qunit-fixture');
@@ -216,14 +216,14 @@ QUnit.test('should wrap the original tag in the player div', function() {
   const player = new Player(tag, { techOrder: ['techFaker'] });
   const el = player.el();
 
-  QUnit.ok(el.parentNode === container, 'player placed at same level as tag');
+  assert.ok(el.parentNode === container, 'player placed at same level as tag');
   // Tag may be placed inside the player element or it may be removed from the DOM
-  QUnit.ok(tag.parentNode !== container, 'tag removed from original place');
+  assert.ok(tag.parentNode !== container, 'tag removed from original place');
 
   player.dispose();
 });
 
-QUnit.test('should set and update the poster value', function() {
+QUnit.test('should set and update the poster value', function(assert) {
   const poster = '#';
   const updatedPoster = 'http://example.com/updated-poster.jpg';
 
@@ -233,7 +233,7 @@ QUnit.test('should set and update the poster value', function() {
 
   const player = TestHelpers.makePlayer({}, tag);
 
-  QUnit.equal(player.poster(), poster, 'the poster property should equal the tag attribute');
+  assert.equal(player.poster(), poster, 'the poster property should equal the tag attribute');
 
   let pcEmitted = false;
 
@@ -242,8 +242,8 @@ QUnit.test('should set and update the poster value', function() {
   });
 
   player.poster(updatedPoster);
-  QUnit.ok(pcEmitted, 'posterchange event was emitted');
-  QUnit.equal(player.poster(), updatedPoster, 'the updated poster is returned');
+  assert.ok(pcEmitted, 'posterchange event was emitted');
+  assert.equal(player.poster(), updatedPoster, 'the updated poster is returned');
 
   player.dispose();
 });
@@ -251,23 +251,23 @@ QUnit.test('should set and update the poster value', function() {
 // hasStarted() is equivalent to the "show poster flag" in the
 // standard, for the purpose of displaying the poster image
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play
-QUnit.test('should hide the poster when play is called', function() {
+QUnit.test('should hide the poster when play is called', function(assert) {
   const player = TestHelpers.makePlayer({
     poster: 'https://example.com/poster.jpg'
   });
 
-  QUnit.equal(player.hasStarted(), false, 'the show poster flag is true before play');
+  assert.equal(player.hasStarted(), false, 'the show poster flag is true before play');
   player.tech_.trigger('play');
-  QUnit.equal(player.hasStarted(), true, 'the show poster flag is false after play');
+  assert.equal(player.hasStarted(), true, 'the show poster flag is false after play');
 
   player.tech_.trigger('loadstart');
-  QUnit.equal(player.hasStarted(), false, 'the resource selection algorithm sets the show poster flag to true');
+  assert.equal(player.hasStarted(), false, 'the resource selection algorithm sets the show poster flag to true');
 
   player.tech_.trigger('play');
-  QUnit.equal(player.hasStarted(), true, 'the show poster flag is false after play');
+  assert.equal(player.hasStarted(), true, 'the show poster flag is false after play');
 });
 
-QUnit.test('should load a media controller', function() {
+QUnit.test('should load a media controller', function(assert) {
   const player = TestHelpers.makePlayer({
     preload: 'none',
     sources: [
@@ -276,12 +276,12 @@ QUnit.test('should load a media controller', function() {
     ]
   });
 
-  QUnit.ok(player.el().children[0].className.indexOf('vjs-tech') !== -1, 'media controller loaded');
+  assert.ok(player.el().children[0].className.indexOf('vjs-tech') !== -1, 'media controller loaded');
 
   player.dispose();
 });
 
-QUnit.test('should be able to initialize player twice on the same tag using string reference', function() {
+QUnit.test('should be able to initialize player twice on the same tag using string reference', function(assert) {
   let videoTag = TestHelpers.makeTag();
   const id = videoTag.id;
 
@@ -291,10 +291,10 @@ QUnit.test('should be able to initialize player twice on the same tag using stri
 
   let player = videojs(videoTag.id, { techOrder: ['techFaker'] });
 
-  QUnit.ok(player, 'player is created');
+  assert.ok(player, 'player is created');
   player.dispose();
 
-  QUnit.ok(!document.getElementById(id), 'element is removed');
+  assert.ok(!document.getElementById(id), 'element is removed');
   videoTag = TestHelpers.makeTag();
   fixture.appendChild(videoTag);
 
@@ -304,61 +304,61 @@ QUnit.test('should be able to initialize player twice on the same tag using stri
   player.dispose();
 });
 
-QUnit.test('should set controls and trigger events', function() {
+QUnit.test('should set controls and trigger events', function(assert) {
   const player = TestHelpers.makePlayer({ controls: false });
 
-  QUnit.ok(player.controls() === false, 'controls set through options');
+  assert.ok(player.controls() === false, 'controls set through options');
   const hasDisabledClass = player.el().className.indexOf('vjs-controls-disabled');
 
-  QUnit.ok(hasDisabledClass !== -1, 'Disabled class added to player');
+  assert.ok(hasDisabledClass !== -1, 'Disabled class added to player');
 
   player.controls(true);
-  QUnit.ok(player.controls() === true, 'controls updated');
+  assert.ok(player.controls() === true, 'controls updated');
   const hasEnabledClass = player.el().className.indexOf('vjs-controls-enabled');
 
-  QUnit.ok(hasEnabledClass !== -1, 'Disabled class added to player');
+  assert.ok(hasEnabledClass !== -1, 'Disabled class added to player');
 
   player.on('controlsenabled', function() {
-    QUnit.ok(true, 'enabled fired once');
+    assert.ok(true, 'enabled fired once');
   });
   player.on('controlsdisabled', function() {
-    QUnit.ok(true, 'disabled fired once');
+    assert.ok(true, 'disabled fired once');
   });
   player.controls(false);
 
   player.dispose();
 });
 
-QUnit.test('should toggle user the user state between active and inactive', function() {
+QUnit.test('should toggle user the user state between active and inactive', function(assert) {
   const player = TestHelpers.makePlayer({});
 
-  QUnit.expect(9);
+  assert.expect(9);
 
-  QUnit.ok(player.userActive(), 'User should be active at player init');
+  assert.ok(player.userActive(), 'User should be active at player init');
 
   player.on('userinactive', function() {
-    QUnit.ok(true, 'userinactive event triggered');
+    assert.ok(true, 'userinactive event triggered');
   });
 
   player.on('useractive', function() {
-    QUnit.ok(true, 'useractive event triggered');
+    assert.ok(true, 'useractive event triggered');
   });
 
   player.userActive(false);
-  QUnit.ok(player.userActive() === false, 'Player state changed to inactive');
-  QUnit.ok(player.el().className.indexOf('vjs-user-active') === -1, 'Active class removed');
-  QUnit.ok(player.el().className.indexOf('vjs-user-inactive') !== -1, 'Inactive class added');
+  assert.ok(player.userActive() === false, 'Player state changed to inactive');
+  assert.ok(player.el().className.indexOf('vjs-user-active') === -1, 'Active class removed');
+  assert.ok(player.el().className.indexOf('vjs-user-inactive') !== -1, 'Inactive class added');
 
   player.userActive(true);
-  QUnit.ok(player.userActive() === true, 'Player state changed to active');
-  QUnit.ok(player.el().className.indexOf('vjs-user-inactive') === -1, 'Inactive class removed');
-  QUnit.ok(player.el().className.indexOf('vjs-user-active') !== -1, 'Active class added');
+  assert.ok(player.userActive() === true, 'Player state changed to active');
+  assert.ok(player.el().className.indexOf('vjs-user-inactive') === -1, 'Inactive class removed');
+  assert.ok(player.el().className.indexOf('vjs-user-active') !== -1, 'Active class added');
 
   player.dispose();
 });
 
-QUnit.test('should add a touch-enabled classname when touch is supported', function() {
-  QUnit.expect(1);
+QUnit.test('should add a touch-enabled classname when touch is supported', function(assert) {
+  assert.expect(1);
 
   // Fake touch support. Real touch support isn't needed for this test.
   const origTouch = browser.TOUCH_ENABLED;
@@ -367,40 +367,40 @@ QUnit.test('should add a touch-enabled classname when touch is supported', funct
 
   const player = TestHelpers.makePlayer({});
 
-  QUnit.ok(player.el().className.indexOf('vjs-touch-enabled'), 'touch-enabled classname added');
+  assert.ok(player.el().className.indexOf('vjs-touch-enabled'), 'touch-enabled classname added');
 
   browser.TOUCH_ENABLED = origTouch;
   player.dispose();
 });
 
-QUnit.test('should allow for tracking when native controls are used', function() {
+QUnit.test('should allow for tracking when native controls are used', function(assert) {
   const player = TestHelpers.makePlayer({});
 
-  QUnit.expect(6);
+  assert.expect(6);
 
   // Make sure native controls is false before starting test
   player.usingNativeControls(false);
 
   player.on('usingnativecontrols', function() {
-    QUnit.ok(true, 'usingnativecontrols event triggered');
+    assert.ok(true, 'usingnativecontrols event triggered');
   });
 
   player.on('usingcustomcontrols', function() {
-    QUnit.ok(true, 'usingcustomcontrols event triggered');
+    assert.ok(true, 'usingcustomcontrols event triggered');
   });
 
   player.usingNativeControls(true);
-  QUnit.ok(player.usingNativeControls() === true, 'Using native controls is true');
-  QUnit.ok(player.el().className.indexOf('vjs-using-native-controls') !== -1, 'Native controls class added');
+  assert.ok(player.usingNativeControls() === true, 'Using native controls is true');
+  assert.ok(player.el().className.indexOf('vjs-using-native-controls') !== -1, 'Native controls class added');
 
   player.usingNativeControls(false);
-  QUnit.ok(player.usingNativeControls() === false, 'Using native controls is false');
-  QUnit.ok(player.el().className.indexOf('vjs-using-native-controls') === -1, 'Native controls class removed');
+  assert.ok(player.usingNativeControls() === false, 'Using native controls is false');
+  assert.ok(player.el().className.indexOf('vjs-using-native-controls') === -1, 'Native controls class removed');
 
   player.dispose();
 });
 
-QUnit.test('make sure that controls listeners do not get added too many times', function() {
+QUnit.test('make sure that controls listeners do not get added too many times', function(assert) {
   const player = TestHelpers.makePlayer({});
   let listeners = 0;
 
@@ -415,18 +415,18 @@ QUnit.test('make sure that controls listeners do not get added too many times', 
 
   player.controls(true);
 
-  QUnit.equal(listeners, 0, 'addTechControlsListeners_ should not have gotten called yet');
+  assert.equal(listeners, 0, 'addTechControlsListeners_ should not have gotten called yet');
 
   player.usingNativeControls(false);
   player.controls(false);
 
   player.controls(true);
-  QUnit.equal(listeners, 1, 'addTechControlsListeners_ should have gotten called once');
+  assert.equal(listeners, 1, 'addTechControlsListeners_ should have gotten called once');
 
   player.dispose();
 });
 
-QUnit.test('should select the proper tech based on the the sourceOrder option', function() {
+QUnit.test('should select the proper tech based on the the sourceOrder option', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
   const html =
         '<video id="example_1">' +
@@ -458,18 +458,18 @@ QUnit.test('should select the proper tech based on the the sourceOrder option', 
 
   let player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported'], sourceOrder: true });
 
-  QUnit.equal(player.techName_, 'PlaysUnsupported', 'selected the PlaysUnsupported tech when sourceOrder is truthy');
+  assert.equal(player.techName_, 'PlaysUnsupported', 'selected the PlaysUnsupported tech when sourceOrder is truthy');
   player.dispose();
 
   fixture.innerHTML += html;
   tag = document.getElementById('example_1');
 
   player = new Player(tag, { techOrder: ['techFaker', 'playsUnsupported']});
-  QUnit.equal(player.techName_, 'TechFaker', 'selected the TechFaker tech when sourceOrder is falsey');
+  assert.equal(player.techName_, 'TechFaker', 'selected the TechFaker tech when sourceOrder is falsey');
   player.dispose();
 });
 
-QUnit.test('should register players with generated ids', function() {
+QUnit.test('should register players with generated ids', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   const video = document.createElement('video');
@@ -480,17 +480,17 @@ QUnit.test('should register players with generated ids', function() {
   const player = new Player(video, { techOrder: ['techFaker'] });
   const id = player.el().id;
 
-  QUnit.equal(player.el().id, player.id(), 'the player and element ids are equal');
-  QUnit.ok(Player.players[id], 'the generated id is registered');
+  assert.equal(player.el().id, player.id(), 'the player and element ids are equal');
+  assert.ok(Player.players[id], 'the generated id is registered');
 });
 
-QUnit.test('should not add multiple first play events despite subsequent loads', function() {
-  QUnit.expect(1);
+QUnit.test('should not add multiple first play events despite subsequent loads', function(assert) {
+  assert.expect(1);
 
   const player = TestHelpers.makePlayer({});
 
   player.on('firstplay', function() {
-    QUnit.ok(true, 'First play should fire once.');
+    assert.ok(true, 'First play should fire once.');
   });
 
   // Checking to make sure onLoadStart removes first play listener before adding a new one.
@@ -499,7 +499,7 @@ QUnit.test('should not add multiple first play events despite subsequent loads',
   player.tech_.trigger('play');
 });
 
-QUnit.test('should fire firstplay after resetting the player', function() {
+QUnit.test('should fire firstplay after resetting the player', function(assert) {
   const player = TestHelpers.makePlayer({});
 
   let fpFired = false;
@@ -511,13 +511,13 @@ QUnit.test('should fire firstplay after resetting the player', function() {
   // init firstplay listeners
   player.tech_.trigger('loadstart');
   player.tech_.trigger('play');
-  QUnit.ok(fpFired, 'First firstplay fired');
+  assert.ok(fpFired, 'First firstplay fired');
 
   // reset the player
   player.tech_.trigger('loadstart');
   fpFired = false;
   player.tech_.trigger('play');
-  QUnit.ok(fpFired, 'Second firstplay fired');
+  assert.ok(fpFired, 'Second firstplay fired');
 
   // the play event can fire before the loadstart event.
   // in that case we still want the firstplay even to fire.
@@ -528,47 +528,47 @@ QUnit.test('should fire firstplay after resetting the player', function() {
   // reset the player
   player.tech_.trigger('loadstart');
   // player.tech_.trigger('play');
-  QUnit.ok(fpFired, 'Third firstplay fired');
+  assert.ok(fpFired, 'Third firstplay fired');
 });
 
-QUnit.test('should remove vjs-has-started class', function() {
-  QUnit.expect(3);
+QUnit.test('should remove vjs-has-started class', function(assert) {
+  assert.expect(3);
 
   const player = TestHelpers.makePlayer({});
 
   player.tech_.trigger('loadstart');
   player.tech_.trigger('play');
-  QUnit.ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added');
+  assert.ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added');
 
   player.tech_.trigger('loadstart');
-  QUnit.ok(player.el().className.indexOf('vjs-has-started') === -1, 'vjs-has-started class removed');
+  assert.ok(player.el().className.indexOf('vjs-has-started') === -1, 'vjs-has-started class removed');
 
   player.tech_.trigger('play');
-  QUnit.ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added again');
+  assert.ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added again');
 });
 
-QUnit.test('should add and remove vjs-ended class', function() {
-  QUnit.expect(4);
+QUnit.test('should add and remove vjs-ended class', function(assert) {
+  assert.expect(4);
 
   const player = TestHelpers.makePlayer({});
 
   player.tech_.trigger('loadstart');
   player.tech_.trigger('play');
   player.tech_.trigger('ended');
-  QUnit.ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class added');
+  assert.ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class added');
 
   player.tech_.trigger('play');
-  QUnit.ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
+  assert.ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
 
   player.tech_.trigger('ended');
-  QUnit.ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class re-added');
+  assert.ok(player.el().className.indexOf('vjs-ended') !== -1, 'vjs-ended class re-added');
 
   player.tech_.trigger('loadstart');
-  QUnit.ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
+  assert.ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
 });
 
-QUnit.test('player should handle different error types', function() {
-  QUnit.expect(8);
+QUnit.test('player should handle different error types', function(assert) {
+  assert.expect(8);
   const player = TestHelpers.makePlayer({});
   const testMsg = 'test message';
 
@@ -577,7 +577,7 @@ QUnit.test('player should handle different error types', function() {
 
   // error code supplied
   function errCode() {
-    QUnit.equal(player.error().code, 1, 'error code is correct');
+    assert.equal(player.error().code, 1, 'error code is correct');
   }
   player.on('error', errCode);
   player.error(1);
@@ -585,8 +585,8 @@ QUnit.test('player should handle different error types', function() {
 
   // error instance supplied
   function errInst() {
-    QUnit.equal(player.error().code, 2, 'MediaError code is correct');
-    QUnit.equal(player.error().message, testMsg, 'MediaError message is correct');
+    assert.equal(player.error().code, 2, 'MediaError code is correct');
+    assert.equal(player.error().message, testMsg, 'MediaError message is correct');
   }
   player.on('error', errInst);
   player.error(new MediaError({ code: 2, message: testMsg }));
@@ -594,8 +594,8 @@ QUnit.test('player should handle different error types', function() {
 
   // error message supplied
   function errMsg() {
-    QUnit.equal(player.error().code, 0, 'error message code is correct');
-    QUnit.equal(player.error().message, testMsg, 'error message is correct');
+    assert.equal(player.error().code, 0, 'error message code is correct');
+    assert.equal(player.error().message, testMsg, 'error message is correct');
   }
   player.on('error', errMsg);
   player.error(testMsg);
@@ -603,21 +603,21 @@ QUnit.test('player should handle different error types', function() {
 
   // error config supplied
   function errConfig() {
-    QUnit.equal(player.error().code, 3, 'error config code is correct');
-    QUnit.equal(player.error().message, testMsg, 'error config message is correct');
+    assert.equal(player.error().code, 3, 'error config code is correct');
+    assert.equal(player.error().message, testMsg, 'error config message is correct');
   }
   player.on('error', errConfig);
   player.error({ code: 3, message: testMsg });
   player.off('error', errConfig);
 
   // check for vjs-error classname
-  QUnit.ok(player.el().className.indexOf('vjs-error') >= 0, 'player does not have vjs-error classname');
+  assert.ok(player.el().className.indexOf('vjs-error') >= 0, 'player does not have vjs-error classname');
 
   // restore error logging
   log.error.restore();
 });
 
-QUnit.test('Data attributes on the video element should persist in the new wrapper element', function() {
+QUnit.test('Data attributes on the video element should persist in the new wrapper element', function(assert) {
   const dataId = 123;
 
   const tag = TestHelpers.makeTag();
@@ -626,10 +626,10 @@ QUnit.test('Data attributes on the video element should persist in the new wrapp
 
   const player = TestHelpers.makePlayer({}, tag);
 
-  QUnit.equal(player.el().getAttribute('data-id'), dataId, 'data-id should be available on the new player element after creation');
+  assert.equal(player.el().getAttribute('data-id'), dataId, 'data-id should be available on the new player element after creation');
 });
 
-QUnit.test('should restore attributes from the original video tag when creating a new element', function() {
+QUnit.test('should restore attributes from the original video tag when creating a new element', function(assert) {
   // simulate attributes stored from the original tag
   const tag = Dom.createEl('video');
 
@@ -645,27 +645,27 @@ QUnit.test('should restore attributes from the original video tag when creating 
   // create the element
   const el = Html5.prototype.createEl.call(html5Mock);
 
-  QUnit.equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
-  QUnit.equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
-  QUnit.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
+  assert.equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
+  assert.equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
+  assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
 });
 
-QUnit.test('should honor default inactivity timeout', function() {
+QUnit.test('should honor default inactivity timeout', function(assert) {
   const clock = sinon.useFakeTimers();
 
   // default timeout is 2000ms
   const player = TestHelpers.makePlayer({});
 
-  QUnit.equal(player.userActive(), true, 'User is active on creation');
+  assert.equal(player.userActive(), true, 'User is active on creation');
   clock.tick(1800);
-  QUnit.equal(player.userActive(), true, 'User is still active');
+  assert.equal(player.userActive(), true, 'User is still active');
   clock.tick(500);
-  QUnit.equal(player.userActive(), false, 'User is inactive after timeout expired');
+  assert.equal(player.userActive(), false, 'User is inactive after timeout expired');
 
   clock.restore();
 });
 
-QUnit.test('should honor configured inactivity timeout', function() {
+QUnit.test('should honor configured inactivity timeout', function(assert) {
   const clock = sinon.useFakeTimers();
 
   // default timeout is 2000ms, set to shorter 200ms
@@ -673,17 +673,17 @@ QUnit.test('should honor configured inactivity timeout', function() {
     inactivityTimeout: 200
   });
 
-  QUnit.equal(player.userActive(), true, 'User is active on creation');
+  assert.equal(player.userActive(), true, 'User is active on creation');
   clock.tick(150);
-  QUnit.equal(player.userActive(), true, 'User is still active');
+  assert.equal(player.userActive(), true, 'User is still active');
   clock.tick(350);
   // make sure user is now inactive after 500ms
-  QUnit.equal(player.userActive(), false, 'User is inactive after timeout expired');
+  assert.equal(player.userActive(), false, 'User is inactive after timeout expired');
 
   clock.restore();
 });
 
-QUnit.test('should honor disabled inactivity timeout', function() {
+QUnit.test('should honor disabled inactivity timeout', function(assert) {
   const clock = sinon.useFakeTimers();
 
   // default timeout is 2000ms, disable by setting to zero
@@ -691,14 +691,14 @@ QUnit.test('should honor disabled inactivity timeout', function() {
     inactivityTimeout: 0
   });
 
-  QUnit.equal(player.userActive(), true, 'User is active on creation');
+  assert.equal(player.userActive(), true, 'User is active on creation');
   clock.tick(5000);
-  QUnit.equal(player.userActive(), true, 'User is still active');
+  assert.equal(player.userActive(), true, 'User is still active');
 
   clock.restore();
 });
 
-QUnit.test('should clear pending errors on disposal', function() {
+QUnit.test('should clear pending errors on disposal', function(assert) {
   const clock = sinon.useFakeTimers();
 
   const player = TestHelpers.makePlayer();
@@ -711,12 +711,12 @@ QUnit.test('should clear pending errors on disposal', function() {
   try {
     clock.tick(5000);
   } catch (e) {
-    return QUnit.ok(!e, 'threw an error: ' + e.message);
+    return assert.ok(!e, 'threw an error: ' + e.message);
   }
-  QUnit.ok(true, 'did not throw an error after disposal');
+  assert.ok(true, 'did not throw an error after disposal');
 });
 
-QUnit.test('pause is called when player ended event is fired and player is not paused', function() {
+QUnit.test('pause is called when player ended event is fired and player is not paused', function(assert) {
   const video = document.createElement('video');
   const player = TestHelpers.makePlayer({}, video);
   let pauses = 0;
@@ -728,10 +728,10 @@ QUnit.test('pause is called when player ended event is fired and player is not p
     pauses++;
   };
   player.tech_.trigger('ended');
-  QUnit.equal(pauses, 1, 'pause was called');
+  assert.equal(pauses, 1, 'pause was called');
 });
 
-QUnit.test('pause is not called if the player is paused and ended is fired', function() {
+QUnit.test('pause is not called if the player is paused and ended is fired', function(assert) {
   const video = document.createElement('video');
   const player = TestHelpers.makePlayer({}, video);
   let pauses = 0;
@@ -743,62 +743,62 @@ QUnit.test('pause is not called if the player is paused and ended is fired', fun
     pauses++;
   };
   player.tech_.trigger('ended');
-  QUnit.equal(pauses, 0, 'pause was not called when ended fired');
+  assert.equal(pauses, 0, 'pause was not called when ended fired');
 });
 
-QUnit.test('should add an audio class if an audio el is used', function() {
+QUnit.test('should add an audio class if an audio el is used', function(assert) {
   const audio = document.createElement('audio');
   const player = TestHelpers.makePlayer({}, audio);
   const audioClass = 'vjs-audio';
 
-  QUnit.ok(player.el().className.indexOf(audioClass) !== -1, 'added ' + audioClass + ' css class');
+  assert.ok(player.el().className.indexOf(audioClass) !== -1, 'added ' + audioClass + ' css class');
 });
 
-QUnit.test('should add a video player region if a video el is used', function() {
+QUnit.test('should add a video player region if a video el is used', function(assert) {
   const video = document.createElement('video');
   const player = TestHelpers.makePlayer({}, video);
 
-  QUnit.ok(player.el().getAttribute('role') === 'region', 'region role is present');
-  QUnit.ok(player.el().getAttribute('aria-label') === 'video player', 'video player label present');
+  assert.ok(player.el().getAttribute('role') === 'region', 'region role is present');
+  assert.ok(player.el().getAttribute('aria-label') === 'video player', 'video player label present');
 });
 
-QUnit.test('should add an audio player region if an audio el is used', function() {
+QUnit.test('should add an audio player region if an audio el is used', function(assert) {
   const audio = document.createElement('audio');
   const player = TestHelpers.makePlayer({}, audio);
 
-  QUnit.ok(player.el().getAttribute('role') === 'region', 'region role is present');
-  QUnit.ok(player.el().getAttribute('aria-label') === 'audio player', 'audio player label present');
+  assert.ok(player.el().getAttribute('role') === 'region', 'region role is present');
+  assert.ok(player.el().getAttribute('aria-label') === 'audio player', 'audio player label present');
 });
 
-QUnit.test('should not be scrubbing while not seeking', function() {
+QUnit.test('should not be scrubbing while not seeking', function(assert) {
   const player = TestHelpers.makePlayer();
 
-  QUnit.equal(player.scrubbing(), false, 'player is not scrubbing');
-  QUnit.ok(player.el().className.indexOf('scrubbing') === -1, 'scrubbing class is not present');
+  assert.equal(player.scrubbing(), false, 'player is not scrubbing');
+  assert.ok(player.el().className.indexOf('scrubbing') === -1, 'scrubbing class is not present');
   player.scrubbing(false);
-  QUnit.equal(player.scrubbing(), false, 'player is not scrubbing');
+  assert.equal(player.scrubbing(), false, 'player is not scrubbing');
 });
 
-QUnit.test('should be scrubbing while seeking', function() {
+QUnit.test('should be scrubbing while seeking', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.scrubbing(true);
-  QUnit.equal(player.scrubbing(), true, 'player is scrubbing');
-  QUnit.ok(player.el().className.indexOf('scrubbing') !== -1, 'scrubbing class is present');
+  assert.equal(player.scrubbing(), true, 'player is scrubbing');
+  assert.ok(player.el().className.indexOf('scrubbing') !== -1, 'scrubbing class is present');
 });
 
-QUnit.test('should throw on startup no techs are specified', function() {
+QUnit.test('should throw on startup no techs are specified', function(assert) {
   const techOrder = videojs.options.techOrder;
 
   videojs.options.techOrder = null;
-  QUnit.throws(function() {
+  assert.throws(function() {
     videojs(TestHelpers.makeTag());
   }, 'a falsey techOrder should throw');
 
   videojs.options.techOrder = techOrder;
 });
 
-QUnit.test('should have a sensible toJSON that is equivalent to player.options', function() {
+QUnit.test('should have a sensible toJSON that is equivalent to player.options', function(assert) {
   const playerOptions = {
     html5: {
       nativeTextTracks: false
@@ -807,7 +807,7 @@ QUnit.test('should have a sensible toJSON that is equivalent to player.options',
 
   const player = TestHelpers.makePlayer(playerOptions);
 
-  QUnit.deepEqual(player.toJSON(), player.options_, 'simple player options toJSON produces output equivalent to player.options_');
+  assert.deepEqual(player.toJSON(), player.options_, 'simple player options toJSON produces output equivalent to player.options_');
 
   const playerOptions2 = {
     tracks: [{
@@ -826,11 +826,11 @@ QUnit.test('should have a sensible toJSON that is equivalent to player.options',
 
   popts.tracks[0].player = undefined;
 
-  QUnit.deepEqual(player2.toJSON(), popts, 'no circular references');
+  assert.deepEqual(player2.toJSON(), popts, 'no circular references');
 });
 
-QUnit.test('should ignore case in language codes and try primary code', function() {
-  QUnit.expect(3);
+QUnit.test('should ignore case in language codes and try primary code', function(assert) {
+  assert.expect(3);
 
   const player = TestHelpers.makePlayer({
     languages: {
@@ -845,20 +845,20 @@ QUnit.test('should ignore case in language codes and try primary code', function
   });
 
   player.language('en-gb');
-  QUnit.strictEqual(player.localize('Good'), 'Brilliant', 'Used subcode specific localisation');
-  QUnit.strictEqual(player.localize('Error'), 'Problem', 'Used primary code localisation');
+  assert.strictEqual(player.localize('Good'), 'Brilliant', 'Used subcode specific localisation');
+  assert.strictEqual(player.localize('Error'), 'Problem', 'Used primary code localisation');
   player.language('en-GB');
-  QUnit.strictEqual(player.localize('Good'), 'Brilliant', 'Ignored case');
+  assert.strictEqual(player.localize('Good'), 'Brilliant', 'Ignored case');
 });
 
-QUnit.test('inherits language from parent element', function() {
+QUnit.test('inherits language from parent element', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
   const oldLang = fixture.getAttribute('lang');
 
   fixture.setAttribute('lang', 'x-test');
   const player = TestHelpers.makePlayer();
 
-  QUnit.equal(player.language(), 'x-test', 'player inherits parent element language');
+  assert.equal(player.language(), 'x-test', 'player inherits parent element language');
 
   player.dispose();
   if (oldLang) {
@@ -868,67 +868,67 @@ QUnit.test('inherits language from parent element', function() {
   }
 });
 
-QUnit.test('should return correct values for canPlayType', function() {
+QUnit.test('should return correct values for canPlayType', function(assert) {
   const player = TestHelpers.makePlayer();
 
-  QUnit.equal(player.canPlayType('video/mp4'), 'maybe', 'player can play mp4 files');
-  QUnit.equal(player.canPlayType('video/unsupported-format'), '', 'player can not play unsupported files');
+  assert.equal(player.canPlayType('video/mp4'), 'maybe', 'player can play mp4 files');
+  assert.equal(player.canPlayType('video/unsupported-format'), '', 'player can not play unsupported files');
 
   player.dispose();
 });
 
-QUnit.test('createModal()', function() {
+QUnit.test('createModal()', function(assert) {
   const player = TestHelpers.makePlayer();
   const modal = player.createModal('foo');
   const spy = sinon.spy();
 
   modal.on('dispose', spy);
 
-  QUnit.expect(5);
-  QUnit.strictEqual(modal.el().parentNode, player.el(), 'the modal is injected into the player');
-  QUnit.strictEqual(modal.content(), 'foo', 'content is set properly');
-  QUnit.ok(modal.opened(), 'modal is opened by default');
+  assert.expect(5);
+  assert.strictEqual(modal.el().parentNode, player.el(), 'the modal is injected into the player');
+  assert.strictEqual(modal.content(), 'foo', 'content is set properly');
+  assert.ok(modal.opened(), 'modal is opened by default');
   modal.close();
-  QUnit.ok(spy.called, 'modal was disposed when closed');
-  QUnit.strictEqual(player.children().indexOf(modal), -1, 'modal was removed from player\'s children');
+  assert.ok(spy.called, 'modal was disposed when closed');
+  assert.strictEqual(player.children().indexOf(modal), -1, 'modal was removed from player\'s children');
 });
 
-QUnit.test('createModal() options object', function() {
+QUnit.test('createModal() options object', function(assert) {
   const player = TestHelpers.makePlayer();
   const modal = player.createModal('foo', {content: 'bar', label: 'boo'});
 
-  QUnit.expect(2);
-  QUnit.strictEqual(modal.content(), 'foo', 'content argument takes precedence');
-  QUnit.strictEqual(modal.options_.label, 'boo', 'modal options are set properly');
+  assert.expect(2);
+  assert.strictEqual(modal.content(), 'foo', 'content argument takes precedence');
+  assert.strictEqual(modal.options_.label, 'boo', 'modal options are set properly');
   modal.close();
 });
 
-QUnit.test('you can clear error in the error event', function() {
+QUnit.test('you can clear error in the error event', function(assert) {
   const player = TestHelpers.makePlayer();
 
   sinon.stub(log, 'error');
 
   player.error({code: 4});
-  QUnit.ok(player.error(), 'we have an error');
+  assert.ok(player.error(), 'we have an error');
   player.error(null);
 
   player.one('error', function() {
     player.error(null);
   });
   player.error({code: 4});
-  QUnit.ok(!player.error(), 'we no longer have an error');
+  assert.ok(!player.error(), 'we no longer have an error');
 
   log.error.restore();
 });
 
-QUnit.test('Player#tech will return tech given the appropriate input', function() {
+QUnit.test('Player#tech will return tech given the appropriate input', function(assert) {
   const tech_ = {};
   const returnedTech = Player.prototype.tech.call({tech_}, {IWillNotUseThisInPlugins: true});
 
-  QUnit.equal(returnedTech, tech_, 'We got back the tech we wanted');
+  assert.equal(returnedTech, tech_, 'We got back the tech we wanted');
 });
 
-QUnit.test('Player#tech alerts and throws without the appropriate input', function() {
+QUnit.test('Player#tech alerts and throws without the appropriate input', function(assert) {
   let alertCalled;
   const oldAlert = window.alert;
 
@@ -938,16 +938,16 @@ QUnit.test('Player#tech alerts and throws without the appropriate input', functi
 
   const tech_ = {};
 
-  throws(function() {
+  assert.throws(function() {
     Player.prototype.tech.call({tech_});
   }, new RegExp('https://github.com/videojs/video.js/issues/2617'),
   'we threw an error');
 
-  QUnit.ok(alertCalled, 'we called an alert');
+  assert.ok(alertCalled, 'we called an alert');
   window.alert = oldAlert;
 });
 
-QUnit.test('player#reset loads the Html5 tech and then techCalls reset', function() {
+QUnit.test('player#reset loads the Html5 tech and then techCalls reset', function(assert) {
   let loadedTech;
   let loadedSource;
   let techCallMethod;
@@ -967,12 +967,12 @@ QUnit.test('player#reset loads the Html5 tech and then techCalls reset', functio
 
   Player.prototype.reset.call(testPlayer);
 
-  QUnit.equal(loadedTech, 'Html5', 'we loaded the html5 tech');
-  QUnit.equal(loadedSource, null, 'with a null source');
-  QUnit.equal(techCallMethod, 'reset', 'we then reset the tech');
+  assert.equal(loadedTech, 'Html5', 'we loaded the html5 tech');
+  assert.equal(loadedSource, null, 'with a null source');
+  assert.equal(techCallMethod, 'reset', 'we then reset the tech');
 });
 
-QUnit.test('player#reset loads the first item in the techOrder and then techCalls reset', function() {
+QUnit.test('player#reset loads the first item in the techOrder and then techCalls reset', function(assert) {
   let loadedTech;
   let loadedSource;
   let techCallMethod;
@@ -992,21 +992,21 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
 
   Player.prototype.reset.call(testPlayer);
 
-  QUnit.equal(loadedTech, 'Flash', 'we loaded the Flash tech');
-  QUnit.equal(loadedSource, null, 'with a null source');
-  QUnit.equal(techCallMethod, 'reset', 'we then reset the tech');
+  assert.equal(loadedTech, 'Flash', 'we loaded the Flash tech');
+  assert.equal(loadedSource, null, 'with a null source');
+  assert.equal(techCallMethod, 'reset', 'we then reset the tech');
 });
 
-QUnit.test('Remove waiting class on timeupdate after tech waiting', function() {
+QUnit.test('Remove waiting class on timeupdate after tech waiting', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.tech_.trigger('waiting');
-  QUnit.ok(/vjs-waiting/.test(player.el().className), 'vjs-waiting is added to the player el on tech waiting');
+  assert.ok(/vjs-waiting/.test(player.el().className), 'vjs-waiting is added to the player el on tech waiting');
   player.trigger('timeupdate');
-  QUnit.ok(!(/vjs-waiting/).test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
+  assert.ok(!(/vjs-waiting/).test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
 });
 
-QUnit.test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE option', function() {
+QUnit.test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE option', function(assert) {
   // clear the HEAD before running this test
   let styles = document.querySelectorAll('style');
   let i = styles.length;
@@ -1027,17 +1027,17 @@ QUnit.test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE 
   TestHelpers.makePlayer({}, tag);
 
   styles = document.querySelectorAll('style');
-  QUnit.equal(styles.length, 0, 'we should not get any style elements included in the DOM');
+  assert.equal(styles.length, 0, 'we should not get any style elements included in the DOM');
 
   window.VIDEOJS_NO_DYNAMIC_STYLE = false;
   tag = TestHelpers.makeTag();
   TestHelpers.makePlayer({}, tag);
   styles = document.querySelectorAll('style');
-  QUnit.equal(styles.length, 1, 'we should have one style element in the DOM');
-  QUnit.equal(styles[0].className, 'vjs-styles-dimensions', 'the class name is the one we expected');
+  assert.equal(styles.length, 1, 'we should have one style element in the DOM');
+  assert.equal(styles[0].className, 'vjs-styles-dimensions', 'the class name is the one we expected');
 });
 
-QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the tech el', function() {
+QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the tech el', function(assert) {
   // clear the HEAD before running this test
   const styles = document.querySelectorAll('style');
   let i = styles.length;
@@ -1059,11 +1059,11 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
 
   player.width(300);
   player.height(600);
-  QUnit.equal(player.tech_.el().width, 300, 'the width is equal to 300');
-  QUnit.equal(player.tech_.el().height, 600, 'the height is equal 600');
+  assert.equal(player.tech_.el().width, 300, 'the width is equal to 300');
+  assert.equal(player.tech_.el().height, 600, 'the height is equal 600');
 
   player.width(600);
   player.height(300);
-  QUnit.equal(player.tech_.el().width, 600, 'the width is equal to 600');
-  QUnit.equal(player.tech_.el().height, 300, 'the height is equal 300');
+  assert.equal(player.tech_.el().width, 600, 'the width is equal to 600');
+  assert.equal(player.tech_.el().height, 300, 'the height is equal 300');
 });

--- a/test/unit/plugins.test.js
+++ b/test/unit/plugins.test.js
@@ -8,16 +8,16 @@ import sinon from 'sinon';
 
 QUnit.module('Plugins');
 
-QUnit.test('Plugin should get initialized and receive options', function() {
-  QUnit.expect(2);
+QUnit.test('Plugin should get initialized and receive options', function(assert) {
+  assert.expect(2);
 
   registerPlugin('myPlugin1', function(options) {
-    QUnit.ok(true, 'Plugin initialized');
-    QUnit.ok(options.test, 'Option passed through');
+    assert.ok(true, 'Plugin initialized');
+    assert.ok(options.test, 'Option passed through');
   });
 
   registerPlugin('myPlugin2', function(options) {
-    QUnit.ok(false, 'Plugin initialized and should not have been');
+    assert.ok(false, 'Plugin initialized and should not have been');
   });
 
   const player = TestHelpers.makePlayer({
@@ -31,17 +31,17 @@ QUnit.test('Plugin should get initialized and receive options', function() {
   player.dispose();
 });
 
-QUnit.test('Plugin should have the option of being initilized outside of player init', function() {
-  QUnit.expect(3);
+QUnit.test('Plugin should have the option of being initilized outside of player init', function(assert) {
+  assert.expect(3);
 
   registerPlugin('myPlugin3', function(options) {
-    QUnit.ok(true, 'Plugin initialized after player init');
-    QUnit.ok(options.test, 'Option passed through');
+    assert.ok(true, 'Plugin initialized after player init');
+    assert.ok(options.test, 'Option passed through');
   });
 
   const player = TestHelpers.makePlayer({});
 
-  QUnit.ok(player.myPlugin3, 'Plugin has direct access on player instance');
+  assert.ok(player.myPlugin3, 'Plugin has direct access on player instance');
 
   player.myPlugin3({
     test: true
@@ -50,11 +50,11 @@ QUnit.test('Plugin should have the option of being initilized outside of player 
   player.dispose();
 });
 
-QUnit.test('Plugin should be able to add a UI component', function() {
-  QUnit.expect(2);
+QUnit.test('Plugin should be able to add a UI component', function(assert) {
+  assert.expect(2);
 
   registerPlugin('myPlugin4', function(options) {
-    QUnit.ok((this instanceof Player), 'Plugin executed in player scope by default');
+    assert.ok((this instanceof Player), 'Plugin executed in player scope by default');
     this.addChild('component');
   });
 
@@ -66,12 +66,12 @@ QUnit.test('Plugin should be able to add a UI component', function() {
 
   const comp = player.getChild('component');
 
-  QUnit.ok(comp, 'Plugin added a component to the player');
+  assert.ok(comp, 'Plugin added a component to the player');
 
   player.dispose();
 });
 
-QUnit.test('Plugin should overwrite plugin of same name', function() {
+QUnit.test('Plugin should overwrite plugin of same name', function(assert) {
   let v1Called = 0;
   let v2Called = 0;
   let v3Called = 0;
@@ -98,15 +98,15 @@ QUnit.test('Plugin should overwrite plugin of same name', function() {
   });
   player2.myPlugin5({});
 
-  QUnit.ok(v1Called === 1, 'First version of plugin called once');
-  QUnit.ok(v2Called === 1, 'Plugin overwritten for new player');
-  QUnit.ok(v3Called === 1, 'Plugin overwritten for existing player');
+  assert.ok(v1Called === 1, 'First version of plugin called once');
+  assert.ok(v2Called === 1, 'Plugin overwritten for new player');
+  assert.ok(v3Called === 1, 'Plugin overwritten for existing player');
 
   player.dispose();
   player2.dispose();
 });
 
-QUnit.test('Plugins should get events in registration order', function() {
+QUnit.test('Plugins should get events in registration order', function(assert) {
   const order = [];
   const expectedOrder = [];
   const pluginName = 'orderPlugin';
@@ -133,13 +133,13 @@ QUnit.test('Plugins should get events in registration order', function() {
 
   player.testerPlugin({});
 
-  QUnit.deepEqual(order,
+  assert.deepEqual(order,
             expectedOrder,
             'plugins should receive events in order of initialization');
   player.dispose();
 });
 
-QUnit.test('Plugins should not get events after stopImmediatePropagation is called', function() {
+QUnit.test('Plugins should not get events after stopImmediatePropagation is called', function(assert) {
   const order = [];
   const expectedOrder = [];
   const pluginName = 'orderPlugin';
@@ -167,16 +167,16 @@ QUnit.test('Plugins should not get events after stopImmediatePropagation is call
 
   player.testerPlugin({});
 
-  QUnit.deepEqual(order,
+  assert.deepEqual(order,
             expectedOrder.slice(0, order.length),
             'plugins should receive events in order of ' +
             'initialization, until stopImmediatePropagation');
 
-  QUnit.equal(order.length, 1, 'only one event listener should have triggered');
+  assert.equal(order.length, 1, 'only one event listener should have triggered');
   player.dispose();
 });
 
-QUnit.test('Plugin that does not exist logs an error', function() {
+QUnit.test('Plugin that does not exist logs an error', function(assert) {
 
   // stub the global log functions
   const console = window.console = {
@@ -197,14 +197,14 @@ QUnit.test('Plugin that does not exist logs an error', function() {
     }
   });
 
-  QUnit.ok(error.called, 'error was called');
+  assert.ok(error.called, 'error was called');
 
   if (IE_VERSION && IE_VERSION < 11) {
-    QUnit.equal(error.firstCall.args[0],
+    assert.equal(error.firstCall.args[0],
                 'VIDEOJS: ERROR: Unable to find plugin: nonExistingPlugin');
   } else {
-    QUnit.equal(error.firstCall.args[2], 'Unable to find plugin:');
-    QUnit.equal(error.firstCall.args[3], 'nonExistingPlugin');
+    assert.equal(error.firstCall.args[2], 'Unable to find plugin:');
+    assert.equal(error.firstCall.args[3], 'nonExistingPlugin');
   }
 
   // tear down logging stubs

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -5,7 +5,7 @@ import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 
 QUnit.module('PosterImage', {
-  setup() {
+  beforeEach() {
     // Store the original background support so we can test different vals
     this.origVal = browser.BACKGROUND_SIZE_SUPPORTED;
     this.poster1 = '#poster1';
@@ -26,64 +26,64 @@ QUnit.module('PosterImage', {
       }
     };
   },
-  teardown() {
+  afterEach() {
     browser.BACKGROUND_SIZE_SUPPORTED = this.origVal;
   }
 });
 
-QUnit.test('should create and update a poster image', function() {
+QUnit.test('should create and update a poster image', function(assert) {
   browser.BACKGROUND_SIZE_SUPPORTED = true;
 
   const posterImage = new PosterImage(this.mockPlayer);
   let backgroundImage = posterImage.el().style.backgroundImage;
 
-  QUnit.notEqual(backgroundImage.indexOf(this.poster1), -1, 'Background image used');
+  assert.notEqual(backgroundImage.indexOf(this.poster1), -1, 'Background image used');
 
   // Update with a new poster source and check the new value
   this.mockPlayer.poster_ = this.poster2;
   this.mockPlayer.trigger('posterchange');
   backgroundImage = posterImage.el().style.backgroundImage;
-  QUnit.notEqual(backgroundImage.indexOf(this.poster2), -1, 'Background image updated');
+  assert.notEqual(backgroundImage.indexOf(this.poster2), -1, 'Background image updated');
 });
 
-QUnit.test('should create and update a fallback image in older browsers', function() {
+QUnit.test('should create and update a fallback image in older browsers', function(assert) {
   browser.BACKGROUND_SIZE_SUPPORTED = false;
 
   const posterImage = new PosterImage(this.mockPlayer);
 
-  QUnit.notEqual(posterImage.fallbackImg_.src.indexOf(this.poster1),
+  assert.notEqual(posterImage.fallbackImg_.src.indexOf(this.poster1),
                  -1,
                  'Fallback image created');
 
   // Update with a new poster source and check the new value
   this.mockPlayer.poster_ = this.poster2;
   this.mockPlayer.trigger('posterchange');
-  QUnit.notEqual(posterImage.fallbackImg_.src.indexOf(this.poster2),
+  assert.notEqual(posterImage.fallbackImg_.src.indexOf(this.poster2),
                  -1,
                  'Fallback image updated');
 });
 
-QUnit.test('should remove itself from the document flow when there is no poster', function() {
+QUnit.test('should remove itself from the document flow when there is no poster', function(assert) {
   const posterImage = new PosterImage(this.mockPlayer);
 
-  QUnit.equal(posterImage.el().style.display, '', 'Poster image shows by default');
+  assert.equal(posterImage.el().style.display, '', 'Poster image shows by default');
 
   // Update with an empty string
   this.mockPlayer.poster_ = '';
   this.mockPlayer.trigger('posterchange');
-  QUnit.equal(posterImage.hasClass('vjs-hidden'),
+  assert.equal(posterImage.hasClass('vjs-hidden'),
               true,
               'Poster image hides with an empty source');
 
   // Updated with a valid source
   this.mockPlayer.poster_ = this.poster2;
   this.mockPlayer.trigger('posterchange');
-  QUnit.equal(posterImage.hasClass('vjs-hidden'),
+  assert.equal(posterImage.hasClass('vjs-hidden'),
               false,
               'Poster image shows again when there is a source');
 });
 
-QUnit.test('should hide the poster in the appropriate player states', function() {
+QUnit.test('should hide the poster in the appropriate player states', function(assert) {
   const posterImage = new PosterImage(this.mockPlayer);
   const playerDiv = document.createElement('div');
   const fixture = document.getElementById('qunit-fixture');
@@ -98,12 +98,12 @@ QUnit.test('should hide the poster in the appropriate player states', function()
   fixture.appendChild(playerDiv);
 
   playerDiv.className = 'video-js vjs-has-started';
-  QUnit.equal(TestHelpers.getComputedStyle(el, 'display'),
+  assert.equal(TestHelpers.getComputedStyle(el, 'display'),
               'none',
               'The poster hides when the video has started (CSS may not be loaded)');
 
   playerDiv.className = 'video-js vjs-has-started vjs-audio';
-  QUnit.equal(TestHelpers.getComputedStyle(el, 'display'),
+  assert.equal(TestHelpers.getComputedStyle(el, 'display'),
               'block',
               'The poster continues to show when playing audio');
 });

--- a/test/unit/setup.test.js
+++ b/test/unit/setup.test.js
@@ -3,7 +3,7 @@ import TestHelpers from './test-helpers.js';
 
 QUnit.module('Setup');
 
-QUnit.test('should set options from data-setup even if autoSetup is not called before initialisation', function() {
+QUnit.test('should set options from data-setup even if autoSetup is not called before initialisation', function(assert) {
   const el = TestHelpers.makeTag();
 
   el.setAttribute('data-setup',
@@ -11,7 +11,7 @@ QUnit.test('should set options from data-setup even if autoSetup is not called b
 
   const player = TestHelpers.makePlayer({}, el);
 
-  QUnit.ok(player.options_.controls === true);
-  QUnit.ok(player.options_.autoplay === false);
-  QUnit.ok(player.options_.preload === 'auto');
+  assert.ok(player.options_.controls === true);
+  assert.ok(player.options_.autoplay === false);
+  assert.ok(player.options_.preload === 'auto');
 });

--- a/test/unit/tech/flash-rtmp.test.js
+++ b/test/unit/tech/flash-rtmp.test.js
@@ -9,50 +9,50 @@ const streamToPartsAndBack = function(url) {
   return Flash.streamFromParts(parts.connection, parts.stream);
 };
 
-QUnit.test('test using both streamToParts and streamFromParts', function() {
-  QUnit.ok(streamToPartsAndBack('rtmp://myurl.com/isthis') === 'rtmp://myurl.com/&isthis');
-  QUnit.ok(streamToPartsAndBack('rtmp://myurl.com/&isthis') === 'rtmp://myurl.com/&isthis');
-  QUnit.ok(streamToPartsAndBack('rtmp://myurl.com/isthis/andthis') === 'rtmp://myurl.com/isthis/&andthis');
+QUnit.test('test using both streamToParts and streamFromParts', function(assert) {
+  assert.ok(streamToPartsAndBack('rtmp://myurl.com/isthis') === 'rtmp://myurl.com/&isthis');
+  assert.ok(streamToPartsAndBack('rtmp://myurl.com/&isthis') === 'rtmp://myurl.com/&isthis');
+  assert.ok(streamToPartsAndBack('rtmp://myurl.com/isthis/andthis') === 'rtmp://myurl.com/isthis/&andthis');
 });
 
-QUnit.test('test streamToParts', function() {
+QUnit.test('test streamToParts', function(assert) {
   let parts = Flash.streamToParts('http://myurl.com/streaming&/is/fun');
 
-  QUnit.ok(parts.connection === 'http://myurl.com/streaming');
-  QUnit.ok(parts.stream === '/is/fun');
+  assert.ok(parts.connection === 'http://myurl.com/streaming');
+  assert.ok(parts.stream === '/is/fun');
 
   parts = Flash.streamToParts('http://myurl.com/&streaming&/is/fun');
-  QUnit.ok(parts.connection === 'http://myurl.com/');
-  QUnit.ok(parts.stream === 'streaming&/is/fun');
+  assert.ok(parts.connection === 'http://myurl.com/');
+  assert.ok(parts.stream === 'streaming&/is/fun');
 
   parts = Flash.streamToParts('http://myurl.com/really?streaming=fun&really=fun');
-  QUnit.ok(parts.connection === 'http://myurl.com/');
-  QUnit.ok(parts.stream === 'really?streaming=fun&really=fun');
+  assert.ok(parts.connection === 'http://myurl.com/');
+  assert.ok(parts.stream === 'really?streaming=fun&really=fun');
 
   parts = Flash.streamToParts('http://myurl.com/streaming/is/fun');
-  QUnit.ok(parts.connection === 'http://myurl.com/streaming/is/');
-  QUnit.ok(parts.stream === 'fun');
+  assert.ok(parts.connection === 'http://myurl.com/streaming/is/');
+  assert.ok(parts.stream === 'fun');
 
   parts = Flash.streamToParts('whatisgoingonhere');
-  QUnit.ok(parts.connection === 'whatisgoingonhere');
-  QUnit.ok(parts.stream === '');
+  assert.ok(parts.connection === 'whatisgoingonhere');
+  assert.ok(parts.stream === '');
 
   parts = Flash.streamToParts();
-  QUnit.ok(parts.connection === '');
-  QUnit.ok(parts.stream === '');
+  assert.ok(parts.connection === '');
+  assert.ok(parts.stream === '');
 });
 
-QUnit.test('test isStreamingSrc', function() {
+QUnit.test('test isStreamingSrc', function(assert) {
   const isStreamingSrc = Flash.isStreamingSrc;
 
-  QUnit.ok(isStreamingSrc('rtmp://streaming.is/fun'));
-  QUnit.ok(isStreamingSrc('rtmps://streaming.is/fun'));
-  QUnit.ok(isStreamingSrc('rtmpe://streaming.is/fun'));
-  QUnit.ok(isStreamingSrc('rtmpt://streaming.is/fun'));
+  assert.ok(isStreamingSrc('rtmp://streaming.is/fun'));
+  assert.ok(isStreamingSrc('rtmps://streaming.is/fun'));
+  assert.ok(isStreamingSrc('rtmpe://streaming.is/fun'));
+  assert.ok(isStreamingSrc('rtmpt://streaming.is/fun'));
   // test invalid protocols
-  QUnit.ok(!isStreamingSrc('rtmp:streaming.is/fun'));
-  QUnit.ok(!isStreamingSrc('rtmpz://streaming.is/fun'));
-  QUnit.ok(!isStreamingSrc('http://streaming.is/fun'));
-  QUnit.ok(!isStreamingSrc('https://streaming.is/fun'));
-  QUnit.ok(!isStreamingSrc('file://streaming.is/fun'));
+  assert.ok(!isStreamingSrc('rtmp:streaming.is/fun'));
+  assert.ok(!isStreamingSrc('rtmpz://streaming.is/fun'));
+  assert.ok(!isStreamingSrc('http://streaming.is/fun'));
+  assert.ok(!isStreamingSrc('https://streaming.is/fun'));
+  assert.ok(!isStreamingSrc('file://streaming.is/fun'));
 });

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -13,24 +13,24 @@ class MockFlash extends Flash {
 
 QUnit.module('Flash');
 
-QUnit.test('Flash.canPlaySource', function() {
+QUnit.test('Flash.canPlaySource', function(assert) {
   const canPlaySource = Flash.canPlaySource;
 
   // Supported
-  QUnit.ok(canPlaySource({type: 'video/mp4; codecs=avc1.42E01E,mp4a.40.2' }, {}),
+  assert.ok(canPlaySource({type: 'video/mp4; codecs=avc1.42E01E,mp4a.40.2' }, {}),
            'codecs supported');
-  QUnit.ok(canPlaySource({type: 'video/mp4' }, {}), 'video/mp4 supported');
-  QUnit.ok(canPlaySource({type: 'video/x-flv' }, {}), 'video/x-flv supported');
-  QUnit.ok(canPlaySource({type: 'video/flv' }, {}), 'video/flv supported');
-  QUnit.ok(canPlaySource({type: 'video/m4v' }, {}), 'video/m4v supported');
-  QUnit.ok(canPlaySource({type: 'VIDEO/FLV' }, {}), 'capitalized mime type');
+  assert.ok(canPlaySource({type: 'video/mp4' }, {}), 'video/mp4 supported');
+  assert.ok(canPlaySource({type: 'video/x-flv' }, {}), 'video/x-flv supported');
+  assert.ok(canPlaySource({type: 'video/flv' }, {}), 'video/flv supported');
+  assert.ok(canPlaySource({type: 'video/m4v' }, {}), 'video/m4v supported');
+  assert.ok(canPlaySource({type: 'VIDEO/FLV' }, {}), 'capitalized mime type');
 
   // Not supported
-  QUnit.ok(!canPlaySource({ type: 'video/webm; codecs="vp8, vorbis"' }, {}));
-  QUnit.ok(!canPlaySource({ type: 'video/webm' }, {}));
+  assert.ok(!canPlaySource({ type: 'video/webm; codecs="vp8, vorbis"' }, {}));
+  assert.ok(!canPlaySource({ type: 'video/webm' }, {}));
 });
 
-QUnit.test('currentTime', function() {
+QUnit.test('currentTime', function(assert) {
   const getCurrentTime = Flash.prototype.currentTime;
   const setCurrentTime = Flash.prototype.setCurrentTime;
   let seekingCount = 0;
@@ -67,38 +67,38 @@ QUnit.test('currentTime', function() {
   // Test the currentTime getter
   getPropVal = 3;
   result = getCurrentTime.call(mockFlash);
-  QUnit.equal(result, 3, 'currentTime is retreived from the swf element');
+  assert.equal(result, 3, 'currentTime is retreived from the swf element');
 
   // Test the currentTime setter
   setCurrentTime.call(mockFlash, 10);
-  QUnit.equal(setPropVal, 10, 'currentTime is set on the swf element');
-  QUnit.equal(seekingCount, 1, 'triggered seeking');
+  assert.equal(setPropVal, 10, 'currentTime is set on the swf element');
+  assert.equal(seekingCount, 1, 'triggered seeking');
 
   // Test current time while seeking
   setCurrentTime.call(mockFlash, 20);
   seeking = true;
   result = getCurrentTime.call(mockFlash);
-  QUnit.equal(result,
+  assert.equal(result,
               20,
               'currentTime is retrieved from the lastSeekTarget while seeking');
-  QUnit.notEqual(result,
+  assert.notEqual(result,
                  getPropVal,
                  'currentTime is not retrieved from the element while seeking');
-  QUnit.equal(seekingCount, 2, 'triggered seeking');
+  assert.equal(seekingCount, 2, 'triggered seeking');
 
   // clamp seeks to seekable
   setCurrentTime.call(mockFlash, 1001);
   result = getCurrentTime.call(mockFlash);
-  QUnit.equal(result, mockFlash.seekable().end(0), 'clamped to the seekable end');
-  QUnit.equal(seekingCount, 3, 'triggered seeking');
+  assert.equal(result, mockFlash.seekable().end(0), 'clamped to the seekable end');
+  assert.equal(seekingCount, 3, 'triggered seeking');
 
   setCurrentTime.call(mockFlash, 1);
   result = getCurrentTime.call(mockFlash);
-  QUnit.equal(result, mockFlash.seekable().start(0), 'clamped to the seekable start');
-  QUnit.equal(seekingCount, 4, 'triggered seeking');
+  assert.equal(result, mockFlash.seekable().start(0), 'clamped to the seekable start');
+  assert.equal(seekingCount, 4, 'triggered seeking');
 });
 
-QUnit.test('dispose removes the object element even before ready fires', function() {
+QUnit.test('dispose removes the object element even before ready fires', function(assert) {
   // This test appears to test bad functionaly that was fixed
   // so it's debateable whether or not it's useful
   const dispose = Flash.prototype.dispose;
@@ -111,10 +111,10 @@ QUnit.test('dispose removes the object element even before ready fires', functio
   mockFlash.el_ = {};
 
   dispose.call(mockFlash);
-  QUnit.strictEqual(mockFlash.el_, null, 'swf el is nulled');
+  assert.strictEqual(mockFlash.el_, null, 'swf el is nulled');
 });
 
-QUnit.test('ready triggering before and after disposing the tech', function() {
+QUnit.test('ready triggering before and after disposing the tech', function(assert) {
   const checkReady = sinon.stub(Flash, 'checkReady');
   const fixtureDiv = document.getElementById('qunit-fixture');
   const playerDiv = document.createElement('div');
@@ -136,51 +136,51 @@ QUnit.test('ready triggering before and after disposing the tech', function() {
   };
 
   Flash.onReady(techEl.id);
-  QUnit.ok(checkReady.called, 'checkReady should be called before the tech is disposed');
+  assert.ok(checkReady.called, 'checkReady should be called before the tech is disposed');
 
   // remove the tech el from the player div to simulate being disposed
   playerDiv.removeChild(techEl);
   Flash.onReady(techEl.id);
-  QUnit.ok(!checkReady.calledTwice,
+  assert.ok(!checkReady.calledTwice,
            'checkReady should not be called after the tech is disposed');
 
   Flash.checkReady.restore();
 });
 
-QUnit.test('should have the source handler interface', function() {
-  QUnit.ok(Flash.registerSourceHandler, 'has the registerSourceHandler function');
+QUnit.test('should have the source handler interface', function(assert) {
+  assert.ok(Flash.registerSourceHandler, 'has the registerSourceHandler function');
 });
 
-QUnit.test('canPlayType should select the correct types to play', function() {
+QUnit.test('canPlayType should select the correct types to play', function(assert) {
   const canPlayType = Flash.nativeSourceHandler.canPlayType;
 
-  QUnit.equal(canPlayType('video/flv'), 'maybe', 'should be able to play FLV files');
-  QUnit.equal(canPlayType('video/x-flv'), 'maybe', 'should be able to play x-FLV files');
-  QUnit.equal(canPlayType('video/mp4'), 'maybe', 'should be able to play MP4 files');
-  QUnit.equal(canPlayType('video/m4v'), 'maybe', 'should be able to play M4V files');
-  QUnit.equal(canPlayType('video/ogg'),
+  assert.equal(canPlayType('video/flv'), 'maybe', 'should be able to play FLV files');
+  assert.equal(canPlayType('video/x-flv'), 'maybe', 'should be able to play x-FLV files');
+  assert.equal(canPlayType('video/mp4'), 'maybe', 'should be able to play MP4 files');
+  assert.equal(canPlayType('video/m4v'), 'maybe', 'should be able to play M4V files');
+  assert.equal(canPlayType('video/ogg'),
               '',
               'should return empty string if it can not play the video');
 });
 
-QUnit.test('canHandleSource should be able to work with src objects without a type', function() {
+QUnit.test('canHandleSource should be able to work with src objects without a type', function(assert) {
   const canHandleSource = Flash.nativeSourceHandler.canHandleSource;
 
-  QUnit.equal('maybe',
+  assert.equal('maybe',
               canHandleSource({ src: 'test.video.mp4' }, {}),
               'should guess that it is a mp4 video');
-  QUnit.equal('maybe',
+  assert.equal('maybe',
               canHandleSource({ src: 'test.video.m4v' }, {}),
               'should guess that it is a m4v video');
-  QUnit.equal('maybe',
+  assert.equal('maybe',
               canHandleSource({ src: 'test.video.flv' }, {}),
               'should guess that it is a flash video');
-  QUnit.equal('',
+  assert.equal('',
               canHandleSource({ src: 'test.video.wgg' }, {}),
               'should return empty string if it can not play the video');
 });
 
-QUnit.test('seekable', function() {
+QUnit.test('seekable', function(assert) {
   const seekable = Flash.prototype.seekable;
   let result;
   const mockFlash = {
@@ -192,18 +192,18 @@ QUnit.test('seekable', function() {
   // Test a normal duration
   mockFlash.duration_ = 23;
   result = seekable.call(mockFlash);
-  QUnit.equal(result.length, 1, 'seekable is non-empty');
-  QUnit.equal(result.start(0), 0, 'starts at zero');
-  QUnit.equal(result.end(0), mockFlash.duration_, 'ends at the duration');
+  assert.equal(result.length, 1, 'seekable is non-empty');
+  assert.equal(result.start(0), 0, 'starts at zero');
+  assert.equal(result.end(0), mockFlash.duration_, 'ends at the duration');
 
   // Test a zero duration
   mockFlash.duration_ = 0;
   result = seekable.call(mockFlash);
-  QUnit.equal(result.length, mockFlash.duration_,
+  assert.equal(result.length, mockFlash.duration_,
               'seekable is empty with a zero duration');
 });
 
-QUnit.test('play after ended seeks to the beginning', function() {
+QUnit.test('play after ended seeks to the beginning', function(assert) {
   let plays = 0;
   const seeks = [];
 
@@ -223,12 +223,12 @@ QUnit.test('play after ended seeks to the beginning', function() {
     }
   });
 
-  QUnit.equal(plays, 1, 'called play on the SWF');
-  QUnit.equal(seeks.length, 1, 'seeked on play');
-  QUnit.equal(seeks[0], 0, 'seeked to the beginning');
+  assert.equal(plays, 1, 'called play on the SWF');
+  assert.equal(seeks.length, 1, 'seeked on play');
+  assert.equal(seeks[0], 0, 'seeked to the beginning');
 });
 
-QUnit.test('duration returns NaN, Infinity or duration according to the HTML standard', function() {
+QUnit.test('duration returns NaN, Infinity or duration according to the HTML standard', function(assert) {
   const duration = Flash.prototype.duration;
   let mockedDuration = -1;
   let mockedReadyState = 0;
@@ -247,16 +247,16 @@ QUnit.test('duration returns NaN, Infinity or duration according to the HTML sta
   };
 
   result = duration.call(mockFlash);
-  QUnit.ok(Number.isNaN(result), 'duration returns NaN when readyState equals 0');
+  assert.ok(Number.isNaN(result), 'duration returns NaN when readyState equals 0');
 
   mockedReadyState = 1;
   result = duration.call(mockFlash);
-  QUnit.ok(!Number.isFinite(result),
+  assert.ok(!Number.isFinite(result),
            'duration returns Infinity when duration property is less then 0');
 
   mockedDuration = 1;
   result = duration.call(mockFlash);
-  QUnit.equal(result,
+  assert.equal(result,
               1,
               'duration returns duration property when readyState' +
               ' and duration property are both higher than 0');

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -7,7 +7,7 @@ import * as browser from '../../../src/js/utils/browser.js';
 import document from 'global/document';
 
 QUnit.module('HTML5', {
-  setup() {
+  beforeEach(assert) {
     const el = document.createElement('div');
 
     el.innerHTML = '<div />';
@@ -43,17 +43,17 @@ QUnit.module('HTML5', {
     };
     tech = new Html5({});
   },
-  teardown() {
+  afterEach(assert) {
     tech.dispose();
     player = null;
     tech = null;
   }
 });
 
-QUnit.test('should detect whether the volume can be changed', function() {
+QUnit.test('should detect whether the volume can be changed', function(assert) {
 
   if (!{}.__defineSetter__) {
-    QUnit.ok(true, 'your browser does not support this test, skipping it');
+    assert.ok(true, 'your browser does not support this test, skipping it');
     return;
   }
   const testVid = Html5.TEST_VID;
@@ -64,32 +64,32 @@ QUnit.test('should detect whether the volume can be changed', function() {
 
   Html5.TEST_VID = new ConstVolumeVideo();
 
-  QUnit.ok(!Html5.canControlVolume());
+  assert.ok(!Html5.canControlVolume());
   Html5.TEST_VID = testVid;
 });
 
-QUnit.test('test playbackRate', function() {
+QUnit.test('test playbackRate', function(assert) {
   // Android 2.3 always returns 0 for playback rate
   if (!Html5.canControlPlaybackRate()) {
-    QUnit.ok('Playback rate is not supported');
+    assert.ok('Playback rate is not supported');
     return;
   }
 
   tech.createEl();
 
   tech.el().playbackRate = 1.25;
-  QUnit.strictEqual(tech.playbackRate(), 1.25);
+  assert.strictEqual(tech.playbackRate(), 1.25);
 
   tech.setPlaybackRate(0.75);
-  QUnit.strictEqual(tech.playbackRate(), 0.75);
+  assert.strictEqual(tech.playbackRate(), 0.75);
 });
 
-QUnit.test('should export played', function() {
+QUnit.test('should export played', function(assert) {
   tech.createEl();
-  QUnit.deepEqual(tech.played(), tech.el().played, 'returns the played attribute');
+  assert.deepEqual(tech.played(), tech.el().played, 'returns the played attribute');
 });
 
-QUnit.test('should remove the controls attribute when recreating the element', function() {
+QUnit.test('should remove the controls attribute when recreating the element', function(assert) {
   player.tagAttributes = {
     controls: true
   };
@@ -99,13 +99,13 @@ QUnit.test('should remove the controls attribute when recreating the element', f
 
   // On the iPhone controls are always true
   if (!browser.IS_IPHONE) {
-    QUnit.ok(!el.controls, 'controls attribute is absent');
+    assert.ok(!el.controls, 'controls attribute is absent');
   }
 
-  QUnit.ok(player.tagAttributes.controls, 'tag attribute is still present');
+  assert.ok(player.tagAttributes.controls, 'tag attribute is still present');
 });
 
-QUnit.test('patchCanPlayType patches canplaytype with our function, conditionally', function() {
+QUnit.test('patchCanPlayType patches canplaytype with our function, conditionally', function(assert) {
   // the patch runs automatically so we need to first unpatch
   Html5.unpatchCanPlayType();
 
@@ -116,17 +116,17 @@ QUnit.test('patchCanPlayType patches canplaytype with our function, conditionall
   browser.ANDROID_VERSION = 4.0;
   Html5.patchCanPlayType();
 
-  QUnit.notStrictEqual(video.canPlayType,
+  assert.notStrictEqual(video.canPlayType,
                  canPlayType,
                  'original canPlayType and patched canPlayType should not be equal');
 
   const patchedCanPlayType = video.canPlayType;
   const unpatchedCanPlayType = Html5.unpatchCanPlayType();
 
-  QUnit.strictEqual(canPlayType,
+  assert.strictEqual(canPlayType,
                     Html5.TEST_VID.constructor.prototype.canPlayType,
                     'original canPlayType and unpatched canPlayType should be equal');
-  QUnit.strictEqual(patchedCanPlayType,
+  assert.strictEqual(patchedCanPlayType,
                     unpatchedCanPlayType,
                     'patched canPlayType and function returned from unpatch are equal');
 
@@ -134,24 +134,24 @@ QUnit.test('patchCanPlayType patches canplaytype with our function, conditionall
   Html5.unpatchCanPlayType();
 });
 
-QUnit.test('should return maybe for HLS urls on Android 4.0 or above', function() {
+QUnit.test('should return maybe for HLS urls on Android 4.0 or above', function(assert) {
   const oldAV = browser.ANDROID_VERSION;
   const video = document.createElement('video');
 
   browser.ANDROID_VERSION = 4.0;
   Html5.patchCanPlayType();
 
-  QUnit.strictEqual(video.canPlayType('application/x-mpegurl'),
+  assert.strictEqual(video.canPlayType('application/x-mpegurl'),
                     'maybe',
                     'android version 4.0 or above should be a maybe for x-mpegurl');
-  QUnit.strictEqual(video.canPlayType('application/x-mpegURL'),
+  assert.strictEqual(video.canPlayType('application/x-mpegURL'),
                     'maybe',
                     'android version 4.0 or above should be a maybe for x-mpegURL');
-  QUnit.strictEqual(video.canPlayType('application/vnd.apple.mpegurl'),
+  assert.strictEqual(video.canPlayType('application/vnd.apple.mpegurl'),
                     'maybe',
                     'android version 4.0 or above should be a ' +
                     'maybe for vnd.apple.mpegurl');
-  QUnit.strictEqual(video.canPlayType('application/vnd.apple.mpegURL'),
+  assert.strictEqual(video.canPlayType('application/vnd.apple.mpegURL'),
                     'maybe',
                     'android version 4.0 or above should be a ' +
                     'maybe for vnd.apple.mpegurl');
@@ -160,14 +160,14 @@ QUnit.test('should return maybe for HLS urls on Android 4.0 or above', function(
   Html5.unpatchCanPlayType();
 });
 
-QUnit.test('should return a maybe for mp4 on OLD ANDROID', function() {
+QUnit.test('should return a maybe for mp4 on OLD ANDROID', function(assert) {
   const isOldAndroid = browser.IS_OLD_ANDROID;
   const video = document.createElement('video');
 
   browser.IS_OLD_ANDROID = true;
   Html5.patchCanPlayType();
 
-  QUnit.strictEqual(video.canPlayType('video/mp4'),
+  assert.strictEqual(video.canPlayType('video/mp4'),
                     'maybe',
                     'old android should return a maybe for video/mp4');
 
@@ -175,17 +175,17 @@ QUnit.test('should return a maybe for mp4 on OLD ANDROID', function() {
   Html5.unpatchCanPlayType();
 });
 
-QUnit.test('error events may not set the errors property', function() {
-  QUnit.equal(tech.error(), undefined, 'no tech-level error');
+QUnit.test('error events may not set the errors property', function(assert) {
+  assert.equal(tech.error(), undefined, 'no tech-level error');
   tech.trigger('error');
-  QUnit.ok(true, 'no error was thrown');
+  assert.ok(true, 'no error was thrown');
 });
 
-QUnit.test('should have the source handler interface', function() {
-  QUnit.ok(Html5.registerSourceHandler, 'has the registerSourceHandler function');
+QUnit.test('should have the source handler interface', function(assert) {
+  assert.ok(Html5.registerSourceHandler, 'has the registerSourceHandler function');
 });
 
-QUnit.test('native source handler canPlayType', function() {
+QUnit.test('native source handler canPlayType', function(assert) {
   // Stub the test video canPlayType (used in canPlayType) to control results
   const origCPT = Html5.TEST_VID.canPlayType;
 
@@ -198,16 +198,16 @@ QUnit.test('native source handler canPlayType', function() {
 
   const canPlayType = Html5.nativeSourceHandler.canPlayType;
 
-  QUnit.equal(canPlayType('video/mp4'),
+  assert.equal(canPlayType('video/mp4'),
               'maybe',
               'Native source handler reported type support');
-  QUnit.equal(canPlayType('foo'), '', 'Native source handler handled bad type');
+  assert.equal(canPlayType('foo'), '', 'Native source handler handled bad type');
 
   // Reset test video canPlayType
   Html5.TEST_VID.canPlayType = origCPT;
 });
 
-QUnit.test('native source handler canHandleSource', function() {
+QUnit.test('native source handler canHandleSource', function(assert) {
   // Stub the test video canPlayType (used in canHandleSource) to control results
   const origCPT = Html5.TEST_VID.canPlayType;
 
@@ -220,30 +220,30 @@ QUnit.test('native source handler canHandleSource', function() {
 
   const canHandleSource = Html5.nativeSourceHandler.canHandleSource;
 
-  QUnit.equal(canHandleSource({ type: 'video/mp4', src: 'video.flv' }, {}),
+  assert.equal(canHandleSource({ type: 'video/mp4', src: 'video.flv' }, {}),
               'maybe',
               'Native source handler reported type support');
-  QUnit.equal(canHandleSource({ src: 'http://www.example.com/video.mp4' }, {}),
+  assert.equal(canHandleSource({ src: 'http://www.example.com/video.mp4' }, {}),
               'maybe',
               'Native source handler reported extension support');
-  QUnit.equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo&token=bar' }, {}),
+  assert.equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo&token=bar' }, {}),
               'maybe',
               'Native source handler reported extension support');
-  QUnit.equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo' }, {}),
+  assert.equal(canHandleSource({ src: 'https://example.com/video.sd.mp4?s=foo' }, {}),
               'maybe',
               'Native source handler reported extension support');
 
   // Test for issue videojs/video.js#1785 and other potential failures
-  QUnit.equal(canHandleSource({ src: '' }, {}),
+  assert.equal(canHandleSource({ src: '' }, {}),
               '',
               'Native source handler handled empty src');
-  QUnit.equal(canHandleSource({}, {}),
+  assert.equal(canHandleSource({}, {}),
               '',
               'Native source handler handled empty object');
-  QUnit.equal(canHandleSource({ src: 'foo' }, {}),
+  assert.equal(canHandleSource({ src: 'foo' }, {}),
               '',
               'Native source handler handled bad src');
-  QUnit.equal(canHandleSource({ type: 'foo' }, {}),
+  assert.equal(canHandleSource({ type: 'foo' }, {}),
               '',
               'Native source handler handled bad type');
 
@@ -252,7 +252,7 @@ QUnit.test('native source handler canHandleSource', function() {
 });
 
 if (Html5.supportsNativeTextTracks()) {
-  QUnit.test('add native textTrack listeners on startup', function() {
+  QUnit.test('add native textTrack listeners on startup', function(assert) {
     const adds = [];
     const rems = [];
     const tt = {
@@ -268,12 +268,12 @@ if (Html5.supportsNativeTextTracks()) {
     const htmlTech = new Html5({el});
     /* eslint-enable no-unused-vars */
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
   });
 
-  QUnit.test('remove all tracks from emulated list on dispose', function() {
+  QUnit.test('remove all tracks from emulated list on dispose', function(assert) {
     const adds = [];
     const rems = [];
     const tt = {
@@ -289,20 +289,20 @@ if (Html5.supportsNativeTextTracks()) {
 
     htmlTech.dispose();
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
-    QUnit.equal(rems[0][0], 'change', 'change event handler removed');
-    QUnit.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
-    QUnit.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
-    QUnit.equal(adds[0][0], rems[0][0], 'change event handler removed');
-    QUnit.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
-    QUnit.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(rems[0][0], 'change', 'change event handler removed');
+    assert.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
+    assert.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
+    assert.equal(adds[0][0], rems[0][0], 'change event handler removed');
+    assert.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
+    assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 }
 
 if (Html5.supportsNativeAudioTracks()) {
-  QUnit.test('add native audioTrack listeners on startup', function() {
+  QUnit.test('add native audioTrack listeners on startup', function(assert) {
     const adds = [];
     const rems = [];
     const at = {
@@ -318,12 +318,12 @@ if (Html5.supportsNativeAudioTracks()) {
     const htmlTech = new Html5({el});
     /* eslint-enable no-unused-vars */
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
   });
 
-  QUnit.test('remove all tracks from emulated list on dispose', function() {
+  QUnit.test('remove all tracks from emulated list on dispose', function(assert) {
     const adds = [];
     const rems = [];
     const at = {
@@ -339,20 +339,20 @@ if (Html5.supportsNativeAudioTracks()) {
 
     htmlTech.dispose();
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
-    QUnit.equal(rems[0][0], 'change', 'change event handler removed');
-    QUnit.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
-    QUnit.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
-    QUnit.equal(adds[0][0], rems[0][0], 'change event handler removed');
-    QUnit.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
-    QUnit.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(rems[0][0], 'change', 'change event handler removed');
+    assert.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
+    assert.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
+    assert.equal(adds[0][0], rems[0][0], 'change event handler removed');
+    assert.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
+    assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 }
 
 if (Html5.supportsNativeVideoTracks()) {
-  QUnit.test('add native videoTrack listeners on startup', function() {
+  QUnit.test('add native videoTrack listeners on startup', function(assert) {
     const adds = [];
     const rems = [];
     const vt = {
@@ -368,12 +368,12 @@ if (Html5.supportsNativeVideoTracks()) {
     const htmlTech = new Html5({el});
     /* eslint-enable no-unused-vars */
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
   });
 
-  QUnit.test('remove all tracks from emulated list on dispose', function() {
+  QUnit.test('remove all tracks from emulated list on dispose', function(assert) {
     const adds = [];
     const rems = [];
     const vt = {
@@ -389,34 +389,34 @@ if (Html5.supportsNativeVideoTracks()) {
 
     htmlTech.dispose();
 
-    QUnit.equal(adds[0][0], 'change', 'change event handler added');
-    QUnit.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
-    QUnit.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
-    QUnit.equal(rems[0][0], 'change', 'change event handler removed');
-    QUnit.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
-    QUnit.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
-    QUnit.equal(adds[0][0], rems[0][0], 'change event handler removed');
-    QUnit.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
-    QUnit.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
+    assert.equal(adds[0][0], 'change', 'change event handler added');
+    assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
+    assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+    assert.equal(rems[0][0], 'change', 'change event handler removed');
+    assert.equal(rems[1][0], 'addtrack', 'addtrack event handler removed');
+    assert.equal(rems[2][0], 'removetrack', 'removetrack event handler removed');
+    assert.equal(adds[0][0], rems[0][0], 'change event handler removed');
+    assert.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
+    assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 }
 
-QUnit.test('should always return currentSource_ if set', function() {
+QUnit.test('should always return currentSource_ if set', function(assert) {
   const currentSrc = Html5.prototype.currentSrc;
 
-  QUnit.equal(currentSrc.call({el_: {currentSrc: 'test1'}}),
+  assert.equal(currentSrc.call({el_: {currentSrc: 'test1'}}),
               'test1',
               'sould return source from element if nothing else set');
-  QUnit.equal(currentSrc.call({currentSource_: {src: 'test2'}}),
+  assert.equal(currentSrc.call({currentSource_: {src: 'test2'}}),
               'test2',
               'sould return source from currentSource_, if nothing else set');
-  QUnit.equal(currentSrc.call({currentSource_: {src: 'test2'},
+  assert.equal(currentSrc.call({currentSource_: {src: 'test2'},
                                el_: {currentSrc: 'test1'}}),
               'test2',
               'sould return source from  source set, not from element');
 });
 
-QUnit.test('should fire makeup events when a video tag is initialized late', function() {
+QUnit.test('should fire makeup events when a video tag is initialized late', function(assert) {
   const lateInit = Html5.prototype.handleLateInit_;
   let triggeredEvents = [];
   const mockHtml5 = {
@@ -439,7 +439,7 @@ QUnit.test('should fire makeup events when a video tag is initialized late', fun
   function testStates(statesObject, expectedEvents) {
     lateInit.call(mockHtml5, statesObject);
     mockHtml5.triggerReady();
-    QUnit.deepEqual(triggeredEvents,
+    assert.deepEqual(triggeredEvents,
                     expectedEvents,
                     'wrong events triggered for ' +
                     `networkState:${statesObject.networkState} ` +
@@ -467,7 +467,7 @@ QUnit.test('should fire makeup events when a video tag is initialized late', fun
              ['loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough']);
 });
 
-QUnit.test('Html5.resetMediaElement should remove sources and call load', function() {
+QUnit.test('Html5.resetMediaElement should remove sources and call load', function(assert) {
   let selector;
   const removedChildren = [];
   let removedAttribute;
@@ -493,15 +493,15 @@ QUnit.test('Html5.resetMediaElement should remove sources and call load', functi
   };
 
   Html5.resetMediaElement(testEl);
-  QUnit.equal(selector, 'source', 'we got the source elements from the test el');
-  QUnit.deepEqual(removedChildren,
+  assert.equal(selector, 'source', 'we got the source elements from the test el');
+  assert.deepEqual(removedChildren,
                   children.reverse(),
                   'we removed the children that were present');
-  QUnit.equal(removedAttribute, 'src', 'we removed the src attribute');
-  QUnit.ok(loaded, 'we called load on the element');
+  assert.equal(removedAttribute, 'src', 'we removed the src attribute');
+  assert.ok(loaded, 'we called load on the element');
 });
 
-QUnit.test('Html5#reset calls Html5.resetMediaElement when called', function() {
+QUnit.test('Html5#reset calls Html5.resetMediaElement when called', function(assert) {
   const oldResetMedia = Html5.resetMediaElement;
   let resetEl;
 
@@ -513,7 +513,7 @@ QUnit.test('Html5#reset calls Html5.resetMediaElement when called', function() {
 
   Html5.prototype.reset.call({el_: el});
 
-  QUnit.equal(resetEl, el, 'we called resetMediaElement with the tech\'s el');
+  assert.equal(resetEl, el, 'we called resetMediaElement with the tech\'s el');
 
   Html5.resetMediaElement = oldResetMedia;
 });

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -15,19 +15,19 @@ import TextTrackList from '../../../src/js/tracks/text-track-list';
 import sinon from 'sinon';
 
 QUnit.module('Media Tech', {
-  setup() {
+  beforeEach(assert) {
     this.noop = function() {};
     this.clock = sinon.useFakeTimers();
     this.featuresProgessEvents = Tech.prototype.featuresProgessEvents;
     Tech.prototype.featuresProgressEvents = false;
   },
-  teardown() {
+  afterEach(assert) {
     this.clock.restore();
     Tech.prototype.featuresProgessEvents = this.featuresProgessEvents;
   }
 });
 
-QUnit.test('should synthesize timeupdate events by default', function() {
+QUnit.test('should synthesize timeupdate events by default', function(assert) {
   let timeupdates = 0;
   const tech = new Tech();
 
@@ -38,10 +38,10 @@ QUnit.test('should synthesize timeupdate events by default', function() {
   tech.trigger('play');
 
   this.clock.tick(250);
-  QUnit.equal(timeupdates, 1, 'triggered at least one timeupdate');
+  assert.equal(timeupdates, 1, 'triggered at least one timeupdate');
 });
 
-QUnit.test('stops manual timeupdates while paused', function() {
+QUnit.test('stops manual timeupdates while paused', function(assert) {
   let timeupdates = 0;
   const tech = new Tech();
 
@@ -51,19 +51,19 @@ QUnit.test('stops manual timeupdates while paused', function() {
 
   tech.trigger('play');
   this.clock.tick(10 * 250);
-  QUnit.ok(timeupdates > 0, 'timeupdates fire during playback');
+  assert.ok(timeupdates > 0, 'timeupdates fire during playback');
 
   tech.trigger('pause');
   timeupdates = 0;
   this.clock.tick(10 * 250);
-  QUnit.equal(timeupdates, 0, 'timeupdates do not fire when paused');
+  assert.equal(timeupdates, 0, 'timeupdates do not fire when paused');
 
   tech.trigger('play');
   this.clock.tick(10 * 250);
-  QUnit.ok(timeupdates > 0, 'timeupdates fire when playback resumes');
+  assert.ok(timeupdates > 0, 'timeupdates fire when playback resumes');
 });
 
-QUnit.test('should synthesize progress events by default', function() {
+QUnit.test('should synthesize progress events by default', function(assert) {
   let progresses = 0;
   let bufferedPercent = 0.5;
   const tech = new Tech();
@@ -76,19 +76,19 @@ QUnit.test('should synthesize progress events by default', function() {
   };
 
   this.clock.tick(500);
-  QUnit.equal(progresses, 0, 'waits until ready');
+  assert.equal(progresses, 0, 'waits until ready');
 
   tech.trigger('ready');
   this.clock.tick(500);
-  QUnit.equal(progresses, 1, 'triggered one event');
+  assert.equal(progresses, 1, 'triggered one event');
 
   tech.trigger('ready');
   bufferedPercent = 0.75;
   this.clock.tick(500);
-  QUnit.equal(progresses, 2, 'repeated readies are ok');
+  assert.equal(progresses, 2, 'repeated readies are ok');
 });
 
-QUnit.test('dispose() should stop time tracking', function() {
+QUnit.test('dispose() should stop time tracking', function(assert) {
   const tech = new Tech();
 
   tech.dispose();
@@ -98,41 +98,41 @@ QUnit.test('dispose() should stop time tracking', function() {
   try {
     this.clock.tick(10 * 1000);
   } catch (e) {
-    return QUnit.equal(e, undefined, 'threw an exception');
+    return assert.equal(e, undefined, 'threw an exception');
   }
-  QUnit.ok(true, 'no exception was thrown');
+  assert.ok(true, 'no exception was thrown');
 });
 
-QUnit.test('dispose() should clear all tracks that are passed when its created', function() {
+QUnit.test('dispose() should clear all tracks that are passed when its created', function(assert) {
   const audioTracks = new AudioTrackList([new AudioTrack(), new AudioTrack()]);
   const videoTracks = new VideoTrackList([new VideoTrack(), new VideoTrack()]);
   const textTracks = new TextTrackList([new TextTrack({tech: {}}),
                                         new TextTrack({tech: {}})]);
 
-  QUnit.equal(audioTracks.length, 2, 'should have two audio tracks at the start');
-  QUnit.equal(videoTracks.length, 2, 'should have two video tracks at the start');
-  QUnit.equal(textTracks.length, 2, 'should have two text tracks at the start');
+  assert.equal(audioTracks.length, 2, 'should have two audio tracks at the start');
+  assert.equal(videoTracks.length, 2, 'should have two video tracks at the start');
+  assert.equal(textTracks.length, 2, 'should have two text tracks at the start');
 
   const tech = new Tech({audioTracks, videoTracks, textTracks});
 
-  QUnit.equal(tech.videoTracks().length,
+  assert.equal(tech.videoTracks().length,
               videoTracks.length,
               'should hold video tracks that we passed');
-  QUnit.equal(tech.audioTracks().length,
+  assert.equal(tech.audioTracks().length,
               audioTracks.length,
               'should hold audio tracks that we passed');
-  QUnit.equal(tech.textTracks().length,
+  assert.equal(tech.textTracks().length,
               textTracks.length,
               'should hold text tracks that we passed');
 
   tech.dispose();
 
-  QUnit.equal(audioTracks.length, 0, 'should have zero audio tracks after dispose');
-  QUnit.equal(videoTracks.length, 0, 'should have zero video tracks after dispose');
-  QUnit.equal(textTracks.length, 0, 'should have zero text tracks after dispose');
+  assert.equal(audioTracks.length, 0, 'should have zero audio tracks after dispose');
+  assert.equal(videoTracks.length, 0, 'should have zero video tracks after dispose');
+  assert.equal(textTracks.length, 0, 'should have zero text tracks after dispose');
 });
 
-QUnit.test('dispose() should clear all tracks that are added after creation', function() {
+QUnit.test('dispose() should clear all tracks that are added after creation', function(assert) {
   const tech = new Tech();
 
   tech.addRemoteTextTrack({});
@@ -144,30 +144,30 @@ QUnit.test('dispose() should clear all tracks that are added after creation', fu
   tech.videoTracks().addTrack_(new VideoTrack());
   tech.videoTracks().addTrack_(new VideoTrack());
 
-  QUnit.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
-  QUnit.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.remoteTextTrackEls().length,
+  assert.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
+  assert.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.remoteTextTrackEls().length,
               2,
               'should have two remote text tracks els');
-  QUnit.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
+  assert.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
 
   tech.dispose();
 
-  QUnit.equal(tech.audioTracks().length,
+  assert.equal(tech.audioTracks().length,
               0,
               'should have zero audio tracks after dispose');
-  QUnit.equal(tech.videoTracks().length,
+  assert.equal(tech.videoTracks().length,
               0,
               'should have zero video tracks after dispose');
-  QUnit.equal(tech.remoteTextTrackEls().length,
+  assert.equal(tech.remoteTextTrackEls().length,
               0,
               'should have zero remote text tracks els');
-  QUnit.equal(tech.remoteTextTracks().length, 0, 'should have zero remote text tracks');
-  QUnit.equal(tech.textTracks().length, 0, 'should have zero video tracks after dispose');
+  assert.equal(tech.remoteTextTracks().length, 0, 'should have zero remote text tracks');
+  assert.equal(tech.textTracks().length, 0, 'should have zero video tracks after dispose');
 });
 
-QUnit.test('should add the source handler interface to a tech', function() {
+QUnit.test('should add the source handler interface to a tech', function(assert) {
   const sourceA = { src: 'foo.mp4', type: 'video/mp4' };
   const sourceB = { src: 'no-support', type: 'no-support' };
 
@@ -178,16 +178,16 @@ QUnit.test('should add the source handler interface to a tech', function() {
   Tech.withSourceHandlers(MyTech);
 
   // Check for the expected class methods
-  QUnit.ok(MyTech.registerSourceHandler,
+  assert.ok(MyTech.registerSourceHandler,
            'added a registerSourceHandler function to the Tech');
-  QUnit.ok(MyTech.selectSourceHandler,
+  assert.ok(MyTech.selectSourceHandler,
            'added a selectSourceHandler function to the Tech');
 
   // Create an instance of Tech
   const tech = new MyTech();
 
   // Check for the expected instance methods
-  QUnit.ok(tech.setSource, 'added a setSource function to the tech instance');
+  assert.ok(tech.setSource, 'added a setSource function to the tech instance');
 
   // Create an internal state class for the source handler
   // The internal class would be used by a source handler to maintain state
@@ -209,7 +209,7 @@ QUnit.test('should add the source handler interface to a tech', function() {
       return '';
     },
     canHandleSource(source, options) {
-      QUnit.strictEqual(tech.options_,
+      assert.strictEqual(tech.options_,
                         options,
                         'tech options passed to canHandleSource');
       if (source.type !== 'no-support') {
@@ -218,13 +218,13 @@ QUnit.test('should add the source handler interface to a tech', function() {
       return '';
     },
     handleSource(s, t, o) {
-      QUnit.strictEqual(tech,
+      assert.strictEqual(tech,
                         t,
                         'tech instance passed to source handler');
-      QUnit.strictEqual(sourceA,
+      assert.strictEqual(sourceA,
                         s,
                         'tech instance passed to the source handler');
-      QUnit.strictEqual(tech.options_,
+      assert.strictEqual(tech.options_,
                         o,
                         'tech options passed to the source handler handleSource');
       return new HandlerInternalState();
@@ -241,41 +241,41 @@ QUnit.test('should add the source handler interface to a tech', function() {
       return '';
     },
     handleSource(source, tech_, options) {
-      QUnit.ok(false, 'handlerTwo supports nothing and should never be called');
+      assert.ok(false, 'handlerTwo supports nothing and should never be called');
     }
   };
 
   // Test registering source handlers
   MyTech.registerSourceHandler(handlerOne);
-  QUnit.strictEqual(MyTech.sourceHandlers[0],
+  assert.strictEqual(MyTech.sourceHandlers[0],
                     handlerOne,
                     'handlerOne was added to the source handler array');
   MyTech.registerSourceHandler(handlerTwo, 0);
-  QUnit.strictEqual(MyTech.sourceHandlers[0],
+  assert.strictEqual(MyTech.sourceHandlers[0],
                     handlerTwo,
                     'handlerTwo was registered at the correct index (0)');
 
   // Test handler selection
-  QUnit.strictEqual(MyTech.selectSourceHandler(sourceA, tech.options_),
+  assert.strictEqual(MyTech.selectSourceHandler(sourceA, tech.options_),
                     handlerOne,
                     'handlerOne was selected to handle the valid source');
-  QUnit.strictEqual(MyTech.selectSourceHandler(sourceB, tech.options_),
+  assert.strictEqual(MyTech.selectSourceHandler(sourceB, tech.options_),
                     null,
                     'no handler was selected to handle the invalid source');
 
   // Test canPlayType return values
-  QUnit.strictEqual(MyTech.canPlayType(sourceA.type),
+  assert.strictEqual(MyTech.canPlayType(sourceA.type),
                     'probably',
                     'the Tech returned probably for the valid source');
-  QUnit.strictEqual(MyTech.canPlayType(sourceB.type),
+  assert.strictEqual(MyTech.canPlayType(sourceB.type),
                     '',
                     'the Tech returned an empty string for the invalid source');
 
   // Test canPlaySource return values
-  QUnit.strictEqual(MyTech.canPlaySource(sourceA, tech.options_),
+  assert.strictEqual(MyTech.canPlaySource(sourceA, tech.options_),
                     'probably',
                     'the Tech returned probably for the valid source');
-  QUnit.strictEqual(MyTech.canPlaySource(sourceB, tech.options_),
+  assert.strictEqual(MyTech.canPlaySource(sourceB, tech.options_),
                     '',
                     'the Tech returned an empty string for the invalid source');
 
@@ -288,52 +288,52 @@ QUnit.test('should add the source handler interface to a tech', function() {
   tech.videoTracks().addTrack_(new VideoTrack());
   tech.videoTracks().addTrack_(new VideoTrack());
 
-  QUnit.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
-  QUnit.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.remoteTextTrackEls().length,
+  assert.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
+  assert.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.remoteTextTrackEls().length,
               2,
               'should have two remote text tracks els');
-  QUnit.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
+  assert.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
 
   // Pass a source through the source handler process of a tech instance
   tech.setSource(sourceA);
 
   // verify that the Tracks are still there
-  QUnit.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
-  QUnit.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
-  QUnit.equal(tech.remoteTextTrackEls().length,
+  assert.equal(tech.audioTracks().length, 2, 'should have two audio tracks at the start');
+  assert.equal(tech.videoTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.textTracks().length, 2, 'should have two video tracks at the start');
+  assert.equal(tech.remoteTextTrackEls().length,
               2,
               'should have two remote text tracks els');
-  QUnit.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
+  assert.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
 
-  QUnit.strictEqual(tech.currentSource_, sourceA, 'sourceA was handled and stored');
-  QUnit.ok(tech.sourceHandler_.dispose, 'the handlerOne state instance was stored');
+  assert.strictEqual(tech.currentSource_, sourceA, 'sourceA was handled and stored');
+  assert.ok(tech.sourceHandler_.dispose, 'the handlerOne state instance was stored');
 
   // Pass a second source
   tech.setSource(sourceA);
-  QUnit.strictEqual(tech.currentSource_, sourceA, 'sourceA was handled and stored');
-  QUnit.ok(tech.sourceHandler_.dispose, 'the handlerOne state instance was stored');
+  assert.strictEqual(tech.currentSource_, sourceA, 'sourceA was handled and stored');
+  assert.ok(tech.sourceHandler_.dispose, 'the handlerOne state instance was stored');
 
   // verify that all the tracks were removed as we got a new source
-  QUnit.equal(tech.audioTracks().length, 0, 'should have zero audio tracks');
-  QUnit.equal(tech.videoTracks().length, 0, 'should have zero video tracks');
-  QUnit.equal(tech.textTracks().length, 2, 'should have two text tracks');
-  QUnit.equal(tech.remoteTextTrackEls().length,
+  assert.equal(tech.audioTracks().length, 0, 'should have zero audio tracks');
+  assert.equal(tech.videoTracks().length, 0, 'should have zero video tracks');
+  assert.equal(tech.textTracks().length, 2, 'should have two text tracks');
+  assert.equal(tech.remoteTextTrackEls().length,
               2,
               'should have two remote text tracks els');
-  QUnit.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
+  assert.equal(tech.remoteTextTracks().length, 2, 'should have two remote text tracks');
 
   // Check that the handler dipose method works
-  QUnit.ok(disposeCalled, 'dispose has been called for the handler yet');
+  assert.ok(disposeCalled, 'dispose has been called for the handler yet');
   disposeCalled = false;
   tech.dispose();
-  QUnit.ok(disposeCalled,
+  assert.ok(disposeCalled,
            'the handler dispose method was called when the tech was disposed');
 });
 
-QUnit.test('should handle unsupported sources with the source handler API', function() {
+QUnit.test('should handle unsupported sources with the source handler API', function(assert) {
   // Define a new tech class
   const MyTech = extendFn(Tech);
 
@@ -350,11 +350,11 @@ QUnit.test('should handle unsupported sources with the source handler API', func
   };
 
   tech.setSource('');
-  QUnit.ok(usedNative,
+  assert.ok(usedNative,
            'native source handler was used when an unsupported source was set');
 });
 
-QUnit.test('should allow custom error events to be set', function() {
+QUnit.test('should allow custom error events to be set', function(assert) {
   const tech = new Tech();
   const errors = [];
 
@@ -362,26 +362,26 @@ QUnit.test('should allow custom error events to be set', function() {
     errors.push(tech.error());
   });
 
-  QUnit.equal(tech.error(), null, 'error is null by default');
+  assert.equal(tech.error(), null, 'error is null by default');
 
   tech.error(new MediaError(1));
-  QUnit.equal(errors.length, 1, 'triggered an error event');
-  QUnit.equal(errors[0].code, 1, 'set the proper code');
+  assert.equal(errors.length, 1, 'triggered an error event');
+  assert.equal(errors[0].code, 1, 'set the proper code');
 
   tech.error(2);
-  QUnit.equal(errors.length, 2, 'triggered an error event');
-  QUnit.equal(errors[1].code, 2, 'wrapped the error code');
+  assert.equal(errors.length, 2, 'triggered an error event');
+  assert.equal(errors[1].code, 2, 'wrapped the error code');
 });
 
-QUnit.test('should track whether a video has played', function() {
+QUnit.test('should track whether a video has played', function(assert) {
   const tech = new Tech();
 
-  QUnit.equal(tech.played().length, 0, 'starts with zero length');
+  assert.equal(tech.played().length, 0, 'starts with zero length');
   tech.trigger('playing');
-  QUnit.equal(tech.played().length, 1, 'has length after playing');
+  assert.equal(tech.played().length, 1, 'has length after playing');
 });
 
-QUnit.test('delegates seekable to the source handler', function() {
+QUnit.test('delegates seekable to the source handler', function(assert) {
   const MyTech = extendFn(Tech, {
     seekable() {
       throw new Error('You should not be calling me!');
@@ -417,24 +417,24 @@ QUnit.test('delegates seekable to the source handler', function() {
     type: 'video/mp4'
   });
   tech.seekable();
-  QUnit.equal(seekableCount, 1, 'called the source handler');
+  assert.equal(seekableCount, 1, 'called the source handler');
 });
 
-QUnit.test('Tech.isTech returns correct answers for techs and components', function() {
+QUnit.test('Tech.isTech returns correct answers for techs and components', function(assert) {
   const isTech = Tech.isTech;
 
-  QUnit.ok(isTech(Tech), 'Tech is a Tech');
-  QUnit.ok(isTech(Html5), 'Html5 is a Tech');
-  QUnit.ok(isTech(new Html5({}, {})), 'An html5 instance is a Tech');
-  QUnit.ok(isTech(Flash), 'Flash is a Tech');
-  QUnit.ok(!isTech(5), 'A number is not a Tech');
-  QUnit.ok(!isTech('this is a tech'), 'A string is not a Tech');
-  QUnit.ok(!isTech(Button), 'A Button is not a Tech');
-  QUnit.ok(!isTech(new Button({}, {})), 'A Button instance is not a Tech');
-  QUnit.ok(!isTech(isTech), 'A function is not a Tech');
+  assert.ok(isTech(Tech), 'Tech is a Tech');
+  assert.ok(isTech(Html5), 'Html5 is a Tech');
+  assert.ok(isTech(new Html5({}, {})), 'An html5 instance is a Tech');
+  assert.ok(isTech(Flash), 'Flash is a Tech');
+  assert.ok(!isTech(5), 'A number is not a Tech');
+  assert.ok(!isTech('this is a tech'), 'A string is not a Tech');
+  assert.ok(!isTech(Button), 'A Button is not a Tech');
+  assert.ok(!isTech(new Button({}, {})), 'A Button instance is not a Tech');
+  assert.ok(!isTech(isTech), 'A function is not a Tech');
 });
 
-QUnit.test('Tech#setSource clears currentSource_ after repeated loadstart', function() {
+QUnit.test('Tech#setSource clears currentSource_ after repeated loadstart', function(assert) {
   let disposed = false;
   const MyTech = extendFn(Tech);
 
@@ -464,21 +464,21 @@ QUnit.test('Tech#setSource clears currentSource_ after repeated loadstart', func
   tech.setSource('test');
   tech.currentSource_ = 'test';
   tech.trigger('loadstart');
-  QUnit.equal(tech.currentSource_, 'test', 'Current source is test');
+  assert.equal(tech.currentSource_, 'test', 'Current source is test');
 
   // Second loadstart
   tech.trigger('loadstart');
-  QUnit.equal(tech.currentSource_, null, 'Current source is null');
-  QUnit.equal(disposed, true, 'disposed is true');
+  assert.equal(tech.currentSource_, null, 'Current source is null');
+  assert.equal(disposed, true, 'disposed is true');
 
   // Third loadstart
   tech.currentSource_ = 'test';
   tech.trigger('loadstart');
-  QUnit.equal(tech.currentSource_, null, 'Current source is still null');
+  assert.equal(tech.currentSource_, null, 'Current source is still null');
 
 });
 
-QUnit.test('setSource after tech dispose should dispose source handler once', function() {
+QUnit.test('setSource after tech dispose should dispose source handler once', function(assert) {
   const MyTech = extendFn(Tech);
 
   Tech.withSourceHandlers(MyTech);
@@ -506,23 +506,23 @@ QUnit.test('setSource after tech dispose should dispose source handler once', fu
 
   tech.setSource('test');
 
-  QUnit.equal(disposeCount, 0, 'did not call sourceHandler_ dispose for initial dispose');
+  assert.equal(disposeCount, 0, 'did not call sourceHandler_ dispose for initial dispose');
   tech.dispose();
-  QUnit.ok(!tech.sourceHandler_, 'sourceHandler should be unset');
-  QUnit.equal(disposeCount, 1, 'called the source handler dispose');
+  assert.ok(!tech.sourceHandler_, 'sourceHandler should be unset');
+  assert.equal(disposeCount, 1, 'called the source handler dispose');
 
   // this would normally be done above tech on src after dispose
   tech.el_ = tech.createEl();
 
   tech.setSource('test');
-  QUnit.equal(disposeCount, 1, 'did not dispose after initial setSource');
+  assert.equal(disposeCount, 1, 'did not dispose after initial setSource');
 
   tech.setSource('test');
-  QUnit.equal(disposeCount, 2, 'did dispose on second setSource');
+  assert.equal(disposeCount, 2, 'did dispose on second setSource');
 
 });
 
-QUnit.test('setSource after previous setSource should dispose source handler once', function() {
+QUnit.test('setSource after previous setSource should dispose source handler once', function(assert) {
   const MyTech = extendFn(Tech);
 
   Tech.withSourceHandlers(MyTech);
@@ -549,13 +549,13 @@ QUnit.test('setSource after previous setSource should dispose source handler onc
   const tech = new MyTech();
 
   tech.setSource('test');
-  QUnit.equal(disposeCount, 0, 'did not call dispose for initial setSource');
+  assert.equal(disposeCount, 0, 'did not call dispose for initial setSource');
 
   tech.setSource('test');
-  QUnit.equal(disposeCount, 1, 'did dispose for second setSource');
+  assert.equal(disposeCount, 1, 'did dispose for second setSource');
 
   tech.setSource('test');
-  QUnit.equal(disposeCount, 2, 'did dispose for third setSource');
+  assert.equal(disposeCount, 2, 'did dispose for third setSource');
 
 });
 

--- a/test/unit/tracks/audio-track-list.test.js
+++ b/test/unit/tracks/audio-track-list.test.js
@@ -5,7 +5,7 @@ import EventTarget from '../../../src/js/event-target.js';
 
 QUnit.module('Audio Track List');
 
-QUnit.test('trigger "change" when "enabledchange" is fired on a track', function() {
+QUnit.test('trigger "change" when "enabledchange" is fired on a track', function(assert) {
   const track = new EventTarget();
 
   track.loaded_ = true;
@@ -17,48 +17,48 @@ QUnit.test('trigger "change" when "enabledchange" is fired on a track', function
 
   audioTrackList.on('change', changeHandler);
   track.trigger('enabledchange');
-  QUnit.equal(changes, 1, 'one change events for trigger');
+  assert.equal(changes, 1, 'one change events for trigger');
 
   audioTrackList.off('change', changeHandler);
   audioTrackList.onchange = changeHandler;
 
   track.trigger('enabledchange');
-  QUnit.equal(changes, 2, 'one change events for another trigger');
+  assert.equal(changes, 2, 'one change events for another trigger');
 });
 
-QUnit.test('only one track is ever enabled', function() {
+QUnit.test('only one track is ever enabled', function(assert) {
   const track = new AudioTrack({enabled: true});
   const track2 = new AudioTrack({enabled: true});
   const track3 = new AudioTrack({enabled: true});
   const track4 = new AudioTrack();
   const list = new AudioTrackList([track, track2]);
 
-  QUnit.equal(track.enabled, false, 'track is disabled');
-  QUnit.equal(track2.enabled, true, 'track2 is enabled');
+  assert.equal(track.enabled, false, 'track is disabled');
+  assert.equal(track2.enabled, true, 'track2 is enabled');
 
   track.enabled = true;
-  QUnit.equal(track.enabled, true, 'track is enabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track.enabled, true, 'track is enabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
 
   list.addTrack_(track3);
-  QUnit.equal(track.enabled, false, 'track is disabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
-  QUnit.equal(track3.enabled, true, 'track3 is enabled');
+  assert.equal(track.enabled, false, 'track is disabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track3.enabled, true, 'track3 is enabled');
 
   track.enabled = true;
-  QUnit.equal(track.enabled, true, 'track is disabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
-  QUnit.equal(track3.enabled, false, 'track3 is disabled');
+  assert.equal(track.enabled, true, 'track is disabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track3.enabled, false, 'track3 is disabled');
 
   list.addTrack_(track4);
-  QUnit.equal(track.enabled, true, 'track is enabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
-  QUnit.equal(track3.enabled, false, 'track3 is disabled');
-  QUnit.equal(track4.enabled, false, 'track4 is disabled');
+  assert.equal(track.enabled, true, 'track is enabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track3.enabled, false, 'track3 is disabled');
+  assert.equal(track4.enabled, false, 'track4 is disabled');
 
 });
 
-QUnit.test('all tracks can be disabled', function() {
+QUnit.test('all tracks can be disabled', function(assert) {
   const track = new AudioTrack();
   const track2 = new AudioTrack();
 
@@ -68,19 +68,19 @@ QUnit.test('all tracks can be disabled', function() {
   const list = new AudioTrackList([track, track2]);
   /* eslint-enable no-unused-vars */
 
-  QUnit.equal(track.enabled, false, 'track is disabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track.enabled, false, 'track is disabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
 
   track.enabled = true;
-  QUnit.equal(track.enabled, true, 'track is enabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track.enabled, true, 'track is enabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
 
   track.enabled = false;
-  QUnit.equal(track.enabled, false, 'track is disabled');
-  QUnit.equal(track2.enabled, false, 'track2 is disabled');
+  assert.equal(track.enabled, false, 'track is disabled');
+  assert.equal(track2.enabled, false, 'track2 is disabled');
 });
 
-QUnit.test('trigger a change event per enabled change', function() {
+QUnit.test('trigger a change event per enabled change', function(assert) {
   const track = new AudioTrack({enabled: true});
   const track2 = new AudioTrack({enabled: true});
   const track3 = new AudioTrack({enabled: true});
@@ -90,18 +90,18 @@ QUnit.test('trigger a change event per enabled change', function() {
 
   list.on('change', () => change++);
   track.enabled = true;
-  QUnit.equal(change, 1, 'one change triggered');
+  assert.equal(change, 1, 'one change triggered');
 
   list.addTrack_(track3);
-  QUnit.equal(change, 2, 'another change triggered by adding an enabled track');
+  assert.equal(change, 2, 'another change triggered by adding an enabled track');
 
   track.enabled = true;
-  QUnit.equal(change, 3, 'another change trigger by changing enabled');
+  assert.equal(change, 3, 'another change trigger by changing enabled');
 
   track.enabled = false;
-  QUnit.equal(change, 4, 'another change trigger by changing enabled');
+  assert.equal(change, 4, 'another change trigger by changing enabled');
 
   list.addTrack_(track4);
-  QUnit.equal(change, 4, 'no change triggered by adding a disabled track');
+  assert.equal(change, 4, 'no change triggered by adding a disabled track');
 
 });

--- a/test/unit/tracks/audio-track.test.js
+++ b/test/unit/tracks/audio-track.test.js
@@ -13,32 +13,32 @@ TrackBaseline(AudioTrack, {
   kind: 'main'
 });
 
-QUnit.test('can create an enabled propert on an AudioTrack', function() {
+QUnit.test('can create an enabled propert on an AudioTrack', function(assert) {
   const enabled = true;
   const track = new AudioTrack({
     enabled
   });
 
-  QUnit.equal(track.enabled, enabled, 'enabled value matches what we passed in');
+  assert.equal(track.enabled, enabled, 'enabled value matches what we passed in');
 });
 
-QUnit.test('defaults when items not provided', function() {
+QUnit.test('defaults when items not provided', function(assert) {
   const track = new AudioTrack();
 
-  QUnit.equal(track.kind, '', 'kind defaulted to empty string');
-  QUnit.equal(track.enabled, false, 'enabled defaulted to true since there is one track');
-  QUnit.equal(track.label, '', 'label defaults to empty string');
-  QUnit.equal(track.language, '', 'language defaults to empty string');
-  QUnit.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
+  assert.equal(track.kind, '', 'kind defaulted to empty string');
+  assert.equal(track.enabled, false, 'enabled defaulted to true since there is one track');
+  assert.equal(track.label, '', 'label defaults to empty string');
+  assert.equal(track.language, '', 'language defaults to empty string');
+  assert.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
 });
 
-QUnit.test('kind can only be one of several options, defaults to empty string', function() {
+QUnit.test('kind can only be one of several options, defaults to empty string', function(assert) {
   const track1 = new AudioTrack({
     kind: 'foo'
   });
 
-  QUnit.equal(track1.kind, '', 'the kind is set to empty string, not foo');
-  QUnit.notEqual(track1.kind, 'foo', 'the kind is set to empty string, not foo');
+  assert.equal(track1.kind, '', 'the kind is set to empty string, not foo');
+  assert.notEqual(track1.kind, 'foo', 'the kind is set to empty string, not foo');
 
   // loop through all possible kinds to verify
   for (const key in AudioTrackKind) {
@@ -47,50 +47,50 @@ QUnit.test('kind can only be one of several options, defaults to empty string', 
       kind: currentKind
     });
 
-    QUnit.equal(track.kind, currentKind, 'the kind is set to ' + currentKind);
+    assert.equal(track.kind, currentKind, 'the kind is set to ' + currentKind);
   }
 });
 
-QUnit.test('enabled can only be instantiated to true or false, defaults to false', function() {
+QUnit.test('enabled can only be instantiated to true or false, defaults to false', function(assert) {
   let track = new AudioTrack({
     enabled: 'foo'
   });
 
-  QUnit.equal(track.enabled, false, 'the enabled value is set to false, not foo');
-  QUnit.notEqual(track.enabled, 'foo', 'the enabled value is not set to foo');
+  assert.equal(track.enabled, false, 'the enabled value is set to false, not foo');
+  assert.notEqual(track.enabled, 'foo', 'the enabled value is not set to foo');
 
   track = new AudioTrack({
     enabled: true
   });
 
-  QUnit.equal(track.enabled, true, 'the enabled value is set to true');
+  assert.equal(track.enabled, true, 'the enabled value is set to true');
 
   track = new AudioTrack({
     enabled: false
   });
 
-  QUnit.equal(track.enabled, false, 'the enabled value is set to false');
+  assert.equal(track.enabled, false, 'the enabled value is set to false');
 });
 
-QUnit.test('enabled can only be changed to true or false', function() {
+QUnit.test('enabled can only be changed to true or false', function(assert) {
   const track = new AudioTrack();
 
   track.enabled = 'foo';
-  QUnit.notEqual(track.enabled, 'foo', 'enabled not set to invalid value, foo');
-  QUnit.equal(track.enabled, false, 'enabled remains on the old value, false');
+  assert.notEqual(track.enabled, 'foo', 'enabled not set to invalid value, foo');
+  assert.equal(track.enabled, false, 'enabled remains on the old value, false');
 
   track.enabled = true;
-  QUnit.equal(track.enabled, true, 'enabled was set to true');
+  assert.equal(track.enabled, true, 'enabled was set to true');
 
   track.enabled = 'baz';
-  QUnit.notEqual(track.enabled, 'baz', 'enabled not set to invalid value, baz');
-  QUnit.equal(track.enabled, true, 'enabled remains on the old value, true');
+  assert.notEqual(track.enabled, 'baz', 'enabled not set to invalid value, baz');
+  assert.equal(track.enabled, true, 'enabled remains on the old value, true');
 
   track.enabled = false;
-  QUnit.equal(track.enabled, false, 'enabled was set to false');
+  assert.equal(track.enabled, false, 'enabled was set to false');
 });
 
-QUnit.test('when enabled is changed enabledchange event is fired', function() {
+QUnit.test('when enabled is changed enabledchange event is fired', function(assert) {
   const track = new AudioTrack({
     tech: this.tech,
     enabled: false
@@ -104,19 +104,19 @@ QUnit.test('when enabled is changed enabledchange event is fired', function() {
   // two events
   track.enabled = true;
   track.enabled = false;
-  QUnit.equal(eventsTriggered, 2, 'two enabled changes');
+  assert.equal(eventsTriggered, 2, 'two enabled changes');
 
   // no event here
   track.enabled = false;
   track.enabled = false;
-  QUnit.equal(eventsTriggered, 2, 'still two enabled changes');
+  assert.equal(eventsTriggered, 2, 'still two enabled changes');
 
   // one event
   track.enabled = true;
-  QUnit.equal(eventsTriggered, 3, 'three enabled changes');
+  assert.equal(eventsTriggered, 3, 'three enabled changes');
 
   // no events
   track.enabled = true;
   track.enabled = true;
-  QUnit.equal(eventsTriggered, 3, 'still three enabled changes');
+  assert.equal(eventsTriggered, 3, 'still three enabled changes');
 });

--- a/test/unit/tracks/audio-tracks.test.js
+++ b/test/unit/tracks/audio-tracks.test.js
@@ -4,15 +4,15 @@ import TestHelpers from '../test-helpers.js';
 import sinon from 'sinon';
 
 QUnit.module('Tracks', {
-  setup() {
+  beforeEach(assert) {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach(assert) {
     this.clock.restore();
   }
 });
 
-QUnit.test('Player track methods call the tech', function() {
+QUnit.test('Player track methods call the tech', function(assert) {
   const player = TestHelpers.makePlayer();
   let calls = 0;
 
@@ -22,11 +22,11 @@ QUnit.test('Player track methods call the tech', function() {
 
   player.audioTracks();
 
-  QUnit.equal(calls, 1, 'audioTrack defers to the tech');
+  assert.equal(calls, 1, 'audioTrack defers to the tech');
   player.dispose();
 });
 
-QUnit.test('listen to remove and add track events in native audio tracks', function() {
+QUnit.test('listen to remove and add track events in native audio tracks', function(assert) {
   const oldTestVid = Html5.TEST_VID;
   const oldAudioTracks = Html5.prototype.audioTracks;
   const events = {};
@@ -67,36 +67,36 @@ QUnit.test('listen to remove and add track events in native audio tracks', funct
   const html = new Html5({});
   /* eslint-enable no-unused-vars */
 
-  QUnit.ok(events.removetrack, 'removetrack listener was added');
-  QUnit.ok(events.addtrack, 'addtrack listener was added');
+  assert.ok(events.removetrack, 'removetrack listener was added');
+  assert.ok(events.addtrack, 'addtrack listener was added');
 
   Html5.TEST_VID = oldTestVid;
   Html5.prototype.audioTracks = oldAudioTracks;
 });
 
-QUnit.test('html5 tech supports native audio tracks if the video supports it', function() {
+QUnit.test('html5 tech supports native audio tracks if the video supports it', function(assert) {
   const oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {
     audioTracks: []
   };
 
-  QUnit.ok(Html5.supportsNativeAudioTracks(), 'native audio tracks are supported');
+  assert.ok(Html5.supportsNativeAudioTracks(), 'native audio tracks are supported');
 
   Html5.TEST_VID = oldTestVid;
 });
 
-QUnit.test('html5 tech does not support native audio tracks if the video does not supports it', function() {
+QUnit.test('html5 tech does not support native audio tracks if the video does not supports it', function(assert) {
   const oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {};
 
-  QUnit.ok(!Html5.supportsNativeAudioTracks(), 'native audio tracks are not supported');
+  assert.ok(!Html5.supportsNativeAudioTracks(), 'native audio tracks are not supported');
 
   Html5.TEST_VID = oldTestVid;
 });
 
-QUnit.test('when switching techs, we should not get a new audio track', function() {
+QUnit.test('when switching techs, we should not get a new audio track', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.loadTech_('TechFaker');
@@ -105,5 +105,5 @@ QUnit.test('when switching techs, we should not get a new audio track', function
   player.loadTech_('TechFaker');
   const secondTracks = player.audioTracks();
 
-  QUnit.ok(firstTracks === secondTracks, 'the tracks are equal');
+  assert.ok(firstTracks === secondTracks, 'the tracks are equal');
 });

--- a/test/unit/tracks/html-track-element-list.test.js
+++ b/test/unit/tracks/html-track-element-list.test.js
@@ -34,19 +34,19 @@ QUnit.test('HTMLTrackElementList\'s length is set correctly', function(assert) {
   const htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
   assert.equal(htmlTrackElementList.length,
-              genericHtmlTrackElements.length,
-              `the length is ${genericHtmlTrackElements.length}`);
+               genericHtmlTrackElements.length,
+               `the length is ${genericHtmlTrackElements.length}`);
 });
 
 QUnit.test('can get html track element by track', function(assert) {
   const htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
   assert.equal(htmlTrackElementList.getTrackElementByTrack_(track1).kind,
-              'captions',
-              'track1 has kind of captions');
+               'captions',
+               'track1 has kind of captions');
   assert.equal(htmlTrackElementList.getTrackElementByTrack_(track2).kind,
-              'chapters',
-              'track2 has kind of captions');
+               'chapters',
+               'track2 has kind of captions');
 });
 
 QUnit.test('length is updated when new tracks are added or removed', function(assert) {
@@ -54,21 +54,21 @@ QUnit.test('length is updated when new tracks are added or removed', function(as
 
   htmlTrackElementList.addTrackElement_({tech() {}});
   assert.equal(htmlTrackElementList.length,
-              genericHtmlTrackElements.length + 1,
-              `the length is ${genericHtmlTrackElements.length + 1}`);
+               genericHtmlTrackElements.length + 1,
+               `the length is ${genericHtmlTrackElements.length + 1}`);
   htmlTrackElementList.addTrackElement_({tech() {}});
   assert.equal(htmlTrackElementList.length,
-              genericHtmlTrackElements.length + 2,
-              `the length is ${genericHtmlTrackElements.length + 2}`);
+               genericHtmlTrackElements.length + 2,
+               `the length is ${genericHtmlTrackElements.length + 2}`);
 
   htmlTrackElementList.removeTrackElement_(
     htmlTrackElementList.getTrackElementByTrack_(track1));
   assert.equal(htmlTrackElementList.length,
-              genericHtmlTrackElements.length + 1,
-              `the length is ${genericHtmlTrackElements.length + 1}`);
+               genericHtmlTrackElements.length + 1,
+               `the length is ${genericHtmlTrackElements.length + 1}`);
   htmlTrackElementList.removeTrackElement_(
     htmlTrackElementList.getTrackElementByTrack_(track2));
   assert.equal(htmlTrackElementList.length,
-              genericHtmlTrackElements.length,
-              `the length is ${genericHtmlTrackElements.length}`);
+               genericHtmlTrackElements.length,
+               `the length is ${genericHtmlTrackElements.length}`);
 });

--- a/test/unit/tracks/html-track-element-list.test.js
+++ b/test/unit/tracks/html-track-element-list.test.js
@@ -30,45 +30,45 @@ const genericHtmlTrackElements = [{
 
 QUnit.module('HTML Track Element List');
 
-QUnit.test('HTMLTrackElementList\'s length is set correctly', function() {
+QUnit.test('HTMLTrackElementList\'s length is set correctly', function(assert) {
   const htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
-  QUnit.equal(htmlTrackElementList.length,
+  assert.equal(htmlTrackElementList.length,
               genericHtmlTrackElements.length,
               `the length is ${genericHtmlTrackElements.length}`);
 });
 
-QUnit.test('can get html track element by track', function() {
+QUnit.test('can get html track element by track', function(assert) {
   const htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
-  QUnit.equal(htmlTrackElementList.getTrackElementByTrack_(track1).kind,
+  assert.equal(htmlTrackElementList.getTrackElementByTrack_(track1).kind,
               'captions',
               'track1 has kind of captions');
-  QUnit.equal(htmlTrackElementList.getTrackElementByTrack_(track2).kind,
+  assert.equal(htmlTrackElementList.getTrackElementByTrack_(track2).kind,
               'chapters',
               'track2 has kind of captions');
 });
 
-QUnit.test('length is updated when new tracks are added or removed', function() {
+QUnit.test('length is updated when new tracks are added or removed', function(assert) {
   const htmlTrackElementList = new HTMLTrackElementList(genericHtmlTrackElements);
 
   htmlTrackElementList.addTrackElement_({tech() {}});
-  QUnit.equal(htmlTrackElementList.length,
+  assert.equal(htmlTrackElementList.length,
               genericHtmlTrackElements.length + 1,
               `the length is ${genericHtmlTrackElements.length + 1}`);
   htmlTrackElementList.addTrackElement_({tech() {}});
-  QUnit.equal(htmlTrackElementList.length,
+  assert.equal(htmlTrackElementList.length,
               genericHtmlTrackElements.length + 2,
               `the length is ${genericHtmlTrackElements.length + 2}`);
 
   htmlTrackElementList.removeTrackElement_(
     htmlTrackElementList.getTrackElementByTrack_(track1));
-  QUnit.equal(htmlTrackElementList.length,
+  assert.equal(htmlTrackElementList.length,
               genericHtmlTrackElements.length + 1,
               `the length is ${genericHtmlTrackElements.length + 1}`);
   htmlTrackElementList.removeTrackElement_(
     htmlTrackElementList.getTrackElementByTrack_(track2));
-  QUnit.equal(htmlTrackElementList.length,
+  assert.equal(htmlTrackElementList.length,
               genericHtmlTrackElements.length,
               `the length is ${genericHtmlTrackElements.length}`);
 });

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -1,6 +1,5 @@
 /* eslint-env qunit */
 import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
-import window from 'global/window';
 
 const defaultTech = {
   textTracks() {},
@@ -12,7 +11,7 @@ const defaultTech = {
 QUnit.module('HTML Track Element');
 
 QUnit.test('html track element requires a tech', function(assert) {
-  window.throws(
+  assert.throws(
     function() {
       return new HTMLTrackElement();
     },

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -11,7 +11,7 @@ const defaultTech = {
 
 QUnit.module('HTML Track Element');
 
-QUnit.test('html track element requires a tech', function() {
+QUnit.test('html track element requires a tech', function(assert) {
   window.throws(
     function() {
       return new HTMLTrackElement();
@@ -21,7 +21,7 @@ QUnit.test('html track element requires a tech', function() {
   );
 });
 
-QUnit.test('can create a html track element with various properties', function() {
+QUnit.test('can create a html track element with various properties', function(assert) {
   const kind = 'chapters';
   const label = 'English';
   const language = 'en';
@@ -35,30 +35,30 @@ QUnit.test('can create a html track element with various properties', function()
     tech: defaultTech
   });
 
-  QUnit.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
-  QUnit.equal(htmlTrackElement.kind, kind, 'we have a kind');
-  QUnit.equal(htmlTrackElement.label, label, 'we have a label');
-  QUnit.equal(htmlTrackElement.readyState, 0, 'we have a readyState');
-  QUnit.equal(htmlTrackElement.src, src, 'we have a src');
-  QUnit.equal(htmlTrackElement.srclang, language, 'we have a srclang');
-  QUnit.equal(htmlTrackElement.track.cues, null, 'we have a track');
+  assert.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
+  assert.equal(htmlTrackElement.kind, kind, 'we have a kind');
+  assert.equal(htmlTrackElement.label, label, 'we have a label');
+  assert.equal(htmlTrackElement.readyState, 0, 'we have a readyState');
+  assert.equal(htmlTrackElement.src, src, 'we have a src');
+  assert.equal(htmlTrackElement.srclang, language, 'we have a srclang');
+  assert.equal(htmlTrackElement.track.cues, null, 'we have a track');
 });
 
-QUnit.test('defaults when items not provided', function() {
+QUnit.test('defaults when items not provided', function(assert) {
   const htmlTrackElement = new HTMLTrackElement({
     tech: defaultTech
   });
 
-  QUnit.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
-  QUnit.equal(htmlTrackElement.kind, 'subtitles', 'we have a kind');
-  QUnit.equal(htmlTrackElement.label, '', 'we have a label');
-  QUnit.equal(htmlTrackElement.readyState, 0, 'we have a readyState');
-  QUnit.equal(typeof htmlTrackElement.src, 'undefined', 'we have a src');
-  QUnit.equal(htmlTrackElement.srclang, '', 'we have a srclang');
-  QUnit.equal(htmlTrackElement.track.cues.length, 0, 'we have a track');
+  assert.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
+  assert.equal(htmlTrackElement.kind, 'subtitles', 'we have a kind');
+  assert.equal(htmlTrackElement.label, '', 'we have a label');
+  assert.equal(htmlTrackElement.readyState, 0, 'we have a readyState');
+  assert.equal(typeof htmlTrackElement.src, 'undefined', 'we have a src');
+  assert.equal(htmlTrackElement.srclang, '', 'we have a srclang');
+  assert.equal(htmlTrackElement.track.cues.length, 0, 'we have a track');
 });
 
-QUnit.test('fires loadeddata when track cues become populated', function() {
+QUnit.test('fires loadeddata when track cues become populated', function(assert) {
   let changes = 0;
   const loadHandler = function() {
     changes++;
@@ -72,6 +72,6 @@ QUnit.test('fires loadeddata when track cues become populated', function() {
   // trigger loaded cues event
   htmlTrackElement.track.trigger('loadeddata');
 
-  QUnit.equal(changes, 1, 'a loadeddata event trigger addEventListener');
-  QUnit.equal(htmlTrackElement.readyState, 2, 'readyState is loaded');
+  assert.equal(changes, 1, 'a loadeddata event trigger addEventListener');
+  assert.equal(htmlTrackElement.readyState, 2, 'readyState is loaded');
 });

--- a/test/unit/tracks/text-track-controls.test.js
+++ b/test/unit/tracks/text-track-controls.test.js
@@ -5,10 +5,10 @@ import * as browser from '../../../src/js/utils/browser.js';
 import sinon from 'sinon';
 
 QUnit.module('Text Track Controls', {
-  setup() {
+  beforeEach(assert) {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach(assert) {
     this.clock.restore();
   }
 });
@@ -18,57 +18,57 @@ const track = {
   label: 'test'
 };
 
-QUnit.test('should be displayed when text tracks list is not empty', function() {
+QUnit.test('should be displayed when text tracks list is not empty', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [track]
   });
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
            'control is displayed');
-  QUnit.equal(player.textTracks().length, 1, 'textTracks contains one item');
+  assert.equal(player.textTracks().length, 1, 'textTracks contains one item');
 
   player.dispose();
 });
 
-QUnit.test('should be displayed when a text track is added to an empty track list', function() {
+QUnit.test('should be displayed when a text track is added to an empty track list', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.addRemoteTextTrack(track);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
            'control is displayed');
-  QUnit.equal(player.textTracks().length, 1, 'textTracks contains one item');
+  assert.equal(player.textTracks().length, 1, 'textTracks contains one item');
 
   player.dispose();
 });
 
-QUnit.test('should not be displayed when text tracks list is empty', function() {
+QUnit.test('should not be displayed when text tracks list is empty', function(assert) {
   const player = TestHelpers.makePlayer();
 
-  QUnit.ok(player.controlBar.captionsButton.hasClass('vjs-hidden'),
+  assert.ok(player.controlBar.captionsButton.hasClass('vjs-hidden'),
            'control is not displayed');
-  QUnit.equal(player.textTracks().length, 0, 'textTracks is empty');
+  assert.equal(player.textTracks().length, 0, 'textTracks is empty');
 
   player.dispose();
 });
 
-QUnit.test('should not be displayed when last text track is removed', function() {
+QUnit.test('should not be displayed when last text track is removed', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [track]
   });
 
   player.removeRemoteTextTrack(player.textTracks()[0]);
 
-  QUnit.ok(player.controlBar.captionsButton.hasClass('vjs-hidden'),
+  assert.ok(player.controlBar.captionsButton.hasClass('vjs-hidden'),
            'control is not displayed');
-  QUnit.equal(player.textTracks().length, 0, 'textTracks is empty');
+  assert.equal(player.textTracks().length, 0, 'textTracks is empty');
 
   player.dispose();
 });
 
-QUnit.test('menu should contain "Settings", "Off" and one track', function() {
+QUnit.test('menu should contain "Settings", "Off" and one track', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [track]
   });
@@ -77,17 +77,17 @@ QUnit.test('menu should contain "Settings", "Off" and one track', function() {
 
   const menuItems = player.controlBar.captionsButton.items;
 
-  QUnit.equal(menuItems.length, 3, 'menu contains three items');
-  QUnit.equal(menuItems[0].track.label,
+  assert.equal(menuItems.length, 3, 'menu contains three items');
+  assert.equal(menuItems[0].track.label,
               'captions settings',
               'menu contains "captions settings"');
-  QUnit.equal(menuItems[1].track.label, 'captions off', 'menu contains "captions off"');
-  QUnit.equal(menuItems[2].track.label, 'test', 'menu contains "test" track');
+  assert.equal(menuItems[1].track.label, 'captions off', 'menu contains "captions off"');
+  assert.equal(menuItems[2].track.label, 'test', 'menu contains "test" track');
 
   player.dispose();
 });
 
-QUnit.test('menu should update with addRemoteTextTrack', function() {
+QUnit.test('menu should update with addRemoteTextTrack', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [track]
   });
@@ -96,15 +96,15 @@ QUnit.test('menu should update with addRemoteTextTrack', function() {
 
   player.addRemoteTextTrack(track);
 
-  QUnit.equal(player.controlBar.captionsButton.items.length,
+  assert.equal(player.controlBar.captionsButton.items.length,
               4,
               'menu does contain added track');
-  QUnit.equal(player.textTracks().length, 2, 'textTracks contains two items');
+  assert.equal(player.textTracks().length, 2, 'textTracks contains two items');
 
   player.dispose();
 });
 
-QUnit.test('menu should update with removeRemoteTextTrack', function() {
+QUnit.test('menu should update with removeRemoteTextTrack', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [track, track]
   });
@@ -113,10 +113,10 @@ QUnit.test('menu should update with removeRemoteTextTrack', function() {
 
   player.removeRemoteTextTrack(player.textTracks()[0]);
 
-  QUnit.equal(player.controlBar.captionsButton.items.length,
+  assert.equal(player.controlBar.captionsButton.items.length,
               3,
               'menu does not contain removed track');
-  QUnit.equal(player.textTracks().length, 1, 'textTracks contains one item');
+  assert.equal(player.textTracks().length, 1, 'textTracks contains one item');
 
   player.dispose();
 });
@@ -126,57 +126,57 @@ const descriptionstrack = {
   label: 'desc'
 };
 
-QUnit.test('descriptions should be displayed when text tracks list is not empty', function() {
+QUnit.test('descriptions should be displayed when text tracks list is not empty', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [descriptionstrack]
   });
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
            'descriptions control is displayed');
-  QUnit.equal(player.textTracks().length, 1, 'textTracks contains one item');
+  assert.equal(player.textTracks().length, 1, 'textTracks contains one item');
 
   player.dispose();
 });
 
-QUnit.test('descriptions should be displayed when a text track is added to an empty track list', function() {
+QUnit.test('descriptions should be displayed when a text track is added to an empty track list', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.addRemoteTextTrack(descriptionstrack);
 
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
            'control is displayed');
-  QUnit.equal(player.textTracks().length, 1, 'textTracks contains one item');
+  assert.equal(player.textTracks().length, 1, 'textTracks contains one item');
 
   player.dispose();
 });
 
-QUnit.test('descriptions should not be displayed when text tracks list is empty', function() {
+QUnit.test('descriptions should not be displayed when text tracks list is empty', function(assert) {
   const player = TestHelpers.makePlayer();
 
-  QUnit.ok(player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
+  assert.ok(player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
            'control is not displayed');
-  QUnit.equal(player.textTracks().length, 0, 'textTracks is empty');
+  assert.equal(player.textTracks().length, 0, 'textTracks is empty');
 
   player.dispose();
 });
 
-QUnit.test('descriptions should not be displayed when last text track is removed', function() {
+QUnit.test('descriptions should not be displayed when last text track is removed', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [descriptionstrack]
   });
 
   player.removeRemoteTextTrack(player.textTracks()[0]);
 
-  QUnit.ok(player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
+  assert.ok(player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
            'control is not displayed');
-  QUnit.equal(player.textTracks().length, 0, 'textTracks is empty');
+  assert.equal(player.textTracks().length, 0, 'textTracks is empty');
 
   player.dispose();
 });
 
-QUnit.test('descriptions menu should contain "Off" and one track', function() {
+QUnit.test('descriptions menu should contain "Off" and one track', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks: [descriptionstrack]
   });
@@ -185,17 +185,17 @@ QUnit.test('descriptions menu should contain "Off" and one track', function() {
 
   const menuItems = player.controlBar.descriptionsButton.items;
 
-  QUnit.equal(menuItems.length, 2, 'descriptions menu contains two items');
-  QUnit.equal(menuItems[0].track.label,
+  assert.equal(menuItems.length, 2, 'descriptions menu contains two items');
+  assert.equal(menuItems[0].track.label,
               'descriptions off',
               'menu contains "descriptions off"');
-  QUnit.equal(menuItems[1].track.label, 'desc', 'menu contains "desc" track');
+  assert.equal(menuItems[1].track.label, 'desc', 'menu contains "desc" track');
 
   player.dispose();
 });
 
-QUnit.test('enabling a captions track should disable the descriptions menu button', function() {
-  QUnit.expect(14);
+QUnit.test('enabling a captions track should disable the descriptions menu button', function(assert) {
+  assert.expect(14);
 
   const player = TestHelpers.makePlayer({
     tracks: [track, descriptionstrack]
@@ -203,21 +203,21 @@ QUnit.test('enabling a captions track should disable the descriptions menu butto
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-hidden'),
            'captions control is displayed');
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-hidden'),
            'descriptions control is displayed');
-  QUnit.equal(player.textTracks().length, 2, 'textTracks contains two items');
+  assert.equal(player.textTracks().length, 2, 'textTracks contains two items');
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
            'captions control is NOT disabled');
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
            'descriptions control is NOT disabled');
 
   for (let i = 0; i < player.textTracks().length; i++) {
     if (player.textTracks()[i].kind === 'descriptions') {
       player.textTracks()[i].mode = 'showing';
-      QUnit.ok(player.textTracks()[i].kind === 'descriptions' &&
+      assert.ok(player.textTracks()[i].kind === 'descriptions' &&
                player.textTracks()[i].mode === 'showing',
                'descriptions mode set to showing');
     }
@@ -225,15 +225,15 @@ QUnit.test('enabling a captions track should disable the descriptions menu butto
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
            'captions control is NOT disabled');
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
            'descriptions control is NOT disabled');
 
   for (let i = 0; i < player.textTracks().length; i++) {
     if (player.textTracks()[i].kind === 'captions') {
       player.textTracks()[i].mode = 'showing';
-      QUnit.ok(player.textTracks()[i].kind === 'captions' &&
+      assert.ok(player.textTracks()[i].kind === 'captions' &&
                player.textTracks()[i].mode === 'showing',
                'captions mode set to showing');
     }
@@ -241,15 +241,15 @@ QUnit.test('enabling a captions track should disable the descriptions menu butto
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
            'captions control is NOT disabled');
-  QUnit.ok(player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
+  assert.ok(player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
            'descriptions control IS disabled');
 
   for (let i = 0; i < player.textTracks().length; i++) {
     if (player.textTracks()[i].kind === 'captions') {
       player.textTracks()[i].mode = 'disabled';
-      QUnit.ok(player.textTracks()[i].kind === 'captions' &&
+      assert.ok(player.textTracks()[i].kind === 'captions' &&
                player.textTracks()[i].mode === 'disabled',
                'captions mode set to disabled');
     }
@@ -257,9 +257,9 @@ QUnit.test('enabling a captions track should disable the descriptions menu butto
 
   this.clock.tick(1000);
 
-  QUnit.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.captionsButton.hasClass('vjs-disabled'),
            'captions control is NOT disabled');
-  QUnit.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
+  assert.ok(!player.controlBar.descriptionsButton.hasClass('vjs-disabled'),
            'descriptions control is NOT disabled');
 
   player.dispose();
@@ -270,7 +270,7 @@ if (!browser.IS_IE8) {
   // However, this test tests a specific with iOS7 where
   // the TextTrackList doesn't report track mode changes.
   // TODO: figure out why this test doens't work on IE8. https://github.com/videojs/video.js/issues/1861
-  QUnit.test('menu items should polyfill mode change events', function() {
+  QUnit.test('menu items should polyfill mode change events', function(assert) {
     const player = TestHelpers.makePlayer({});
     let changes;
 
@@ -286,10 +286,10 @@ if (!browser.IS_IE8) {
     });
     changes = 0;
     trackMenuItem.trigger('tap');
-    QUnit.equal(changes, 1, 'taps trigger change events');
+    assert.equal(changes, 1, 'taps trigger change events');
 
     trackMenuItem.trigger('click');
-    QUnit.equal(changes, 2, 'clicks trigger change events');
+    assert.equal(changes, 2, 'clicks trigger change events');
 
     player.dispose();
   });

--- a/test/unit/tracks/text-track-cue-list.test.js
+++ b/test/unit/tracks/text-track-cue-list.test.js
@@ -13,81 +13,81 @@ const genericTracks = [
 
 QUnit.module('Text Track Cue List');
 
-QUnit.test('TextTrackCueList\'s length is set correctly', function() {
+QUnit.test('TextTrackCueList\'s length is set correctly', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
-  QUnit.equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
+  assert.equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
-QUnit.test('can get cues by id', function() {
+QUnit.test('can get cues by id', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
-  QUnit.equal(ttcl.getCueById('1').id, 1, 'id "1" has id of "1"');
-  QUnit.equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
-  QUnit.equal(ttcl.getCueById('3').id, 3, 'id "3" has id of "3"');
-  QUnit.ok(!ttcl.getCueById(1), 'there isn\'t an item with "numeric" id of `1`');
+  assert.equal(ttcl.getCueById('1').id, 1, 'id "1" has id of "1"');
+  assert.equal(ttcl.getCueById('2').id, 2, 'id "2" has id of "2"');
+  assert.equal(ttcl.getCueById('3').id, 3, 'id "3" has id of "3"');
+  assert.ok(!ttcl.getCueById(1), 'there isn\'t an item with "numeric" id of `1`');
 });
 
-QUnit.test('length is updated when new tracks are added or removed', function() {
+QUnit.test('length is updated when new tracks are added or removed', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
-  QUnit.equal(ttcl.length, genericTracks.length + 1,
+  assert.equal(ttcl.length, genericTracks.length + 1,
               'the length is ' + (genericTracks.length + 1));
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
-  QUnit.equal(ttcl.length, genericTracks.length + 2,
+  assert.equal(ttcl.length, genericTracks.length + 2,
               'the length is ' + (genericTracks.length + 2));
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
-  QUnit.equal(ttcl.length, genericTracks.length + 1,
+  assert.equal(ttcl.length, genericTracks.length + 1,
               'the length is ' + (genericTracks.length + 1));
   ttcl.setCues_(genericTracks);
-  QUnit.equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
+  assert.equal(ttcl.length, genericTracks.length, 'the length is ' + genericTracks.length);
 });
 
-QUnit.test('can access items by index', function() {
+QUnit.test('can access items by index', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
   const length = ttcl.length;
 
-  QUnit.expect(length);
+  assert.expect(length);
 
   for (let i = 0; i < length; i++) {
-    QUnit.equal(ttcl[i].id, String(i + 1), 'the id of a track matches the index + 1');
+    assert.equal(ttcl[i].id, String(i + 1), 'the id of a track matches the index + 1');
   }
 });
 
-QUnit.test('can access new items by index', function() {
+QUnit.test('can access new items by index', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
 
-  QUnit.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
-  QUnit.equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
+  assert.equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
 });
 
-QUnit.test('cannot access removed items by index', function() {
+QUnit.test('cannot access removed items by index', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}, {id: '101'}]));
-  QUnit.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
-  QUnit.equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
+  assert.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(ttcl[4].id, '101', 'id of item at index 4 is 101');
 
   ttcl.setCues_(genericTracks);
 
-  QUnit.ok(!ttcl[3], 'nothing at index 3');
-  QUnit.ok(!ttcl[4], 'nothing at index 4');
+  assert.ok(!ttcl[3], 'nothing at index 3');
+  assert.ok(!ttcl[4], 'nothing at index 4');
 });
 
-QUnit.test('new item available at old index', function() {
+QUnit.test('new item available at old index', function(assert) {
   const ttcl = new TextTrackCueList(genericTracks);
 
   ttcl.setCues_(genericTracks.concat([{id: '100'}]));
-  QUnit.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(ttcl[3].id, '100', 'id of item at index 3 is 100');
 
   ttcl.setCues_(genericTracks);
-  QUnit.ok(!ttcl[3], 'nothing at index 3');
+  assert.ok(!ttcl[3], 'nothing at index 3');
 
   ttcl.setCues_(genericTracks.concat([{id: '101'}]));
-  QUnit.equal(ttcl[3].id, '101', 'id of new item at index 3 is now 101');
+  assert.equal(ttcl[3].id, '101', 'id of new item at index 3 is now 101');
 });

--- a/test/unit/tracks/text-track-list-converter.test.js
+++ b/test/unit/tracks/text-track-list-converter.test.js
@@ -24,7 +24,7 @@ const cleanup = (item) => {
 };
 
 if (Html5.supportsNativeTextTracks()) {
-  QUnit.test('trackToJson_ produces correct representation for native track object', function(a) {
+  QUnit.test('trackToJson_ produces correct representation for native track object', function(assert) {
     const track = document.createElement('track');
 
     track.src = 'example.com/english.vtt';
@@ -32,7 +32,7 @@ if (Html5.supportsNativeTextTracks()) {
     track.srclang = 'en';
     track.label = 'English';
 
-    a.deepEqual(cleanup(c.trackToJson_(track.track)), {
+    assert.deepEqual(cleanup(c.trackToJson_(track.track)), {
       kind: 'captions',
       label: 'English',
       language: 'en',
@@ -40,7 +40,7 @@ if (Html5.supportsNativeTextTracks()) {
     }, 'the json output is same');
   });
 
-  QUnit.test('textTracksToJson produces good json output', function(a) {
+  QUnit.test('textTracksToJson produces good json output', function(assert) {
     const emulatedTrack = new TextTrack({
       kind: 'captions',
       label: 'English',
@@ -76,7 +76,7 @@ if (Html5.supportsNativeTextTracks()) {
       }
     };
 
-    a.deepEqual(cleanup(c.textTracksToJson(tech)), [{
+    assert.deepEqual(cleanup(c.textTracksToJson(tech)), [{
       kind: 'captions',
       label: 'Spanish',
       language: 'es',
@@ -89,7 +89,7 @@ if (Html5.supportsNativeTextTracks()) {
     }], 'the output is correct');
   });
 
-  QUnit.test('jsonToTextTracks calls addRemoteTextTrack on the tech with mixed tracks', function(a) {
+  QUnit.test('jsonToTextTracks calls addRemoteTextTrack on the tech with mixed tracks', function(assert) {
     const emulatedTrack = new TextTrack({
       kind: 'captions',
       label: 'English',
@@ -136,11 +136,11 @@ if (Html5.supportsNativeTextTracks()) {
 
     c.jsonToTextTracks(cleanup(c.textTracksToJson(tech)), tech);
 
-    a.equal(addRemotes, 2, 'we added two text tracks');
+    assert.equal(addRemotes, 2, 'we added two text tracks');
   });
 }
 
-QUnit.test('trackToJson_ produces correct representation for emulated track object', function(a) {
+QUnit.test('trackToJson_ produces correct representation for emulated track object', function(assert) {
   const track = new TextTrack({
     kind: 'captions',
     label: 'English',
@@ -149,7 +149,7 @@ QUnit.test('trackToJson_ produces correct representation for emulated track obje
     tech: {}
   });
 
-  a.deepEqual(cleanup(c.trackToJson_(track)), {
+  assert.deepEqual(cleanup(c.trackToJson_(track)), {
     src: 'example.com/english.vtt',
     kind: 'captions',
     label: 'English',
@@ -158,7 +158,7 @@ QUnit.test('trackToJson_ produces correct representation for emulated track obje
   }, 'the json output is same');
 });
 
-QUnit.test('textTracksToJson produces good json output for emulated only', function(a) {
+QUnit.test('textTracksToJson produces good json output for emulated only', function(assert) {
   const emulatedTrack = new TextTrack({
     kind: 'captions',
     label: 'English',
@@ -197,7 +197,7 @@ QUnit.test('textTracksToJson produces good json output for emulated only', funct
     }
   };
 
-  a.deepEqual(cleanup(c.textTracksToJson(tech)), [{
+  assert.deepEqual(cleanup(c.textTracksToJson(tech)), [{
     src: 'example.com/spanish.vtt',
     kind: 'captions',
     label: 'Spanish',
@@ -212,7 +212,7 @@ QUnit.test('textTracksToJson produces good json output for emulated only', funct
   }], 'the output is correct');
 });
 
-QUnit.test('jsonToTextTracks calls addRemoteTextTrack on the tech with emulated tracks only', function(a) {
+QUnit.test('jsonToTextTracks calls addRemoteTextTrack on the tech with emulated tracks only', function(assert) {
   const emulatedTrack = new TextTrack({
     kind: 'captions',
     label: 'English',
@@ -260,5 +260,5 @@ QUnit.test('jsonToTextTracks calls addRemoteTextTrack on the tech with emulated 
 
   c.jsonToTextTracks(cleanup(c.textTracksToJson(tech)), tech);
 
-  a.equal(addRemotes, 2, 'we added two text tracks');
+  assert.equal(addRemotes, 2, 'we added two text tracks');
 });

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -4,7 +4,7 @@ import TextTrack from '../../../src/js/tracks/text-track.js';
 import EventTarget from '../../../src/js/event-target.js';
 
 QUnit.module('Text Track List');
-QUnit.test('trigger "change" event when "modechange" is fired on a track', function() {
+QUnit.test('trigger "change" event when "modechange" is fired on a track', function(assert) {
   const tt = new EventTarget();
   const ttl = new TextTrackList([tt]);
   let changes = 0;
@@ -19,10 +19,10 @@ QUnit.test('trigger "change" event when "modechange" is fired on a track', funct
   ttl.onchange = changeHandler;
 
   tt.trigger('modechange');
-  QUnit.equal(changes, 2, 'two change events should have fired');
+  assert.equal(changes, 2, 'two change events should have fired');
 });
 
-QUnit.test('trigger "change" event when mode changes on a TextTrack', function() {
+QUnit.test('trigger "change" event when mode changes on a TextTrack', function(assert) {
   const tt = new TextTrack({
     tech: {
       on() {}
@@ -43,5 +43,5 @@ QUnit.test('trigger "change" event when mode changes on a TextTrack', function()
   tt.mode = 'hidden';
   tt.mode = 'disabled';
 
-  QUnit.equal(changes, 3, 'three change events should have fired');
+  assert.equal(changes, 3, 'three change events should have fired');
 });

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -26,7 +26,7 @@ QUnit.module('Text Track Settings', {
   }
 });
 
-QUnit.test('should update settings', function() {
+QUnit.test('should update settings', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks,
     persistTextTrackSettings: true
@@ -44,40 +44,40 @@ QUnit.test('should update settings', function() {
   };
 
   player.textTrackSettings.setValues(newSettings);
-  QUnit.deepEqual(player.textTrackSettings.getValues(),
+  assert.deepEqual(player.textTrackSettings.getValues(),
                   newSettings,
                   'values are updated');
 
-  QUnit.equal(player.$('.vjs-fg-color > select').selectedIndex,
+  assert.equal(player.$('.vjs-fg-color > select').selectedIndex,
               2,
               'fg-color is set to new value');
-  QUnit.equal(player.$('.vjs-bg-color > select').selectedIndex,
+  assert.equal(player.$('.vjs-bg-color > select').selectedIndex,
               1,
               'bg-color is set to new value');
-  QUnit.equal(player.$('.window-color > select').selectedIndex,
+  assert.equal(player.$('.window-color > select').selectedIndex,
               1,
               'window-color is set to new value');
-  QUnit.equal(player.$('.vjs-text-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-text-opacity > select').selectedIndex,
               1,
               'text-opacity is set to new value');
-  QUnit.equal(player.$('.vjs-bg-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-bg-opacity > select').selectedIndex,
               1,
               'bg-opacity is set to new value');
-  QUnit.equal(player.$('.vjs-window-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-window-opacity > select').selectedIndex,
               1,
               'window-opacity is set to new value');
-  QUnit.equal(player.$('.vjs-edge-style select').selectedIndex,
+  assert.equal(player.$('.vjs-edge-style select').selectedIndex,
               1,
               'edge-style is set to new value');
-  QUnit.equal(player.$('.vjs-font-family select').selectedIndex,
+  assert.equal(player.$('.vjs-font-family select').selectedIndex,
               3,
               'font-family is set to new value');
-  QUnit.equal(player.$('.vjs-font-percent select').selectedIndex,
+  assert.equal(player.$('.vjs-font-percent select').selectedIndex,
               3,
               'font-percent is set to new value');
 
   Events.trigger(player.$('.vjs-done-button'), 'click');
-  QUnit.deepEqual(safeParseTuple(
+  assert.deepEqual(safeParseTuple(
                     window.localStorage.getItem('vjs-text-track-settings'))[1],
                   newSettings,
                   'values are saved');
@@ -85,7 +85,7 @@ QUnit.test('should update settings', function() {
   player.dispose();
 });
 
-QUnit.test('should restore default settings', function() {
+QUnit.test('should restore default settings', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks,
     persistTextTrackSettings: true
@@ -105,71 +105,71 @@ QUnit.test('should restore default settings', function() {
   Events.trigger(player.$('.vjs-default-button'), 'click');
   Events.trigger(player.$('.vjs-done-button'), 'click');
 
-  QUnit.deepEqual(player.textTrackSettings.getValues(),
+  assert.deepEqual(player.textTrackSettings.getValues(),
                   defaultSettings,
                   'values are defaulted');
   // TODO:
   // MikeA: need to figure out how to modify saveSettings
   // to factor in defaults are no longer null
-  // QUnit.deepEqual(window.localStorage.getItem('vjs-text-track-settings'),
+  // assert.deepEqual(window.localStorage.getItem('vjs-text-track-settings'),
   //                 defaultSettings,
   //                 'values are saved');
 
-  QUnit.equal(player.$('.vjs-fg-color > select').selectedIndex,
+  assert.equal(player.$('.vjs-fg-color > select').selectedIndex,
               0,
               'fg-color is set to default value');
-  QUnit.equal(player.$('.vjs-bg-color > select').selectedIndex,
+  assert.equal(player.$('.vjs-bg-color > select').selectedIndex,
               0,
               'bg-color is set to default value');
-  QUnit.equal(player.$('.window-color > select').selectedIndex,
+  assert.equal(player.$('.window-color > select').selectedIndex,
               0,
               'window-color is set to default value');
-  QUnit.equal(player.$('.vjs-text-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-text-opacity > select').selectedIndex,
               0,
               'text-opacity is set to default value');
-  QUnit.equal(player.$('.vjs-bg-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-bg-opacity > select').selectedIndex,
               0,
               'bg-opacity is set to default value');
-  QUnit.equal(player.$('.vjs-window-opacity > select').selectedIndex,
+  assert.equal(player.$('.vjs-window-opacity > select').selectedIndex,
               0,
               'window-opacity is set to default value');
-  QUnit.equal(player.$('.vjs-edge-style select').selectedIndex,
+  assert.equal(player.$('.vjs-edge-style select').selectedIndex,
               0,
               'edge-style is set to default value');
-  QUnit.equal(player.$('.vjs-font-family select').selectedIndex,
+  assert.equal(player.$('.vjs-font-family select').selectedIndex,
               0,
               'font-family is set to default value');
-  QUnit.equal(player.$('.vjs-font-percent select').selectedIndex,
+  assert.equal(player.$('.vjs-font-percent select').selectedIndex,
               2,
               'font-percent is set to default value');
 
   player.dispose();
 });
 
-QUnit.test('should open on click', function() {
+QUnit.test('should open on click', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks
   });
 
   Events.trigger(player.$('.vjs-texttrack-settings'), 'click');
-  QUnit.ok(!player.textTrackSettings.hasClass('vjs-hidden'), 'settings open');
+  assert.ok(!player.textTrackSettings.hasClass('vjs-hidden'), 'settings open');
 
   player.dispose();
 });
 
-QUnit.test('should close on done click', function() {
+QUnit.test('should close on done click', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks
   });
 
   Events.trigger(player.$('.vjs-texttrack-settings'), 'click');
   Events.trigger(player.$('.vjs-done-button'), 'click');
-  QUnit.ok(player.textTrackSettings.hasClass('vjs-hidden'), 'settings closed');
+  assert.ok(player.textTrackSettings.hasClass('vjs-hidden'), 'settings closed');
 
   player.dispose();
 });
 
-QUnit.test('if persist option is set, restore settings on init', function() {
+QUnit.test('if persist option is set, restore settings on init', function(assert) {
   const oldRestoreSettings = TextTrackSettings.prototype.restoreSettings;
   let restore = 0;
 
@@ -182,14 +182,14 @@ QUnit.test('if persist option is set, restore settings on init', function() {
     persistTextTrackSettings: true
   });
 
-  QUnit.equal(restore, 1, 'restore was called');
+  assert.equal(restore, 1, 'restore was called');
 
   TextTrackSettings.prototype.restoreSettings = oldRestoreSettings;
 
   player.dispose();
 });
 
-QUnit.test('if persist option is set, save settings when "done"', function() {
+QUnit.test('if persist option is set, save settings when "done"', function(assert) {
   const player = TestHelpers.makePlayer({
     tracks,
     persistTextTrackSettings: true
@@ -203,14 +203,14 @@ QUnit.test('if persist option is set, save settings when "done"', function() {
 
   Events.trigger(player.$('.vjs-done-button'), 'click');
 
-  QUnit.equal(save, 1, 'save was called');
+  assert.equal(save, 1, 'save was called');
 
   TextTrackSettings.prototype.saveSettings = oldSaveSettings;
 
   player.dispose();
 });
 
-QUnit.test('do not try to restore or save settings if persist option is not set', function() {
+QUnit.test('do not try to restore or save settings if persist option is not set', function(assert) {
   const oldRestoreSettings = TextTrackSettings.prototype.restoreSettings;
   const oldSaveSettings = TextTrackSettings.prototype.saveSettings;
   let save = 0;
@@ -228,12 +228,12 @@ QUnit.test('do not try to restore or save settings if persist option is not set'
     persistTextTrackSettings: false
   });
 
-  QUnit.equal(restore, 0, 'restore was not called');
+  assert.equal(restore, 0, 'restore was not called');
 
   Events.trigger(player.$('.vjs-done-button'), 'click');
 
   // saveSettings is called but does nothing
-  QUnit.equal(save, 1, 'save was not called');
+  assert.equal(save, 1, 'save was not called');
 
   TextTrackSettings.prototype.saveSettings = oldSaveSettings;
   TextTrackSettings.prototype.restoreSettings = oldRestoreSettings;
@@ -241,7 +241,7 @@ QUnit.test('do not try to restore or save settings if persist option is not set'
   player.dispose();
 });
 
-QUnit.test('should restore saved settings', function() {
+QUnit.test('should restore saved settings', function(assert) {
   const newSettings = {
     backgroundOpacity: '0.5',
     textOpacity: '0.5',
@@ -261,12 +261,12 @@ QUnit.test('should restore saved settings', function() {
     persistTextTrackSettings: true
   });
 
-  QUnit.deepEqual(player.textTrackSettings.getValues(), newSettings);
+  assert.deepEqual(player.textTrackSettings.getValues(), newSettings);
 
   player.dispose();
 });
 
-QUnit.test('should not restore saved settings', function() {
+QUnit.test('should not restore saved settings', function(assert) {
   const newSettings = {
     backgroundOpacity: '0.5',
     textOpacity: '0.5',
@@ -286,7 +286,7 @@ QUnit.test('should not restore saved settings', function() {
     persistTextTrackSettings: false
   });
 
-  QUnit.deepEqual(player.textTrackSettings.getValues(), defaultSettings);
+  assert.deepEqual(player.textTrackSettings.getValues(), defaultSettings);
 
   player.dispose();
 });

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -28,111 +28,111 @@ TrackBaseline(TextTrack, {
   tech: defaultTech
 });
 
-QUnit.test('requires a tech', function() {
+QUnit.test('requires a tech', function(assert) {
   const error = new Error('A tech was not provided.');
 
-  QUnit.throws(() => new TextTrack({}), error, 'a tech is required');
-  QUnit.throws(() => new TextTrack({tech: null}), error, 'a tech is required');
+  assert.throws(() => new TextTrack({}), error, 'a tech is required');
+  assert.throws(() => new TextTrack({tech: null}), error, 'a tech is required');
 });
 
-QUnit.test('can create a TextTrack with a mode property', function() {
+QUnit.test('can create a TextTrack with a mode property', function(assert) {
   const mode = 'disabled';
   const tt = new TextTrack({
     mode,
     tech: defaultTech
   });
 
-  QUnit.equal(tt.mode, mode, 'we have a mode');
+  assert.equal(tt.mode, mode, 'we have a mode');
 });
 
-QUnit.test('defaults when items not provided', function() {
+QUnit.test('defaults when items not provided', function(assert) {
   const tt = new TextTrack({
     tech: TechFaker
   });
 
-  QUnit.equal(tt.kind, 'subtitles', 'kind defaulted to subtitles');
-  QUnit.equal(tt.mode, 'disabled', 'mode defaulted to disabled');
-  QUnit.equal(tt.label, '', 'label defaults to empty string');
-  QUnit.equal(tt.language, '', 'language defaults to empty string');
+  assert.equal(tt.kind, 'subtitles', 'kind defaulted to subtitles');
+  assert.equal(tt.mode, 'disabled', 'mode defaulted to disabled');
+  assert.equal(tt.label, '', 'label defaults to empty string');
+  assert.equal(tt.language, '', 'language defaults to empty string');
 });
 
-QUnit.test('kind can only be one of several options, defaults to subtitles', function() {
+QUnit.test('kind can only be one of several options, defaults to subtitles', function(assert) {
   let tt = new TextTrack({
     tech: defaultTech,
     kind: 'foo'
   });
 
-  QUnit.equal(tt.kind, 'subtitles', 'the kind is set to subtitles, not foo');
-  QUnit.notEqual(tt.kind, 'foo', 'the kind is set to subtitles, not foo');
+  assert.equal(tt.kind, 'subtitles', 'the kind is set to subtitles, not foo');
+  assert.notEqual(tt.kind, 'foo', 'the kind is set to subtitles, not foo');
 
   tt = new TextTrack({
     tech: defaultTech,
     kind: 'subtitles'
   });
 
-  QUnit.equal(tt.kind, 'subtitles', 'the kind is set to subtitles');
+  assert.equal(tt.kind, 'subtitles', 'the kind is set to subtitles');
 
   tt = new TextTrack({
     tech: defaultTech,
     kind: 'captions'
   });
 
-  QUnit.equal(tt.kind, 'captions', 'the kind is set to captions');
+  assert.equal(tt.kind, 'captions', 'the kind is set to captions');
 
   tt = new TextTrack({
     tech: defaultTech,
     kind: 'descriptions'
   });
 
-  QUnit.equal(tt.kind, 'descriptions', 'the kind is set to descriptions');
+  assert.equal(tt.kind, 'descriptions', 'the kind is set to descriptions');
 
   tt = new TextTrack({
     tech: defaultTech,
     kind: 'chapters'
   });
 
-  QUnit.equal(tt.kind, 'chapters', 'the kind is set to chapters');
+  assert.equal(tt.kind, 'chapters', 'the kind is set to chapters');
 
   tt = new TextTrack({
     tech: defaultTech,
     kind: 'metadata'
   });
 
-  QUnit.equal(tt.kind, 'metadata', 'the kind is set to metadata');
+  assert.equal(tt.kind, 'metadata', 'the kind is set to metadata');
 });
 
-QUnit.test('mode can only be one of several options, defaults to disabled', function() {
+QUnit.test('mode can only be one of several options, defaults to disabled', function(assert) {
   let tt = new TextTrack({
     tech: defaultTech,
     mode: 'foo'
   });
 
-  QUnit.equal(tt.mode, 'disabled', 'the mode is set to disabled, not foo');
-  QUnit.notEqual(tt.mode, 'foo', 'the mode is set to disabld, not foo');
+  assert.equal(tt.mode, 'disabled', 'the mode is set to disabled, not foo');
+  assert.notEqual(tt.mode, 'foo', 'the mode is set to disabld, not foo');
 
   tt = new TextTrack({
     tech: defaultTech,
     mode: 'disabled'
   });
 
-  QUnit.equal(tt.mode, 'disabled', 'the mode is set to disabled');
+  assert.equal(tt.mode, 'disabled', 'the mode is set to disabled');
 
   tt = new TextTrack({
     tech: defaultTech,
     mode: 'hidden'
   });
 
-  QUnit.equal(tt.mode, 'hidden', 'the mode is set to hidden');
+  assert.equal(tt.mode, 'hidden', 'the mode is set to hidden');
 
   tt = new TextTrack({
     tech: defaultTech,
     mode: 'showing'
   });
 
-  QUnit.equal(tt.mode, 'showing', 'the mode is set to showing');
+  assert.equal(tt.mode, 'showing', 'the mode is set to showing');
 });
 
-QUnit.test('cue and activeCues are read only', function() {
+QUnit.test('cue and activeCues are read only', function(assert) {
   const mode = 'disabled';
   const tt = new TextTrack({
     mode,
@@ -142,68 +142,68 @@ QUnit.test('cue and activeCues are read only', function() {
   tt.cues = 'foo';
   tt.activeCues = 'bar';
 
-  QUnit.notEqual(tt.cues, 'foo', 'cues is still original value');
-  QUnit.notEqual(tt.activeCues, 'bar', 'activeCues is still original value');
+  assert.notEqual(tt.cues, 'foo', 'cues is still original value');
+  assert.notEqual(tt.activeCues, 'bar', 'activeCues is still original value');
 });
 
-QUnit.test('mode can only be set to a few options', function() {
+QUnit.test('mode can only be set to a few options', function(assert) {
   const tt = new TextTrack({
     tech: defaultTech
   });
 
   tt.mode = 'foo';
 
-  QUnit.notEqual(tt.mode, 'foo', 'the mode is still the old value, disabled');
-  QUnit.equal(tt.mode, 'disabled', 'still on the default mode, disabled');
+  assert.notEqual(tt.mode, 'foo', 'the mode is still the old value, disabled');
+  assert.equal(tt.mode, 'disabled', 'still on the default mode, disabled');
 
   tt.mode = 'hidden';
-  QUnit.equal(tt.mode, 'hidden', 'mode set to hidden');
+  assert.equal(tt.mode, 'hidden', 'mode set to hidden');
 
   tt.mode = 'bar';
-  QUnit.notEqual(tt.mode, 'bar', 'the mode is still the old value, hidden');
-  QUnit.equal(tt.mode, 'hidden', 'still on the previous mode, hidden');
+  assert.notEqual(tt.mode, 'bar', 'the mode is still the old value, hidden');
+  assert.equal(tt.mode, 'hidden', 'still on the previous mode, hidden');
 
   tt.mode = 'showing';
-  QUnit.equal(tt.mode, 'showing', 'mode set to showing');
+  assert.equal(tt.mode, 'showing', 'mode set to showing');
 
   tt.mode = 'baz';
-  QUnit.notEqual(tt.mode, 'baz', 'the mode is still the old value, showing');
-  QUnit.equal(tt.mode, 'showing', 'still on the previous mode, showing');
+  assert.notEqual(tt.mode, 'baz', 'the mode is still the old value, showing');
+  assert.equal(tt.mode, 'showing', 'still on the previous mode, showing');
 });
 
-QUnit.test('cues and activeCues return a TextTrackCueList', function() {
+QUnit.test('cues and activeCues return a TextTrackCueList', function(assert) {
   const tt = new TextTrack({
     tech: defaultTech
   });
 
-  QUnit.ok(tt.cues.getCueById, 'cues are a TextTrackCueList');
-  QUnit.ok(tt.activeCues.getCueById, 'activeCues are a TextTrackCueList');
+  assert.ok(tt.cues.getCueById, 'cues are a TextTrackCueList');
+  assert.ok(tt.activeCues.getCueById, 'activeCues are a TextTrackCueList');
 });
 
-QUnit.test('cues can be added and removed from a TextTrack', function() {
+QUnit.test('cues can be added and removed from a TextTrack', function(assert) {
   const tt = new TextTrack({
     tech: defaultTech
   });
   const cues = tt.cues;
 
-  QUnit.equal(cues.length, 0, 'start with zero cues');
+  assert.equal(cues.length, 0, 'start with zero cues');
 
   tt.addCue({id: '1'});
 
-  QUnit.equal(cues.length, 1, 'we have one cue');
+  assert.equal(cues.length, 1, 'we have one cue');
 
   tt.removeCue(cues.getCueById('1'));
 
-  QUnit.equal(cues.length, 0, 'we have removed our one cue');
+  assert.equal(cues.length, 0, 'we have removed our one cue');
 
   tt.addCue({id: '1'});
   tt.addCue({id: '2'});
   tt.addCue({id: '3'});
 
-  QUnit.equal(cues.length, 3, 'we now have 3 cues');
+  assert.equal(cues.length, 3, 'we now have 3 cues');
 });
 
-QUnit.test('fires cuechange when cues become active and inactive', function() {
+QUnit.test('fires cuechange when cues become active and inactive', function(assert) {
   const player = TestHelpers.makePlayer();
   let changes = 0;
   const tt = new TextTrack({
@@ -229,7 +229,7 @@ QUnit.test('fires cuechange when cues become active and inactive', function() {
 
   player.tech_.trigger('timeupdate');
 
-  QUnit.equal(changes, 2, 'a cuechange event trigger addEventListener and oncuechange');
+  assert.equal(changes, 2, 'a cuechange event trigger addEventListener and oncuechange');
 
   player.tech_.currentTime = function() {
     return 7;
@@ -237,12 +237,12 @@ QUnit.test('fires cuechange when cues become active and inactive', function() {
 
   player.tech_.trigger('timeupdate');
 
-  QUnit.equal(changes, 4, 'a cuechange event trigger addEventListener and oncuechange');
+  assert.equal(changes, 4, 'a cuechange event trigger addEventListener and oncuechange');
 
   player.dispose();
 });
 
-QUnit.test('tracks are parsed if vttjs is loaded', function() {
+QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   const clock = sinon.useFakeTimers();
   const oldVTT = window.WebVTT;
   let parserCreated = false;
@@ -277,13 +277,13 @@ QUnit.test('tracks are parsed if vttjs is loaded', function() {
 
   xhrHandler(null, {}, 'WEBVTT\n');
 
-  QUnit.ok(parserCreated, 'WebVTT is loaded, so we can just parse');
+  assert.ok(parserCreated, 'WebVTT is loaded, so we can just parse');
 
   clock.restore();
   window.WebVTT = oldVTT;
 });
 
-QUnit.test('tracks are parsed once vttjs is loaded', function() {
+QUnit.test('tracks are parsed once vttjs is loaded', function(assert) {
   const clock = sinon.useFakeTimers();
   const oldVTT = window.WebVTT;
   let parserCreated = false;
@@ -312,10 +312,10 @@ QUnit.test('tracks are parsed once vttjs is loaded', function() {
 
   xhrHandler(null, {}, 'WEBVTT\n');
 
-  QUnit.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
+  assert.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
 
   clock.tick(100);
-  QUnit.ok(!parserCreated, 'WebVTT still not loaded, do not try to parse yet');
+  assert.ok(!parserCreated, 'WebVTT still not loaded, do not try to parse yet');
 
   window.WebVTT = () => {};
   window.WebVTT.StringDecoder = () => {};
@@ -331,13 +331,13 @@ QUnit.test('tracks are parsed once vttjs is loaded', function() {
   };
 
   testTech.trigger('vttjsloaded');
-  QUnit.ok(parserCreated, 'WebVTT is loaded, so we can parse now');
+  assert.ok(parserCreated, 'WebVTT is loaded, so we can parse now');
 
   clock.restore();
   window.WebVTT = oldVTT;
 });
 
-QUnit.test('stops processing if vttjs loading errored out', function() {
+QUnit.test('stops processing if vttjs loading errored out', function(assert) {
   const clock = sinon.useFakeTimers();
   const errorSpy = sinon.spy();
   const oldVTT = window.WebVTT;
@@ -375,18 +375,18 @@ QUnit.test('stops processing if vttjs loading errored out', function() {
 
   xhrHandler(null, {}, 'WEBVTT\n');
 
-  QUnit.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
+  assert.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
 
   testTech.trigger('vttjserror');
   const offSpyCall = testTech.off.getCall(0);
 
-  QUnit.ok(errorSpy.called, 'vttjs failed to load, so log.error was called');
+  assert.ok(errorSpy.called, 'vttjs failed to load, so log.error was called');
   if (errorSpy.called) {
-    QUnit.ok(/^vttjs failed to load, stopping trying to process/.test(errorSpy.getCall(0).args[0]),
+    assert.ok(/^vttjs failed to load, stopping trying to process/.test(errorSpy.getCall(0).args[0]),
        'log.error was called with the expected message');
   }
-  QUnit.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
-  QUnit.ok(offSpyCall, 'tech.off was called');
+  assert.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');
+  assert.ok(offSpyCall, 'tech.off was called');
 
   clock.restore();
   window.WebVTT = oldVTT;

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -16,27 +16,27 @@ import document from 'global/document';
 import sinon from 'sinon';
 
 QUnit.module('Tracks', {
-  setup() {
+  beforeEach(assert) {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach(assert) {
     this.clock.restore();
   }
 });
 
-QUnit.test('should place title list item into ul', function() {
+QUnit.test('should place title list item into ul', function(assert) {
   const player = TestHelpers.makePlayer();
   const chaptersButton = new ChaptersButton(player);
 
   const menuContentElement = chaptersButton.el().getElementsByTagName('UL')[0];
   const titleElement = menuContentElement.children[0];
 
-  QUnit.ok(titleElement.innerHTML === 'Chapters', 'title element placed in ul');
+  assert.ok(titleElement.innerHTML === 'Chapters', 'title element placed in ul');
 
   player.dispose();
 });
 
-QUnit.test('Player track methods call the tech', function() {
+QUnit.test('Player track methods call the tech', function(assert) {
   const player = TestHelpers.makePlayer();
   let calls = 0;
 
@@ -50,12 +50,12 @@ QUnit.test('Player track methods call the tech', function() {
   player.addTextTrack();
   player.textTracks();
 
-  QUnit.equal(calls, 2, 'both textTrack and addTextTrack defer to the tech');
+  assert.equal(calls, 2, 'both textTrack and addTextTrack defer to the tech');
 
   player.dispose();
 });
 
-QUnit.test('TextTrackDisplay initializes tracks on player ready', function() {
+QUnit.test('TextTrackDisplay initializes tracks on player ready', function(assert) {
   let calls = 0;
   /* eslint-disable no-unused-vars */
   const ttd = new TextTrackDisplay({
@@ -72,10 +72,10 @@ QUnit.test('TextTrackDisplay initializes tracks on player ready', function() {
   }, {});
   /* eslint-enable no-unused-vars */
 
-  QUnit.equal(calls, 1, 'only a player.ready call was made');
+  assert.equal(calls, 1, 'only a player.ready call was made');
 });
 
-QUnit.test('listen to remove and add track events in native text tracks', function() {
+QUnit.test('listen to remove and add track events in native text tracks', function(assert) {
   const oldTestVid = Html5.TEST_VID;
   const oldTextTracks = Html5.prototype.textTracks;
   const events = {};
@@ -116,14 +116,14 @@ QUnit.test('listen to remove and add track events in native text tracks', functi
   const html = new Html5({});
   /* eslint-enable no-unused-vars */
 
-  QUnit.ok(events.removetrack, 'removetrack listener was added');
-  QUnit.ok(events.addtrack, 'addtrack listener was added');
+  assert.ok(events.removetrack, 'removetrack listener was added');
+  assert.ok(events.addtrack, 'addtrack listener was added');
 
   Html5.TEST_VID = oldTestVid;
   Html5.prototype.textTracks = oldTextTracks;
 });
 
-QUnit.test('update texttrack buttons on removetrack or addtrack', function() {
+QUnit.test('update texttrack buttons on removetrack or addtrack', function(assert) {
   let update = 0;
   const events = {};
   const oldCaptionsUpdate = CaptionsButton.prototype.update;
@@ -186,19 +186,19 @@ QUnit.test('update texttrack buttons on removetrack or addtrack', function() {
 
   player.player_ = player;
 
-  QUnit.equal(update, 4, 'update was called on the four buttons during init');
+  assert.equal(update, 4, 'update was called on the four buttons during init');
 
   for (let i = 0; i < events.removetrack.length; i++) {
     events.removetrack[i]();
   }
 
-  QUnit.equal(update, 8, 'update was called on the four buttons for remove track');
+  assert.equal(update, 8, 'update was called on the four buttons for remove track');
 
   for (let i = 0; i < events.addtrack.length; i++) {
     events.addtrack[i]();
   }
 
-  QUnit.equal(update, 12, 'update was called on the four buttons for remove track');
+  assert.equal(update, 12, 'update was called on the four buttons for remove track');
 
   Tech.prototype.textTracks = oldTextTracks;
   Tech.prototype.featuresNativeTextTracks = false;
@@ -209,7 +209,7 @@ QUnit.test('update texttrack buttons on removetrack or addtrack', function() {
   player.dispose();
 });
 
-QUnit.test('if native text tracks are not supported, create a texttrackdisplay', function() {
+QUnit.test('if native text tracks are not supported, create a texttrackdisplay', function(assert) {
   const oldTestVid = Html5.TEST_VID;
   const oldIsFirefox = browser.IS_FIREFOX;
   const oldTextTrackDisplay = Component.getComponent('TextTrackDisplay');
@@ -241,7 +241,7 @@ QUnit.test('if native text tracks are not supported, create a texttrackdisplay',
 
   const player = TestHelpers.makePlayer({}, tag);
 
-  QUnit.ok(called, 'text track display was created');
+  assert.ok(called, 'text track display was created');
 
   Html5.TEST_VID = oldTestVid;
   browser.IS_FIREFOX = oldIsFirefox;
@@ -250,7 +250,7 @@ QUnit.test('if native text tracks are not supported, create a texttrackdisplay',
   player.dispose();
 });
 
-QUnit.test('html5 tech supports native text tracks if the video supports it, unless mode is a number', function() {
+QUnit.test('html5 tech supports native text tracks if the video supports it, unless mode is a number', function(assert) {
   const oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {
@@ -259,13 +259,13 @@ QUnit.test('html5 tech supports native text tracks if the video supports it, unl
     }]
   };
 
-  QUnit.ok(!Html5.supportsNativeTextTracks(),
+  assert.ok(!Html5.supportsNativeTextTracks(),
            'native text tracks are not supported if mode is a number');
 
   Html5.TEST_VID = oldTestVid;
 });
 
-QUnit.test('html5 tech supports native text tracks if the video supports it, unless it is firefox', function() {
+QUnit.test('html5 tech supports native text tracks if the video supports it, unless it is firefox', function(assert) {
   const oldTestVid = Html5.TEST_VID;
   const oldIsFirefox = browser.IS_FIREFOX;
 
@@ -275,7 +275,7 @@ QUnit.test('html5 tech supports native text tracks if the video supports it, unl
 
   browser.IS_FIREFOX = true;
 
-  QUnit.ok(!Html5.supportsNativeTextTracks(),
+  assert.ok(!Html5.supportsNativeTextTracks(),
            'if textTracks are available on video element,' +
            ' native text tracks are supported');
 
@@ -283,7 +283,7 @@ QUnit.test('html5 tech supports native text tracks if the video supports it, unl
   browser.IS_FIREFOX = oldIsFirefox;
 });
 
-QUnit.test('when switching techs, we should not get a new text track', function() {
+QUnit.test('when switching techs, we should not get a new text track', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.loadTech_('TechFaker');
@@ -292,7 +292,7 @@ QUnit.test('when switching techs, we should not get a new text track', function(
   player.loadTech_('TechFaker');
   const secondTracks = player.textTracks();
 
-  QUnit.ok(firstTracks === secondTracks, 'the tracks are equal');
+  assert.ok(firstTracks === secondTracks, 'the tracks are equal');
 });
 
 if (Html5.supportsNativeTextTracks()) {
@@ -308,8 +308,8 @@ if (Html5.supportsNativeTextTracks()) {
     el.appendChild(track);
 
     const addtrack = function() {
-      QUnit.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
-      QUnit.equal(emulatedTt.length, 1, 'we have one text track');
+      assert.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
+      assert.equal(emulatedTt.length, 1, 'we have one text track');
 
       emulatedTt.off('addtrack', addtrack);
       el.removeChild(track);
@@ -317,8 +317,8 @@ if (Html5.supportsNativeTextTracks()) {
 
     emulatedTt.on('addtrack', addtrack);
     emulatedTt.on('removetrack', function() {
-      QUnit.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
-      QUnit.equal(emulatedTt.length, 0, 'we have no more text tracks');
+      assert.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
+      assert.equal(emulatedTt.length, 0, 'we have no more text tracks');
       done();
     });
   });
@@ -335,14 +335,14 @@ if (Html5.supportsNativeTextTracks()) {
     el.appendChild(track);
 
     const addtrack = function() {
-      QUnit.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
-      QUnit.equal(emulatedTt.length, 1, 'we have one text track');
+      assert.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
+      assert.equal(emulatedTt.length, 1, 'we have one text track');
 
       emulatedTt.off('addtrack', addtrack);
       html.dispose();
 
-      QUnit.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
-      QUnit.equal(emulatedTt.length, 0, 'we have no more text tracks');
+      assert.equal(emulatedTt.length, tt.length, 'we have matching tracks length');
+      assert.equal(emulatedTt.length, 0, 'we have no more text tracks');
 
       done();
     };
@@ -351,7 +351,7 @@ if (Html5.supportsNativeTextTracks()) {
   });
 }
 
-QUnit.test('should check for text track changes when emulating text tracks', function() {
+QUnit.test('should check for text track changes when emulating text tracks', function(assert) {
   const tech = new Tech();
   let numTextTrackChanges = 0;
 
@@ -359,10 +359,10 @@ QUnit.test('should check for text track changes when emulating text tracks', fun
     numTextTrackChanges++;
   });
   tech.emulateTextTracks();
-  QUnit.equal(numTextTrackChanges, 1, 'we got a texttrackchange event');
+  assert.equal(numTextTrackChanges, 1, 'we got a texttrackchange event');
 });
 
-QUnit.test('removes cuechange event when text track is hidden for emulated tracks', function() {
+QUnit.test('removes cuechange event when text track is hidden for emulated tracks', function(assert) {
   const player = TestHelpers.makePlayer();
   const tt = new TextTrack({
     tech: player.tech_,
@@ -384,32 +384,32 @@ QUnit.test('removes cuechange event when text track is hidden for emulated track
   });
 
   tt.mode = 'showing';
-  QUnit.equal(numTextTrackChanges, 1,
+  assert.equal(numTextTrackChanges, 1,
     'texttrackchange should be called once for mode change');
   tt.mode = 'showing';
-  QUnit.equal(numTextTrackChanges, 2,
+  assert.equal(numTextTrackChanges, 2,
     'texttrackchange should be called once for mode change');
 
   player.tech_.currentTime = function() {
     return 3;
   };
   player.tech_.trigger('timeupdate');
-  QUnit.equal(numTextTrackChanges, 3,
+  assert.equal(numTextTrackChanges, 3,
     'texttrackchange should be triggered once for the cuechange');
 
   tt.mode = 'hidden';
-  QUnit.equal(numTextTrackChanges, 4,
+  assert.equal(numTextTrackChanges, 4,
     'texttrackchange should be called once for the mode change');
 
   player.tech_.currentTime = function() {
     return 7;
   };
   player.tech_.trigger('timeupdate');
-  QUnit.equal(numTextTrackChanges, 4,
+  assert.equal(numTextTrackChanges, 4,
     'texttrackchange should be not be called since mode is hidden');
 });
 
-QUnit.test('should return correct remote text track values', function() {
+QUnit.test('should return correct remote text track values', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
   const html = `
     <video id="example_1" class="video-js" autoplay preload="none">
@@ -425,28 +425,28 @@ QUnit.test('should return correct remote text track values', function() {
 
   this.clock.tick(1);
 
-  QUnit.equal(player.remoteTextTracks().length, 1, 'add text track via html');
-  QUnit.equal(player.remoteTextTrackEls().length, 1, 'add html track element via html');
+  assert.equal(player.remoteTextTracks().length, 1, 'add text track via html');
+  assert.equal(player.remoteTextTrackEls().length, 1, 'add html track element via html');
 
   const htmlTrackElement = player.addRemoteTextTrack({
     kind: 'captions',
     label: 'label'
   });
 
-  QUnit.equal(player.remoteTextTracks().length, 2, 'add text track via method');
-  QUnit.equal(player.remoteTextTrackEls().length, 2, 'add html track element via method');
+  assert.equal(player.remoteTextTracks().length, 2, 'add text track via method');
+  assert.equal(player.remoteTextTrackEls().length, 2, 'add html track element via method');
 
   player.removeRemoteTextTrack(htmlTrackElement.track);
 
-  QUnit.equal(player.remoteTextTracks().length, 1, 'remove text track via method');
-  QUnit.equal(player.remoteTextTrackEls().length,
+  assert.equal(player.remoteTextTracks().length, 1, 'remove text track via method');
+  assert.equal(player.remoteTextTrackEls().length,
               1,
               'remove html track element via method');
 
   player.dispose();
 });
 
-QUnit.test('should uniformly create html track element when adding text track', function() {
+QUnit.test('should uniformly create html track element when adding text track', function(assert) {
   const player = TestHelpers.makePlayer();
   const track = {
     kind: 'kind',
@@ -456,35 +456,35 @@ QUnit.test('should uniformly create html track element when adding text track', 
     default: 'default'
   };
 
-  QUnit.equal(player.remoteTextTrackEls().length, 0, 'no html text tracks');
+  assert.equal(player.remoteTextTrackEls().length, 0, 'no html text tracks');
 
   const htmlTrackElement = player.addRemoteTextTrack(track);
 
-  QUnit.equal(htmlTrackElement.kind,
+  assert.equal(htmlTrackElement.kind,
               htmlTrackElement.track.kind,
               'verify html track element kind');
-  QUnit.equal(htmlTrackElement.src,
+  assert.equal(htmlTrackElement.src,
               htmlTrackElement.track.src,
               'verify html track element src');
-  QUnit.equal(htmlTrackElement.srclang,
+  assert.equal(htmlTrackElement.srclang,
               htmlTrackElement.track.language,
               'verify html track element language');
-  QUnit.equal(htmlTrackElement.label,
+  assert.equal(htmlTrackElement.label,
               htmlTrackElement.track.label,
               'verify html track element label');
-  QUnit.equal(htmlTrackElement.default,
+  assert.equal(htmlTrackElement.default,
               htmlTrackElement.track.default,
               'verify html track element default');
 
-  QUnit.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
-  QUnit.equal(player.remoteTextTrackEls().getTrackElementByTrack_(htmlTrackElement.track),
+  assert.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
+  assert.equal(player.remoteTextTrackEls().getTrackElementByTrack_(htmlTrackElement.track),
               htmlTrackElement,
               'verify same html track element');
 
   player.dispose();
 });
 
-QUnit.test('default text tracks should show by default', function() {
+QUnit.test('default text tracks should show by default', function(assert) {
   const tag = TestHelpers.makeTag();
   const capt = document.createElement('track');
 
@@ -504,11 +504,11 @@ QUnit.test('default text tracks should show by default', function() {
 
   const tracks = player.textTracks();
 
-  QUnit.equal(tracks[0].kind, 'captions', 'the captions track is present');
-  QUnit.equal(tracks[0].mode, 'showing', 'the captions track is showing');
+  assert.equal(tracks[0].kind, 'captions', 'the captions track is present');
+  assert.equal(tracks[0].mode, 'showing', 'the captions track is showing');
 });
 
-QUnit.test('default captions take precedence over default descriptions', function() {
+QUnit.test('default captions take precedence over default descriptions', function(assert) {
   const tag = TestHelpers.makeTag();
   const desc = document.createElement('track');
   const capt = document.createElement('track');
@@ -532,13 +532,13 @@ QUnit.test('default captions take precedence over default descriptions', functio
 
   const tracks = player.textTracks();
 
-  QUnit.equal(tracks[0].kind, 'descriptions', 'the descriptions track is first');
-  QUnit.equal(tracks[0].mode, 'disabled', 'the descriptions track is disabled');
-  QUnit.equal(tracks[1].kind, 'captions', 'the captions track is second');
-  QUnit.equal(tracks[1].mode, 'showing', 'the captions track is showing');
+  assert.equal(tracks[0].kind, 'descriptions', 'the descriptions track is first');
+  assert.equal(tracks[0].mode, 'disabled', 'the descriptions track is disabled');
+  assert.equal(tracks[1].kind, 'captions', 'the captions track is second');
+  assert.equal(tracks[1].mode, 'showing', 'the captions track is showing');
 });
 
-QUnit.test('removeRemoteTextTrack should be able to take both a track and the response from addRemoteTextTrack', function() {
+QUnit.test('removeRemoteTextTrack should be able to take both a track and the response from addRemoteTextTrack', function(assert) {
   const player = TestHelpers.makePlayer();
   const track = {
     kind: 'kind',
@@ -549,19 +549,19 @@ QUnit.test('removeRemoteTextTrack should be able to take both a track and the re
   };
   let htmlTrackElement = player.addRemoteTextTrack(track);
 
-  QUnit.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
+  assert.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
 
   player.removeRemoteTextTrack(htmlTrackElement);
 
-  QUnit.equal(player.remoteTextTrackEls().length,
+  assert.equal(player.remoteTextTrackEls().length,
               0,
               'the track element was removed correctly');
 
   htmlTrackElement = player.addRemoteTextTrack(track);
-  QUnit.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
+  assert.equal(player.remoteTextTrackEls().length, 1, 'html track element exist');
 
   player.removeRemoteTextTrack(htmlTrackElement.track);
-  QUnit.equal(player.remoteTextTrackEls().length,
+  assert.equal(player.remoteTextTrackEls().length,
               0,
               'the track element was removed correctly');
 });

--- a/test/unit/tracks/track-baseline.js
+++ b/test/unit/tracks/track-baseline.js
@@ -9,16 +9,16 @@ import * as browser from '../../../src/js/utils/browser.js';
  */
 const TrackBaseline = function(TrackClass, options) {
 
-  QUnit.test('is setup with id, kind, label, and language', function() {
+  QUnit.test('is setup with id, kind, label, and language', function(assert) {
     const track = new TrackClass(options);
 
-    QUnit.equal(track.kind, options.kind, 'we have a kind');
-    QUnit.equal(track.label, options.label, 'we have a label');
-    QUnit.equal(track.language, options.language, 'we have a language');
-    QUnit.equal(track.id, options.id, 'we have a id');
+    assert.equal(track.kind, options.kind, 'we have a kind');
+    assert.equal(track.label, options.label, 'we have a label');
+    assert.equal(track.language, options.language, 'we have a language');
+    assert.equal(track.id, options.id, 'we have a id');
   });
 
-  QUnit.test('kind, label, language, id, are read only', function() {
+  QUnit.test('kind, label, language, id, are read only', function(assert) {
     const track = new TrackClass(options);
 
     track.kind = 'subtitles';
@@ -26,20 +26,20 @@ const TrackBaseline = function(TrackClass, options) {
     track.language = 'es';
     track.id = '2';
 
-    QUnit.equal(track.kind, options.kind, 'we have a kind');
-    QUnit.equal(track.label, options.label, 'we have a label');
-    QUnit.equal(track.language, options.language, 'we have a language');
-    QUnit.equal(track.id, options.id, 'we have an id');
+    assert.equal(track.kind, options.kind, 'we have a kind');
+    assert.equal(track.label, options.label, 'we have a label');
+    assert.equal(track.language, options.language, 'we have a language');
+    assert.equal(track.id, options.id, 'we have an id');
   });
 
-  QUnit.test('returns an instance of itself on non ie8 browsers', function() {
+  QUnit.test('returns an instance of itself on non ie8 browsers', function(assert) {
     const track = new TrackClass(options);
 
     if (browser.IS_IE8) {
-      QUnit.ok(track, 'returns an object on ie8');
+      assert.ok(track, 'returns an object on ie8');
       return;
     }
-    QUnit.ok(track instanceof TrackClass, 'returns an instance');
+    assert.ok(track instanceof TrackClass, 'returns an instance');
   });
 };
 

--- a/test/unit/tracks/track-list.test.js
+++ b/test/unit/tracks/track-list.test.js
@@ -15,95 +15,95 @@ QUnit.module('Track List', {
   }
 });
 
-QUnit.test('TrackList\'s length is set correctly', function() {
+QUnit.test('TrackList\'s length is set correctly', function(assert) {
   const trackList = new TrackList(this.tracks);
 
-  QUnit.equal(trackList.length, this.tracks.length, 'length is ' + this.tracks.length);
+  assert.equal(trackList.length, this.tracks.length, 'length is ' + this.tracks.length);
 });
 
-QUnit.test('can get tracks by int and string id', function() {
+QUnit.test('can get tracks by int and string id', function(assert) {
   const trackList = new TrackList(this.tracks);
 
-  QUnit.equal(trackList.getTrackById('1').id, '1', 'id "1" has id of "1"');
-  QUnit.equal(trackList.getTrackById('2').id, '2', 'id "2" has id of "2"');
-  QUnit.equal(trackList.getTrackById('3').id, '3', 'id "3" has id of "3"');
+  assert.equal(trackList.getTrackById('1').id, '1', 'id "1" has id of "1"');
+  assert.equal(trackList.getTrackById('2').id, '2', 'id "2" has id of "2"');
+  assert.equal(trackList.getTrackById('3').id, '3', 'id "3" has id of "3"');
 
 });
 
-QUnit.test('length is updated when new tracks are added or removed', function() {
+QUnit.test('length is updated when new tracks are added or removed', function(assert) {
   const trackList = new TrackList(this.tracks);
 
   trackList.addTrack_(newTrack('100'));
-  QUnit.equal(trackList.length,
+  assert.equal(trackList.length,
               this.tracks.length + 1,
               'the length is ' + (this.tracks.length + 1));
   trackList.addTrack_(newTrack('101'));
-  QUnit.equal(trackList.length,
+  assert.equal(trackList.length,
               this.tracks.length + 2,
               'the length is ' + (this.tracks.length + 2));
 
   trackList.removeTrack_(trackList.getTrackById('101'));
-  QUnit.equal(trackList.length,
+  assert.equal(trackList.length,
               this.tracks.length + 1,
               'the length is ' + (this.tracks.length + 1));
   trackList.removeTrack_(trackList.getTrackById('100'));
-  QUnit.equal(trackList.length,
+  assert.equal(trackList.length,
               this.tracks.length,
               'the length is ' + this.tracks.length);
 });
 
-QUnit.test('can access items by index', function() {
+QUnit.test('can access items by index', function(assert) {
   const trackList = new TrackList(this.tracks);
   const length = trackList.length;
 
-  QUnit.expect(length);
+  assert.expect(length);
 
   for (let i = 0; i < length; i++) {
-    QUnit.equal(trackList[i].id,
+    assert.equal(trackList[i].id,
                 String(i + 1),
                 'the id of a track matches the index + 1');
   }
 });
 
-QUnit.test('can access new items by index', function() {
+QUnit.test('can access new items by index', function(assert) {
   const trackList = new TrackList(this.tracks);
 
   trackList.addTrack_(newTrack('100'));
-  QUnit.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
 
   trackList.addTrack_(newTrack('101'));
-  QUnit.equal(trackList[4].id, '101', 'id of item at index 4 is 101');
+  assert.equal(trackList[4].id, '101', 'id of item at index 4 is 101');
 });
 
-QUnit.test('cannot access removed items by index', function() {
+QUnit.test('cannot access removed items by index', function(assert) {
   const trackList = new TrackList(this.tracks);
 
   trackList.addTrack_(newTrack('100'));
   trackList.addTrack_(newTrack('101'));
-  QUnit.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
-  QUnit.equal(trackList[4].id, '101', 'id of item at index 4 is 101');
+  assert.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(trackList[4].id, '101', 'id of item at index 4 is 101');
 
   trackList.removeTrack_(trackList.getTrackById('101'));
   trackList.removeTrack_(trackList.getTrackById('100'));
 
-  QUnit.ok(!trackList[3], 'nothing at index 3');
-  QUnit.ok(!trackList[4], 'nothing at index 4');
+  assert.ok(!trackList[3], 'nothing at index 3');
+  assert.ok(!trackList[4], 'nothing at index 4');
 });
 
-QUnit.test('new item available at old index', function() {
+QUnit.test('new item available at old index', function(assert) {
   const trackList = new TrackList(this.tracks);
 
   trackList.addTrack_(newTrack('100'));
-  QUnit.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
+  assert.equal(trackList[3].id, '100', 'id of item at index 3 is 100');
 
   trackList.removeTrack_(trackList.getTrackById('100'));
-  QUnit.ok(!trackList[3], 'nothing at index 3');
+  assert.ok(!trackList[3], 'nothing at index 3');
 
   trackList.addTrack_(newTrack('101'));
-  QUnit.equal(trackList[3].id, '101', 'id of new item at index 3 is now 101');
+  assert.equal(trackList[3].id, '101', 'id of new item at index 3 is now 101');
 });
 
-QUnit.test('a "addtrack" event is triggered when new tracks are added', function() {
+QUnit.test('a "addtrack" event is triggered when new tracks are added', function(assert) {
   const trackList = new TrackList(this.tracks);
   let tracks = 0;
   let adds = 0;
@@ -125,11 +125,11 @@ QUnit.test('a "addtrack" event is triggered when new tracks are added', function
   trackList.addTrack_(newTrack('102'));
   trackList.addTrack_(newTrack('103'));
 
-  QUnit.equal(adds, 4, 'we got ' + adds + ' "addtrack" events');
-  QUnit.equal(tracks, 4, 'we got a track with every event');
+  assert.equal(adds, 4, 'we got ' + adds + ' "addtrack" events');
+  assert.equal(tracks, 4, 'we got a track with every event');
 });
 
-QUnit.test('a "removetrack" event is triggered when tracks are removed', function() {
+QUnit.test('a "removetrack" event is triggered when tracks are removed', function(assert) {
   const trackList = new TrackList(this.tracks);
   let tracks = 0;
   let rms = 0;
@@ -148,6 +148,6 @@ QUnit.test('a "removetrack" event is triggered when tracks are removed', functio
   trackList.onremovetrack = rmHandler;
   trackList.removeTrack_(trackList.getTrackById('3'));
 
-  QUnit.equal(rms, 3, 'we got ' + rms + ' "removetrack" events');
-  QUnit.equal(tracks, 3, 'we got a track with every event');
+  assert.equal(rms, 3, 'we got ' + rms + ' "removetrack" events');
+  assert.equal(tracks, 3, 'we got a track with every event');
 });

--- a/test/unit/tracks/track.test.js
+++ b/test/unit/tracks/track.test.js
@@ -22,13 +22,13 @@ TrackBaseline(Track, {
   tech: new TechFaker()
 });
 
-QUnit.test('defaults when items not provided', function() {
+QUnit.test('defaults when items not provided', function(assert) {
   const track = new Track({
     tech: defaultTech
   });
 
-  QUnit.equal(track.kind, '', 'kind defaulted to empty string');
-  QUnit.equal(track.label, '', 'label defaults to empty string');
-  QUnit.equal(track.language, '', 'language defaults to empty string');
-  QUnit.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
+  assert.equal(track.kind, '', 'kind defaulted to empty string');
+  assert.equal(track.label, '', 'label defaults to empty string');
+  assert.equal(track.language, '', 'language defaults to empty string');
+  assert.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
 });

--- a/test/unit/tracks/video-track-list.test.js
+++ b/test/unit/tracks/video-track-list.test.js
@@ -5,7 +5,7 @@ import EventTarget from '../../../src/js/event-target.js';
 
 QUnit.module('Video Track List');
 
-QUnit.test('trigger "change" when "selectedchange" is fired on a track', function() {
+QUnit.test('trigger "change" when "selectedchange" is fired on a track', function(assert) {
   const track = new EventTarget();
 
   track.loaded_ = true;
@@ -17,67 +17,67 @@ QUnit.test('trigger "change" when "selectedchange" is fired on a track', functio
 
   videoTrackList.on('change', changeHandler);
   track.trigger('selectedchange');
-  QUnit.equal(changes, 1, 'one change events for trigger');
+  assert.equal(changes, 1, 'one change events for trigger');
 
   videoTrackList.off('change', changeHandler);
   videoTrackList.onchange = changeHandler;
 
   track.trigger('selectedchange');
-  QUnit.equal(changes, 2, 'one change events for another trigger');
+  assert.equal(changes, 2, 'one change events for another trigger');
 });
 
-QUnit.test('only one track is ever selected', function() {
+QUnit.test('only one track is ever selected', function(assert) {
   const track = new VideoTrack({selected: true});
   const track2 = new VideoTrack({selected: true});
   const track3 = new VideoTrack({selected: true});
   const track4 = new VideoTrack();
   const list = new VideoTrackList([track, track2]);
 
-  QUnit.equal(track.selected, false, 'track is unselected');
-  QUnit.equal(track2.selected, true, 'track2 is selected');
+  assert.equal(track.selected, false, 'track is unselected');
+  assert.equal(track2.selected, true, 'track2 is selected');
 
   track.selected = true;
-  QUnit.equal(track.selected, true, 'track is selected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track.selected, true, 'track is selected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
 
   list.addTrack_(track3);
-  QUnit.equal(track.selected, false, 'track is unselected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
-  QUnit.equal(track3.selected, true, 'track3 is selected');
+  assert.equal(track.selected, false, 'track is unselected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track3.selected, true, 'track3 is selected');
 
   track.selected = true;
-  QUnit.equal(track.selected, true, 'track is unselected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
-  QUnit.equal(track3.selected, false, 'track3 is unselected');
+  assert.equal(track.selected, true, 'track is unselected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track3.selected, false, 'track3 is unselected');
 
   list.addTrack_(track4);
-  QUnit.equal(track.selected, true, 'track is selected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
-  QUnit.equal(track3.selected, false, 'track3 is unselected');
-  QUnit.equal(track4.selected, false, 'track4 is unselected');
+  assert.equal(track.selected, true, 'track is selected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track3.selected, false, 'track3 is unselected');
+  assert.equal(track4.selected, false, 'track4 is unselected');
 
 });
 
-QUnit.test('all tracks can be unselected', function() {
+QUnit.test('all tracks can be unselected', function(assert) {
   const track = new VideoTrack();
   const track2 = new VideoTrack();
   /* eslint-disable no-unused-vars */
   const list = new VideoTrackList([track, track2]);
   /* eslint-enable no-unused-vars */
 
-  QUnit.equal(track.selected, false, 'track is unselected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track.selected, false, 'track is unselected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
 
   track.selected = true;
-  QUnit.equal(track.selected, true, 'track is selected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track.selected, true, 'track is selected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
 
   track.selected = false;
-  QUnit.equal(track.selected, false, 'track is unselected');
-  QUnit.equal(track2.selected, false, 'track2 is unselected');
+  assert.equal(track.selected, false, 'track is unselected');
+  assert.equal(track2.selected, false, 'track2 is unselected');
 });
 
-QUnit.test('trigger a change event per selected change', function() {
+QUnit.test('trigger a change event per selected change', function(assert) {
   const track = new VideoTrack({selected: true});
   const track2 = new VideoTrack({selected: true});
   const track3 = new VideoTrack({selected: true});
@@ -87,17 +87,17 @@ QUnit.test('trigger a change event per selected change', function() {
 
   list.on('change', () => change++);
   track.selected = true;
-  QUnit.equal(change, 1, 'one change triggered');
+  assert.equal(change, 1, 'one change triggered');
 
   list.addTrack_(track3);
-  QUnit.equal(change, 2, 'another change triggered by adding an selected track');
+  assert.equal(change, 2, 'another change triggered by adding an selected track');
 
   track.selected = true;
-  QUnit.equal(change, 3, 'another change trigger by changing selected');
+  assert.equal(change, 3, 'another change trigger by changing selected');
 
   track.selected = false;
-  QUnit.equal(change, 4, 'another change trigger by changing selected');
+  assert.equal(change, 4, 'another change trigger by changing selected');
 
   list.addTrack_(track4);
-  QUnit.equal(change, 4, 'no change triggered by adding a unselected track');
+  assert.equal(change, 4, 'no change triggered by adding a unselected track');
 });

--- a/test/unit/tracks/video-track.test.js
+++ b/test/unit/tracks/video-track.test.js
@@ -13,84 +13,84 @@ TrackBaseline(VideoTrack, {
   kind: 'main'
 });
 
-QUnit.test('can create an VideoTrack a selected property', function() {
+QUnit.test('can create an VideoTrack a selected property', function(assert) {
   const selected = true;
   const track = new VideoTrack({
     selected
   });
 
-  QUnit.equal(track.selected, selected, 'selected value matches what we passed in');
+  assert.equal(track.selected, selected, 'selected value matches what we passed in');
 });
 
-QUnit.test('defaults when items not provided', function() {
+QUnit.test('defaults when items not provided', function(assert) {
   const track = new VideoTrack();
 
-  QUnit.equal(track.kind, '', 'kind defaulted to empty string');
-  QUnit.equal(track.selected,
+  assert.equal(track.kind, '', 'kind defaulted to empty string');
+  assert.equal(track.selected,
               false,
               'selected defaulted to true since there is one track');
-  QUnit.equal(track.label, '', 'label defaults to empty string');
-  QUnit.equal(track.language, '', 'language defaults to empty string');
-  QUnit.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
+  assert.equal(track.label, '', 'label defaults to empty string');
+  assert.equal(track.language, '', 'language defaults to empty string');
+  assert.ok(track.id.match(/vjs_track_\d{5}/), 'id defaults to vjs_track_GUID');
 });
 
-QUnit.test('kind can only be one of several options, defaults to empty string', function() {
+QUnit.test('kind can only be one of several options, defaults to empty string', function(assert) {
   const track1 = new VideoTrack({
     kind: 'foo'
   });
 
-  QUnit.equal(track1.kind, '', 'the kind is set to empty string, not foo');
-  QUnit.notEqual(track1.kind, 'foo', 'the kind is set to empty string, not foo');
+  assert.equal(track1.kind, '', 'the kind is set to empty string, not foo');
+  assert.notEqual(track1.kind, 'foo', 'the kind is set to empty string, not foo');
 
   // loop through all possible kinds to verify
   for (const key in VideoTrackKind) {
     const currentKind = VideoTrackKind[key];
     const track = new VideoTrack({kind: currentKind});
 
-    QUnit.equal(track.kind, currentKind, 'the kind is set to ' + currentKind);
+    assert.equal(track.kind, currentKind, 'the kind is set to ' + currentKind);
   }
 });
 
-QUnit.test('selected can only be instantiated to true or false, defaults to false', function() {
+QUnit.test('selected can only be instantiated to true or false, defaults to false', function(assert) {
   let track = new VideoTrack({
     selected: 'foo'
   });
 
-  QUnit.equal(track.selected, false, 'the selected value is set to false, not foo');
-  QUnit.notEqual(track.selected, 'foo', 'the selected value is not set to foo');
+  assert.equal(track.selected, false, 'the selected value is set to false, not foo');
+  assert.notEqual(track.selected, 'foo', 'the selected value is not set to foo');
 
   track = new VideoTrack({
     selected: true
   });
 
-  QUnit.equal(track.selected, true, 'the selected value is set to true');
+  assert.equal(track.selected, true, 'the selected value is set to true');
 
   track = new VideoTrack({
     selected: false
   });
 
-  QUnit.equal(track.selected, false, 'the selected value is set to false');
+  assert.equal(track.selected, false, 'the selected value is set to false');
 });
 
-QUnit.test('selected can only be changed to true or false', function() {
+QUnit.test('selected can only be changed to true or false', function(assert) {
   const track = new VideoTrack();
 
   track.selected = 'foo';
-  QUnit.notEqual(track.selected, 'foo', 'selected not set to invalid value, foo');
-  QUnit.equal(track.selected, false, 'selected remains on the old value, false');
+  assert.notEqual(track.selected, 'foo', 'selected not set to invalid value, foo');
+  assert.equal(track.selected, false, 'selected remains on the old value, false');
 
   track.selected = true;
-  QUnit.equal(track.selected, true, 'selected was set to true');
+  assert.equal(track.selected, true, 'selected was set to true');
 
   track.selected = 'baz';
-  QUnit.notEqual(track.selected, 'baz', 'selected not set to invalid value, baz');
-  QUnit.equal(track.selected, true, 'selected remains on the old value, true');
+  assert.notEqual(track.selected, 'baz', 'selected not set to invalid value, baz');
+  assert.equal(track.selected, true, 'selected remains on the old value, true');
 
   track.selected = false;
-  QUnit.equal(track.selected, false, 'selected was set to false');
+  assert.equal(track.selected, false, 'selected was set to false');
 });
 
-QUnit.test('when selected is changed selectedchange event is fired', function() {
+QUnit.test('when selected is changed selectedchange event is fired', function(assert) {
   const track = new VideoTrack({
     selected: false
   });
@@ -103,14 +103,14 @@ QUnit.test('when selected is changed selectedchange event is fired', function() 
   // two events
   track.selected = true;
   track.selected = false;
-  QUnit.equal(eventsTriggered, 2, 'two selected changes');
+  assert.equal(eventsTriggered, 2, 'two selected changes');
 
   // no event here
   track.selected = false;
   track.selected = false;
-  QUnit.equal(eventsTriggered, 2, 'still two selected changes');
+  assert.equal(eventsTriggered, 2, 'still two selected changes');
 
   // one event
   track.selected = true;
-  QUnit.equal(eventsTriggered, 3, 'three selected changes');
+  assert.equal(eventsTriggered, 3, 'three selected changes');
 });

--- a/test/unit/tracks/video-tracks.test.js
+++ b/test/unit/tracks/video-tracks.test.js
@@ -4,15 +4,15 @@ import TestHelpers from '../test-helpers.js';
 import sinon from 'sinon';
 
 QUnit.module('Video Tracks', {
-  setup() {
+  beforeEach(assert) {
     this.clock = sinon.useFakeTimers();
   },
-  teardown() {
+  afterEach(assert) {
     this.clock.restore();
   }
 });
 
-QUnit.test('Player track methods call the tech', function() {
+QUnit.test('Player track methods call the tech', function(assert) {
   let calls = 0;
   const player = TestHelpers.makePlayer();
 
@@ -22,11 +22,11 @@ QUnit.test('Player track methods call the tech', function() {
 
   player.videoTracks();
 
-  QUnit.equal(calls, 1, 'videoTrack defers to the tech');
+  assert.equal(calls, 1, 'videoTrack defers to the tech');
   player.dispose();
 });
 
-QUnit.test('listen to remove and add track events in native video tracks', function() {
+QUnit.test('listen to remove and add track events in native video tracks', function(assert) {
   const oldTestVid = Html5.TEST_VID;
   const oldVideoTracks = Html5.prototype.videoTracks;
   const events = {};
@@ -67,36 +67,36 @@ QUnit.test('listen to remove and add track events in native video tracks', funct
   const html = new Html5({});
   /* eslint-enable no-unused-vars */
 
-  QUnit.ok(events.removetrack, 'removetrack listener was added');
-  QUnit.ok(events.addtrack, 'addtrack listener was added');
+  assert.ok(events.removetrack, 'removetrack listener was added');
+  assert.ok(events.addtrack, 'addtrack listener was added');
 
   Html5.TEST_VID = oldTestVid;
   Html5.prototype.videoTracks = oldVideoTracks;
 });
 
-QUnit.test('html5 tech supports native video tracks if the video supports it', function() {
+QUnit.test('html5 tech supports native video tracks if the video supports it', function(assert) {
   const oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {
     videoTracks: []
   };
 
-  QUnit.ok(Html5.supportsNativeVideoTracks(), 'native video tracks are supported');
+  assert.ok(Html5.supportsNativeVideoTracks(), 'native video tracks are supported');
 
   Html5.TEST_VID = oldTestVid;
 });
 
-QUnit.test('html5 tech does not support native video tracks if the video does not supports it', function() {
+QUnit.test('html5 tech does not support native video tracks if the video does not supports it', function(assert) {
   const oldTestVid = Html5.TEST_VID;
 
   Html5.TEST_VID = {};
 
-  QUnit.ok(!Html5.supportsNativeVideoTracks(), 'native video tracks are not supported');
+  assert.ok(!Html5.supportsNativeVideoTracks(), 'native video tracks are not supported');
 
   Html5.TEST_VID = oldTestVid;
 });
 
-QUnit.test('when switching techs, we should not get a new video track', function() {
+QUnit.test('when switching techs, we should not get a new video track', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.loadTech_('TechFaker');
@@ -105,5 +105,5 @@ QUnit.test('when switching techs, we should not get a new video track', function
   player.loadTech_('TechFaker');
   const secondTracks = player.videoTracks();
 
-  QUnit.ok(firstTracks === secondTracks, 'the tracks are equal');
+  assert.ok(firstTracks === secondTracks, 'the tracks are equal');
 });

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -4,7 +4,7 @@ import * as Dom from '../../../src/js/utils/dom.js';
 
 QUnit.module('dom');
 
-QUnit.test('should return the element with the ID', function() {
+QUnit.test('should return the element with the ID', function(assert) {
   const el1 = document.createElement('div');
   const el2 = document.createElement('div');
   const fixture = document.getElementById('qunit-fixture');
@@ -15,11 +15,11 @@ QUnit.test('should return the element with the ID', function() {
   el1.id = 'test_id1';
   el2.id = 'test_id2';
 
-  QUnit.ok(Dom.getEl('test_id1') === el1, 'found element for ID');
-  QUnit.ok(Dom.getEl('#test_id2') === el2, 'found element for CSS ID');
+  assert.ok(Dom.getEl('test_id1') === el1, 'found element for ID');
+  assert.ok(Dom.getEl('#test_id2') === el2, 'found element for CSS ID');
 });
 
-QUnit.test('should create an element', function() {
+QUnit.test('should create an element', function(assert) {
   const div = Dom.createEl();
   const span = Dom.createEl('span', {
     innerHTML: 'fdsa'
@@ -27,113 +27,113 @@ QUnit.test('should create an element', function() {
     'data-test': 'asdf'
   });
 
-  QUnit.ok(div.nodeName === 'DIV');
-  QUnit.ok(span.nodeName === 'SPAN');
-  QUnit.ok(span.getAttribute('data-test') === 'asdf');
-  QUnit.ok(span.innerHTML === 'fdsa');
+  assert.ok(div.nodeName === 'DIV');
+  assert.ok(span.nodeName === 'SPAN');
+  assert.ok(span.getAttribute('data-test') === 'asdf');
+  assert.ok(span.innerHTML === 'fdsa');
 });
 
-QUnit.test('should insert an element first in another', function() {
+QUnit.test('should insert an element first in another', function(assert) {
   const el1 = document.createElement('div');
   const el2 = document.createElement('div');
   const parent = document.createElement('div');
 
   Dom.insertElFirst(el1, parent);
-  QUnit.ok(parent.firstChild === el1, 'inserts first into empty parent');
+  assert.ok(parent.firstChild === el1, 'inserts first into empty parent');
 
   Dom.insertElFirst(el2, parent);
-  QUnit.ok(parent.firstChild === el2, 'inserts first into parent with child');
+  assert.ok(parent.firstChild === el2, 'inserts first into parent with child');
 });
 
-QUnit.test('should get and remove data from an element', function() {
+QUnit.test('should get and remove data from an element', function(assert) {
   const el = document.createElement('div');
   const data = Dom.getElData(el);
 
-  QUnit.ok(typeof data === 'object', 'data object created');
+  assert.ok(typeof data === 'object', 'data object created');
 
   // Add data
   const testData = { asdf: 'fdsa' };
 
   data.test = testData;
-  QUnit.ok(Dom.getElData(el).test === testData, 'data added');
+  assert.ok(Dom.getElData(el).test === testData, 'data added');
 
   // Remove all data
   Dom.removeElData(el);
 
-  QUnit.ok(!Dom.hasElData(el), 'cached item emptied');
+  assert.ok(!Dom.hasElData(el), 'cached item emptied');
 });
 
-QUnit.test('addElClass()', function() {
+QUnit.test('addElClass()', function(assert) {
   const el = document.createElement('div');
 
-  QUnit.expect(5);
+  assert.expect(5);
 
   Dom.addElClass(el, 'test-class');
-  QUnit.strictEqual(el.className, 'test-class', 'adds a single class');
+  assert.strictEqual(el.className, 'test-class', 'adds a single class');
 
   Dom.addElClass(el, 'test-class');
-  QUnit.strictEqual(el.className, 'test-class', 'does not duplicate classes');
+  assert.strictEqual(el.className, 'test-class', 'does not duplicate classes');
 
-  QUnit.throws(function() {
+  assert.throws(function() {
     Dom.addElClass(el, 'foo foo-bar');
   }, 'throws when attempting to add a class with whitespace');
 
   Dom.addElClass(el, 'test2_className');
-  QUnit.strictEqual(el.className, 'test-class test2_className', 'adds second class');
+  assert.strictEqual(el.className, 'test-class test2_className', 'adds second class');
 
   Dom.addElClass(el, 'FOO');
-  QUnit.strictEqual(el.className, 'test-class test2_className FOO', 'adds third class');
+  assert.strictEqual(el.className, 'test-class test2_className FOO', 'adds third class');
 });
 
-QUnit.test('removeElClass()', function() {
+QUnit.test('removeElClass()', function(assert) {
   const el = document.createElement('div');
 
   el.className = 'test-class foo foo test2_className FOO bar';
 
-  QUnit.expect(5);
+  assert.expect(5);
 
   Dom.removeElClass(el, 'test-class');
-  QUnit.strictEqual(el.className, 'foo foo test2_className FOO bar', 'removes one class');
+  assert.strictEqual(el.className, 'foo foo test2_className FOO bar', 'removes one class');
 
   Dom.removeElClass(el, 'foo');
-  QUnit.strictEqual(el.className,
+  assert.strictEqual(el.className,
                     'test2_className FOO bar',
                     'removes all instances of a class');
 
-  QUnit.throws(function() {
+  assert.throws(function() {
     Dom.removeElClass(el, 'test2_className bar');
   }, 'throws when attempting to remove a class with whitespace');
 
   Dom.removeElClass(el, 'test2_className');
-  QUnit.strictEqual(el.className, 'FOO bar', 'removes another class');
+  assert.strictEqual(el.className, 'FOO bar', 'removes another class');
 
   Dom.removeElClass(el, 'FOO');
-  QUnit.strictEqual(el.className, 'bar', 'removes another class');
+  assert.strictEqual(el.className, 'bar', 'removes another class');
 });
 
-QUnit.test('hasElClass()', function() {
+QUnit.test('hasElClass()', function(assert) {
   const el = document.createElement('div');
 
   el.className = 'test-class foo foo test2_className FOO bar';
 
-  QUnit.strictEqual(Dom.hasElClass(el, 'test-class'), true, 'class detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'foo'), true, 'class detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'test2_className'), true, 'class detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'FOO'), true, 'class detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'bar'), true, 'class detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'test2'),
+  assert.strictEqual(Dom.hasElClass(el, 'test-class'), true, 'class detected');
+  assert.strictEqual(Dom.hasElClass(el, 'foo'), true, 'class detected');
+  assert.strictEqual(Dom.hasElClass(el, 'test2_className'), true, 'class detected');
+  assert.strictEqual(Dom.hasElClass(el, 'FOO'), true, 'class detected');
+  assert.strictEqual(Dom.hasElClass(el, 'bar'), true, 'class detected');
+  assert.strictEqual(Dom.hasElClass(el, 'test2'),
                     false,
                     'valid substring - but not a class - correctly not detected');
-  QUnit.strictEqual(Dom.hasElClass(el, 'className'),
+  assert.strictEqual(Dom.hasElClass(el, 'className'),
                     false,
                     'valid substring - but not a class - correctly not detected');
 
-  QUnit.throws(function() {
+  assert.throws(function() {
     Dom.hasElClass(el, 'FOO bar');
   }, 'throws when attempting to detect a class with whitespace');
 });
 
-QUnit.test('toggleElClass()', function() {
+QUnit.test('toggleElClass()', function(assert) {
   const el = Dom.createEl('div', {className: 'foo bar'});
 
   const predicateToggles = [
@@ -219,36 +219,36 @@ QUnit.test('toggleElClass()', function() {
     }
   ];
 
-  QUnit.expect(3 + predicateToggles.length);
+  assert.expect(3 + predicateToggles.length);
 
   Dom.toggleElClass(el, 'bar');
-  QUnit.strictEqual(el.className, 'foo', 'toggles a class off, if present');
+  assert.strictEqual(el.className, 'foo', 'toggles a class off, if present');
 
   Dom.toggleElClass(el, 'bar');
-  QUnit.strictEqual(el.className, 'foo bar', 'toggles a class on, if absent');
+  assert.strictEqual(el.className, 'foo bar', 'toggles a class on, if absent');
 
-  QUnit.throws(function() {
+  assert.throws(function() {
     Dom.toggleElClass(el, 'foo bar');
   }, 'throws when attempting to toggle a class with whitespace');
 
   predicateToggles.forEach(x => {
     Dom.toggleElClass(el, x.toggle, x.predicate);
-    QUnit.strictEqual(el.className, x.className, x.message);
+    assert.strictEqual(el.className, x.className, x.message);
   });
 });
 
-QUnit.test('should set element attributes from object', function() {
+QUnit.test('should set element attributes from object', function(assert) {
   const el = document.createElement('div');
 
   el.id = 'el1';
   Dom.setElAttributes(el, {'controls': true, 'data-test': 'asdf'});
 
-  QUnit.equal(el.getAttribute('id'), 'el1');
-  QUnit.equal(el.getAttribute('controls'), '');
-  QUnit.equal(el.getAttribute('data-test'), 'asdf');
+  assert.equal(el.getAttribute('id'), 'el1');
+  assert.equal(el.getAttribute('controls'), '');
+  assert.equal(el.getAttribute('data-test'), 'asdf');
 });
 
-QUnit.test('should read tag attributes from elements, including HTML5 in all browsers', function() {
+QUnit.test('should read tag attributes from elements, including HTML5 in all browsers', function(assert) {
   // Creating the source/track tags outside of the video tag prevents log errors
   const tags = `
   <video id="vid1" controls autoplay loop muted preload="none" src="http://google.com" poster="http://www2.videojs.com/img/video-js-html5-video-player.png" data-test="asdf" data-empty-string="">
@@ -269,35 +269,35 @@ QUnit.test('should read tag attributes from elements, including HTML5 in all bro
 
   // vid1
   // was using deepEqual, but ie8 would send all properties as attributes
-  QUnit.equal(vid1Vals.autoplay, true);
-  QUnit.equal(vid1Vals.controls, true);
-  QUnit.equal(vid1Vals['data-test'], 'asdf');
-  QUnit.equal(vid1Vals['data-empty-string'], '');
-  QUnit.equal(vid1Vals.id, 'vid1');
-  QUnit.equal(vid1Vals.loop, true);
-  QUnit.equal(vid1Vals.muted, true);
-  QUnit.equal(vid1Vals.poster, 'http://www2.videojs.com/img/video-js-html5-video-player.png');
-  QUnit.equal(vid1Vals.preload, 'none');
-  QUnit.equal(vid1Vals.src, 'http://google.com');
+  assert.equal(vid1Vals.autoplay, true);
+  assert.equal(vid1Vals.controls, true);
+  assert.equal(vid1Vals['data-test'], 'asdf');
+  assert.equal(vid1Vals['data-empty-string'], '');
+  assert.equal(vid1Vals.id, 'vid1');
+  assert.equal(vid1Vals.loop, true);
+  assert.equal(vid1Vals.muted, true);
+  assert.equal(vid1Vals.poster, 'http://www2.videojs.com/img/video-js-html5-video-player.png');
+  assert.equal(vid1Vals.preload, 'none');
+  assert.equal(vid1Vals.src, 'http://google.com');
 
   // sourceVals
-  QUnit.equal(sourceVals.title, 'test');
-  QUnit.equal(sourceVals.media, 'fdsa');
-  QUnit.equal(sourceVals.type, 'video/mp4');
-  QUnit.equal(sourceVals.src, 'http://google.com');
-  QUnit.equal(sourceVals.id, 'source');
+  assert.equal(sourceVals.title, 'test');
+  assert.equal(sourceVals.media, 'fdsa');
+  assert.equal(sourceVals.type, 'video/mp4');
+  assert.equal(sourceVals.src, 'http://google.com');
+  assert.equal(sourceVals.id, 'source');
 
   // trackVals
-  QUnit.equal(trackVals.default, true);
-  QUnit.equal(trackVals.id, 'track');
-  QUnit.equal(trackVals.kind, 'captions');
-  QUnit.equal(trackVals.label, 'testlabel');
-  QUnit.equal(trackVals.src, 'http://google.com');
-  QUnit.equal(trackVals.srclang, 'en');
-  QUnit.equal(trackVals.title, 'test');
+  assert.equal(trackVals.default, true);
+  assert.equal(trackVals.id, 'track');
+  assert.equal(trackVals.kind, 'captions');
+  assert.equal(trackVals.label, 'testlabel');
+  assert.equal(trackVals.src, 'http://google.com');
+  assert.equal(trackVals.srclang, 'en');
+  assert.equal(trackVals.title, 'test');
 });
 
-QUnit.test('Dom.findElPosition should find top and left position', function() {
+QUnit.test('Dom.findElPosition should find top and left position', function(assert) {
   const d = document.createElement('div');
   let position = Dom.findElPosition(d);
 
@@ -305,17 +305,17 @@ QUnit.test('Dom.findElPosition should find top and left position', function() {
   d.style.left = '20px';
   d.style.position = 'absolute';
 
-  QUnit.deepEqual(position,
+  assert.deepEqual(position,
                   {left: 0, top: 0},
                   'If element isn\'t in the DOM, we should get zeros');
 
   document.body.appendChild(d);
   position = Dom.findElPosition(d);
-  QUnit.deepEqual(position, {left: 20, top: 10}, 'The position was not correct');
+  assert.deepEqual(position, {left: 20, top: 10}, 'The position was not correct');
 
   d.getBoundingClientRect = null;
   position = Dom.findElPosition(d);
-  QUnit.deepEqual(position,
+  assert.deepEqual(position,
                   {left: 0, top: 0},
                   'If there is no gBCR, we should get zeros');
 });
@@ -482,7 +482,7 @@ QUnit.test('Dom.appendContent', function(assert) {
   assert.strictEqual(el.firstChild.nextSibling, p2, 'the second paragraph was appended');
 });
 
-QUnit.test('$() and $$()', function() {
+QUnit.test('$() and $$()', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
   const container = document.createElement('div');
   const children = [
@@ -496,45 +496,45 @@ QUnit.test('$() and $$()', function() {
 
   const totalDivCount = document.getElementsByTagName('div').length;
 
-  QUnit.expect(12);
+  assert.expect(12);
 
-  QUnit.strictEqual(Dom.$('#qunit-fixture'),
+  assert.strictEqual(Dom.$('#qunit-fixture'),
                     fixture,
                     'can find an element in the document context');
-  QUnit.strictEqual(Dom.$$('div').length,
+  assert.strictEqual(Dom.$$('div').length,
                     totalDivCount,
                     'finds elements in the document context');
 
-  QUnit.strictEqual(Dom.$('div', container),
+  assert.strictEqual(Dom.$('div', container),
                     children[0],
                     'can find an element in a DOM element context');
-  QUnit.strictEqual(Dom.$$('div', container).length,
+  assert.strictEqual(Dom.$$('div', container).length,
                     children.length,
                     'finds elements in a DOM element context');
 
-  QUnit.strictEqual(Dom.$('#qunit-fixture', document.querySelector('unknown')),
+  assert.strictEqual(Dom.$('#qunit-fixture', document.querySelector('unknown')),
               fixture,
               'falls back to document given a bad context element');
-  QUnit.strictEqual(Dom.$$('div', document.querySelector('unknown')).length,
+  assert.strictEqual(Dom.$$('div', document.querySelector('unknown')).length,
               totalDivCount,
               'falls back to document given a bad context element');
 
-  QUnit.strictEqual(Dom.$('#qunit-fixture', 'body'),
+  assert.strictEqual(Dom.$('#qunit-fixture', 'body'),
               fixture,
               'can find an element in a selector context');
-  QUnit.strictEqual(Dom.$$('div', '#qunit-fixture').length,
+  assert.strictEqual(Dom.$$('div', '#qunit-fixture').length,
               1 + children.length,
               'finds elements in a selector context');
 
-  QUnit.strictEqual(Dom.$('#qunit-fixture', 'unknown'),
+  assert.strictEqual(Dom.$('#qunit-fixture', 'unknown'),
               fixture,
               'falls back to document given a bad context selector');
-  QUnit.strictEqual(Dom.$$('div', 'unknown').length,
+  assert.strictEqual(Dom.$$('div', 'unknown').length,
               totalDivCount,
               'falls back to document given a bad context selector');
 
-  QUnit.strictEqual(Dom.$('div', children[0]), null, 'returns null for missing elements');
-  QUnit.strictEqual(Dom.$$('div', children[0]).length,
+  assert.strictEqual(Dom.$('div', children[0]), null, 'returns null for missing elements');
+  assert.strictEqual(Dom.$$('div', children[0]).length,
                     0,
                     'returns 0 for missing elements');
 });

--- a/test/unit/utils/fn.test.js
+++ b/test/unit/utils/fn.test.js
@@ -3,10 +3,10 @@ import * as Fn from '../../../src/js/utils/fn.js';
 
 QUnit.module('fn');
 
-QUnit.test('should add context to a function', function() {
+QUnit.test('should add context to a function', function(assert) {
   const newContext = { test: 'obj'};
   const asdf = function() {
-    QUnit.ok(this === newContext);
+    assert.ok(this === newContext);
   };
   const fdsa = Fn.bind(newContext, asdf);
 

--- a/test/unit/utils/format-time.test.js
+++ b/test/unit/utils/format-time.test.js
@@ -3,33 +3,33 @@ import formatTime from '../../../src/js/utils/format-time.js';
 
 QUnit.module('format-time');
 
-QUnit.test('should format time as a string', function() {
-  QUnit.ok(formatTime(1) === '0:01');
-  QUnit.ok(formatTime(10) === '0:10');
-  QUnit.ok(formatTime(60) === '1:00');
-  QUnit.ok(formatTime(600) === '10:00');
-  QUnit.ok(formatTime(3600) === '1:00:00');
-  QUnit.ok(formatTime(36000) === '10:00:00');
-  QUnit.ok(formatTime(360000) === '100:00:00');
+QUnit.test('should format time as a string', function(assert) {
+  assert.ok(formatTime(1) === '0:01');
+  assert.ok(formatTime(10) === '0:10');
+  assert.ok(formatTime(60) === '1:00');
+  assert.ok(formatTime(600) === '10:00');
+  assert.ok(formatTime(3600) === '1:00:00');
+  assert.ok(formatTime(36000) === '10:00:00');
+  assert.ok(formatTime(360000) === '100:00:00');
 
   // Using guide should provide extra leading zeros
-  QUnit.ok(formatTime(1, 1) === '0:01');
-  QUnit.ok(formatTime(1, 10) === '0:01');
-  QUnit.ok(formatTime(1, 60) === '0:01');
-  QUnit.ok(formatTime(1, 600) === '00:01');
-  QUnit.ok(formatTime(1, 3600) === '0:00:01');
+  assert.ok(formatTime(1, 1) === '0:01');
+  assert.ok(formatTime(1, 10) === '0:01');
+  assert.ok(formatTime(1, 60) === '0:01');
+  assert.ok(formatTime(1, 600) === '00:01');
+  assert.ok(formatTime(1, 3600) === '0:00:01');
   // Don't do extra leading zeros for hours
-  QUnit.ok(formatTime(1, 36000) === '0:00:01');
-  QUnit.ok(formatTime(1, 360000) === '0:00:01');
+  assert.ok(formatTime(1, 36000) === '0:00:01');
+  assert.ok(formatTime(1, 360000) === '0:00:01');
 
   // Do not display negative time
-  QUnit.ok(formatTime(-1) === '0:00');
-  QUnit.ok(formatTime(-1, 3600) === '0:00:00');
+  assert.ok(formatTime(-1) === '0:00');
+  assert.ok(formatTime(-1, 3600) === '0:00:00');
 });
 
-QUnit.test('should format invalid times as dashes', function() {
-  QUnit.equal(formatTime(Infinity, 90), '-:-');
-  QUnit.equal(formatTime(NaN), '-:-');
-  QUnit.equal(formatTime(10, Infinity), '0:00:10');
-  QUnit.equal(formatTime(90, NaN), '1:30');
+QUnit.test('should format invalid times as dashes', function(assert) {
+  assert.equal(formatTime(Infinity, 90), '-:-');
+  assert.equal(formatTime(NaN), '-:-');
+  assert.equal(formatTime(10, Infinity), '0:00:10');
+  assert.equal(formatTime(90, NaN), '1:30');
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -37,7 +37,7 @@ QUnit.module('log', {
 const getConsoleArgs = (...arr) =>
   IE_VERSION && IE_VERSION < 11 ? [arr.join(' ')] : arr;
 
-QUnit.test('logging functions should work', function() {
+QUnit.test('logging functions should work', function(assert) {
 
   // Need to reset history here because there are extra messages logged
   // when running via Karma.
@@ -47,28 +47,28 @@ QUnit.test('logging functions should work', function() {
   log.warn('warn1', 'warn2');
   log.error('error1', 'error2');
 
-  QUnit.ok(window.console.log.called, 'log was called');
-  QUnit.deepEqual(
+  assert.ok(window.console.log.called, 'log was called');
+  assert.deepEqual(
     window.console.log.firstCall.args,
     getConsoleArgs('VIDEOJS:', 'log1', 'log2')
   );
 
-  QUnit.ok(window.console.warn.called, 'warn was called');
-  QUnit.deepEqual(
+  assert.ok(window.console.warn.called, 'warn was called');
+  assert.deepEqual(
     window.console.warn.firstCall.args,
     getConsoleArgs('VIDEOJS:', 'WARN:', 'warn1', 'warn2')
   );
 
-  QUnit.ok(window.console.error.called, 'error was called');
-  QUnit.deepEqual(
+  assert.ok(window.console.error.called, 'error was called');
+  assert.deepEqual(
     window.console.error.firstCall.args,
     getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2')
   );
 
-  QUnit.equal(log.history.length, 3, 'there should be three messages in the log history');
+  assert.equal(log.history.length, 3, 'there should be three messages in the log history');
 });
 
-QUnit.test('in IE pre-11 (or when requested) objects and arrays are stringified', function() {
+QUnit.test('in IE pre-11 (or when requested) objects and arrays are stringified', function(assert) {
 
   // Run a custom log call, explicitly requesting object/array stringification.
   logByType('log', [
@@ -80,7 +80,7 @@ QUnit.test('in IE pre-11 (or when requested) objects and arrays are stringified'
     null
   ], true);
 
-  QUnit.ok(window.console.log.called, 'log was called');
-  QUnit.deepEqual(window.console.log.firstCall.args,
+  assert.ok(window.console.log.called, 'log was called');
+  assert.deepEqual(window.console.log.firstCall.args,
             ['VIDEOJS: test {"foo":"bar"} [1,2,3] 0 false null']);
 });

--- a/test/unit/utils/merge-options.test.js
+++ b/test/unit/utils/merge-options.test.js
@@ -2,7 +2,7 @@
 import mergeOptions from '../../../src/js/utils/merge-options.js';
 
 QUnit.module('merge-options');
-QUnit.test('should merge options objects', function() {
+QUnit.test('should merge options objects', function(assert) {
   const ob1 = {
     a: true,
     b: { b1: true, b2: true, b3: true },
@@ -20,7 +20,7 @@ QUnit.test('should merge options objects', function() {
 
   const ob3 = mergeOptions(ob1, ob2);
 
-  QUnit.deepEqual(ob3, {
+  assert.deepEqual(ob3, {
     a: false,
     b: { b1: true, b2: false, b3: true, b4: true },
     c: true,

--- a/test/unit/utils/time-ranges.test.js
+++ b/test/unit/utils/time-ranges.test.js
@@ -3,8 +3,8 @@ import { createTimeRanges, createTimeRange } from '../../../src/js/utils/time-ra
 
 QUnit.module('time-ranges');
 
-QUnit.test('should export the deprecated createTimeRange function', function() {
-  QUnit.equal(createTimeRange,
+QUnit.test('should export the deprecated createTimeRange function', function(assert) {
+  assert.equal(createTimeRange,
               createTimeRanges,
               'createTimeRange is an alias to createTimeRanges');
 });
@@ -12,11 +12,11 @@ QUnit.test('should export the deprecated createTimeRange function', function() {
 QUnit.test('should create a fake single timerange', function(assert) {
   const tr = createTimeRanges(0, 10);
 
-  QUnit.equal(tr.length, 1, 'length should be 1');
-  QUnit.equal(tr.start(0),
+  assert.equal(tr.length, 1, 'length should be 1');
+  assert.equal(tr.start(0),
               0,
               'works if start is called with valid index');
-  QUnit.equal(tr.end(0),
+  assert.equal(tr.end(0),
               10,
               'works if end is called with with valid index');
   assert.throws(()=>tr.start(1),
@@ -33,9 +33,9 @@ QUnit.test('should create a fake multiple timerange', function(assert) {
     [11, 20]
   ]);
 
-  QUnit.equal(tr.length, 2, 'length should equal 2');
-  QUnit.equal(tr.start(1), 11, 'works if start is called with valid index');
-  QUnit.equal(tr.end(1), 20, 'works if end is called with with valid index');
+  assert.equal(tr.length, 2, 'length should equal 2');
+  assert.equal(tr.start(1), 11, 'works if start is called with valid index');
+  assert.equal(tr.end(1), 20, 'works if end is called with with valid index');
   assert.throws(()=>tr.start(-1),
                 /Failed to execute 'start'/,
                 'fails if start is called with an invalid index');

--- a/test/unit/utils/to-title-case.test.js
+++ b/test/unit/utils/to-title-case.test.js
@@ -3,8 +3,8 @@ import toTitleCase from '../../../src/js/utils/to-title-case.js';
 
 QUnit.module('to-title-case');
 
-QUnit.test('should make a string start with an uppercase letter', function() {
+QUnit.test('should make a string start with an uppercase letter', function(assert) {
   const foo = toTitleCase('bar');
 
-  QUnit.ok(foo === 'Bar');
+  assert.ok(foo === 'Bar');
 });

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -6,19 +6,19 @@ import proxyquireify from 'proxyquireify';
 const proxyquire = proxyquireify(require);
 
 QUnit.module('url');
-QUnit.test('should parse the details of a url correctly', function() {
-  QUnit.equal(Url.parseUrl('#').protocol,
+QUnit.test('should parse the details of a url correctly', function(assert) {
+  assert.equal(Url.parseUrl('#').protocol,
               window.location.protocol,
               'parsed relative url protocol');
-  QUnit.equal(Url.parseUrl('#').host, window.location.host, 'parsed relative url host');
+  assert.equal(Url.parseUrl('#').host, window.location.host, 'parsed relative url host');
 
-  QUnit.equal(Url.parseUrl('http://example.com').protocol, 'http:', 'parsed example url protocol');
-  QUnit.equal(Url.parseUrl('http://example.com').hostname, 'example.com', 'parsed example url hostname');
+  assert.equal(Url.parseUrl('http://example.com').protocol, 'http:', 'parsed example url protocol');
+  assert.equal(Url.parseUrl('http://example.com').hostname, 'example.com', 'parsed example url hostname');
 
-  QUnit.equal(Url.parseUrl('http://example.com:1234').port, '1234', 'parsed example url port');
+  assert.equal(Url.parseUrl('http://example.com:1234').port, '1234', 'parsed example url port');
 });
 
-QUnit.test('should strip port from hosts using http or https', function() {
+QUnit.test('should strip port from hosts using http or https', function(assert) {
   const origDocCreate = document.createElement;
 
   // attempts to create elements will return an anchor tag that
@@ -38,41 +38,41 @@ QUnit.test('should strip port from hosts using http or https', function() {
 
   document.createElement = origDocCreate;
 
-  QUnit.ok(!(/.*:80$/).test(url.host), ':80 is not appended to the host');
+  assert.ok(!(/.*:80$/).test(url.host), ':80 is not appended to the host');
 
 });
 
-QUnit.test('should get an absolute URL', function() {
+QUnit.test('should get an absolute URL', function(assert) {
   // Errors on compiled tests that don't use unit.html. Need a better solution.
-  // QUnit.ok(Url.getAbsoluteURL('unit.html') === window.location.href);
-  QUnit.ok(Url.getAbsoluteURL('http://asdf.com') === 'http://asdf.com');
-  QUnit.ok(Url.getAbsoluteURL('https://asdf.com/index.html') === 'https://asdf.com/index.html');
+  // assert.ok(Url.getAbsoluteURL('unit.html') === window.location.href);
+  assert.ok(Url.getAbsoluteURL('http://asdf.com') === 'http://asdf.com');
+  assert.ok(Url.getAbsoluteURL('https://asdf.com/index.html') === 'https://asdf.com/index.html');
 });
 
 // getFileExtension tests
-QUnit.test('should get the file extension of the passed path', function() {
-  QUnit.equal(Url.getFileExtension('/foo/bar/test.video.wgg'), 'wgg');
-  QUnit.equal(Url.getFileExtension('test./video.mp4'), 'mp4');
-  QUnit.equal(Url.getFileExtension('.bar/test.video.m4v'), 'm4v');
-  QUnit.equal(Url.getFileExtension('foo/.bar/test.video.flv'), 'flv');
-  QUnit.equal(Url.getFileExtension('foo/.bar/test.video.flv?foo=bar'), 'flv');
-  QUnit.equal(Url.getFileExtension('http://www.test.com/video.mp4'), 'mp4');
-  QUnit.equal(Url.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
+QUnit.test('should get the file extension of the passed path', function(assert) {
+  assert.equal(Url.getFileExtension('/foo/bar/test.video.wgg'), 'wgg');
+  assert.equal(Url.getFileExtension('test./video.mp4'), 'mp4');
+  assert.equal(Url.getFileExtension('.bar/test.video.m4v'), 'm4v');
+  assert.equal(Url.getFileExtension('foo/.bar/test.video.flv'), 'flv');
+  assert.equal(Url.getFileExtension('foo/.bar/test.video.flv?foo=bar'), 'flv');
+  assert.equal(Url.getFileExtension('http://www.test.com/video.mp4'), 'mp4');
+  assert.equal(Url.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
 
   // edge cases
-  QUnit.equal(Url.getFileExtension('http://...'), '');
-  QUnit.equal(Url.getFileExtension('foo/.bar/testvideo'), '');
-  QUnit.equal(Url.getFileExtension(''), '');
-  QUnit.equal(Url.getFileExtension(null), '');
-  QUnit.equal(Url.getFileExtension(undefined), '');
+  assert.equal(Url.getFileExtension('http://...'), '');
+  assert.equal(Url.getFileExtension('foo/.bar/testvideo'), '');
+  assert.equal(Url.getFileExtension(''), '');
+  assert.equal(Url.getFileExtension(null), '');
+  assert.equal(Url.getFileExtension(undefined), '');
 
   // with capital letters
-  QUnit.equal(Url.getFileExtension('test.video.MP4'), 'mp4');
-  QUnit.equal(Url.getFileExtension('test.video.FLV'), 'flv');
+  assert.equal(Url.getFileExtension('test.video.MP4'), 'mp4');
+  assert.equal(Url.getFileExtension('test.video.FLV'), 'flv');
 });
 
 // isCrossOrigin tests
-QUnit.test('isCrossOrigin can identify cross origin urls', function() {
+QUnit.test('isCrossOrigin can identify cross origin urls', function(assert) {
   const win = {
     location: {}
   };
@@ -82,19 +82,19 @@ QUnit.test('isCrossOrigin can identify cross origin urls', function() {
 
   win.location.protocol = window.location.protocol;
   win.location.host = window.location.host;
-  QUnit.ok(!Url_.isCrossOrigin(`http://${win.location.host}/example.vtt`), 'http://google.com from http://google.com is not cross origin');
-  QUnit.ok(Url_.isCrossOrigin(`https://${win.location.host}/example.vtt`), 'https://google.com from http://google.com is cross origin');
-  QUnit.ok(!Url_.isCrossOrigin(`//${win.location.host}/example.vtt`), '//google.com from http://google.com is not cross origin');
-  QUnit.ok(Url_.isCrossOrigin('http://example.com/example.vtt'), 'http://example.com from http://google.com is cross origin');
-  QUnit.ok(Url_.isCrossOrigin('https://example.com/example.vtt'), 'https://example.com from http://google.com is cross origin');
-  QUnit.ok(Url_.isCrossOrigin('//example.com/example.vtt'), '//example.com from http://google.com is cross origin');
+  assert.ok(!Url_.isCrossOrigin(`http://${win.location.host}/example.vtt`), 'http://google.com from http://google.com is not cross origin');
+  assert.ok(Url_.isCrossOrigin(`https://${win.location.host}/example.vtt`), 'https://google.com from http://google.com is cross origin');
+  assert.ok(!Url_.isCrossOrigin(`//${win.location.host}/example.vtt`), '//google.com from http://google.com is not cross origin');
+  assert.ok(Url_.isCrossOrigin('http://example.com/example.vtt'), 'http://example.com from http://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('https://example.com/example.vtt'), 'https://example.com from http://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('//example.com/example.vtt'), '//example.com from http://google.com is cross origin');
   // we cannot test that relative urls work on https, though
-  QUnit.ok(!Url_.isCrossOrigin('example.vtt'), 'relative url is not cross origin');
+  assert.ok(!Url_.isCrossOrigin('example.vtt'), 'relative url is not cross origin');
 
   win.location.protocol = 'https:';
   win.location.host = 'google.com';
-  QUnit.ok(Url_.isCrossOrigin('http://google.com/example.vtt'), 'http://google.com from https://google.com is cross origin');
-  QUnit.ok(Url_.isCrossOrigin('http://example.com/example.vtt'), 'http://example.com from https://google.com is cross origin');
-  QUnit.ok(Url_.isCrossOrigin('https://example.com/example.vtt'), 'https://example.com from https://google.com is cross origin');
-  QUnit.ok(Url_.isCrossOrigin('//example.com/example.vtt'), '//example.com from https://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('http://google.com/example.vtt'), 'http://google.com from https://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('http://example.com/example.vtt'), 'http://example.com from https://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('https://example.com/example.vtt'), 'https://example.com from https://google.com is cross origin');
+  assert.ok(Url_.isCrossOrigin('//example.com/example.vtt'), '//example.com from https://google.com is cross origin');
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -6,18 +6,18 @@ import document from 'global/document';
 
 QUnit.module('video.js');
 
-QUnit.test('should create a video tag and have access children in old IE', function() {
+QUnit.test('should create a video tag and have access children in old IE', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   fixture.innerHTML += '<video id="test_vid_id"><source type="video/mp4"></video>';
 
   const vid = document.getElementById('test_vid_id');
 
-  QUnit.ok(vid.childNodes.length === 1);
-  QUnit.ok(vid.childNodes[0].getAttribute('type') === 'video/mp4');
+  assert.ok(vid.childNodes.length === 1);
+  assert.ok(vid.childNodes[0].getAttribute('type') === 'video/mp4');
 });
 
-QUnit.test('should return a video player instance', function() {
+QUnit.test('should return a video player instance', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   fixture.innerHTML += '<video id="test_vid_id"></video>' +
@@ -25,24 +25,24 @@ QUnit.test('should return a video player instance', function() {
 
   const player = videojs('test_vid_id', { techOrder: ['techFaker'] });
 
-  QUnit.ok(player, 'created player from tag');
-  QUnit.ok(player.id() === 'test_vid_id');
-  QUnit.ok(videojs.getPlayers().test_vid_id === player,
+  assert.ok(player, 'created player from tag');
+  assert.ok(player.id() === 'test_vid_id');
+  assert.ok(videojs.getPlayers().test_vid_id === player,
            'added player to global reference');
 
   const playerAgain = videojs('test_vid_id');
 
-  QUnit.ok(player === playerAgain, 'did not create a second player from same tag');
+  assert.ok(player === playerAgain, 'did not create a second player from same tag');
 
-  QUnit.equal(player, playerAgain, 'we did not make a new player');
+  assert.equal(player, playerAgain, 'we did not make a new player');
 
   const tag2 = document.getElementById('test_vid_id2');
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
-  QUnit.ok(player2.id() === 'test_vid_id2', 'created player from element');
+  assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
 });
 
-QUnit.test('should return a video player instance from el html5 tech', function() {
+QUnit.test('should return a video player instance from el html5 tech', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   fixture.innerHTML += '<video id="test_vid_id"></video>' +
@@ -52,23 +52,23 @@ QUnit.test('should return a video player instance from el html5 tech', function(
 
   const player = videojs(vid);
 
-  QUnit.ok(player, 'created player from tag');
-  QUnit.ok(player.id() === 'test_vid_id');
-  QUnit.ok(videojs.getPlayers().test_vid_id === player,
+  assert.ok(player, 'created player from tag');
+  assert.ok(player.id() === 'test_vid_id');
+  assert.ok(videojs.getPlayers().test_vid_id === player,
            'added player to global reference');
 
   const playerAgain = videojs(vid);
 
-  QUnit.ok(player === playerAgain, 'did not create a second player from same tag');
-  QUnit.equal(player, playerAgain, 'we did not make a new player');
+  assert.ok(player === playerAgain, 'did not create a second player from same tag');
+  assert.equal(player, playerAgain, 'we did not make a new player');
 
   const tag2 = document.getElementById('test_vid_id2');
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
-  QUnit.ok(player2.id() === 'test_vid_id2', 'created player from element');
+  assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
 });
 
-QUnit.test('should return a video player instance from el techfaker', function() {
+QUnit.test('should return a video player instance from el techfaker', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   fixture.innerHTML += '<video id="test_vid_id"></video>' +
@@ -77,66 +77,66 @@ QUnit.test('should return a video player instance from el techfaker', function()
   const vid = document.querySelector('#test_vid_id');
   const player = videojs(vid, {techOrder: ['techFaker']});
 
-  QUnit.ok(player, 'created player from tag');
-  QUnit.ok(player.id() === 'test_vid_id');
-  QUnit.ok(videojs.getPlayers().test_vid_id === player,
+  assert.ok(player, 'created player from tag');
+  assert.ok(player.id() === 'test_vid_id');
+  assert.ok(videojs.getPlayers().test_vid_id === player,
            'added player to global reference');
 
   const playerAgain = videojs(vid);
 
-  QUnit.ok(player === playerAgain, 'did not create a second player from same tag');
-  QUnit.equal(player, playerAgain, 'we did not make a new player');
+  assert.ok(player === playerAgain, 'did not create a second player from same tag');
+  assert.equal(player, playerAgain, 'we did not make a new player');
 
   const tag2 = document.getElementById('test_vid_id2');
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
-  QUnit.ok(player2.id() === 'test_vid_id2', 'created player from element');
+  assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
 });
 
-QUnit.test('should add the value to the languages object', function() {
+QUnit.test('should add the value to the languages object', function(assert) {
   const code = 'es';
   const data = {Hello: 'Hola'};
   const result = videojs.addLanguage(code, data);
 
-  QUnit.ok(videojs.options.languages[code], 'should exist');
-  QUnit.equal(videojs.options.languages.es.Hello, 'Hola', 'should match');
-  QUnit.deepEqual(result.Hello, videojs.options.languages.es.Hello, 'should also match');
+  assert.ok(videojs.options.languages[code], 'should exist');
+  assert.equal(videojs.options.languages.es.Hello, 'Hola', 'should match');
+  assert.deepEqual(result.Hello, videojs.options.languages.es.Hello, 'should also match');
 });
 
-QUnit.test('should add the value to the languages object with lower case lang code', function() {
+QUnit.test('should add the value to the languages object with lower case lang code', function(assert) {
   const code = 'DE';
   const data = {Hello: 'Guten Tag'};
   const result = videojs.addLanguage(code, data);
 
-  QUnit.ok(videojs.options.languages[code.toLowerCase()], 'should exist');
-  QUnit.equal(videojs.options.languages[code.toLowerCase()].Hello,
+  assert.ok(videojs.options.languages[code.toLowerCase()], 'should exist');
+  assert.equal(videojs.options.languages[code.toLowerCase()].Hello,
               'Guten Tag',
               'should match');
-  QUnit.deepEqual(result,
+  assert.deepEqual(result,
                   videojs.options.languages[code.toLowerCase()],
                   'should also match');
 });
 
-QUnit.test('should expose plugin registry function', function() {
+QUnit.test('should expose plugin registry function', function(assert) {
   const pluginName = 'foo';
   const pluginFunction = function(options) {};
 
-  QUnit.ok(videojs.plugin, 'should exist');
+  assert.ok(videojs.plugin, 'should exist');
 
   videojs.plugin(pluginName, pluginFunction);
 
   const player = TestHelpers.makePlayer();
 
-  QUnit.ok(player.foo, 'should exist');
-  QUnit.equal(player.foo, pluginFunction, 'should be equal');
+  assert.ok(player.foo, 'should exist');
+  assert.equal(player.foo, pluginFunction, 'should be equal');
 });
 
-QUnit.test('should expose options and players properties for backward-compatibility', function() {
-  QUnit.ok(typeof videojs.options, 'object', 'options should be an object');
-  QUnit.ok(typeof videojs.players, 'object', 'players should be an object');
+QUnit.test('should expose options and players properties for backward-compatibility', function(assert) {
+  assert.ok(typeof videojs.options, 'object', 'options should be an object');
+  assert.ok(typeof videojs.players, 'object', 'players should be an object');
 });
 
-QUnit.test('should expose DOM functions', function() {
+QUnit.test('should expose DOM functions', function(assert) {
 
   // Keys are videojs methods, values are Dom methods.
   const methods = {
@@ -156,11 +156,11 @@ QUnit.test('should expose DOM functions', function() {
 
   const keys = Object.keys(methods);
 
-  QUnit.expect(keys.length);
+  assert.expect(keys.length);
   keys.forEach(function(vjsName) {
     const domName = methods[vjsName];
 
-    QUnit.strictEqual(videojs[vjsName],
+    assert.strictEqual(videojs[vjsName],
                       Dom[domName],
                       `videojs.${vjsName} is a reference to Dom.${domName}`);
   });


### PR DESCRIPTION
## Description
This updates tests to use QUnit 2.0-style assertions and test module lifecycle methods.

## Specific Changes proposed
- Move assertions from `QUnit.ok()` or `ok()` style to `assert.ok()` style.
- Replace `setup()` with `beforeEach()` and `teardown()` with `afterEach()`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Reviewed by Two Core Contributors
