### PR TITLE
Stop Android treating swipe as tap

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -10,7 +10,6 @@ import * as Guid from './utils/guid.js';
 import * as Events from './utils/events.js';
 import log from './utils/log.js';
 import toTitleCase from './utils/to-title-case.js';
-import assign from 'object.assign';
 import mergeOptions from './utils/merge-options.js';
 
 /**
@@ -1179,8 +1178,11 @@ class Component {
     this.on('touchstart', function(event) {
       // If more than one finger, don't consider treating this as a click
       if (event.touches.length === 1) {
-        // Copy the touches object to prevent modifying the original
-        firstTouch = assign({}, event.touches[0]);
+        // Copy pageX/pageY from the object
+        firstTouch = {
+          pageX: event.touches[0].pageX,
+          pageY: event.touches[0].pageY
+        };
         // Record start time so we can detect a tap vs. "touch and hold"
         touchStart = new Date().getTime();
         // Reset couldBeTap tracking


### PR DESCRIPTION
## Description
On Android, a short duration swipe is always considered a tap. Scrolling a page can easily start playback unintentionally - see #3157.

`assign()` returns `{}` [in the touchstart handler](https://github.com/videojs/video.js/blob/master/src/js/component.js#L1183), so `touchDistance` is always `NaN` [in the touchmove handler](https://github.com/videojs/video.js/blob/master/src/js/component.js#L1202).

It seems `pageX`, `pageY` etc are "own" properties of the Touch on iOS Safari (and of the object used in the tests) but not on Android Chrome, hence the difference in behaviour of `assign()`.

## Specific Changes proposed
Copy the specific properties needed instead of using `assign()`. Unless I'm missing something about the point of using `assign()` in the first place...

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

