### PR TITLE
Silence "The play() request was interrupted by a call to pause()"

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -441,8 +441,8 @@ class Html5 extends Tech {
 
     // Catch/silence error when a pause interrupts a play request
     // on browsers which return a promise
-    if (playPromise !== undefined) {
-      playPromise.catch((e) => {});
+    if (playPromise !== undefined && typeof playPromise.then === 'function') {
+      playPromise.then(null, (e) => {});
     }
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -437,7 +437,13 @@ class Html5 extends Tech {
    * @method play
    */
   play() {
-    this.el_.play();
+    const playPromise = this.el_.play();
+
+    // Catch/silence error when a pause interrupts a play request
+    // on browsers which return a promise
+    if (playPromise !== undefined) {
+      playPromise.catch((e) => {});
+    }
   }
 
   /**

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -517,3 +517,20 @@ QUnit.test('Html5#reset calls Html5.resetMediaElement when called', function() {
 
   Html5.resetMediaElement = oldResetMedia;
 });
+
+QUnit.test('Exception in play promise should be caught', function() {
+  const oldEl = tech.el_;
+  
+  tech.el_ = {
+    play: () => {
+      return new Promise(function(resolve, reject) {
+        reject(new DOMException());
+      });
+    }
+  };
+
+  tech.play();
+  QUnit.ok(true, 'error was caught');
+ 
+  tech.el_ = oldEl;
+});


### PR DESCRIPTION
## Description
On browsers that return a promise for `play()` (so far Chrome), an `AbortError` DOMException is thrown if a `pause()` occurs before playback starts. This doesn't break anything, but logs an annoying error to the console. 

## Specific Changes proposed
Just catch the exception and do nothing.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors