### PR TITLE
Feature/clean up player objects in tests

### DIFF
--- a/test/unit/button.test.js
+++ b/test/unit/button.test.js
@@ -24,4 +24,6 @@ QUnit.test('should localize its text', function(assert) {
   assert.ok(el.nodeName.toLowerCase().match('button'));
   assert.ok(el.innerHTML.match(/vjs-control-text"?>Juego/));
   assert.equal(el.getAttribute('title'), 'Juego');
+  player.dispose();
+
 });

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -110,6 +110,7 @@ QUnit.test('should hide playback rate control if it\'s not supported', function(
   const playbackRate = new PlaybackRateMenuButton(player);
 
   assert.ok(playbackRate.el().className.indexOf('vjs-hidden') >= 0, 'playbackRate is not hidden');
+  player.dispose();
 });
 
 QUnit.test('Fullscreen control text should be correct when fullscreenchange is triggered', function() {
@@ -122,4 +123,5 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
   player.isFullscreen(false);
   player.trigger('fullscreenchange');
   QUnit.equal(fullscreentoggle.controlText(), 'Fullscreen', 'Control Text is correct while switching back to normal mode');
+  player.dispose();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -188,6 +188,7 @@ QUnit.test('should set the width, height, and aspect ratio via a css class', fun
   // Change the aspect ratio
   player.aspectRatio('4:1');
   assert.ok(confirmSetting('padding-top', '25%'), 'aspect ratio percent should match the newly set aspect ratio');
+  player.dispose();
 });
 
 QUnit.test('should use an class name that begins with an alpha character', function(assert) {
@@ -203,6 +204,8 @@ QUnit.test('should use an class name that begins with an alpha character', funct
 
   assert.ok(/\s*\.alpha1-dimensions\s*\{/.test(getStyleText(alphaPlayer.styleEl_)), 'appends -dimensions to an alpha player ID');
   assert.ok(/\s*\.dimensions-1numeric\s*\{/.test(getStyleText(numericPlayer.styleEl_)), 'prepends dimensions- to a numeric player ID');
+  alphaPlayer.dispose();
+  numericPlayer.dispose();
 });
 
 QUnit.test('should wrap the original tag in the player div', function(assert) {
@@ -265,6 +268,7 @@ QUnit.test('should hide the poster when play is called', function(assert) {
 
   player.tech_.trigger('play');
   assert.equal(player.hasStarted(), true, 'the show poster flag is false after play');
+  player.dispose();
 });
 
 QUnit.test('should load a media controller', function(assert) {
@@ -482,6 +486,7 @@ QUnit.test('should register players with generated ids', function(assert) {
 
   assert.equal(player.el().id, player.id(), 'the player and element ids are equal');
   assert.ok(Player.players[id], 'the generated id is registered');
+  player.dispose();
 });
 
 QUnit.test('should not add multiple first play events despite subsequent loads', function(assert) {
@@ -497,6 +502,7 @@ QUnit.test('should not add multiple first play events despite subsequent loads',
   player.tech_.trigger('loadstart');
   player.tech_.trigger('loadstart');
   player.tech_.trigger('play');
+  player.dispose();
 });
 
 QUnit.test('should fire firstplay after resetting the player', function(assert) {
@@ -529,6 +535,7 @@ QUnit.test('should fire firstplay after resetting the player', function(assert) 
   player.tech_.trigger('loadstart');
   // player.tech_.trigger('play');
   assert.ok(fpFired, 'Third firstplay fired');
+  player.dispose();
 });
 
 QUnit.test('should remove vjs-has-started class', function(assert) {
@@ -544,7 +551,9 @@ QUnit.test('should remove vjs-has-started class', function(assert) {
   assert.ok(player.el().className.indexOf('vjs-has-started') === -1, 'vjs-has-started class removed');
 
   player.tech_.trigger('play');
+
   assert.ok(player.el().className.indexOf('vjs-has-started') !== -1, 'vjs-has-started class added again');
+  player.dispose();
 });
 
 QUnit.test('should add and remove vjs-ended class', function(assert) {
@@ -565,6 +574,7 @@ QUnit.test('should add and remove vjs-ended class', function(assert) {
 
   player.tech_.trigger('loadstart');
   assert.ok(player.el().className.indexOf('vjs-ended') === -1, 'vjs-ended class removed');
+  player.dispose();
 });
 
 QUnit.test('player should handle different error types', function(assert) {
@@ -615,6 +625,8 @@ QUnit.test('player should handle different error types', function(assert) {
 
   // restore error logging
   log.error.restore();
+
+  player.dispose();
 });
 
 QUnit.test('Data attributes on the video element should persist in the new wrapper element', function(assert) {
@@ -627,6 +639,8 @@ QUnit.test('Data attributes on the video element should persist in the new wrapp
   const player = TestHelpers.makePlayer({}, tag);
 
   assert.equal(player.el().getAttribute('data-id'), dataId, 'data-id should be available on the new player element after creation');
+
+  player.dispose();
 });
 
 QUnit.test('should restore attributes from the original video tag when creating a new element', function(assert) {
@@ -663,6 +677,7 @@ QUnit.test('should honor default inactivity timeout', function(assert) {
   assert.equal(player.userActive(), false, 'User is inactive after timeout expired');
 
   clock.restore();
+  player.dispose();
 });
 
 QUnit.test('should honor configured inactivity timeout', function(assert) {
@@ -681,6 +696,7 @@ QUnit.test('should honor configured inactivity timeout', function(assert) {
   assert.equal(player.userActive(), false, 'User is inactive after timeout expired');
 
   clock.restore();
+  player.dispose();
 });
 
 QUnit.test('should honor disabled inactivity timeout', function(assert) {
@@ -696,6 +712,7 @@ QUnit.test('should honor disabled inactivity timeout', function(assert) {
   assert.equal(player.userActive(), true, 'User is still active');
 
   clock.restore();
+  player.dispose();
 });
 
 QUnit.test('should clear pending errors on disposal', function(assert) {
@@ -729,6 +746,7 @@ QUnit.test('pause is called when player ended event is fired and player is not p
   };
   player.tech_.trigger('ended');
   assert.equal(pauses, 1, 'pause was called');
+  player.dispose();
 });
 
 QUnit.test('pause is not called if the player is paused and ended is fired', function(assert) {
@@ -743,7 +761,9 @@ QUnit.test('pause is not called if the player is paused and ended is fired', fun
     pauses++;
   };
   player.tech_.trigger('ended');
+
   assert.equal(pauses, 0, 'pause was not called when ended fired');
+  player.dispose();
 });
 
 QUnit.test('should add an audio class if an audio el is used', function(assert) {
@@ -752,6 +772,7 @@ QUnit.test('should add an audio class if an audio el is used', function(assert) 
   const audioClass = 'vjs-audio';
 
   assert.ok(player.el().className.indexOf(audioClass) !== -1, 'added ' + audioClass + ' css class');
+  player.dispose();
 });
 
 QUnit.test('should add a video player region if a video el is used', function(assert) {
@@ -760,6 +781,7 @@ QUnit.test('should add a video player region if a video el is used', function(as
 
   assert.ok(player.el().getAttribute('role') === 'region', 'region role is present');
   assert.ok(player.el().getAttribute('aria-label') === 'video player', 'video player label present');
+  player.dispose();
 });
 
 QUnit.test('should add an audio player region if an audio el is used', function(assert) {
@@ -768,6 +790,7 @@ QUnit.test('should add an audio player region if an audio el is used', function(
 
   assert.ok(player.el().getAttribute('role') === 'region', 'region role is present');
   assert.ok(player.el().getAttribute('aria-label') === 'audio player', 'audio player label present');
+  player.dispose();
 });
 
 QUnit.test('should not be scrubbing while not seeking', function(assert) {
@@ -776,7 +799,9 @@ QUnit.test('should not be scrubbing while not seeking', function(assert) {
   assert.equal(player.scrubbing(), false, 'player is not scrubbing');
   assert.ok(player.el().className.indexOf('scrubbing') === -1, 'scrubbing class is not present');
   player.scrubbing(false);
+
   assert.equal(player.scrubbing(), false, 'player is not scrubbing');
+  player.dispose();
 });
 
 QUnit.test('should be scrubbing while seeking', function(assert) {
@@ -785,6 +810,7 @@ QUnit.test('should be scrubbing while seeking', function(assert) {
   player.scrubbing(true);
   assert.equal(player.scrubbing(), true, 'player is scrubbing');
   assert.ok(player.el().className.indexOf('scrubbing') !== -1, 'scrubbing class is present');
+  player.dispose();
 });
 
 QUnit.test('should throw on startup no techs are specified', function(assert) {
@@ -827,6 +853,9 @@ QUnit.test('should have a sensible toJSON that is equivalent to player.options',
   popts.tracks[0].player = undefined;
 
   assert.deepEqual(player2.toJSON(), popts, 'no circular references');
+
+  player.dispose();
+  player2.dispose();
 });
 
 QUnit.test('should ignore case in language codes and try primary code', function(assert) {
@@ -849,6 +878,7 @@ QUnit.test('should ignore case in language codes and try primary code', function
   assert.strictEqual(player.localize('Error'), 'Problem', 'Used primary code localisation');
   player.language('en-GB');
   assert.strictEqual(player.localize('Good'), 'Brilliant', 'Ignored case');
+  player.dispose();
 });
 
 QUnit.test('inherits language from parent element', function(assert) {
@@ -889,8 +919,10 @@ QUnit.test('createModal()', function(assert) {
   assert.strictEqual(modal.content(), 'foo', 'content is set properly');
   assert.ok(modal.opened(), 'modal is opened by default');
   modal.close();
+
   assert.ok(spy.called, 'modal was disposed when closed');
   assert.strictEqual(player.children().indexOf(modal), -1, 'modal was removed from player\'s children');
+  player.dispose();
 });
 
 QUnit.test('createModal() options object', function(assert) {
@@ -901,6 +933,7 @@ QUnit.test('createModal() options object', function(assert) {
   assert.strictEqual(modal.content(), 'foo', 'content argument takes precedence');
   assert.strictEqual(modal.options_.label, 'boo', 'modal options are set properly');
   modal.close();
+  player.dispose();
 });
 
 QUnit.test('you can clear error in the error event', function(assert) {
@@ -919,6 +952,7 @@ QUnit.test('you can clear error in the error event', function(assert) {
   assert.ok(!player.error(), 'we no longer have an error');
 
   log.error.restore();
+  player.dispose();
 });
 
 QUnit.test('Player#tech will return tech given the appropriate input', function(assert) {
@@ -1004,6 +1038,7 @@ QUnit.test('Remove waiting class on timeupdate after tech waiting', function(ass
   assert.ok(/vjs-waiting/.test(player.el().className), 'vjs-waiting is added to the player el on tech waiting');
   player.trigger('timeupdate');
   assert.ok(!(/vjs-waiting/).test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
+  player.dispose();
 });
 
 QUnit.test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE option', function(assert) {
@@ -1064,6 +1099,8 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
 
   player.width(600);
   player.height(300);
+
   assert.equal(player.tech_.el().width, 600, 'the width is equal to 600');
   assert.equal(player.tech_.el().height, 300, 'the height is equal 300');
+  player.dispose();
 });

--- a/test/unit/setup.test.js
+++ b/test/unit/setup.test.js
@@ -14,4 +14,5 @@ QUnit.test('should set options from data-setup even if autoSetup is not called b
   assert.ok(player.options_.controls === true);
   assert.ok(player.options_.autoplay === false);
   assert.ok(player.options_.preload === 'auto');
+  player.dispose();
 });

--- a/test/unit/tracks/audio-tracks.test.js
+++ b/test/unit/tracks/audio-tracks.test.js
@@ -106,4 +106,5 @@ QUnit.test('when switching techs, we should not get a new audio track', function
   const secondTracks = player.audioTracks();
 
   assert.ok(firstTracks === secondTracks, 'the tracks are equal');
+  player.dispose();
 });

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -293,6 +293,8 @@ QUnit.test('when switching techs, we should not get a new text track', function(
   const secondTracks = player.textTracks();
 
   assert.ok(firstTracks === secondTracks, 'the tracks are equal');
+
+  player.dispose();
 });
 
 if (Html5.supportsNativeTextTracks()) {
@@ -407,6 +409,7 @@ QUnit.test('removes cuechange event when text track is hidden for emulated track
   player.tech_.trigger('timeupdate');
   assert.equal(numTextTrackChanges, 4,
     'texttrackchange should be not be called since mode is hidden');
+  player.dispose();
 });
 
 QUnit.test('should return correct remote text track values', function(assert) {
@@ -506,6 +509,8 @@ QUnit.test('default text tracks should show by default', function(assert) {
 
   assert.equal(tracks[0].kind, 'captions', 'the captions track is present');
   assert.equal(tracks[0].mode, 'showing', 'the captions track is showing');
+
+  player.dispose();
 });
 
 QUnit.test('default captions take precedence over default descriptions', function(assert) {
@@ -536,6 +541,7 @@ QUnit.test('default captions take precedence over default descriptions', functio
   assert.equal(tracks[0].mode, 'disabled', 'the descriptions track is disabled');
   assert.equal(tracks[1].kind, 'captions', 'the captions track is second');
   assert.equal(tracks[1].mode, 'showing', 'the captions track is showing');
+  player.dispose();
 });
 
 QUnit.test('removeRemoteTextTrack should be able to take both a track and the response from addRemoteTextTrack', function(assert) {
@@ -564,4 +570,5 @@ QUnit.test('removeRemoteTextTrack should be able to take both a track and the re
   assert.equal(player.remoteTextTrackEls().length,
               0,
               'the track element was removed correctly');
+  player.dispose();
 });

--- a/test/unit/tracks/video-tracks.test.js
+++ b/test/unit/tracks/video-tracks.test.js
@@ -106,4 +106,6 @@ QUnit.test('when switching techs, we should not get a new video track', function
   const secondTracks = player.videoTracks();
 
   assert.ok(firstTracks === secondTracks, 'the tracks are equal');
+
+  player.dispose();
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -129,6 +129,7 @@ QUnit.test('should expose plugin registry function', function(assert) {
 
   assert.ok(player.foo, 'should exist');
   assert.equal(player.foo, pluginFunction, 'should be equal');
+  player.dispose();
 });
 
 QUnit.test('should expose options and players properties for backward-compatibility', function(assert) {


### PR DESCRIPTION
## Description
Fixed Issue #2895 ; cleaned up player objects in tests.
Added player.dispose() function where necessary. 


## Specific Changes proposed
N/A

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
