### PR TITLE
Disable interaction with disabled clickable components

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -84,6 +84,28 @@ class Button extends ClickableComponent {
   }
 
   /**
+   * Enable the component element
+   *
+   * @return {Component}
+   * @method enable
+   */
+  enable() {
+    super.enable();
+    this.el_.removeAttribute('disabled');
+  }
+
+  /**
+   * Enable the component element
+   *
+   * @return {Component}
+   * @method enable
+   */
+  disable() {
+    super.disable();
+    this.el_.setAttribute('disabled', 'disabled');
+  }
+
+  /**
    * Handle KeyPress (document level) - Extend with specific functionality for button
    *
    * @method handleKeyPress

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -84,7 +84,7 @@ class Button extends ClickableComponent {
   }
 
   /**
-   * Enable the component element
+   * Enable the button element
    *
    * @return {Component}
    * @method enable
@@ -95,10 +95,10 @@ class Button extends ClickableComponent {
   }
 
   /**
-   * Enable the component element
+   * Disable the button element
    *
    * @return {Component}
-   * @method enable
+   * @method disable
    */
   disable() {
     super.disable();

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -146,6 +146,8 @@ class ClickableComponent extends Component {
   enable() {
     this.removeClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'false');
+    this.on('tap', this.handleClick);
+    this.on('click', this.handleClick);
     return this;
   }
 
@@ -158,6 +160,8 @@ class ClickableComponent extends Component {
   disable() {
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
+    this.off('tap', this.handleClick);
+    this.off('click', this.handleClick);
     return this;
   }
 

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -24,10 +24,7 @@ class ClickableComponent extends Component {
 
     this.emitTapEvents();
 
-    this.on('tap', this.handleClick);
-    this.on('click', this.handleClick);
-    this.on('focus', this.handleFocus);
-    this.on('blur', this.handleBlur);
+    this.enable();
   }
 
   /**
@@ -56,6 +53,8 @@ class ClickableComponent extends Component {
       // let the screen reader user know that the text of the element may change
       'aria-live': 'polite'
     }, attributes);
+
+    this.tabIndex_ = props.tabIndex;
 
     const el = super.createEl(tag, props, attributes);
 
@@ -146,8 +145,13 @@ class ClickableComponent extends Component {
   enable() {
     this.removeClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'false');
+    if (typeof this.tabIndex_ !== 'undefined') {
+      this.el_.setAttribute('tabindex', this.tabIndex_);
+    }
     this.on('tap', this.handleClick);
     this.on('click', this.handleClick);
+    this.on('focus', this.handleFocus);
+    this.on('blur', this.handleBlur);
     return this;
   }
 
@@ -160,8 +164,13 @@ class ClickableComponent extends Component {
   disable() {
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
+    if (typeof this.tabIndex_ !== 'undefined') {
+      this.el_.removeAttribute('tabindex');
+    }
     this.off('tap', this.handleClick);
     this.off('click', this.handleClick);
+    this.off('focus', this.handleFocus);
+    this.off('blur', this.handleBlur);
     return this;
   }
 

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -146,7 +146,7 @@ class ClickableComponent extends Component {
     this.removeClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'false');
     if (typeof this.tabIndex_ !== 'undefined') {
-      this.el_.setAttribute('tabindex', this.tabIndex_);
+      this.el_.setAttribute('tabIndex', this.tabIndex_);
     }
     this.on('tap', this.handleClick);
     this.on('click', this.handleClick);
@@ -165,7 +165,7 @@ class ClickableComponent extends Component {
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
     if (typeof this.tabIndex_ !== 'undefined') {
-      this.el_.removeAttribute('tabindex');
+      this.el_.removeAttribute('tabIndex');
     }
     this.off('tap', this.handleClick);
     this.off('click', this.handleClick);

--- a/test/unit/clickable-component.test.js
+++ b/test/unit/clickable-component.test.js
@@ -1,6 +1,7 @@
 /* eslint-env qunit */
 import ClickableComponent from '../../src/js/clickable-component.js';
 import TestHelpers from './test-helpers.js';
+import * as Events from '../../src/js/utils/events.js';
 
 QUnit.module('ClickableComponent');
 
@@ -35,6 +36,37 @@ QUnit.test('should be enabled/disabled', function(assert) {
   testClickableComponent.enable();
 
   assert.equal(testClickableComponent.hasClass('vjs-disabled'), false, 'ClickableComponent is enabled');
+
+  testClickableComponent.dispose();
+  player.dispose();
+});
+
+QUnit.test('handleClick should not be triggered when disabled', function() {
+  let clicks = 0;
+
+  class TestClickableComponent extends ClickableComponent {
+    handleClick() {
+      clicks++;
+    }
+  }
+
+  const player = TestHelpers.makePlayer({});
+  const testClickableComponent = new TestClickableComponent(player);
+  const el = testClickableComponent.el();
+
+  // 1st click
+  Events.trigger(el, 'click');
+  QUnit.equal(clicks, 1, 'click on enabled ClickableComponent is handled');
+
+  testClickableComponent.disable();
+  // No click should happen.
+  Events.trigger(el, 'click');
+  QUnit.equal(clicks, 1, 'click on disabled ClickableComponent is not handled');
+
+  testClickableComponent.enable();
+  // 2nd Click
+  Events.trigger(el, 'click');
+  QUnit.equal(clicks, 2, 'click on re-enabled ClickableComponent is handled');
 
   testClickableComponent.dispose();
   player.dispose();


### PR DESCRIPTION
## Description

`enable()` and `disable()` on clickable components is only cosmetic. "Disabled" implies the control should not be functional.
## Specific Changes proposed
- Remove event listeners on `disable()` and add back on `enable()`.
- Move adding listeners from constructor to `enable`
- Remove `tabindex` from disabled components and add `disabled` attribute to disabled buttons to prevent keyboard access.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors
