### PR TITLE
revert back to qunitjs 1.x. Add es5-shim to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "karma-sinon": "^1.0.5",
     "load-grunt-tasks": "^3.1.0",
     "proxyquireify": "^3.0.0",
-    "qunitjs": "^2.0.1",
+    "qunitjs": "^1.23.1",
     "sinon": "^1.16.1",
     "time-grunt": "^1.1.1",
     "uglify-js": "~2.3.6",

--- a/test/globals-shim.js
+++ b/test/globals-shim.js
@@ -1,4 +1,5 @@
 /* eslint-env qunit */
+import 'es5-shim';
 import 'es6-shim';
 import document from 'global/document';
 import window from 'global/window';


### PR DESCRIPTION
QUnitjs 2.0 doesn't seem to support IE8. I asked for clarification here: https://github.com/jquery/qunit/issues/1031

I'm merging this in immediately to unbreak the build but please someone review this when you get a chance.