### PR TITLE
disable the audio tracks that were not clicked on.  

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -53,9 +53,7 @@ class AudioTrackMenuItem extends MenuItem {
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
 
-      if (track === this.track) {
-        track.enabled = true;
-      }
+      track.enabled = track === this.track;
     }
   }
 


### PR DESCRIPTION
## Description
When an audio track menu item is clicked, the other audio tracks should be disabled. Potential fix for #3510. 


## Specific Changes proposed
In the AudioTrackMenuItem click handler, disable the tracks that were not clicked on, in addition to enabling the track that was clicked on.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

I did not see any existing unit tests for this class, did manual testing only.


(FWIW, `contrib feature submit` just printed "undefined" after I entered the description and didn't seem to create a pull request so I did this through Github.  Apologies if this is not formatted as you desire.)