### PR TITLE
Enable coverage reporting for local tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -92,10 +92,11 @@ module.exports = function(config) {
     }
   };
 
-  if (process.env.TRAVIS) {
-    settings.browserify.transform.push('browserify-istanbul');
-    settings.reporters.push('coverage');
+  // coverage reporting
+  settings.browserify.transform.push('browserify-istanbul');
+  settings.reporters.push('coverage');
 
+  if (process.env.TRAVIS) {
     if (process.env.BROWSER_STACK_USERNAME) {
       settings.browsers = [
         'chrome_bs',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -92,8 +92,9 @@ module.exports = function(config) {
     }
   };
 
-  // coverage reporting
-  var coverageFlag = process.env.npm_config_coverage;  // set through npm test --coverage
+  // Coverage reporting
+  // Coverage is enabled by passing the flag --coverage to npm test
+  var coverageFlag = process.env.npm_config_coverage;
   var reportCoverage = process.env.TRAVIS || coverageFlag;
   if (reportCoverage) {
     settings.browserify.transform.push('browserify-istanbul');

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -93,8 +93,12 @@ module.exports = function(config) {
   };
 
   // coverage reporting
-  settings.browserify.transform.push('browserify-istanbul');
-  settings.reporters.push('coverage');
+  var coverageFlag = process.env.npm_config_coverage;  // set through npm test --coverage
+  var reportCoverage = process.env.TRAVIS || coverageFlag;
+  if (reportCoverage) {
+    settings.browserify.transform.push('browserify-istanbul');
+    settings.reporters.push('coverage');
+  }
 
   if (process.env.TRAVIS) {
     if (process.env.BROWSER_STACK_USERNAME) {


### PR DESCRIPTION
 Description
This is in reference to https://github.com/videojs/video.js/issues/3177 to enable test coverage reporting for tests that are run locally. Here's the output:

[http://imgur.com/a/vqgbw](http://imgur.com/a/vqgbw)

## Specific Changes proposed
Enable coverage reporting for all tests, not just ones for travis

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors

