### PR TITLE
Add top-level core npm scripts defined for plugin generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "build": "grunt dist",
     "change": "grunt chg-add",
     "clean": "grunt clean",
-    "docs": "grunt vjsdocs",
     "lint": "vjsstandard",
     "start": "grunt watchAll",
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
   "homepage": "http://videojs.com",
   "author": "Steve Heffernan",
   "scripts": {
+    "build": "grunt dist",
+    "change": "grunt chg-add",
+    "clean": "grunt clean",
+    "docs": "grunt vjsdocs",
     "lint": "vjsstandard",
+    "start": "grunt watchAll",
     "test": "grunt test"
   },
   "repository": {


### PR DESCRIPTION
## Description
Fixes #3542 

A few of the core scripts were left out (the `build:*` ones) because they had no equivalent. They probably shouldn't be generator core scripts anyway.

## Specific Changes proposed
Add the following npm scripts: build, change, clean, docs, start.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

