### PR TITLE
Added 'title' attribute to the audio track button

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-button.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-button.js
@@ -58,6 +58,6 @@ class AudioTrackButton extends TrackButton {
     return items;
   }
 }
-
+AudioTrackButton.prototype.controlText_ = 'Audio';
 Component.registerComponent('AudioTrackButton', AudioTrackButton);
 export default AudioTrackButton;


### PR DESCRIPTION
## Description
Fixes #3528.
The audio track button on the video player was missing the 'title' attribute due to the underlying component not having a controlText_ property.  

## Specific Changes proposed
Assigned controlText_ property of AudioTrackButton to 'Audio'.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

