### PR TITLE
only reset currentSource_ on second loadstart if it has changed

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -851,13 +851,23 @@ Tech.withSourceHandlers = function(_Tech) {
     return this;
   };
 
+  let previousSource;
+
   // On the first loadstart after setSource
   _Tech.prototype.firstLoadStartListener_ = function() {
+    previousSource = this.currentSource_;
     this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
   };
 
   // On successive loadstarts when setSource has not been called again
   _Tech.prototype.successiveLoadStartListener_ = function() {
+
+    // if the second loadstart is for the same source
+    // it is an invalid loadstart, set this event to trigger again
+    if (previousSource.src === this.currentSource_.src) {
+      return this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
+    }
+    previousSource = this.currentSource_;
     this.currentSource_ = null;
     this.disposeSourceHandler();
     this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -851,11 +851,9 @@ Tech.withSourceHandlers = function(_Tech) {
     return this;
   };
 
-  let previousSource;
-
   // On the first loadstart after setSource
   _Tech.prototype.firstLoadStartListener_ = function() {
-    previousSource = this.currentSource_;
+    this.previousSource_ = this.currentSource_;
     this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
   };
 
@@ -864,10 +862,11 @@ Tech.withSourceHandlers = function(_Tech) {
 
     // if the second loadstart is for the same source
     // it is an invalid loadstart, set this event to trigger again
-    if (previousSource.src === this.currentSource_.src) {
+    if (this.currentSource_ && this.previousSource_ &&
+        this.previousSource_.src === this.currentSource_.src) {
       return this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
     }
-    previousSource = this.currentSource_;
+    this.previousSource_ = this.currentSource_;
     this.currentSource_ = null;
     this.disposeSourceHandler();
     this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);


### PR DESCRIPTION
## Description

Previously when a second `loadstart` we would assume that a new source is forthcoming and reset everything. This is not the case and there is currently an issue (#3428) where a second `loadstart` is being triggered on the same source and causing issues. Video.js should be able to handle the second `loadstart` for the same source even though it is not expected.
## Specific Changes proposed
- Keep track of the previousSource on each `loadstart`
- if  `loadStart` is triggered twice or more for the same source, ignore it
- update unit tests to reflect new functionality 
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
