### PR TITLE
Added task to maintain translations

### DIFF
--- a/build/tasks/languages.js
+++ b/build/tasks/languages.js
@@ -1,8 +1,10 @@
 module.exports = function(grunt) {
   grunt.registerTask('check-translations', 'Check that translations are up to date', function(){
     const source = require('../../lang/en.json');
+    const table = require('markdown-table');
     let doc = grunt.file.read('docs/translations-needed.md');
-    let table = '|---|---|\n';
+    const tableRegex = /(<!-- START langtable -->)(.|\n)*(<!-- END langtable -->)/;
+    let tableData = [['Language file', 'Missing translations']];
 
     grunt.file.recurse('lang', (abspath, rootdir, subdir, filename) => {
       if (filename === 'en.json') {
@@ -18,14 +20,16 @@ module.exports = function(grunt) {
       }
       if (missing.length > 0) {
         grunt.log.error(`${filename} is missing ${missing.length} translations.`);
-        table += `|${filename}|${missing.join('|\n| |')}|\n`;
-        table += `| | (${missing.length}) |\n`;
+        tableData.push([`${filename} (missing ${missing.length})`, missing[0]]);
+        for (var i = 1; i < missing.length; i++) {
+          tableData.push(['', missing[i]]);
+        }
       } else {
         grunt.log.ok(`${filename} is up to date.`);
-        table += `|${filename}|(Complete)|\n`;
+        tableData.push([`${filename} (Complete)`, '']);
       }
     });
-    doc = doc.replace(/\|---\|---\|\n(.*\n)+/, table);
+    doc = doc.replace(tableRegex, `$1\n` + table(tableData) + `\n$3`);
     grunt.file.write('docs/translations-needed.md', doc);
   });
 };

--- a/build/tasks/languages.js
+++ b/build/tasks/languages.js
@@ -1,0 +1,31 @@
+module.exports = function(grunt) {
+  grunt.registerTask('check-translations', 'Check that translations are up to date', function(){
+    const source = require('../../lang/en.json');
+    let doc = grunt.file.read('docs/translations-needed.md');
+    let table = '|---|---|\n';
+
+    grunt.file.recurse('lang', (abspath, rootdir, subdir, filename) => {
+      if (filename === 'en.json') {
+        return;
+      }
+      const target = require(`../../${abspath}`);
+      let missing = [];
+      for (const string in source) {
+        if (!target[string]) {
+          grunt.log.writeln(`${filename} missing "${string}"`);
+          missing.push(string);
+        }
+      }
+      if (missing.length > 0) {
+        grunt.log.error(`${filename} is missing ${missing.length} translations.`);
+        table += `|${filename}|${missing.join('|\n| |')}|\n`;
+        table += `| | (${missing.length}) |\n`;
+      } else {
+        grunt.log.ok(`${filename} is up to date.`);
+        table += `|${filename}|(Complete)|\n`;
+      }
+    });
+    doc = doc.replace(/\|---\|---\|\n(.*\n)+/, table);
+    grunt.file.write('docs/translations-needed.md', doc);
+  });
+};

--- a/docs/guides/languages.md
+++ b/docs/guides/languages.md
@@ -110,6 +110,10 @@ NOTE: These need to be added after the core Video.js script.
 Notes:
 - This will add your language key/values to the Video.js player instances individually. If these values already exist in the global dictionary via the process above, those will be overridden for the player instance in question.
 
+Updating default translations
+-----------------------------
+
+A list of the current translations and any strings that need translation are at [docs/translations-needed.md](../translations-needed.md). After updating the language files in /lang/ running `grunt check-languages` will update that list.
 
 Setting Default Language in a Video.js Player
 ---------------------------------------------

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -7,341 +7,341 @@ If you add or update a translation run `grunt check-translations` to update the 
 ## Status of translations
 
 <!-- START langtable -->
-| Language file            | Missing translations                                                                |
-| ------------------------ | ----------------------------------------------------------------------------------- |
-| ar.json ( missing 5)     | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | , opens descriptions settings dialog                                                |
-| ba.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| bg.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| ca.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| cs.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| da.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| de.json ( missing 1)     | descriptions off                                                                    |
-| el.json ( missing 6)     | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | , opens descriptions settings dialog                                                |
-| es.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| fa.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| fi.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| fr.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| hr.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| hu.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| it.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| ja.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| ko.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| nb.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| nl.json ( missing 2)     | Close Modal Dialog                                                                  |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-| nn.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| pl.json ( missing 6)     | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | , opens descriptions settings dialog                                                |
-| pt-BR.json ( missing 13) | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| ru.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| sr.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| sv.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| tr.json ( missing 5)     | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | , opens descriptions settings dialog                                                |
-| uk.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| vi.json ( missing 13)    | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| zh-CN.json ( missing 12) | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
-| zh-TW.json ( missing 12) | Close Modal Dialog                                                                  |
-|                          | Descriptions                                                                        |
-|                          | descriptions off                                                                    |
-|                          | Play Video                                                                          |
-|                          | Close                                                                               |
-|                          | Modal Window                                                                        |
-|                          | This is a modal window                                                              |
-|                          | This modal can be closed by pressing the Escape key or activating the close button. |
-|                          | , opens captions settings dialog                                                    |
-|                          | , opens subtitles settings dialog                                                   |
-|                          | , opens descriptions settings dialog                                                |
-|                          | , selected                                                                          |
+| Language file           | Missing translations                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| ar.json (missing 5)     | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | , opens descriptions settings dialog                                                |
+| ba.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| bg.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| ca.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| cs.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| da.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| de.json (Complete)      |                                                                                     |
+| el.json (missing 6)     | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | , opens descriptions settings dialog                                                |
+| es.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| fa.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| fi.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| fr.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| hr.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| hu.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| it.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| ja.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| ko.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| nb.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| nl.json (missing 2)     | Close Modal Dialog                                                                  |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+| nn.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| pl.json (missing 6)     | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | , opens descriptions settings dialog                                                |
+| pt-BR.json (missing 13) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| ru.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| sr.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| sv.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| tr.json (missing 5)     | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | , opens descriptions settings dialog                                                |
+| uk.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| vi.json (missing 13)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| zh-CN.json (missing 12) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| zh-TW.json (missing 12) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
 <!-- END langtable -->

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -2,373 +2,346 @@
 
 The currently available translations are in the lang dir. This table shows the completeness of those translations. Anything not listed does not exist yet, so go ahead and create it by copying `en.json`.
 
-If you add or update a translation run `grunt check-translations` to update the list.
+If you add or update a translation run `grunt check-translations` to update the list and include this modified doc in the pull request.
 
-## Status
+## Status of translations
 
-| File | Translations needed |
-|---|---|
-|ar.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |, opens descriptions settings dialog|
-| | (5) |
-|ba.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|bg.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|ca.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|cs.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|da.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|de.json|Complete|
-|el.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |, opens descriptions settings dialog|
-| | (6) |
-|es.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|fa.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|fi.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|fr.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|hr.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|hu.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|it.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|ja.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|ko.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|nb.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|nl.json|Close Modal Dialog|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| | (2) |
-|nn.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|pl.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |, opens descriptions settings dialog|
-| | (6) |
-|pt-BR.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|ru.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|sr.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|sv.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|tr.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |, opens descriptions settings dialog|
-| | (5) |
-|uk.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|vi.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |The media is encrypted and we do not have the keys to decrypt it.|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (13) |
-|zh-CN.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (12) |
-|zh-TW.json|Close Modal Dialog|
-| |Descriptions|
-| |descriptions off|
-| |Play Video|
-| |Close|
-| |Modal Window|
-| |This is a modal window|
-| |This modal can be closed by pressing the Escape key or activating the close button.|
-| |, opens captions settings dialog|
-| |, opens subtitles settings dialog|
-| |, opens descriptions settings dialog|
-| |, selected|
-| | (12) |
+<!-- START langtable -->
+| Language file            | Missing translations                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| ar.json ( missing 5)     | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | , opens descriptions settings dialog                                                |
+| ba.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| bg.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| ca.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| cs.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| da.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| de.json ( missing 1)     | descriptions off                                                                    |
+| el.json ( missing 6)     | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | , opens descriptions settings dialog                                                |
+| es.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| fa.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| fi.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| fr.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| hr.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| hu.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| it.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| ja.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| ko.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| nb.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| nl.json ( missing 2)     | Close Modal Dialog                                                                  |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+| nn.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| pl.json ( missing 6)     | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | , opens descriptions settings dialog                                                |
+| pt-BR.json ( missing 13) | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| ru.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| sr.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| sv.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| tr.json ( missing 5)     | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | , opens descriptions settings dialog                                                |
+| uk.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| vi.json ( missing 13)    | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| zh-CN.json ( missing 12) | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+| zh-TW.json ( missing 12) | Close Modal Dialog                                                                  |
+|                          | Descriptions                                                                        |
+|                          | descriptions off                                                                    |
+|                          | Play Video                                                                          |
+|                          | Close                                                                               |
+|                          | Modal Window                                                                        |
+|                          | This is a modal window                                                              |
+|                          | This modal can be closed by pressing the Escape key or activating the close button. |
+|                          | , opens captions settings dialog                                                    |
+|                          | , opens subtitles settings dialog                                                   |
+|                          | , opens descriptions settings dialog                                                |
+|                          | , selected                                                                          |
+<!-- END langtable -->

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -9,27 +9,16 @@ If you add or update a translation run `grunt check-translations` to update the 
 <!-- START langtable -->
 | Language file           | Missing translations                                                                |
 | ----------------------- | ----------------------------------------------------------------------------------- |
-| ar.json (missing 5)     | Close Modal Dialog                                                                  |
+| ar.json (missing 6)     | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | , opens descriptions settings dialog                                                |
-| ba.json (missing 13)    | Close Modal Dialog                                                                  |
+| ba.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | Play Video                                                                          |
-|                         | Close                                                                               |
-|                         | Modal Window                                                                        |
-|                         | This is a modal window                                                              |
-|                         | This modal can be closed by pressing the Escape key or activating the close button. |
-|                         | , opens captions settings dialog                                                    |
-|                         | , opens subtitles settings dialog                                                   |
-|                         | , opens descriptions settings dialog                                                |
-|                         | , selected                                                                          |
-| bg.json (missing 13)    | Close Modal Dialog                                                                  |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -40,9 +29,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| ca.json (missing 13)    | Close Modal Dialog                                                                  |
+| bg.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -53,9 +43,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| cs.json (missing 13)    | Close Modal Dialog                                                                  |
+| ca.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -66,9 +57,24 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| da.json (missing 13)    | Close Modal Dialog                                                                  |
+| cs.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| da.json (missing 14)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -80,28 +86,17 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
 | de.json (Complete)      |                                                                                     |
-| el.json (missing 6)     | Close Modal Dialog                                                                  |
+| el.json (missing 7)     | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | , opens descriptions settings dialog                                                |
-| es.json (missing 13)    | Close Modal Dialog                                                                  |
+| es.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | Play Video                                                                          |
-|                         | Close                                                                               |
-|                         | Modal Window                                                                        |
-|                         | This is a modal window                                                              |
-|                         | This modal can be closed by pressing the Escape key or activating the close button. |
-|                         | , opens captions settings dialog                                                    |
-|                         | , opens subtitles settings dialog                                                   |
-|                         | , opens descriptions settings dialog                                                |
-|                         | , selected                                                                          |
-| fa.json (missing 13)    | Close Modal Dialog                                                                  |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -112,9 +107,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| fi.json (missing 13)    | Close Modal Dialog                                                                  |
+| fa.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -125,9 +121,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| fr.json (missing 13)    | Close Modal Dialog                                                                  |
+| fi.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -138,9 +135,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| hr.json (missing 13)    | Close Modal Dialog                                                                  |
+| fr.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -151,9 +149,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| hu.json (missing 13)    | Close Modal Dialog                                                                  |
+| hr.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -164,9 +163,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| it.json (missing 13)    | Close Modal Dialog                                                                  |
+| hu.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -177,9 +177,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| ja.json (missing 13)    | Close Modal Dialog                                                                  |
+| it.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -190,9 +191,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| ko.json (missing 13)    | Close Modal Dialog                                                                  |
+| ja.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -203,9 +205,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| nb.json (missing 13)    | Close Modal Dialog                                                                  |
+| ko.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -216,30 +219,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| nl.json (missing 2)     | Close Modal Dialog                                                                  |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-| nn.json (missing 13)    | Close Modal Dialog                                                                  |
+| nb.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | Play Video                                                                          |
-|                         | Close                                                                               |
-|                         | Modal Window                                                                        |
-|                         | This is a modal window                                                              |
-|                         | This modal can be closed by pressing the Escape key or activating the close button. |
-|                         | , opens captions settings dialog                                                    |
-|                         | , opens subtitles settings dialog                                                   |
-|                         | , opens descriptions settings dialog                                                |
-|                         | , selected                                                                          |
-| pl.json (missing 6)     | Close Modal Dialog                                                                  |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | Play Video                                                                          |
-|                         | , opens descriptions settings dialog                                                |
-| pt-BR.json (missing 13) | Close Modal Dialog                                                                  |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -250,9 +233,13 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| ru.json (missing 13)    | Close Modal Dialog                                                                  |
+| nl.json (missing 3)     | Close Modal Dialog                                                                  |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+| nn.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -263,9 +250,17 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| sr.json (missing 13)    | Close Modal Dialog                                                                  |
+| pl.json (missing 7)     | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | , opens descriptions settings dialog                                                |
+| pt-BR.json (missing 14) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -276,9 +271,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| sv.json (missing 13)    | Close Modal Dialog                                                                  |
+| ru.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -289,14 +285,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| tr.json (missing 5)     | Close Modal Dialog                                                                  |
+| sr.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | , opens descriptions settings dialog                                                |
-| uk.json (missing 13)    | Close Modal Dialog                                                                  |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -307,9 +299,10 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| vi.json (missing 13)    | Close Modal Dialog                                                                  |
+| sv.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
@@ -320,9 +313,17 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| zh-CN.json (missing 12) | Close Modal Dialog                                                                  |
+| tr.json (missing 6)     | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | , opens descriptions settings dialog                                                |
+| uk.json (missing 14)    | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
 |                         | Modal Window                                                                        |
@@ -332,9 +333,37 @@ If you add or update a translation run `grunt check-translations` to update the 
 |                         | , opens subtitles settings dialog                                                   |
 |                         | , opens descriptions settings dialog                                                |
 |                         | , selected                                                                          |
-| zh-TW.json (missing 12) | Close Modal Dialog                                                                  |
+| vi.json (missing 14)    | Close Modal Dialog                                                                  |
 |                         | Descriptions                                                                        |
 |                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| zh-CN.json (missing 13) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
+|                         | Play Video                                                                          |
+|                         | Close                                                                               |
+|                         | Modal Window                                                                        |
+|                         | This is a modal window                                                              |
+|                         | This modal can be closed by pressing the Escape key or activating the close button. |
+|                         | , opens captions settings dialog                                                    |
+|                         | , opens subtitles settings dialog                                                   |
+|                         | , opens descriptions settings dialog                                                |
+|                         | , selected                                                                          |
+| zh-TW.json (missing 13) | Close Modal Dialog                                                                  |
+|                         | Descriptions                                                                        |
+|                         | descriptions off                                                                    |
+|                         | Audio Track                                                                         |
 |                         | Play Video                                                                          |
 |                         | Close                                                                               |
 |                         | Modal Window                                                                        |

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -1,0 +1,374 @@
+# Translations needed
+
+The currently available translations are in the lang dir. This table shows the completeness of those translations. Anything not listed does not exist yet, so go ahead and create it by copying `en.json`.
+
+If you add or update a translation run `grunt check-translations` to update the list.
+
+## Status
+
+| File | Translations needed |
+|---|---|
+|ar.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |, opens descriptions settings dialog|
+| | (5) |
+|ba.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|bg.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|ca.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|cs.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|da.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|de.json|Complete|
+|el.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |, opens descriptions settings dialog|
+| | (6) |
+|es.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|fa.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|fi.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|fr.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|hr.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|hu.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|it.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|ja.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|ko.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|nb.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|nl.json|Close Modal Dialog|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| | (2) |
+|nn.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|pl.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |, opens descriptions settings dialog|
+| | (6) |
+|pt-BR.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|ru.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|sr.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|sv.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|tr.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |, opens descriptions settings dialog|
+| | (5) |
+|uk.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|vi.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |The media is encrypted and we do not have the keys to decrypt it.|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (13) |
+|zh-CN.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (12) |
+|zh-TW.json|Close Modal Dialog|
+| |Descriptions|
+| |descriptions off|
+| |Play Video|
+| |Close|
+| |Modal Window|
+| |This is a modal window|
+| |This modal can be closed by pressing the Escape key or activating the close button.|
+| |, opens captions settings dialog|
+| |, opens subtitles settings dialog|
+| |, opens descriptions settings dialog|
+| |, selected|
+| | (12) |

--- a/lang/de.json
+++ b/lang/de.json
@@ -30,5 +30,10 @@
   "This modal can be closed by pressing the Escape key or activating the close button.": "Durch Drücken der Esc-Taste bzw. Betätigung der Schaltfläche \"Schließen\" wird dieses modale Fenster geschlossen.",
   ", opens captions settings dialog": ", öffnet Einstellungen für Untertitel",
   ", opens subtitles settings dialog": ", öffnet Einstellungen für Untertitel",
-  ", selected": " (ausgewählt)"
+  ", selected": ", ausgewählt",
+  "Close Modal Dialog": "Modales Fenster schließen",
+  "Descriptions": "Beschreibungen",
+  "descriptions off": "Bescreibungen aus",
+  "The media is encrypted and we do not have the keys to decrypt it.": "Die Entschlüsselungsschülssel für den verschlüsselten Medieninhalt sind nicht verfügbar.",
+  ", opens descriptions settings dialog": ", öffnet Einstellungen für Beschreibungen"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -33,7 +33,7 @@
   ", selected": ", ausgewählt",
   "Close Modal Dialog": "Modales Fenster schließen",
   "Descriptions": "Beschreibungen",
-  "descriptions off": "Bescreibungen aus",
-  "The media is encrypted and we do not have the keys to decrypt it.": "Die Entschlüsselungsschülssel für den verschlüsselten Medieninhalt sind nicht verfügbar.",
+  "descriptions off": "Beschreibungen aus",
+  "The media is encrypted and we do not have the keys to decrypt it.": "Die Entschlüsselungsschlüssel für den verschlüsselten Medieninhalt sind nicht verfügbar.",
   ", opens descriptions settings dialog": ", öffnet Einstellungen für Beschreibungen"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -35,5 +35,6 @@
   "Descriptions": "Beschreibungen",
   "descriptions off": "Beschreibungen aus",
   "The media is encrypted and we do not have the keys to decrypt it.": "Die Entschlüsselungsschlüssel für den verschlüsselten Medieninhalt sind nicht verfügbar.",
-  ", opens descriptions settings dialog": ", öffnet Einstellungen für Beschreibungen"
+  ", opens descriptions settings dialog": ", öffnet Einstellungen für Beschreibungen",
+  "Audio Track": "Tonspur"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -27,6 +27,7 @@
   "The media could not be loaded, either because the server or network failed or because the format is not supported.": "The media could not be loaded, either because the server or network failed or because the format is not supported.",
   "The media playback was aborted due to a corruption problem or because the media used features your browser did not support.": "The media playback was aborted due to a corruption problem or because the media used features your browser did not support.",
   "No compatible source was found for this media.": "No compatible source was found for this media.",
+  "The media is encrypted and we do not have the keys to decrypt it.": "The media is encrypted and we do not have the keys to decrypt it.",
   "Play Video": "Play Video",
   "Close": "Close",
   "Modal Window": "Modal Window",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "karma-safari-launcher": "^1.0.0",
     "karma-sinon": "^1.0.5",
     "load-grunt-tasks": "^3.1.0",
+    "markdown-table": "^1.0.0",
     "proxyquireify": "^3.0.0",
     "qunitjs": "^1.23.1",
     "sinon": "^1.16.1",


### PR DESCRIPTION
## Description
An grunt task to hopefully help keep translations up to date. Compares each language file against the keys in en.json.

Missing translations are outputted to the console and a table in a new doc at docs/translations-needed.md is updated.

`grunt check-translations`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

