### PR TITLE
Changed Audio Track button title to 'Audio Track' and modified en.json

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -21,6 +21,7 @@
   "Close Modal Dialog": "Close Modal Dialog",
   "Descriptions": "Descriptions",
   "descriptions off": "descriptions off",
+  "Audio Track": "Audio Track",
   "You aborted the media playback": "You aborted the media playback",
   "A network error caused the media download to fail part-way.": "A network error caused the media download to fail part-way.",
   "The media could not be loaded, either because the server or network failed or because the format is not supported.": "The media could not be loaded, either because the server or network failed or because the format is not supported.",

--- a/src/js/control-bar/audio-track-controls/audio-track-button.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-button.js
@@ -59,6 +59,6 @@ class AudioTrackButton extends TrackButton {
     return items;
   }
 }
-AudioTrackButton.prototype.controlText_ = 'Audio';
+AudioTrackButton.prototype.controlText_ = 'Audio Track';
 Component.registerComponent('AudioTrackButton', AudioTrackButton);
 export default AudioTrackButton;


### PR DESCRIPTION
## Description

Per discussion on #3565 I changed the audio track title to be 'Audio Track' instead of just 'Audio'
Additionally I updated the en.json.
## Specific Changes proposed
Modified en.json to have an entry for 'Audio Track'.
Modified the AudioTrackButton components controlText_ to be 'Audio Track'

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

