### PR TITLE
Exceptions in event handlers breaks further processing of event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* @imbcmdth Added exception handling to event dispatcher ([view](https://github.com/videojs/video.js/pull/3580))
 
 --------------------
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -7,8 +7,9 @@
  * robust as jquery's, so there's probably some differences.
  */
 
-import  * as Dom from './dom.js';
-import  * as Guid from './guid.js';
+import * as Dom from './dom.js';
+import * as Guid from './guid.js';
+import log from './log.js';
 import window from 'global/window';
 import document from 'global/document';
 
@@ -57,7 +58,11 @@ export function on(elem, type, fn){
           if (event.isImmediatePropagationStopped()) {
             break;
           } else {
-            handlersCopy[m].call(elem, event, hash);
+            try {
+              handlersCopy[m].call(elem, event, hash);
+            } catch (e) {
+              log.error(e);
+            }
           }
         }
       }

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -239,3 +239,21 @@ test('should have relatedTarget correctly set on the event', function() {
 
   Events.trigger(el2, { type:'click', relatedTarget:undefined });
 });
+
+QUnit.test('should execute remaining handlers after an exception in an event handler', function(assert) {
+  assert.expect(1);
+
+  const el = document.createElement('div');
+  const listener1 = function() {
+    throw new Error('GURU MEDITATION ERROR');
+  };
+  const listener2 = function() {
+    assert.ok(true, 'Click Triggered');
+  };
+
+  Events.on(el, 'click', listener1);
+  Events.on(el, 'click', listener2);
+
+  // 1 click
+  Events.trigger(el, 'click');
+});


### PR DESCRIPTION
## Description
In the event dispatch function, we do not guard against event handlers raising exceptions. If that happens, any further processing of event handlers and *any code after the trigger* stops as the exception continues to unwind the stack.

This is particularly problematic if the event was triggered by a source handler during the initialization stages of the handler. The SourceHandler can end up in a state from which it can not recover through no fault of our own. 

See this example of a player broken by a simple exception thrown from an event handler:

http://jsbin.com/fipikerore/edit?html,output

## Specific Changes proposed
Simply add a try/catch around each invocation of an event handler function called from the the `dispatch` function. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created
- [x] Reviewed by Two Core Contributors