### PR TITLE
Fix captions/subtitles being announced by VoiceOver (Fixes #3554)

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -982,6 +982,42 @@ class Component {
   }
 
   /**
+   * Get the value of an attribute on the component's element
+   *
+   * @param {String} attribute Attribute to get
+   * @return {String}
+   * @method getAttribute
+   */
+  getAttribute(attribute) {
+    return Dom.getAttribute(this.el_, attribute);
+  }
+
+  /**
+   * Set the value of an attribute on the component's element
+   *
+   * @param {String} attribute Attribute to set
+   * @param {String} value Value to set the attribute to
+   * @return {Component}
+   * @method setAttribute
+   */
+  setAttribute(attribute, value) {
+    Dom.setAttribute(this.el_, attribute, value);
+    return this;
+  }
+
+  /**
+   * Remove an attribute from the component's element
+   *
+   * @param {String} attribute Attribute to remove
+   * @return {Component}
+   * @method removeAttribute
+   */
+  removeAttribute(attribute) {
+    Dom.removeAttribute(this.el_, attribute);
+    return this;
+  }
+
+  /**
    * Set or get the width of the component (CSS values)
    * Setting the video tag dimension values only works with values in pixels.
    * Percent values will not work.

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -145,7 +145,7 @@ class TextTrackDisplay extends Component {
     return super.createEl('div', {
       className: 'vjs-text-track-display'
     }, {
-      'aria-live': 'assertive',
+      'aria-live': 'off',
       'aria-atomic': 'true'
     });
   }
@@ -197,8 +197,14 @@ class TextTrackDisplay extends Component {
     }
 
     if (captionsSubtitlesTrack) {
+      if (this.getAttribute('aria-live') !== 'off') {
+        this.setAttribute('aria-live', 'off');
+      }
       this.updateForTrack(captionsSubtitlesTrack);
     } else if (descriptionsTrack) {
+      if (this.getAttribute('aria-live') !== 'assertive') {
+        this.setAttribute('aria-live', 'assertive');
+      }
       this.updateForTrack(descriptionsTrack);
     }
   }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -405,6 +405,41 @@ export function getElAttributes(tag) {
 }
 
 /**
+ * Get the value of an element's attribute
+ *
+ * @param {Element} el
+ * @param {String} attribute Attribute to get
+ * @return {String} value of the attribute
+ * @method getAttribute
+ */
+export function getAttribute(el, attribute) {
+  return el.getAttribute(attribute);
+}
+
+/**
+ * Set the value of an element's attribute
+ *
+ * @param {Element} el
+ * @param {String} attribute Attribute to set
+ * @param {String} value Value to set the attribute to
+ * @method setAttribute
+ */
+export function setAttribute(el, attribute, value) {
+  el.setAttribute(attribute, value);
+}
+
+/**
+ * Remove an element's attribute
+ *
+ * @param {Element} el
+ * @param {String} attribute Attribute to remove
+ * @method removeAttribute
+ */
+export function removeAttribute(el, attribute) {
+  el.removeAttribute(attribute);
+}
+
+/**
  * Attempt to block the ability to select text while dragging controls
  *
  * @return {Boolean}


### PR DESCRIPTION
## Description

Fixes #3554, where captions & subtitles are read by VoiceOver on Mac OS X. The bug was introduced by the addition of support for description tracks, which requires cue text to be rendered in an aria-live region.
## Specific Changes proposed

Changes to the text-track-display component, and also methods to get/set/remove attributes on a component.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
