### PR TITLE
add the bundle-collapser browserify plugin to save 16kb minified (5.5%)

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
       standalone: 'videojs'
     },
     plugin: [
+      ['bundle-collapser/plugin'],
       ['browserify-derequire']
     ]
   };
@@ -348,7 +349,7 @@ module.exports = function(grunt) {
             transform: ['babelify']
           },
           plugin: [
-            ['proxyquireify/plugin']
+            ['proxyquireify/plugin', 'bundle-collapser/plugin']
           ],
           banner: false,
           watch: true,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "browserify-derequire": "^0.9.4",
     "browserify-istanbul": "^0.2.1",
     "browserify-versionify": "^1.0.4",
+    "bundle-collapser": "^1.2.1",
     "chg": "^0.3.2",
     "es5-shim": "^4.1.3",
     "es6-shim": "^0.35.1",


### PR DESCRIPTION
## Description
Add bundle-collapser to browserify plugins to save us a lot of bytes!

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

