### PR TITLE
[Deps] update `object.assign`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-runtime": "^6.9.2",
     "global": "4.3.0",
     "lodash-compat": "3.10.2",
-    "object.assign": "4.0.3",
+    "object.assign": "^4.0.4",
     "safe-json-parse": "4.0.0",
     "tsml": "1.0.1",
     "videojs-font": "2.0.0",


### PR DESCRIPTION
Updates `object.assign` to the latest, and uses a semver range so that consumers can `npm dedupe`.

All deps should always use semver ranges - if a dep isn't using semver, *nobody should be using the dep* - and I'm the maintainer of `object.assign`, so I can guarantee you there will never be a breaking change without a semver-major bump.