### PR TITLE
refactor redundant code in html5 tech

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -22,7 +22,6 @@ import toTitleCase from '../utils/to-title-case.js';
  *
  * @param {Object=} options Object of option names and values
  * @param {Function=} ready Ready callback function
- * @extends Tech
  * @class Html5
  */
 class Html5 extends Tech {
@@ -139,8 +138,6 @@ class Html5 extends Tech {
 
   /**
    * Dispose of html5 media element
-   *
-   * @method dispose
    */
   dispose() {
     // Un-ProxyNativeTracks
@@ -169,7 +166,6 @@ class Html5 extends Tech {
    * Create the component's DOM element
    *
    * @return {Element}
-   * @method createEl
    */
   createEl() {
     let el = this.options_.tag;
@@ -395,8 +391,6 @@ class Html5 extends Tech {
 
   /**
    * Play for html5 tech
-   *
-   * @method play
    */
   play() {
     const playPromise = this.el_.play();
@@ -412,7 +406,6 @@ class Html5 extends Tech {
    * Set current time
    *
    * @param {Number} seconds Current time of video
-   * @method setCurrentTime
    */
   setCurrentTime(seconds) {
     try {
@@ -427,7 +420,6 @@ class Html5 extends Tech {
    * Get duration
    *
    * @return {Number}
-   * @method duration
    */
   duration() {
     return this.el_.duration || 0;
@@ -437,7 +429,6 @@ class Html5 extends Tech {
    * Get player width
    *
    * @return {Number}
-   * @method width
    */
   width() {
     return this.el_.offsetWidth;
@@ -447,7 +438,6 @@ class Html5 extends Tech {
    * Get player height
    *
    * @return {Number}
-   * @method height
    */
   height() {
     return this.el_.offsetHeight;
@@ -457,7 +447,6 @@ class Html5 extends Tech {
    * Get if there is fullscreen support
    *
    * @return {Boolean}
-   * @method supportsFullScreen
    */
   supportsFullScreen() {
     if (typeof this.el_.webkitEnterFullScreen === 'function') {
@@ -473,8 +462,6 @@ class Html5 extends Tech {
 
   /**
    * Request to enter fullscreen
-   *
-   * @method enterFullScreen
    */
   enterFullScreen() {
     const video = this.el_;
@@ -507,8 +494,6 @@ class Html5 extends Tech {
 
   /**
    * Request to exit fullscreen
-   *
-   * @method exitFullScreen
    */
   exitFullScreen() {
     this.el_.webkitExitFullScreen();
@@ -519,7 +504,6 @@ class Html5 extends Tech {
    *
    * @param {Object=} src Source object
    * @return {Object}
-   * @method src
    */
   src(src) {
     if (src === undefined) {
@@ -532,8 +516,6 @@ class Html5 extends Tech {
 
   /**
    * Reset the tech. Removes all sources and calls `load`.
-   *
-   * @method reset
    */
   reset() {
     Html5.resetMediaElement(this.el_);
@@ -543,7 +525,6 @@ class Html5 extends Tech {
    * Get current source
    *
    * @return {Object}
-   * @method currentSrc
    */
   currentSrc() {
     if (this.currentSource_) {
@@ -556,7 +537,6 @@ class Html5 extends Tech {
    * Set controls attribute
    *
    * @param {String} val Value for controls attribute
-   * @method setControls
    */
   setControls(val) {
     this.el_.controls = !!val;
@@ -570,7 +550,6 @@ class Html5 extends Tech {
    * @param {String=} label Label to identify the text track
    * @param {String=} language Two letter language abbreviation
    * @return {TextTrackObject}
-   * @method addTextTrack
    */
   addTextTrack(kind, label, language) {
     if (!this.featuresNativeTextTracks) {
@@ -586,7 +565,6 @@ class Html5 extends Tech {
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
    * @return {HTMLTrackElement}
-   * @method addRemoteTextTrack
    */
   addRemoteTextTrack(options = {}) {
     if (!this.featuresNativeTextTracks) {
@@ -627,7 +605,6 @@ class Html5 extends Tech {
    * Remove remote text track from TextTrackList object
    *
    * @param {TextTrackObject} track Texttrack object to remove
-   * @method removeRemoteTextTrack
    */
   removeRemoteTextTrack(track) {
     if (!this.featuresNativeTextTracks) {
@@ -1042,27 +1019,177 @@ Html5.resetMediaElement = function(el) {
   }
 };
 
+/* Native HTML5 element property wrapping ----------------------------------- */
 // Wrap native properties with a getter
 [
+  /**
+   * Paused for html5 tech
+   *
+   * @method Html5.prototype.paused
+   * @return {Boolean}
+   */
   'paused',
+  /**
+   * Get current time
+   *
+   * @method Html5.prototype.currentTime
+   * @return {Number}
+   */
   'currentTime',
+  /**
+   * Get a TimeRange object that represents the intersection
+   * of the time ranges for which the user agent has all
+   * relevant media
+   *
+   * @return {TimeRangeObject}
+   * @method Html5.prototype.buffered
+   */
   'buffered',
+  /**
+   * Get volume level
+   *
+   * @return {Number}
+   * @method Html5.prototype.volume
+   */
   'volume',
+  /**
+   * Get if muted
+   *
+   * @return {Boolean}
+   * @method Html5.prototype.muted
+   */
   'muted',
+  /**
+   * Get poster
+   *
+   * @return {String}
+   * @method Html5.prototype.poster
+   */
   'poster',
+  /**
+   * Get preload attribute
+   *
+   * @return {String}
+   * @method Html5.prototype.preload
+   */
   'preload',
+  /**
+   * Get autoplay attribute
+   *
+   * @return {String}
+   * @method Html5.prototype.autoplay
+   */
   'autoplay',
+  /**
+   * Get controls attribute
+   *
+   * @return {String}
+   * @method Html5.prototype.controls
+   */
+  'controls',
+  /**
+   * Get loop attribute
+   *
+   * @return {String}
+   * @method Html5.prototype.loop
+   */
   'loop',
+  /**
+   * Get error value
+   *
+   * @return {String}
+   * @method Html5.prototype.error
+   */
   'error',
+  /**
+   * Get whether or not the player is in the "seeking" state
+   *
+   * @return {Boolean}
+   * @method Html5.prototype.seeking
+   */
   'seeking',
+  /**
+   * Get a TimeRanges object that represents the
+   * ranges of the media resource to which it is possible
+   * for the user agent to seek.
+   *
+   * @return {TimeRangeObject}
+   * @method Html5.prototype.seekable
+   */
   'seekable',
+  /**
+   * Get if video ended
+   *
+   * @return {Boolean}
+   * @method Html5.prototype.ended
+   */
   'ended',
+  /**
+   * Get the value of the muted content attribute
+   * This attribute has no dynamic effect, it only
+   * controls the default state of the element
+   *
+   * @return {Boolean}
+   * @method Html5.prototype.defaultMuted
+   */
   'defaultMuted',
+  /**
+   * Get desired speed at which the media resource is to play
+   *
+   * @return {Number}
+   * @method Html5.prototype.playbackRate
+   */
   'playbackRate',
+  /**
+   * Returns a TimeRanges object that represents the ranges of the
+   * media resource that the user agent has played.
+   * @see https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-played
+   *
+   * @return {TimeRangeObject} the range of points on the media
+   *                           timeline that has been reached through
+   *                           normal playback
+   * @method Html5.prototype.played
+   */
   'played',
+  /**
+   * Get the current state of network activity for the element, from
+   * the list below
+   * - NETWORK_EMPTY (numeric value 0)
+   * - NETWORK_IDLE (numeric value 1)
+   * - NETWORK_LOADING (numeric value 2)
+   * - NETWORK_NO_SOURCE (numeric value 3)
+   *
+   * @return {Number}
+   * @method Html5.prototype.networkState
+   */
   'networkState',
+  /**
+   * Get a value that expresses the current state of the element
+   * with respect to rendering the current playback position, from
+   * the codes in the list below
+   * - HAVE_NOTHING (numeric value 0)
+   * - HAVE_METADATA (numeric value 1)
+   * - HAVE_CURRENT_DATA (numeric value 2)
+   * - HAVE_FUTURE_DATA (numeric value 3)
+   * - HAVE_ENOUGH_DATA (numeric value 4)
+   *
+   * @return {Number}
+   * @method Html5.prototype.readyState
+   */
   'readyState',
+  /**
+   * Get width of video
+   *
+   * @return {Number}
+   * @method Html5.prototype.videoWidth
+   */
   'videoWidth',
+  /**
+   * Get height of video
+   *
+   * @return {Number}
+   * @method Html5.prototype.videoHeight
+   */
   'videoHeight'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
@@ -1070,15 +1197,65 @@ Html5.resetMediaElement = function(el) {
   };
 });
 
-// Wrap native properties with a setter
+// Wrap native properties with a setter in this format:
+// set + toTitleCase(name)
 [
+  /**
+   * Set volume level
+   *
+   * @param {Number} percentAsDecimal Volume percent as a decimal
+   * @method Html5.prototype.setVolume
+   */
   'volume',
+  /**
+   * Set muted
+   *
+   * @param {Boolean} muted If player is to be muted or note
+   * @method Html5.prototype.setMuted
+   */
   'muted',
+  /**
+   * Set video source
+   *
+   * @param {Object} src Source object
+   * @deprecated since version 5
+   * @method Html5.prototype.setSrc
+   */
   'src',
+  /**
+   * Set poster
+   *
+   * @param {String} val URL to poster image
+   * @method Html5.prototype.setPoster
+   */
   'poster',
+  /**
+   * Set preload attribute
+   *
+   * @param {String} val Value for the preload attribute
+   * @method Htm5.prototype.setPreload
+   */
   'preload',
+  /**
+   * Set autoplay attribute
+   *
+   * @param {Boolean} autoplay Value for the autoplay attribute
+   * @method setAutoplay
+   */
   'autoplay',
+  /**
+   * Set loop attribute
+   *
+   * @param {Boolean} loop Value for the loop attribute
+   * @method Html5.prototype.setLoop
+   */
   'loop',
+  /**
+   * Set desired speed at which the media resource is to play
+   *
+   * @param {Number} val Speed at which the media resource is to play
+   * @method Html5.prototype.setPlaybackRate
+   */
   'playbackRate'
 ].forEach(function(prop) {
   Html5.prototype[`set${toTitleCase(prop)}`] = function(v) {
@@ -1088,7 +1265,17 @@ Html5.resetMediaElement = function(el) {
 
 // wrap native functions with a function
 [
+  /**
+   * Pause for html5 tech
+   *
+   * @method Html5.prototype.pause
+   */
   'pause',
+  /**
+   * Load media into player
+   *
+   * @method Html5.prototype.load
+   */
   'load'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1258,7 +1258,7 @@ Html5.resetMediaElement = function(el) {
    */
   'playbackRate'
 ].forEach(function(prop) {
-  Html5.prototype[`set${toTitleCase(prop)}`] = function(v) {
+  Html5.prototype['set' + toTitleCase(prop)] = function(v) {
     this.el_[prop] = v;
   };
 });

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -101,14 +101,14 @@ class Html5 extends Tech {
         });
       };
       this[`handle${capitalType}TrackAdd_`] = (e) => techTracks.addTrack(e.track);
-      this[`handle${capitalType}TrackRemove_`] = (e) => techTracks.removetrack(e.track);
+      this[`handle${capitalType}TrackRemove_`] = (e) => techTracks.removeTrack(e.track);
 
       elTracks.addEventListener('change', this[`handle${capitalType}TrackChange_`]);
       elTracks.addEventListener('addtrack', this[`handle${capitalType}TrackAdd_`]);
       elTracks.addEventListener('removetrack', this[`handle${capitalType}TrackRemove_`]);
       this[`removeOld${capitalType}Tracks_`] = (e) => this.removeOldTracks_(techTracks, elTracks);
 
-      // Remove (native) trackts that are not used anymore
+      // Remove (native) tracks that are not used anymore
       this.on('loadstart', this[`removeOld${capitalType}Tracks_`]);
     });
 
@@ -632,13 +632,13 @@ class Html5 extends Tech {
 
 /* HTML5 Support Testing ---------------------------------------------------- */
 
-/*
-* Element for testing browser HTML5 video capabilities
-*
-* @type {Element}
-* @constant
-* @private
-*/
+/**
+ * Element for testing browser HTML5 video capabilities
+ *
+ * @type {Element}
+ * @constant
+ * @private
+ */
 Html5.TEST_VID = document.createElement('video');
 const track = document.createElement('track');
 
@@ -647,7 +647,7 @@ track.srclang = 'en';
 track.label = 'English';
 Html5.TEST_VID.appendChild(track);
 
-/*
+/**
  * Check if HTML5 video is supported by this browser/device
  *
  * @return {Boolean}
@@ -666,7 +666,7 @@ Html5.isSupported = function() {
 // Add Source Handler pattern functions to this tech
 Tech.withSourceHandlers(Html5);
 
-/*
+/**
  * The default native source handler.
  * This simply passes the source to the video element. Nothing fancy.
  *
@@ -675,7 +675,7 @@ Tech.withSourceHandlers(Html5);
  */
 Html5.nativeSourceHandler = {};
 
-/*
+/**
  * Check if the video element can play the given videotype
  *
  * @param  {String} type    The mimetype to check
@@ -691,7 +691,7 @@ Html5.nativeSourceHandler.canPlayType = function(type) {
   }
 };
 
-/*
+/**
  * Check if the video element can handle the source natively
  *
  * @param  {Object} source  The source object
@@ -714,7 +714,7 @@ Html5.nativeSourceHandler.canHandleSource = function(source, options) {
   return '';
 };
 
-/*
+/**
  * Pass the source to the video element
  * Adaptive source handlers will have more complicated workflows before passing
  * video data to the video element
@@ -728,15 +728,15 @@ Html5.nativeSourceHandler.handleSource = function(source, tech, options) {
 };
 
 /*
-* Clean up the source handler when disposing the player or switching sources..
-* (no cleanup is needed when supporting the format natively)
-*/
+ * Clean up the source handler when disposing the player or switching sources..
+ * (no cleanup is needed when supporting the format natively)
+ */
 Html5.nativeSourceHandler.dispose = function() {};
 
 // Register the native source handler
 Html5.registerSourceHandler(Html5.nativeSourceHandler);
 
-/*
+/**
  * Check if the volume can be changed in this browser/device.
  * Volume cannot be changed in a lot of mobile devices.
  * Specifically, it can't be changed from 1 on iOS.
@@ -755,7 +755,7 @@ Html5.canControlVolume = function() {
   }
 };
 
-/*
+/**
  * Check if playbackRate is supported in this browser/device.
  *
  * @return {Boolean}
@@ -777,7 +777,7 @@ Html5.canControlPlaybackRate = function() {
   }
 };
 
-/*
+/**
  * Check to see if native text tracks are supported by this browser/device
  *
  * @return {Boolean}
@@ -804,7 +804,7 @@ Html5.supportsNativeTextTracks = function() {
   return supportsTextTracks;
 };
 
-/*
+/**
  * Check to see if native video tracks are supported by this browser/device
  *
  * @return {Boolean}
@@ -815,7 +815,7 @@ Html5.supportsNativeVideoTracks = function() {
   return supportsVideoTracks;
 };
 
-/*
+/**
  * Check to see if native audio tracks are supported by this browser/device
  *
  * @return {Boolean}
@@ -857,21 +857,21 @@ Html5.Events = [
   'volumechange'
 ];
 
-/*
+/**
  * Set the tech's volume control support status
  *
  * @type {Boolean}
  */
 Html5.prototype.featuresVolumeControl = Html5.canControlVolume();
 
-/*
+/**
  * Set the tech's playbackRate support status
  *
  * @type {Boolean}
  */
 Html5.prototype.featuresPlaybackRate = Html5.canControlPlaybackRate();
 
-/*
+/**
  * Set the tech's status on moving the video element.
  * In iOS, if you move a video element in the DOM, it breaks video playback.
  *
@@ -879,20 +879,20 @@ Html5.prototype.featuresPlaybackRate = Html5.canControlPlaybackRate();
  */
 Html5.prototype.movingMediaElementInDOM = !browser.IS_IOS;
 
-/*
+/**
  * Set the the tech's fullscreen resize support status.
  * HTML video is able to automatically resize when going to fullscreen.
  * (No longer appears to be used. Can probably be removed.)
  */
 Html5.prototype.featuresFullscreenResize = true;
 
-/*
+/**
  * Set the tech's progress event support status
  * (this disables the manual progress events of the Tech)
  */
 Html5.prototype.featuresProgressEvents = true;
 
-/*
+/**
  * Sets the tech's status on native text track support
  *
  * @type {Boolean}

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -17,44 +17,6 @@ import assign from 'object.assign';
 import mergeOptions from '../utils/merge-options.js';
 import toTitleCase from '../utils/to-title-case.js';
 
-const NATIVE_GET = [
-  'paused',
-  'currentTime',
-  'buffered',
-  'volume',
-  'muted',
-  'poster',
-  'preload',
-  'autoplay',
-  'loop',
-  'error',
-  'seeking',
-  'seekable',
-  'ended',
-  'defaultMuted',
-  'playbackRate',
-  'played',
-  'networkState',
-  'readyState',
-  'videoWidth',
-  'videoHeight'
-];
-const NATIVE_SET = [
-  'volume',
-  'muted',
-  'src',
-  'poster',
-  'preload',
-  'autoplay',
-  'loop',
-  'playbackRate'
-];
-
-const NATIVE_FN = [
-  'pause',
-  'load'
-];
-
 /**
  * HTML5 Media Controller - Wrapper for HTML5 Media API
  *
@@ -67,22 +29,6 @@ class Html5 extends Tech {
 
   constructor(options, ready) {
     super(options, ready);
-
-    NATIVE_GET.forEach((prop) => {
-      this[prop] = () => this.el_[prop];
-    });
-
-    NATIVE_SET.forEach((prop) => {
-      const setterName = `set${toTitleCase(prop)}`;
-
-      this[setterName] = (v) => {
-        this.el_[prop] = v;
-      };
-    });
-
-    NATIVE_FN.forEach((prop) => {
-      this[prop] = () => this.el_[prop]();
-    });
 
     const source = options.source;
     let crossoriginTracks = false;
@@ -1095,6 +1041,60 @@ Html5.resetMediaElement = function(el) {
     }());
   }
 };
+
+// Wrap native properties with a getter
+[
+  'paused',
+  'currentTime',
+  'buffered',
+  'volume',
+  'muted',
+  'poster',
+  'preload',
+  'autoplay',
+  'loop',
+  'error',
+  'seeking',
+  'seekable',
+  'ended',
+  'defaultMuted',
+  'playbackRate',
+  'played',
+  'networkState',
+  'readyState',
+  'videoWidth',
+  'videoHeight'
+].forEach(function(prop) {
+  Html5.prototype[prop] = function() {
+    return this.el_[prop];
+  };
+});
+
+// Wrap native properties with a setter
+[
+  'volume',
+  'muted',
+  'src',
+  'poster',
+  'preload',
+  'autoplay',
+  'loop',
+  'playbackRate'
+].forEach(function(prop) {
+  Html5.prototype[`set${toTitleCase(prop)}`] = function(v) {
+    this.el_[prop] = v;
+  };
+});
+
+// wrap native functions with a function
+[
+  'pause',
+  'load'
+].forEach(function(prop) {
+  Html5.prototype[prop] = function() {
+    return this.el_[prop]();
+  };
+});
 
 Component.registerComponent('Html5', Html5);
 Tech.registerTech('Html5', Html5);


### PR DESCRIPTION
## Description
* Refactor any redundant code in the html5 tech to save bytes
* saved 254 bytes in the gzipped bundle, or 0.4% savings

## Specific Changes proposed
* List native properties wrappers at the top and loop through and add them in the constructor
* Better video/audio track code

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

