### PR TITLE
Fixes broken links to API docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,5 +33,5 @@ There are two categories of docs: [Guides](./guides/) and [API docs](./api/). Gu
 * [Removing Players](./guides/removing-players.md) - Helpful for using VideoJS in single page apps.
 
 ## API Docs
-- The most relevant API doc is the [player API doc](./api/vjs.Player.md).
-- [Full list of API Docs](./api/)
+- The most relevant API doc is the [player API doc](./guides/api.md).
+- [Full list of API Docs](http://docs.videojs.com/docs/api/index.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,5 +33,4 @@ There are two categories of docs: [Guides](./guides/) and [API docs](./api/). Gu
 * [Removing Players](./guides/removing-players.md) - Helpful for using VideoJS in single page apps.
 
 ## API Docs
-- The most relevant API doc is the [player API doc](./guides/api.md).
 - [Full list of API Docs](http://docs.videojs.com/docs/api/index.html)


### PR DESCRIPTION
## Description
Fixes two broken links to API docs in the "Video.js Documentation" file.

## Specific Changes proposed
Updated the links to what I believe to be logical replacement URLs.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

