### PR TITLE
Fix load progress bar never highlighting first buffered time range

### DIFF
--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -16,6 +16,7 @@ class LoadProgressBar extends Component {
 
   constructor(player, options) {
     super(player, options);
+    this.partEls_ = [];
     this.on(player, 'progress', this.update);
   }
 
@@ -41,7 +42,7 @@ class LoadProgressBar extends Component {
     const buffered = this.player_.buffered();
     const duration = this.player_.duration();
     const bufferedEnd = this.player_.bufferedEnd();
-    const children = this.el_.children;
+    const children = this.partEls_;
 
     // get the percent width of a time compared to the total end
     const percentify = function(time, end) {
@@ -62,6 +63,7 @@ class LoadProgressBar extends Component {
 
       if (!part) {
         part = this.el_.appendChild(Dom.createEl());
+        children[i] = part;
       }
 
       // set the percent based on the width of the progress bar (bufferedEnd)
@@ -73,6 +75,7 @@ class LoadProgressBar extends Component {
     for (let i = children.length; i > buffered.length; i--) {
       this.el_.removeChild(children[i - 1]);
     }
+    children.length = buffered.length;
   }
 
 }


### PR DESCRIPTION
## Description
The load progress bar never highlights the **first** buffered time range.

## Problem
This page demonstrates the problem using a fake tech which always has `buffered` set to `[[0,2],[4,8]]`: http://jsbin.com/cakece/edit?html,output

### Expected results
The load progress bar should show 2 highlighted parts.
![highlight-expected](https://cloud.githubusercontent.com/assets/649348/18517883/33e3a8bc-7a9e-11e6-818d-9238547b893e.PNG)

### Actual results
The load progress bar only shows 1 highlighted part, namely the `[4,8]` range.
![highlight-actual](https://cloud.githubusercontent.com/assets/649348/18518067/ccb33ed6-7a9e-11e6-8693-fcdc3828838f.PNG)
Additionally, when inspecting the DOM, you can see that the `<span class="vjs-control-text">` inside the `<div class="vjs-load-progress">` gets resized.

### Cause
The issue appears to be in [`LoadProgressBar.update`](https://github.com/videojs/video.js/blob/3a859f97d0647fc3d1ef6b2f4b755c71da8bef63/src/js/control-bar/progress-control/load-progress-bar.js#L40). This method keeps `this.el_.children` in sync with `this.player_.buffered()` by adding/removing `<div>` elements for every buffered time range. However, there is an additional `<span class="vjs-control-text">` created in `createEl` which makes the element indexes misalign with the range indexes.

## Specific Changes proposed
* ~~Add a `<div class="vjs-load-progress-ranges">` content element in `LoadProgressBar.createEl` to hold all time range elements~~
* ~~Fix `LoadProgressBar.update` to use `this.contentEl_.children` instead of `this.el_.children`~~
* ~~Update CSS to apply buffered time range styling to `.vjs-load-progress .vjs-load-progress-ranges div` rather than `.vjs-load-progress div`~~

~~Note that this changes the DOM structure of `.vjs-load-progress-bar`, which **may break skins** that style the highlighted buffered ranges. If this is not desirable, I can look into modifying this PR to work without changing the current DOM structure and CSS.~~

**Update 15/9/2016:** I modified the PR to work without changing the current DOM structure and CSS.
* Add `partEls_` field to `LoadProgressBar` to hold all buffered time range part elements
* Fix `LoadProgressBar.update` to use `this.partEls_` instead of `this.el_.children`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

