### PR TITLE
If we create a new element for movingMediaElInDOM, set playerId on the el again

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -190,6 +190,8 @@ class Html5 extends Tech {
           })
         );
       }
+
+      el.playerId = this.options_.playerId;
     }
 
     // Update specific tag settings, in case they were overridden


### PR DESCRIPTION
Fixes #3283. When `videojs` is called with an element, we try to see if we already have a player for that element. In some cases, like if `data-setup` is used with a manual call to `videojs`, we get called multiple times with the same element. On iOS, we cannot move the media element inside the DOM, so, we recreate it. In the process, we lose a marker we use for knowing whether we've created a player for that element.
This makes sure we keep that marker if we re-create the element.