### PR TITLE
remove es2015-loose since it's an option for es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-loose"],
+  "presets": [ ["es2015", {"loose": true}] ],
   "plugins": ["transform-es3-property-literals", "transform-es3-member-expression-literals", "inline-json"]
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "babel-plugin-transform-es3-property-literals": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.14.0",
-    "babel-preset-es2015-loose": "^7.0.0",
     "babel-register": "^6.9.0",
     "babelify": "^7.3.0",
     "blanket": "^1.1.6",


### PR DESCRIPTION
## Description
Followup from #3609. es2015-loose is deprecated because it's available as an option on the es2015 preset.