### PR TITLE
grunt-contrib-uglify to 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-cssmin": "~0.6.0",
-    "grunt-contrib-uglify": "^0.8.0",
+    "grunt-contrib-uglify": "~0.11.0",
     "grunt-contrib-watch": "~0.1.4",
     "grunt-coveralls": "^1.0.0",
     "grunt-fastly": "^0.1.3",


### PR DESCRIPTION
## Description
Fixes #3631 

Uglify 2.7 introduced a breaking change. This means our minified files after that point did not work in IE8. grunt-contrib-uglify released 0.11 which switches the uglify dependency from ^ to ~ and locks it down to the 2.6.x line, avoiding this implicit breakage.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors