### PR TITLE
Make chapters menu items selectable

### DIFF
--- a/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
@@ -22,6 +22,7 @@ class ChaptersTrackMenuItem extends MenuItem {
 
     // Modify options for parent MenuItem class's init.
     options.label = cue.text;
+    options.selectable = true;
     options.selected = (cue.startTime <= currentTime && currentTime < cue.endTime);
     super(player, options);
 


### PR DESCRIPTION
## Description
The chapters menu items weren't `selectable`, resulting in not (visually) selecting chapters menu items when clicking on them.

I found out about this because the settings menu didn't update the label.

## Specific Changes proposed
Make the chapters menu items selectable

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by One Other Core Contributors

