### PR TITLE
check throwIfWhitespace first in hasElClass

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -240,10 +240,10 @@ export function removeElData(el) {
  * @param {String} classToCheck Classname to check
  */
 export function hasElClass(element, classToCheck) {
+  throwIfWhitespace(classToCheck);
   if (element.classList) {
     return element.classList.contains(classToCheck);
   } else {
-    throwIfWhitespace(classToCheck);
     return classRegExp(classToCheck).test(element.className);
   }
 }


### PR DESCRIPTION
## Description
This is because the new spec for HTML has the classList (DOMTokenList)
.contains always return a value. Either true if it exists or false
otherwise.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
