### PR TITLE
Proxy ios webkit events into fullscreenchange

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -586,23 +586,25 @@ class Html5 extends Tech {
    * @method proxyWebkitFullscreen_
    */
   proxyWebkitFullscreen_() {
-    if ('webkitDisplayingFullscreen' in this.el_) {
-      const endFn = function() {
-        this.trigger('fullscreenchange', { isFullscreen: false });
-      };
-
-      const beginFn = function() {
-        this.one('webkitendfullscreen', endFn);
-
-        this.trigger('fullscreenchange', { isFullscreen: true });
-      };
-
-      this.on('webkitbeginfullscreen', beginFn);
-      this.on('dispose', () => {
-        this.off('webkitbeginfullscreen', beginFn);
-        this.off('webkitendfullscreen', endFn);
-      });
+    if (!('webkitDisplayingFullscreen' in this.el_)) {
+      return;
     }
+
+    const endFn = function() {
+      this.trigger('fullscreenchange', { isFullscreen: false });
+    };
+
+    const beginFn = function() {
+      this.one('webkitendfullscreen', endFn);
+
+      this.trigger('fullscreenchange', { isFullscreen: true });
+    };
+
+    this.on('webkitbeginfullscreen', beginFn);
+    this.on('dispose', () => {
+      this.off('webkitbeginfullscreen', beginFn);
+      this.off('webkitendfullscreen', endFn);
+    });
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -587,13 +587,16 @@ class Html5 extends Tech {
    */
   proxyWebkitFullscreen_() {
     if ('webkitDisplayingFullscreen' in this.el_) {
-      this.one('webkitbeginfullscreen', function() {
+      const webkitbeginFn =  function() {
         this.one('webkitendfullscreen', function() {
           this.trigger('fullscreenchange', { isFullscreen: false });
         });
 
         this.trigger('fullscreenchange', { isFullscreen: true });
-      });
+      };
+
+      this.on('webkitbeginfullscreen', webkitbeginFn);
+      this.on('dispose', () => this.off('webkitbeginfullscreen', webkitbeginFn));
     }
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -587,16 +587,21 @@ class Html5 extends Tech {
    */
   proxyWebkitFullscreen_() {
     if ('webkitDisplayingFullscreen' in this.el_) {
-      const webkitbeginFn = function() {
-        this.one('webkitendfullscreen', function() {
-          this.trigger('fullscreenchange', { isFullscreen: false });
-        });
+      const endFn = function() {
+        this.trigger('fullscreenchange', { isFullscreen: false });
+      };
+
+      const beginFn = function() {
+        this.one('webkitendfullscreen', endFn);
 
         this.trigger('fullscreenchange', { isFullscreen: true });
       };
 
-      this.on('webkitbeginfullscreen', webkitbeginFn);
-      this.on('dispose', () => this.off('webkitbeginfullscreen', webkitbeginFn));
+      this.on('webkitbeginfullscreen', beginFn);
+      this.on('dispose', () => {
+        this.off('webkitbeginfullscreen', beginFn);
+        this.off('webkitendfullscreen', endFn);
+      });
     }
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -587,7 +587,7 @@ class Html5 extends Tech {
    */
   proxyWebkitFullscreen_() {
     if ('webkitDisplayingFullscreen' in this.el_) {
-      const webkitbeginFn =  function() {
+      const webkitbeginFn = function() {
         this.one('webkitendfullscreen', function() {
           this.trigger('fullscreenchange', { isFullscreen: false });
         });

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -120,6 +120,10 @@ class Html5 extends Tech {
       this.setControls(true);
     }
 
+    // on iOS, we want to proxy `webkitbeginfullscreen` and `webkitendfullscreen`
+    // into a `fullscreenchange` event
+    this.proxyWebkitFullscreen_();
+
     this.triggerReady();
   }
 
@@ -575,6 +579,25 @@ class Html5 extends Tech {
   }
 
   /**
+   * Proxy iOS `webkitbeginfullscreen` and `webkitendfullscreen` into
+   * `fullscreenchange` event
+   *
+   * @private
+   * @method proxyWebkitFullscreen_
+   */
+  proxyWebkitFullscreen_() {
+    if ('webkitDisplayingFullscreen' in this.el_) {
+      this.one('webkitbeginfullscreen', function() {
+        this.one('webkitendfullscreen', function() {
+          this.trigger('fullscreenchange', { isFullscreen: false });
+        });
+
+        this.trigger('fullscreenchange', { isFullscreen: true });
+      });
+    }
+  }
+
+  /**
    * Get if there is fullscreen support
    *
    * @return {Boolean}
@@ -599,16 +622,6 @@ class Html5 extends Tech {
    */
   enterFullScreen() {
     const video = this.el_;
-
-    if ('webkitDisplayingFullscreen' in video) {
-      this.one('webkitbeginfullscreen', function() {
-        this.one('webkitendfullscreen', function() {
-          this.trigger('fullscreenchange', { isFullscreen: false });
-        });
-
-        this.trigger('fullscreenchange', { isFullscreen: true });
-      });
-    }
 
     if (video.paused && video.networkState <= video.HAVE_METADATA) {
       // attempt to prime the video element for programmatic access


### PR DESCRIPTION
## Description
Previously, the ios webkit events (webkitbeginfullscreen and
webkitendfullscreen) were only proxied into the fullscreenchange event
when requestFullscreen was called directly. So, on iPhones, we would
never be able to get this event. This makes it so these events are
always proxied.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

