### PR TITLE
Set timeupdate feature of html5 tech to disable manual timeupdate events

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -918,6 +918,12 @@ Html5.prototype.featuresFullscreenResize = true;
 Html5.prototype.featuresProgressEvents = true;
 
 /**
+ * Set the tech's timeupdate event support status
+ * (this disables the manual timeupdate events of the Tech)
+ */
+Html5.prototype.featuresTimeupdateEvents = true;
+
+/**
  * Sets the tech's status on native text track support
  *
  * @type {Boolean}


### PR DESCRIPTION
## Description
Due to `timeupdate` events being fired before `canplay` is triggered, the spinner is hidden before the video is actually loaded. See https://github.com/videojs/video.js/issues/3653
Disabling manual `timeupdate` events for the Html5 tech prevents this from happening and only fires `timeupdate` events after `canplay`.

## Specific Changes proposed
Add `Html5.prototype.featuresTimeupdateEvents = true` to the Html5 tech to disable manual `timeupdate` events.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
