### PR TITLE
style(_progress): Provide padding for the `vjs-progress-holder` while…

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -15,6 +15,7 @@
 .video-js .vjs-progress-control {
   @include flex(auto);
   @include display-flex(center);
+  margin: 0 0.45em 0 0.45em;
   min-width: 4em;
 }
 

--- a/src/css/components/_slider.scss
+++ b/src/css/components/_slider.scss
@@ -3,7 +3,6 @@
   position: relative;
   cursor: pointer;
   padding: 0;
-  margin: 0 0.45em 0 0.45em;
 
   @include background-color-with-alpha($secondary-background-color, $secondary-background-transparency);
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/videojs/video.js/issues/3645. Looks like it doesn't effect `volume-bar`,  which is the only other dependent of `Slider`, because it manages its own margins. SEE: https://github.com/videojs/video.js/blob/master/src/css/components/_volume.scss#L28
## Specific Changes proposed

![image](https://cloud.githubusercontent.com/assets/549319/18975972/175f7b5a-8663-11e6-8f36-7e3f99f5ee8b.png)
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

… allowing it to resize on hover. Thereby containing the `MouseTimeDisplay` to the `vjs-progress-holder` instead of it bleeding outside.

NOTE: Guessing that the margin was put in place to provide some spacing between the slider and the surrounding controls. Because the slider itself, or rather, `vjs-progress-holder` becomes larger on hover, we cannot have the "padding" also be responsive on the same element.
