### PR TITLE
Restore timeupdate/loadedmetadata listeners for duration display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+* @misteroneill restore timeupdate/loadedmetadata listeners for duration display ([view](https://github.com/videojs/video.js/pull/3682))
 
 --------------------
 

--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -19,6 +19,12 @@ class DurationDisplay extends Component {
     super(player, options);
 
     this.on(player, 'durationchange', this.updateContent);
+
+    // Also listen for timeupdate and loadedmetadata because removing those
+    // listeners could have broken dependent applications/libraries. These
+    // can likely be removed for 6.0.
+    this.on(player, 'timeupdate', this.updateContent);
+    this.on(player, 'loadedmetadata', this.updateContent);
   }
 
   /**


### PR DESCRIPTION
This addresses a possible source of breakage introduced in #3349 where dependent applications could be using the removed events to manually force a duration display update.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Reviewed by Two Core Contributors

