### PR TITLE
Cache currentTime and buffered from Flash

### DIFF
--- a/src/js/tech/flash-cache.js
+++ b/src/js/tech/flash-cache.js
@@ -1,0 +1,31 @@
+/**
+ * @file flash-cache.js
+ *
+ * Auto-caching method wrapper to avoid calling through to Flash too
+ * often.
+ */
+
+/**
+ * Returns a new getter function that returns a cached value if
+ * invoked multiple times within the specified duration.
+ *
+ * @param {Function} getter the function to be cached
+ * @param {Number} cacheDuration the number of milliseconds to cache
+ * results for
+ * @return {Function} a new function that returns cached results if
+ * invoked multiple times within the cache duration
+ */
+export default function timeExpiringCache(getter, cacheDuration) {
+  const result = function cachedGetter() {
+    const now = new Date().getTime();
+
+    if (now - result.lastCheckTime_ >= cacheDuration) {
+      result.lastCheckTime_ = now;
+      result.cache_ = getter();
+    }
+    return result.cache_;
+  };
+
+  result.lastCheckTime_ = -Infinity;
+  return result;
+}

--- a/test/unit/tech/flash-cache.test.js
+++ b/test/unit/tech/flash-cache.test.js
@@ -1,0 +1,50 @@
+/* eslint-env qunit */
+import timeExpiringCache from '../../../src/js/tech/flash-cache.js';
+import sinon from 'sinon';
+
+QUnit.module('Flash Cache', {
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+  },
+  afterEach() {
+    this.clock.restore();
+  }
+});
+
+QUnit.test('calls the getter on first invocation', function(assert) {
+  let calls = 0;
+  const cached = timeExpiringCache(() => calls++, 100);
+
+  QUnit.equal(cached(), 0, 'returned a value');
+  QUnit.equal(calls, 1, 'called the getter');
+});
+
+QUnit.test('caches results', function(assert) {
+  let calls = 0;
+  const cached = timeExpiringCache(() => calls++, 100);
+
+  for (let i = 0; i < 31; i++) {
+    QUnit.equal(cached(), 0, 'returned a cached value');
+  }
+  QUnit.equal(calls, 1, 'only called getter once');
+});
+
+QUnit.test('refreshes the cache after the result expires', function(assert) {
+  let calls = 0;
+  const cached = timeExpiringCache(() => calls++, 1);
+
+  QUnit.equal(cached(), 0, 'returned a value');
+  QUnit.equal(cached(), 0, 'returned a cached value');
+  QUnit.equal(calls, 1, 'only called getter once');
+  this.clock.tick(1);
+
+  QUnit.equal(cached(), 1, 'returned a value');
+  QUnit.equal(cached(), 1, 'returned a cached value');
+  QUnit.equal(calls, 2, 'called getter again');
+
+  this.clock.tick(10);
+  QUnit.equal(calls, 2, 'only refreshes on-demand');
+  QUnit.equal(cached(), 2, 'returned a value');
+  QUnit.equal(cached(), 2, 'returned a cached value');
+  QUnit.equal(calls, 3, 'called getter again');
+});

--- a/test/unit/tech/flash.test.js
+++ b/test/unit/tech/flash.test.js
@@ -31,8 +31,7 @@ QUnit.test('Flash.canPlaySource', function(assert) {
 });
 
 QUnit.test('currentTime', function(assert) {
-  const getCurrentTime = Flash.prototype.currentTime;
-  const setCurrentTime = Flash.prototype.setCurrentTime;
+  const mockFlash = new MockFlash();
   let seekingCount = 0;
   let seeking = false;
   let setPropVal;
@@ -40,44 +39,42 @@ QUnit.test('currentTime', function(assert) {
   let result;
 
   // Mock out a Flash instance to avoid creating the swf object
-  const mockFlash = {
-    el_: {
-      /* eslint-disable camelcase */
-      vjs_setProperty(prop, val) {
-        setPropVal = val;
-      },
-      vjs_getProperty() {
-        return getPropVal;
-      }
-      /* eslint-enable camelcase */
+  mockFlash.el_ = {
+    /* eslint-disable camelcase */
+    vjs_setProperty(prop, val) {
+      setPropVal = val;
     },
-    seekable() {
-      return createTimeRange(5, 1000);
-    },
-    trigger(event) {
-      if (event === 'seeking') {
-        seekingCount++;
-      }
-    },
-    seeking() {
-      return seeking;
+    vjs_getProperty() {
+      return getPropVal;
     }
+    /* eslint-enable camelcase */
+  };
+  mockFlash.seekable = function() {
+    return createTimeRange(5, 1000);
+  };
+  mockFlash.trigger = function(event) {
+    if (event === 'seeking') {
+      seekingCount++;
+    }
+  };
+  mockFlash.seeking = function() {
+    return seeking;
   };
 
   // Test the currentTime getter
   getPropVal = 3;
-  result = getCurrentTime.call(mockFlash);
+  result = mockFlash.currentTime();
   assert.equal(result, 3, 'currentTime is retreived from the swf element');
 
   // Test the currentTime setter
-  setCurrentTime.call(mockFlash, 10);
+  mockFlash.setCurrentTime(10);
   assert.equal(setPropVal, 10, 'currentTime is set on the swf element');
   assert.equal(seekingCount, 1, 'triggered seeking');
 
   // Test current time while seeking
-  setCurrentTime.call(mockFlash, 20);
+  mockFlash.setCurrentTime(20);
   seeking = true;
-  result = getCurrentTime.call(mockFlash);
+  result = mockFlash.currentTime();
   assert.equal(result,
               20,
               'currentTime is retrieved from the lastSeekTarget while seeking');
@@ -87,13 +84,13 @@ QUnit.test('currentTime', function(assert) {
   assert.equal(seekingCount, 2, 'triggered seeking');
 
   // clamp seeks to seekable
-  setCurrentTime.call(mockFlash, 1001);
-  result = getCurrentTime.call(mockFlash);
+  mockFlash.setCurrentTime(1001);
+  result = mockFlash.currentTime();
   assert.equal(result, mockFlash.seekable().end(0), 'clamped to the seekable end');
   assert.equal(seekingCount, 3, 'triggered seeking');
 
-  setCurrentTime.call(mockFlash, 1);
-  result = getCurrentTime.call(mockFlash);
+  mockFlash.setCurrentTime(1);
+  result = mockFlash.currentTime();
   assert.equal(result, mockFlash.seekable().start(0), 'clamped to the seekable start');
   assert.equal(seekingCount, 4, 'triggered seeking');
 });


### PR DESCRIPTION
## Description

Calling into the SWF too often is expensive. Current time and buffered don't actually change that often but it's very common to call them a couple times in the handling of a single event. Cache their return values for 100ms so the performance penalty of going through ExternalInterface is limited.
## Specific Changes proposed

Cache return values from `currentTime` and `buffered` for 100ms in the Flash tech.
## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
