### PR TITLE
fix: make sure that document.createElement exists before using

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -33,7 +33,9 @@ import xhr from 'xhr';
 import Tech from './tech/tech.js';
 
 // HTML5 Element Shim for IE8
-if (typeof HTMLVideoElement === 'undefined') {
+if (typeof HTMLVideoElement === 'undefined' &&
+    window.document &&
+    window.document.createElement) {
   document.createElement('video');
   document.createElement('audio');
   document.createElement('track');


### PR DESCRIPTION
If you try and require videojs in an environment that doesn't implement `document.createElement` properly -- like in Node.js -- you could potentially get an error. This checks that `window.document && window.document.createElement` is available before calling `createElement`.
We specifically check `window.document` so that `global` module won't cause issues with it's shimming of `document.createElement` in `global/document.

Fixes #3665