### PR TITLE
fix: remove sourcemaps from the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * greenkeeper updated karma dependencies ([view](https://github.com/videojs/video.js/pull/3523))
 * update to latest uglify to fix preserve comments issue. Disable screw ie8 option. ([view](https://github.com/videojs/video.js/pull/3709))
+* remove sourcemap generation ([view](https://github.com/videojs/video.js/pull/3710))
 
 --------------------
 

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -16,7 +16,6 @@ module.exports = function(grunt) {
 
   const browserifyGruntDefaults = {
     browserifyOptions: {
-      debug: true,
       standalone: 'videojs'
     },
     plugin: [
@@ -124,9 +123,6 @@ module.exports = function(grunt) {
     },
     uglify: {
       options: {
-        sourceMap: true,
-        sourceMapIn: 'build/temp/video.js.map',
-        sourceMapRoot: '../../src/js',
         preserveComments: 'some',
         screwIE8: false,
         mangle: true,
@@ -376,14 +372,6 @@ module.exports = function(grunt) {
         }
       }
     },
-    exorcise: {
-      build: {
-        options: {},
-        files: {
-          'build/temp/video.js.map': ['build/temp/video.js'],
-        }
-      }
-    },
     coveralls: {
       options: {
         // warn instead of failing when coveralls errors
@@ -458,7 +446,6 @@ module.exports = function(grunt) {
 
     'jshint',
     'browserify:build',
-    'exorcise:build',
     'concat:novtt',
     'concat:vtt',
     'usebanner:novtt',


### PR DESCRIPTION
Source Maps, while nice, aren't perfect and the ones we were outputting
weren't right.

Fixes #3701, #3106.