### PR TITLE
remove un-needed contructor and function overrides

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -15,10 +15,6 @@ import Component from './component.js';
  */
 class BigPlayButton extends Button {
 
-  constructor(player, options) {
-    super(player, options);
-  }
-
   /**
    * Allow sub components to stack CSS class names
    *

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -16,10 +16,6 @@ import assign from 'object.assign';
  */
 class Button extends ClickableComponent {
 
-  constructor(player, options) {
-    super(player, options);
-  }
-
   /**
    * Create the component's DOM element
    *

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -118,26 +118,6 @@ class ClickableComponent extends Component {
   }
 
   /**
-   * Adds a child component inside this clickable-component
-   *
-   * @param {String|Component} child The class name or instance of a child to add
-   * @param {Object=} options Options, including options to be passed to children of the child.
-   * @return {Component} The child component (created by this process if a string was used)
-   * @method addChild
-   */
-  addChild(child, options = {}) {
-    // TODO: Fix adding an actionable child to a ClickableComponent; currently
-    // it will cause issues with assistive technology (e.g. screen readers)
-    // which support ARIA, since an element with role="button" cannot have
-    // actionable child elements.
-
-    // let className = this.constructor.name;
-    // log.warn(`Adding a child to a ClickableComponent (${className}) can cause issues with assistive technology which supports ARIA, since an element with role="button" cannot have actionable child elements.`);
-
-    return super.addChild(child, options);
-  }
-
-  /**
    * Enable the component element
    *
    * @return {Component}


### PR DESCRIPTION
## Description
- Removes un-needed constructor overrides from `button` and `big-play-button`
- Removes un-needed `addChild` override from `clickable-component`
- Created an [issue](https://github.com/videojs/video.js/issues/3720) for the TODO comment that was removed 
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
