### PR TITLE
fix(events): support adding events to the window object

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -666,18 +666,17 @@ class Component {
       // Add the same function ID so we can easily remove it later
       cleanRemover.guid = fn.guid;
 
-      // Check if this is a DOM node
-      if (first.nodeName) {
-        // Add the listener to the other element
-        Events.on(target, type, fn);
-        Events.on(target, 'dispose', cleanRemover);
-
-      // Should be a component
-      // Not using `instanceof Component` because it makes mock players difficult
-      } else if (typeof first.on === 'function') {
+      // If we are attaching to a component like object use the preferred `on` method
+      if (typeof target.on === 'function') {
         // Add the listener to the other component
         target.on(type, fn);
         target.on('dispose', cleanRemover);
+      } else if (Events.canAttachEvent(target)) {
+        // Add the listener to the other element
+        Events.on(target, type, fn);
+        Events.on(target, 'dispose', cleanRemover);
+      } else {
+        log.warn(`Not adding ${type} listener. Not sure how to add it.`);
       }
     }
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -196,6 +196,20 @@ export function fixEvent(event) {
 }
 
 /**
+ * Determine if the events utility will be able to attach events to this object.
+ *
+ * @param {Object} obj Object to check
+ * @method canAttachEvent
+ * @return {Boolean} True if events can be attached to this object
+ */
+export function canAttachEvent(obj) {
+  const hasAddListener = typeof obj.addEventListener === 'function';
+  const hasAttachEvent = typeof obj.attachEvent === 'function';
+
+  return hasAddListener || hasAttachEvent;
+}
+
+/**
  * Add an event listener to element
  * It stores the handler function in a separate cache object
  * and adds a generic handler to the element's event,


### PR DESCRIPTION
## Fix problem with not being able to add events to the window

When using the `Component#on` function, events added to the `window` object (like a `resize` event) the event handler is silently ignored.

This is caused because the current code uses the presence of a `nodeName` property to determine if the target is a DOM node. For the most part this is a good test, but it doesn't work for the `window` object.
## Specific Changes proposed

This updates the logic for adding event listeners to check if the target is the window object, in addition to the current `nodeName` property check.
This change also adds a final `else` to this if statement that logs a warning so that developers are aware that their event is not being added.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
