### PR TITLE
Add option to have remoteTextTracks automatically 'garbage-collected' when sources change

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2525,9 +2525,9 @@ class Player extends Component {
    *
    * @param {Object} options    Options for remote text track
    */
-  addRemoteTextTrack(options) {
+  addRemoteTextTrack(...theArgs) {
     if (this.tech_) {
-      return this.tech_.addRemoteTextTrack(options);
+      return this.tech_.addRemoteTextTrack(...theArgs);
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2532,9 +2532,9 @@ class Player extends Component {
    * @deprecated The default value of the "manualCleanup" parameter will default
    * to "false" in upcoming versions of Video.js
    */
-  addRemoteTextTrack(...theArgs) {
+  addRemoteTextTrack(options, manualCleanup) {
     if (this.tech_) {
-      return this.tech_.addRemoteTextTrack(...theArgs);
+      return this.tech_.addRemoteTextTrack(options, manualCleanup);
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2521,9 +2521,16 @@ class Player extends Component {
   }
 
   /**
-   * Add a remote text track
+   * Creates a remote text track object and returns an html track element.
    *
-   * @param {Object} options    Options for remote text track
+   * @param {Object} options The object should contain values for
+   * kind, language, label, and src (location of the WebVTT file)
+   * @param {Boolean} [manualCleanup=true] if set to false, the TextTrack will be
+   * automatically removed from the video element whenever the source changes
+   * @return {HTMLTrackElement} An Html Track Element.
+   * This can be an emulated {@link HTMLTrackElement} or a native one.
+   * @deprecated The default value of the "manualCleanup" parameter will default
+   * to "false" in upcoming versions of Video.js
    */
   addRemoteTextTrack(...theArgs) {
     if (this.tech_) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -613,7 +613,6 @@ class Html5 extends Tech {
    *
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
-   * @method createRemoteTextTrack
    */
   createRemoteTextTrack(options) {
     if (!this.featuresNativeTextTracks) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -607,6 +607,14 @@ class Html5 extends Tech {
     return this.el_.addTextTrack(kind, label, language);
   }
 
+  /**
+   * Creates either native TextTrack or an emulated TextTrack depending
+   * on the value of `featuresNativeTextTracks`
+   *
+   * @param {Object} options The object should contain values for
+   * kind, language, label and src (location of the WebVTT file)
+   * @method createRemoteTextTrack
+   */
   createRemoteTextTrack(options) {
     if (!this.featuresNativeTextTracks) {
       return super.createRemoteTextTrack(options);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -607,18 +607,10 @@ class Html5 extends Tech {
     return this.el_.addTextTrack(kind, label, language);
   }
 
-  /**
-   * Creates a remote text track object and returns a html track element
-   *
-   * @param {Object} options The object should contain values for
-   * kind, language, label and src (location of the WebVTT file)
-   * @return {HTMLTrackElement}
-   */
-  addRemoteTextTrack(options = {}) {
+  createRemoteTextTrack(options) {
     if (!this.featuresNativeTextTracks) {
-      return super.addRemoteTextTrack(options);
+      return super.createRemoteTextTrack(options);
     }
-
     const htmlTrackElement = document.createElement('track');
 
     if (options.kind) {
@@ -640,11 +632,20 @@ class Html5 extends Tech {
       htmlTrackElement.src = options.src;
     }
 
-    this.el().appendChild(htmlTrackElement);
+    return htmlTrackElement;
+  }
 
-    // store HTMLTrackElement and TextTrack to remote list
-    this.remoteTextTrackEls().addTrackElement_(htmlTrackElement);
-    this.remoteTextTracks().addTrack_(htmlTrackElement.track);
+  /**
+   * Creates a remote text track object and returns a html track element
+   *
+   * @param {Object} options The object should contain values for
+   * kind, language, label and src (location of the WebVTT file)
+   * @return {HTMLTrackElement}
+   */
+  addRemoteTextTrack(options = {}, ...theRest) {
+    const htmlTrackElement = super.addRemoteTextTrack(options, ...theRest);
+
+    this.el().appendChild(htmlTrackElement);
 
     return htmlTrackElement;
   }
@@ -655,15 +656,7 @@ class Html5 extends Tech {
    * @param {TextTrackObject} track Texttrack object to remove
    */
   removeRemoteTextTrack(track) {
-    if (!this.featuresNativeTextTracks) {
-      return super.removeRemoteTextTrack(track);
-    }
-
-    const trackElement = this.remoteTextTrackEls().getTrackElementByTrack_(track);
-
-    // remove HTMLTrackElement and TextTrack from remote list
-    this.remoteTextTrackEls().removeTrackElement_(trackElement);
-    this.remoteTextTracks().removeTrack_(track);
+    super.removeRemoteTextTrack(track);
 
     const tracks = this.$$('track');
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -643,14 +643,19 @@ class Html5 extends Tech {
   }
 
   /**
-   * Creates a remote text track object and returns a html track element
+   * Creates a remote text track object and returns an html track element.
    *
    * @param {Object} options The object should contain values for
-   * kind, language, label and src (location of the WebVTT file)
-   * @return {HTMLTrackElement}
+   * kind, language, label, and src (location of the WebVTT file)
+   * @param {Boolean} [manualCleanup=true] if set to false, the TextTrack will be
+   * automatically removed from the video element whenever the source changes
+   * @return {HTMLTrackElement} An Html Track Element.
+   * This can be an emulated {@link HTMLTrackElement} or a native one.
+   * @deprecated The default value of the "manualCleanup" parameter will default
+   * to "false" in upcoming versions of Video.js
    */
-  addRemoteTextTrack(options = {}, ...theRest) {
-    const htmlTrackElement = super.addRemoteTextTrack(options, ...theRest);
+  addRemoteTextTrack(options, manualCleanup) {
+    const htmlTrackElement = super.addRemoteTextTrack(options, manualCleanup);
 
     this.el().appendChild(htmlTrackElement);
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -548,9 +548,11 @@ class Tech extends Component {
    *
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
-   * @param {Boolean} manualCleanup if set to false, the TextTrack will be
+   * @param {Boolean} [manualCleanup=true] if set to false, the TextTrack will be
    * automatically removed from the video element whenever the source changes
    * @return {HTMLTrackElement}
+   * @deprecated The default value of the "manualCleanup" parameter will default
+   * to "false" in upcoming versions of Video.js
    * @method addRemoteTextTrack
    */
   addRemoteTextTrack(options, manualCleanup) {
@@ -718,7 +720,7 @@ Tech.prototype.featuresNativeTextTracks = false;
  *
  * ##### EXAMPLE:
  *
- *   Tech.withSourceHandlers.call(MyTech);
+ *   Tech.withSourceHandlers(MyTech);
  *
  */
 Tech.withSourceHandlers = function(_Tech) {

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -560,6 +560,16 @@ class Tech extends Component {
     return createTrackHelper(this, kind, label, language);
   }
 
+  /**
+   * Create an emulated TextTrack for use by addRemoteTextTrack
+   *
+   * This is intended to be overridden by classes that inherit from
+   * Tech in order to create native or custom TextTracks.
+   *
+   * @param {Object} options The object should contain values for
+   * kind, language, label and src (location of the WebVTT file)
+   * @method createRemoteTextTrack
+   */
   createRemoteTextTrack(options) {
     const track = mergeOptions(options, {
       tech: this

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -583,18 +583,18 @@ class Tech extends Component {
   }
 
   /**
-   * Creates a remote text track object and returns a emulated html track element
+   * Creates a remote text track object and returns an html track element.
    *
    * @param {Object} options The object should contain values for
-   * kind, language, label and src (location of the WebVTT file)
+   * kind, language, label, and src (location of the WebVTT file)
    * @param {Boolean} [manualCleanup=true] if set to false, the TextTrack will be
    * automatically removed from the video element whenever the source changes
-   * @return {HTMLTrackElement}
+   * @return {HTMLTrackElement} An Html Track Element.
+   * This can be an emulated {@link HTMLTrackElement} or a native one.
    * @deprecated The default value of the "manualCleanup" parameter will default
    * to "false" in upcoming versions of Video.js
-   * @method addRemoteTextTrack
    */
-  addRemoteTextTrack(options, manualCleanup) {
+  addRemoteTextTrack(options = {}, manualCleanup) {
     const htmlTrackElement = this.createRemoteTextTrack(options);
 
     if (manualCleanup !== true && manualCleanup !== false) {

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -412,7 +412,12 @@ class Tech extends Component {
     });
   }
 
-  addWebVttScript() {
+  /**
+   * Add vtt.js if necessary
+   *
+   * @private
+   */
+  addWebVttScript_() {
     if (!window.WebVTT && this.el().parentNode !== null && this.el().parentNode !== undefined) {
       const script = document.createElement('script');
 
@@ -457,7 +462,7 @@ class Tech extends Component {
     // Initially, Tech.el_ is a child of a dummy-div wait until the Component system
     // signals that the Tech is ready at which point Tech.el_ is part of the DOM
     // before inserting the WebVTT script
-    this.on('ready', this.addWebVttScript);
+    this.on('ready', this.addWebVttScript_);
 
     const updateDisplay = () => this.trigger('texttrackchange');
     const textTracksChanges = () => {
@@ -568,7 +573,6 @@ class Tech extends Component {
    *
    * @param {Object} options The object should contain values for
    * kind, language, label and src (location of the WebVTT file)
-   * @method createRemoteTextTrack
    */
   createRemoteTextTrack(options) {
     const track = mergeOptions(options, {

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -377,7 +377,6 @@ QUnit.test('removes cuechange event when text track is hidden for emulated track
     endTime: 5
   });
   player.tech_.textTracks().addTrack_(tt);
-  player.tech_.emulateTextTracks();
 
   let numTextTrackChanges = 0;
 


### PR DESCRIPTION
## Description
Right now "remoteTextTracks" persist between source changes and must be removed manually by the user. This is problematic in many cases. It means plugins that change sources, such as the playlist API or videojs-contrib-ads, have to be extremely careful about changes the source and take care to cleanup remoteTextTracks. 

We do this because the Video.js API aligns very closely with the media element's native API. I propose that we could be doing more to iron-out the rough patches in the native API. In my opinion, the fact that previous changes to the media-element (adding text track elements) may change the behavior of a source is one of those rough patches.

## Specific Changes proposed
`Tech#addRemoteTextTrack` now accepts a second parameter - a boolean named `manualCleanup` which defaults to true preserving backwards compatibility. When that value is set to `false` the text track will be removed from the video element whenever a source change occurs.

A new instance property named `autoRemoteTextTracks_` is added to `Tech` that keeps track of which TextTracks have automatic life-cycle management.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

