### PR TITLE
fix: currentDimension can return 0 for fluid player on IE

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1155,7 +1155,7 @@ class Component {
 
     // if the computed value is still 0, it's possible that the browser is lying
     // and we want to check the offset values.
-    // This code also runs on IE8 and where-ever getComputedStyle doesn't exist.
+    // This code also runs on IE8 and wherever getComputedStyle doesn't exist.
     if (computedWidthOrHeight === 0) {
       const rule = `offset${toTitleCase(widthOrHeight)}`;
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1155,7 +1155,7 @@ class Component {
 
     // if the computed value is still 0, it's possible that the browser is lying
     // and we want to check the offset values.
-    // This code also runs on IE8 and whereever getComputedStyle doesn't exist.
+    // This code also runs on IE8 and where-ever getComputedStyle doesn't exist.
     if (computedWidthOrHeight === 0) {
       const rule = `offset${toTitleCase(widthOrHeight)}`;
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1148,15 +1148,14 @@ class Component {
       const computedStyle = window.getComputedStyle(this.el_);
 
       computedWidthOrHeight = computedStyle.getPropertyValue(widthOrHeight) || computedStyle[widthOrHeight];
-    } else if (this.el_.currentStyle) {
-      computedWidthOrHeight = this.el_.currentStyle[widthOrHeight];
     }
 
     // remove 'px' from variable and parse as integer
     computedWidthOrHeight = parseFloat(computedWidthOrHeight);
 
     // if the computed value is still 0, it's possible that the browser is lying
-    // and we want to check the offset values
+    // and we want to check the offset values.
+    // This code also runs on IE8 and whereever getComputedStyle doesn't exist.
     if (computedWidthOrHeight === 0) {
       const rule = `offset${toTitleCase(widthOrHeight)}`;
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1149,15 +1149,20 @@ class Component {
 
       computedWidthOrHeight = computedStyle.getPropertyValue(widthOrHeight) || computedStyle[widthOrHeight];
     } else if (this.el_.currentStyle) {
-      // ie 8 doesn't support computed style, shim it
-      // return clientWidth or clientHeight instead for better accuracy
+      computedWidthOrHeight = this.el_.currentStyle[widthOrHeight];
+    }
+
+    // remove 'px' from variable and parse as integer
+    computedWidthOrHeight = parseFloat(computedWidthOrHeight);
+
+    // if the computed value is still 0, it's possible that the browser is lying
+    // and we want to check the offset values
+    if (computedWidthOrHeight === 0) {
       const rule = `offset${toTitleCase(widthOrHeight)}`;
 
       computedWidthOrHeight = this.el_[rule];
     }
 
-    // remove 'px' from variable and parse as integer
-    computedWidthOrHeight = parseFloat(computedWidthOrHeight);
     return computedWidthOrHeight;
   }
 


### PR DESCRIPTION
This is because IE returns 0 for both getComputedStyle and currentStyle.
However, offsetHeight and offsetWidth do contain the correct values we
want. So, if before returning in currentDimension the return value is
still zero, check the offset values.