### PR TITLE
Use ES6 and allow V8 to optimize mergeOptions

### DIFF
--- a/src/js/utils/merge-options.js
+++ b/src/js/utils/merge-options.js
@@ -41,20 +41,17 @@ function customizer(destination, source) {
  * provided objects
  * @function mergeOptions
  */
-export default function mergeOptions() {
-  // contruct the call dynamically to handle the variable number of
-  // objects to merge
-  const args = Array.prototype.slice.call(arguments);
+export default function mergeOptions(...objects) {
 
   // unshift an empty object into the front of the call as the target
   // of the merge
-  args.unshift({});
+  objects.unshift({});
 
   // customize conflict resolution to match our historical merge behavior
-  args.push(customizer);
+  objects.push(customizer);
 
-  merge.apply(null, args);
+  merge.apply(null, objects);
 
   // return the mutated result object
-  return args[0];
+  return objects[0];
 }


### PR DESCRIPTION
## Description
The current implementation causes the `mergeOptions` function to be de-optimized. This change improves readability by switching to ES6 syntax _and_ it results in a roughly 75% improvement in the performance of this function by transpiling to a `for` loop instead of `slice.call`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

