### PR TITLE
chore: pin karma-detect-browsers to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "karma-browserstack-launcher": "^1.0.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
-    "karma-detect-browsers": "^2.1.0",
+    "karma-detect-browsers": "~2.1.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-opera-launcher": "^1.0.0",


### PR DESCRIPTION
Until https://github.com/litixsoft/karma-detect-browsers/issues/17 is fixed, we need to pin it so our builds pass and tests can work locally.