### PR TITLE
test(dom): fix removeElClass test in Safari 10.

### DIFF
--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -105,17 +105,12 @@ QUnit.test('addElClass()', function(assert) {
 QUnit.test('removeElClass()', function(assert) {
   const el = document.createElement('div');
 
-  el.className = 'test-class foo foo test2_className FOO bar';
+  el.className = 'test-class test2_className FOO bar';
 
-  assert.expect(5);
+  assert.expect(4);
 
   Dom.removeElClass(el, 'test-class');
-  assert.strictEqual(el.className, 'foo foo test2_className FOO bar', 'removes one class');
-
-  Dom.removeElClass(el, 'foo');
-  assert.strictEqual(el.className,
-                    'test2_className FOO bar',
-                    'removes all instances of a class');
+  assert.strictEqual(el.className, 'test2_className FOO bar', 'removes one class');
 
   assert.throws(function() {
     Dom.removeElClass(el, 'test2_className bar');


### PR DESCRIPTION
Safari 10 automatically dedupes duplicate class names in an element. So,
our test was failing because we had an extra "foo" in the check. This is
an unlikely scenario that has browser variations, so, better to just
remove it.