### PR TITLE
fix(html5): exit early on emulated tracks in html5

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -657,6 +657,10 @@ class Html5 extends Tech {
   addRemoteTextTrack(options, manualCleanup) {
     const htmlTrackElement = super.addRemoteTextTrack(options, manualCleanup);
 
+    if (!this.featuresNativeTextTracks) {
+      return htmlTrackElement;
+    }
+
     this.el().appendChild(htmlTrackElement);
 
     return htmlTrackElement;
@@ -669,6 +673,10 @@ class Html5 extends Tech {
    */
   removeRemoteTextTrack(track) {
     super.removeRemoteTextTrack(track);
+
+    if (!this.featuresNativeTextTracks) {
+      return;
+    }
 
     const tracks = this.$$('track');
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -657,11 +657,9 @@ class Html5 extends Tech {
   addRemoteTextTrack(options, manualCleanup) {
     const htmlTrackElement = super.addRemoteTextTrack(options, manualCleanup);
 
-    if (!this.featuresNativeTextTracks) {
-      return htmlTrackElement;
+    if (this.featuresNativeTextTracks) {
+      this.el().appendChild(htmlTrackElement);
     }
-
-    this.el().appendChild(htmlTrackElement);
 
     return htmlTrackElement;
   }
@@ -674,17 +672,15 @@ class Html5 extends Tech {
   removeRemoteTextTrack(track) {
     super.removeRemoteTextTrack(track);
 
-    if (!this.featuresNativeTextTracks) {
-      return;
-    }
+    if (this.featuresNativeTextTracks) {
+      const tracks = this.$$('track');
 
-    const tracks = this.$$('track');
+      let i = tracks.length;
 
-    let i = tracks.length;
-
-    while (i--) {
-      if (track === tracks[i] || track === tracks[i].track) {
-        this.el().removeChild(tracks[i]);
+      while (i--) {
+        if (track === tracks[i] || track === tracks[i].track) {
+          this.el().removeChild(tracks[i]);
+        }
       }
     }
   }


### PR DESCRIPTION
addRemoteTextTrack and removeRemoteTextTrack in Html5 tech assumed that
they are always called for native text tracks. However, Html5 tech can
have emulated text tracks. For those, we just exit early after the super
methods are called.