### PR TITLE
fix(flash): lower currentTime cache to 25ms

### DIFF
--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -69,7 +69,7 @@ class Flash extends Tech {
     // relatively slowly over time
     const getCurrentTimeCached = timeExpiringCache(() => {
       return this.el_.vjs_getProperty('currentTime');
-    }, 100);
+    }, 25);
 
     this.currentTime = (time) => {
       // when seeking make the reported time keep up with the requested time


### PR DESCRIPTION
Caching the value of currentTime in flash for more than `35ms` seems to cause video playback in HLS via contrib-hls to stop. Set to `25ms` as a nice round number.