### PR TITLE
Include method to get html track elements from the list

### DIFF
--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -37,7 +37,20 @@ class HtmlTrackElementList {
   }
 
   addTrackElement_(trackElement) {
-    this.trackElements_.push(trackElement);
+    const index = this.trackElements_.length;
+
+    if (!('' + index in this)) {
+      Object.defineProperty(this, index, {
+        get() {
+          return this.trackElements_[index];
+        }
+      });
+    }
+
+    // Do not add duplicate elements
+    if (this.trackElements_.indexOf(trackElement) === -1) {
+      this.trackElements_.push(trackElement);
+    }
   }
 
   getTrackElementByTrack_(track) {


### PR DESCRIPTION
## Description
When accessing a HtmlTrackElementList, you cannot access them using indices like with [TrackList](https://github.com/videojs/video.js/blob/master/src/js/tracks/track-list.js).

Previously trying to access a remoteTextTrack by `player.remoteTextTrackEls()[0]`, resulted in an error `this.player.remoteTextTrackEls(...)[0] is undefined`.

## Specific Changes proposed
I have added code similar to that in TrackList to allow accessing html track elements.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors

