### PR TITLE
Added option to disable native tracks

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -80,7 +80,13 @@ class Tech extends Component {
       this.manualTimeUpdatesOn();
     }
 
-    if (options.nativeCaptions === false || options.nativeTextTracks === false) {
+    ['Text', 'Audio', 'Video'].forEach((track) => {
+      if (options[`native${track}Tracks`] === false) {
+        this[`featuresNative${track}Tracks`] = false;
+      }
+    });
+
+    if (options.nativeCaptions === false) {
       this.featuresNativeTextTracks = false;
     }
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -301,6 +301,30 @@ if (Html5.supportsNativeTextTracks()) {
     assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
   });
 
+  QUnit.test('does not add native textTrack listeners when disabled', function(assert) {
+    const events = [];
+    const tt = {
+      length: 0,
+      addEventListener: (type, fn) => events.push([type, fn]),
+      removeEventListener: (type, fn) => events.push([type, fn])
+    };
+    const el = document.createElement('div');
+
+    el.textTracks = tt;
+
+    /* eslint-disable no-unused-vars */
+    const htmlTech = new Html5({el, nativeTextTracks: false});
+    /* eslint-enable no-unused-vars */
+
+    assert.equal(events.length, 0, 'no listeners added');
+
+    /* eslint-disable no-unused-vars */
+    const htmlTechAlternate = new Html5({el, nativeCaptions: false});
+    /* eslint-enable no-unused-vars */
+
+    assert.equal(events.length, 0, 'no listeners added');
+  });
+
   QUnit.test('remove all tracks from emulated list on dispose', function(assert) {
     const adds = [];
     const rems = [];
@@ -351,6 +375,24 @@ if (Html5.supportsNativeAudioTracks()) {
     assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
   });
 
+  QUnit.test('does not add native audioTrack listeners when disabled', function(assert) {
+    const events = [];
+    const at = {
+      length: 0,
+      addEventListener: (type, fn) => events.push([type, fn]),
+      removeEventListener: (type, fn) => events.push([type, fn])
+    };
+    const el = document.createElement('div');
+
+    el.audioTracks = at;
+
+    /* eslint-disable no-unused-vars */
+    const htmlTech = new Html5({el, nativeAudioTracks: false});
+    /* eslint-enable no-unused-vars */
+
+    assert.equal(events.length, 0, 'no listeners added');
+  });
+
   QUnit.test('remove all tracks from emulated list on dispose', function(assert) {
     const adds = [];
     const rems = [];
@@ -399,6 +441,24 @@ if (Html5.supportsNativeVideoTracks()) {
     assert.equal(adds[0][0], 'change', 'change event handler added');
     assert.equal(adds[1][0], 'addtrack', 'addtrack event handler added');
     assert.equal(adds[2][0], 'removetrack', 'removetrack event handler added');
+  });
+
+  QUnit.test('does not add native audioTrack listeners when disabled', function(assert) {
+    const events = [];
+    const vt = {
+      length: 0,
+      addEventListener: (type, fn) => events.push([type, fn]),
+      removeEventListener: (type, fn) => events.push([type, fn])
+    };
+    const el = document.createElement('div');
+
+    el.videoTracks = vt;
+
+    /* eslint-disable no-unused-vars */
+    const htmlTech = new Html5({el, nativeVideoTracks: false});
+    /* eslint-enable no-unused-vars */
+
+    assert.equal(events.length, 0, 'no listeners added');
   });
 
   QUnit.test('remove all tracks from emulated list on dispose', function(assert) {


### PR DESCRIPTION
## Description
This PR provides a tech level option to disable native audio and video tracks.

## Specific Changes proposed
This adds `nativeAudioTracks` and `nativeVideoTracks` tech options, this will disable hooking into the native track APIs. This would be useful when using videojs-contrib-hls on Edge.

Usage:
```js
videojs(video, {
  html5: {
    nativeAudioTracks: false
  }
});
```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

