### PR TITLE
Remove confusing references to player in HTML5 tech.

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -443,11 +443,11 @@ class Html5 extends Tech {
             if (this.el_.duration === Infinity) {
               this.trigger('durationchange');
             }
-            this.off(this.player_, 'timeupdate', checkProgress);
+            this.off('timeupdate', checkProgress);
           }
         };
 
-        this.on(this.player_, 'timeupdate', checkProgress);
+        this.on('timeupdate', checkProgress);
         return NaN;
       }
     }


### PR DESCRIPTION
## Description
This has no functional change. This simply makes the code easier to understand.

## Specific Changes proposed
Don't reference `player_` inside of a tech since it isn't actually a reference to the Player.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

These references to player_ are actually not the player due to techs not having a reference to the player.