### PR TITLE
Make registerComponent only work with Components

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1541,12 +1541,16 @@ class Component {
    * @return {Component}
    *         The `Component` that was registered.
    */
-  static registerComponent(name, comp) {
-    if (!name) {
-      return;
+  static registerComponent(name, Comp) {
+    if (typeof name !== 'string' || !(/\S/).test(name)) {
+      throw new Error('illegal "name"; must be non-empty string');
     }
 
-    name = toTitleCase(name);
+    if (!Component.prototype.isPrototypeOf(Comp.prototype) && Component !== Comp) {
+      throw new Error('illegal "Comp"; must be a subclass of Component');
+    }
+
+    name = toTitleCase(name.trim());
 
     if (!Component.components_) {
       Component.components_ = {};
@@ -1566,9 +1570,9 @@ class Component {
       }
     }
 
-    Component.components_[name] = comp;
+    Component.components_[name] = Comp;
 
-    return comp;
+    return Comp;
   }
 
   /**
@@ -1661,4 +1665,5 @@ class Component {
 }
 
 Component.registerComponent('Component', Component);
+
 export default Component;

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1571,16 +1571,19 @@ class Component {
       Component.components_ = {};
     }
 
-    if (name === 'Player' && Component.components_[name]) {
-      const players = Component.components_[name].players;
+    const Player = Component.getComponent('Player');
+
+    if (name === 'Player' && Player) {
+      const players = Player.players;
+      const playerNames = Object.keys(players);
 
       // If we have players that were disposed, then their name will still be
       // in Players.players. So, we must loop through and verify that the value
       // for each item is not null. This allows registration of the Player component
       // after all players have been disposed or before any were created.
       if (players &&
-          Object.keys(players).length > 0 &&
-          Object.keys(players).map((playerName) => players[playerName]).every(Boolean)) {
+          playerNames.length > 0 &&
+          playerNames.map((pname) => players[pname]).every(Boolean)) {
         throw new Error('Can not register Player component after player has been created.');
       }
     }

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1535,44 +1535,45 @@ class Component {
    * @param {string} name
    *        The name of the `Component` to register.
    *
-   * @param {Component} comp
+   * @param {Component} ComponentToRegister
    *        The `Component` class to register.
    *
    * @return {Component}
    *         The `Component` that was registered.
    */
-  static registerComponent(name, Comp) {
-    if (typeof name !== 'string' || !(/\S/).test(name)) {
-      throw new Error('illegal "name"; must be non-empty string');
+  static registerComponent(name, ComponentToRegister) {
+    if (typeof name !== 'string' || !name.length) {
+      throw new Error(`illegal component name, "${name}"; must be a non-empty string`);
     }
 
-    if (!Component.prototype.isPrototypeOf(Comp.prototype) && Component !== Comp) {
-      throw new Error('illegal "Comp"; must be a subclass of Component');
+    if (!Component.prototype.isPrototypeOf(ComponentToRegister.prototype) &&
+        Component !== ComponentToRegister) {
+      throw new Error(`illegal component constructor, "${name}"; must be a subclass of Component`);
     }
 
-    name = toTitleCase(name.trim());
+    name = toTitleCase(name);
 
     if (!Component.components_) {
       Component.components_ = {};
     }
 
     if (name === 'Player' && Component.components_[name]) {
-      const Player = Component.components_[name];
+      const players = Component.components_[name].players;
 
       // If we have players that were disposed, then their name will still be
       // in Players.players. So, we must loop through and verify that the value
       // for each item is not null. This allows registration of the Player component
       // after all players have been disposed or before any were created.
-      if (Player.players &&
-          Object.keys(Player.players).length > 0 &&
-          Object.keys(Player.players).map((playerName) => Player.players[playerName]).every(Boolean)) {
+      if (players &&
+          Object.keys(players).length > 0 &&
+          Object.keys(players).map((playerName) => players[playerName]).every(Boolean)) {
         throw new Error('Can not register Player component after player has been created');
       }
     }
 
-    Component.components_[name] = Comp;
+    Component.components_[name] = ComponentToRegister;
 
-    return Comp;
+    return ComponentToRegister;
   }
 
   /**
@@ -1598,12 +1599,6 @@ class Component {
 
     if (Component.components_ && Component.components_[name]) {
       return Component.components_[name];
-    }
-
-    if (window && window.videojs && window.videojs[name]) {
-      log.warn(`The ${name} component was added to the videojs object when it should be registered using videojs.registerComponent(name, component)`);
-
-      return window.videojs[name];
     }
   }
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1542,13 +1542,27 @@ class Component {
    *         The `Component` that was registered.
    */
   static registerComponent(name, ComponentToRegister) {
-    if (typeof name !== 'string' || !name.length) {
-      throw new Error(`illegal component name, "${name}"; must be a non-empty string`);
+    if (typeof name !== 'string' || !name) {
+      throw new Error(`Illegal component name, "${name}"; must be a non-empty string.`);
     }
 
-    if (!Component.prototype.isPrototypeOf(ComponentToRegister.prototype) &&
-        Component !== ComponentToRegister) {
-      throw new Error(`illegal component constructor, "${name}"; must be a subclass of Component`);
+    const Tech = Component.getComponent('Tech');
+
+    // We need to make sure this check is only done if Tech has been registered.
+    const isTech = Tech && Tech.isTech(ComponentToRegister);
+    const isComp = Component === ComponentToRegister ||
+      Component.prototype.isPrototypeOf(ComponentToRegister.prototype);
+
+    if (isTech || !isComp) {
+      let reason;
+
+      if (isTech) {
+        reason = 'techs must be registered using Tech.registerTech()';
+      } else {
+        reason = 'must be a Component subclass';
+      }
+
+      throw new Error(`Illegal component, "${name}"; ${reason}.`);
     }
 
     name = toTitleCase(name);
@@ -1567,7 +1581,7 @@ class Component {
       if (players &&
           Object.keys(players).length > 0 &&
           Object.keys(players).map((playerName) => players[playerName]).every(Boolean)) {
-        throw new Error('Can not register Player component after player has been created');
+        throw new Error('Can not register Player component after player has been created.');
       }
     }
 

--- a/src/js/tech/flash.js
+++ b/src/js/tech/flash.js
@@ -10,7 +10,6 @@ import * as Dom from '../utils/dom.js';
 import * as Url from '../utils/url.js';
 import { createTimeRange } from '../utils/time-ranges.js';
 import FlashRtmpDecorator from './flash-rtmp';
-import Component from '../component';
 import window from 'global/window';
 import {assign} from '../utils/obj';
 
@@ -1075,6 +1074,5 @@ Flash.getEmbedCode = function(swf, flashVars, params, attributes) {
 // Run Flash through the RTMP decorator
 FlashRtmpDecorator(Flash);
 
-Component.registerComponent('Flash', Flash);
 Tech.registerTech('Flash', Flash);
 export default Flash;

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -2,7 +2,6 @@
  * @file html5.js
  */
 import Tech from './tech.js';
-import Component from '../component';
 import * as Dom from '../utils/dom.js';
 import * as Url from '../utils/url.js';
 import * as Fn from '../utils/fn.js';
@@ -1662,6 +1661,5 @@ Html5.nativeSourceHandler.dispose = function() {};
 // Register the native source handler
 Html5.registerSourceHandler(Html5.nativeSourceHandler);
 
-Component.registerComponent('Html5', Html5);
 Tech.registerTech('Html5', Html5);
 export default Html5;

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1187,9 +1187,9 @@ Tech.withSourceHandlers = function(_Tech) {
 
 };
 
+// The base Tech class needs to be registered as a Component. It is the only
+// Tech that can be registered as a Component.
 Component.registerComponent('Tech', Tech);
-// Old name for Tech
-// @deprecated
-Component.registerComponent('MediaTechController', Tech);
 Tech.registerTech('Tech', Tech);
+
 export default Tech;

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -44,9 +44,17 @@ const getFakePlayer = function() {
 QUnit.test('registerComponent() throws with bad arguments', function(assert) {
   assert.throws(
     function() {
-      Component.registerComponent(' \t \r\n  ');
+      Component.registerComponent(null);
     },
-    new Error('illegal "name"; must be non-empty string'),
+    new Error('illegal component name, "null"; must be a non-empty string'),
+    'component names must be non-empty strings'
+  );
+
+  assert.throws(
+    function() {
+      Component.registerComponent('');
+    },
+    new Error('illegal component name, ""; must be a non-empty string'),
     'component names must be non-empty strings'
   );
 
@@ -54,7 +62,7 @@ QUnit.test('registerComponent() throws with bad arguments', function(assert) {
     function() {
       Component.registerComponent('TestComponent5', function() {});
     },
-    new Error('illegal "Comp"; must be a subclass of Component'),
+    new Error('illegal component constructor, "TestComponent5"; must be a subclass of Component'),
     'components must be subclasses of Component'
   );
 });

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -41,6 +41,24 @@ const getFakePlayer = function() {
   };
 };
 
+QUnit.test('registerComponent() throws with bad arguments', function(assert) {
+  assert.throws(
+    function() {
+      Component.registerComponent(' \t \r\n  ');
+    },
+    new Error('illegal "name"; must be non-empty string'),
+    'component names must be non-empty strings'
+  );
+
+  assert.throws(
+    function() {
+      Component.registerComponent('TestComponent5', function() {});
+    },
+    new Error('illegal "Comp"; must be a subclass of Component'),
+    'components must be subclasses of Component'
+  );
+});
+
 QUnit.test('should create an element', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -46,7 +46,7 @@ QUnit.test('registerComponent() throws with bad arguments', function(assert) {
     function() {
       Component.registerComponent(null);
     },
-    new Error('illegal component name, "null"; must be a non-empty string'),
+    new Error('Illegal component name, "null"; must be a non-empty string.'),
     'component names must be non-empty strings'
   );
 
@@ -54,7 +54,7 @@ QUnit.test('registerComponent() throws with bad arguments', function(assert) {
     function() {
       Component.registerComponent('');
     },
-    new Error('illegal component name, ""; must be a non-empty string'),
+    new Error('Illegal component name, ""; must be a non-empty string.'),
     'component names must be non-empty strings'
   );
 
@@ -62,7 +62,19 @@ QUnit.test('registerComponent() throws with bad arguments', function(assert) {
     function() {
       Component.registerComponent('TestComponent5', function() {});
     },
-    new Error('illegal component constructor, "TestComponent5"; must be a subclass of Component'),
+    new Error('Illegal component, "TestComponent5"; must be a Component subclass.'),
+    'components must be subclasses of Component'
+  );
+
+  assert.throws(
+    function() {
+      const Tech = Component.getComponent('Tech');
+
+      class DummyTech extends Tech {}
+
+      Component.registerComponent('TestComponent5', DummyTech);
+    },
+    new Error('Illegal component, "TestComponent5"; techs must be registered using Tech.registerTech().'),
     'components must be subclasses of Component'
   );
 });
@@ -661,7 +673,7 @@ QUnit.test('should use a defined content el for appending children', function(as
   class CompWithContent extends Component {}
 
   CompWithContent.prototype.createEl = function() {
-    // Create the main componenent element
+    // Create the main component element
     const el = Dom.createEl('div');
 
     // Create the element where children will be appended

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -213,7 +213,6 @@ QUnit.test('if native text tracks are not supported, create a texttrackdisplay',
   const oldTestVid = Html5.TEST_VID;
   const oldIsFirefox = browser.IS_FIREFOX;
   const oldTextTrackDisplay = Component.getComponent('TextTrackDisplay');
-  let called = false;
   const tag = document.createElement('video');
   const track1 = document.createElement('track');
   const track2 = document.createElement('track');
@@ -235,13 +234,21 @@ QUnit.test('if native text tracks are not supported, create a texttrackdisplay',
   };
 
   browser.IS_FIREFOX = true;
-  Component.registerComponent('TextTrackDisplay', function() {
-    called = true;
-  });
+
+  const fakeTTDSpy = sinon.spy();
+
+  class FakeTTD extends Component {
+    constructor() {
+      super();
+      fakeTTDSpy();
+    }
+  }
+
+  Component.registerComponent('TextTrackDisplay', FakeTTD);
 
   const player = TestHelpers.makePlayer({}, tag);
 
-  assert.ok(called, 'text track display was created');
+  assert.strictEqual(fakeTTDSpy.callCount, 1, 'text track display was created');
 
   Html5.TEST_VID = oldTestVid;
   browser.IS_FIREFOX = oldIsFirefox;


### PR DESCRIPTION
## Description
This addresses one of the pre-existing cards from the 6.0 project. It prevents techs (and others) from being registered via `registerComponent`.

There is an open question as to whether or not we want to implement similar protections to `registerTech` and adopt `deregisterComponent` and `deregisterTech` methods similar to the way the plugins PR does for plugins.

## Specific Changes proposed
- `registerComponent` now throws if given an object that is not a subclass of `Component` (or `Component` itself).
- `registerComponent` now throws if given a non-empty string as its `name` argument.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

