### PR TITLE
vtt.js: Add `responseType: "arraybuffer"` to loadTrack xhr opts

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -61,7 +61,8 @@ const parseCues = function(srcContent, track) {
  */
 const loadTrack = function(src, track) {
   const opts = {
-    uri: src
+    uri: src,
+    responseType: 'arraybuffer'
   };
   const crossOrigin = isCrossOrigin(src);
 


### PR DESCRIPTION
## Description

Fixes `TypeError: Argument 1 of TextDecoder.decode could not be converted to any of: ArrayBufferView, ArrayBuffer`. #3820 

Suggested fix by @bzbarsky 

I'm not really a JS dev, so don't take my word - but I've built this branch together with a package.json update to point it to the future vtt.js release build, and found that it fixed the issue.

## Specific Changes proposed

Ensuring that types for XHR content are cast explicitly I guess?

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors