### PR TITLE
Remove deprecated Component.extend() and init method in videojs.extend()

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1602,62 +1602,6 @@ class Component {
       return window.videojs[name];
     }
   }
-
-  /**
-   * Sets up the constructor using the supplied init method or uses the init of the
-   * parent object.
-   *
-   * @param {Object} [props={}]
-   *        An object of properties.
-   *
-   * @return {Object}
-   *         the extended object.
-   *
-   * @deprecated since version 5
-   */
-  static extend(props) {
-    props = props || {};
-
-    log.warn('Component.extend({}) has been deprecated, ' +
-      ' use videojs.extend(Component, {}) instead'
-    );
-
-    // Set up the constructor using the supplied init method
-    // or using the init of the parent object
-    // Make sure to check the unobfuscated version for external libs
-    const init = props.init || props.init || this.prototype.init ||
-                 this.prototype.init || function() {};
-    // In Resig's simple class inheritance (previously used) the constructor
-    //  is a function that calls `this.init.apply(arguments)`
-    // However that would prevent us from using `ParentObject.call(this);`
-    //  in a Child constructor because the `this` in `this.init`
-    //  would still refer to the Child and cause an infinite loop.
-    // We would instead have to do
-    //    `ParentObject.prototype.init.apply(this, arguments);`
-    //  Bleh. We're not creating a _super() function, so it's good to keep
-    //  the parent constructor reference simple.
-    const subObj = function() {
-      init.apply(this, arguments);
-    };
-
-    // Inherit from this object's prototype
-    subObj.prototype = Object.create(this.prototype);
-    // Reset the constructor property for subObj otherwise
-    // instances of subObj would have the constructor of the parent Object
-    subObj.prototype.constructor = subObj;
-
-    // Make the class extendable
-    subObj.extend = Component.extend;
-
-    // Extend subObj's prototype with functions and other properties from props
-    for (const name in props) {
-      if (props.hasOwnProperty(name)) {
-        subObj.prototype[name] = props[name];
-      }
-    }
-
-    return subObj;
-  }
 }
 
 Component.registerComponent('Component', Component);

--- a/src/js/extend.js
+++ b/src/js/extend.js
@@ -1,7 +1,4 @@
-import log from './utils/log';
-import {isObject} from './utils/obj';
-
-/**
+/*
  * @file extend.js
  * @module extend
  */
@@ -59,11 +56,7 @@ const extendFn = function(superClass, subClassMethods = {}) {
 
   let methods = {};
 
-  if (isObject(subClassMethods)) {
-    if (typeof subClassMethods.init === 'function') {
-      log.warn('Constructor logic via init() is deprecated; please use constructor() instead.');
-      subClassMethods.constructor = subClassMethods.init;
-    }
+  if (typeof subClassMethods === 'object') {
     if (subClassMethods.constructor !== Object.prototype.constructor) {
       subClass = subClassMethods.constructor;
     }


### PR DESCRIPTION
This removes the `Component.extend()` method entirely, which has been deprecated since 5.0. Additionally, it removes the deprecated support for an `init` method in `videojs.extend()`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Reviewed by Two Core Contributors

