### PR TITLE
Remove deprecation for a Button created with a non-button element

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -29,23 +29,13 @@ class Button extends ClickableComponent {
    *         The element that gets created.
    */
   createEl(tag = 'button', props = {}, attributes = {}) {
+    if (tag !== 'button') {
+      throw new Error('Buttons must be created with a "button" tag.');
+    }
+
     props = assign({
       className: this.buildCSSClass()
     }, props);
-
-    if (tag !== 'button') {
-      log.warn(`Creating a Button with an HTML element of ${tag} is deprecated; use ClickableComponent instead.`);
-
-      // Add properties for clickable element which is not a native HTML button
-      props = assign({
-        tabIndex: 0
-      }, props);
-
-      // Add ARIA attributes for clickable element which is not a native HTML button
-      attributes = assign({
-        role: 'button'
-      }, attributes);
-    }
 
     // Add attributes for button element
     attributes = assign({

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -16,8 +16,9 @@ class Button extends ClickableComponent {
   /**
    * Create the `Button`s DOM element.
    *
-   * @param {string} [tag=button]
-   *        Element's node type. e.g. 'button'
+   * @param {string} [tag="button"]
+   *        The element's node type. This argument is IGNORED: no matter what
+   *        is passed, it will always create a `button` element.
    *
    * @param {Object} [props={}]
    *        An object of properties that should be set on the element.
@@ -28,10 +29,8 @@ class Button extends ClickableComponent {
    * @return {Element}
    *         The element that gets created.
    */
-  createEl(tag = 'button', props = {}, attributes = {}) {
-    if (tag !== 'button') {
-      throw new Error('Buttons must be created with a "button" tag.');
-    }
+  createEl(tag, props = {}, attributes = {}) {
+    tag = 'button';
 
     props = assign({
       className: this.buildCSSClass()


### PR DESCRIPTION
Remove deprecation for a Button created with a non-button element - throw instead.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

