### PR TITLE
Add support for `addtrack` on edge even though it doesn't support `removetrack`

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -119,7 +119,10 @@ class Html5 extends Tech {
       this.on('loadstart', this[`removeOld${capitalType}Tracks_`]);
     });
 
-    if (this.featuresNativeTextTracks) {
+    //  edge only supports the `addtrack` event, so it
+    //  does not technically have native support, but we want to use the support
+    // that it does have.
+    if (this.featuresNativeTextTracks || browser.IS_EDGE) {
       if (crossoriginTracks) {
         log.warn(tsml`Text Tracks are being loaded from another origin but the crossorigin attribute isn't used.
             This may prevent text tracks from loading.`);
@@ -873,16 +876,12 @@ Html5.canControlPlaybackRate = function() {
 /**
  * Check to see if native `TextTrack`s are supported by this browser/device.
  *
- * edge only supports the `addtrack` event, so it
- * does not technically have native support, but we want to use the support
- * that it does have.
- *
  * @return {boolean}
  *         - True if native `TextTrack`s are supported.
  *         - False otherwise
  */
 Html5.supportsNativeTextTracks = function() {
-  return browser.IS_ANY_SAFARI || browser.IS_EDGE;
+  return browser.IS_ANY_SAFARI;
 };
 
 /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -873,12 +873,16 @@ Html5.canControlPlaybackRate = function() {
 /**
  * Check to see if native `TextTrack`s are supported by this browser/device.
  *
+ * edge only supports the `addtrack` event, so it
+ * does not technically have native support, but we want to use the support
+ * that it does have.
+ *
  * @return {boolean}
  *         - True if native `TextTrack`s are supported.
  *         - False otherwise
  */
 Html5.supportsNativeTextTracks = function() {
-  return browser.IS_ANY_SAFARI;
+  return browser.IS_ANY_SAFARI || browser.IS_EDGE;
 };
 
 /**


### PR DESCRIPTION
## Description
* Don't change `featuersNativeTextTracks` as it technically does not have the full feature
* Add a check for `browser.IS_EDGE` and proxyNativeTracks if we are on edge.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors

