### PR TITLE
Fix error in Fn.throttle that broke MouseTimeDisplay

### DIFF
--- a/src/js/utils/fn.js
+++ b/src/js/utils/fn.js
@@ -55,7 +55,7 @@ export const bind = function(context, fn, uid) {
  * @return {Function}
  */
 export const throttle = function(fn, wait) {
-  let last;
+  let last = Date.now();
 
   const throttled = function(...args) {
     const now = Date.now();

--- a/test/unit/utils/fn.test.js
+++ b/test/unit/utils/fn.test.js
@@ -1,7 +1,15 @@
 /* eslint-env qunit */
+import sinon from 'sinon';
 import * as Fn from '../../../src/js/utils/fn.js';
 
-QUnit.module('fn');
+QUnit.module('fn', {
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+  },
+  afterEach() {
+    this.clock.restore();
+  }
+});
 
 QUnit.test('should add context to a function', function(assert) {
   const newContext = { test: 'obj'};
@@ -11,4 +19,29 @@ QUnit.test('should add context to a function', function(assert) {
   const fdsa = Fn.bind(newContext, asdf);
 
   fdsa();
+});
+
+QUnit.test('should throttle functions properly', function(assert) {
+  const tester = sinon.spy();
+  const throttled = Fn.throttle(tester, 100);
+
+  // We must wait a full wait period before the function can be called.
+  this.clock.tick(100);
+  throttled();
+  throttled();
+  this.clock.tick(50);
+  throttled();
+
+  assert.strictEqual(tester.callCount, 1, 'the throttled function has been called the correct number of times');
+
+  this.clock.tick(50);
+  throttled();
+
+  assert.strictEqual(tester.callCount, 2, 'the throttled function has been called the correct number of times');
+
+  throttled();
+  this.clock.tick(100);
+  throttled();
+
+  assert.strictEqual(tester.callCount, 3, 'the throttled function has been called the correct number of times');
 });


### PR DESCRIPTION
## Description
This fixes a breakage in 5.14.0 of the MouseTimeDisplay UI that was caused by my work in 761b877626e9f056464f3ef12923d0bb768c276b

## Specific Changes proposed
- Make the `Fn.throttle` function actually work.
- Add a test to verify and verify manually (which I did).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

