### PR TITLE
tests: add Edge to browserstack tests

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -223,6 +223,7 @@ module.exports = function(grunt) {
       chrome_bs:    { browsers: ['chrome_bs'] },
       firefox_bs:   { browsers: ['firefox_bs'] },
       safari_bs:    { browsers: ['safari_bs'] },
+      edge_bs:      { browsers: ['edge_bs'] },
       ie11_bs:      { browsers: ['ie11_bs'] },
       ie10_bs:      { browsers: ['ie10_bs'] },
       ie9_bs:       { browsers: ['ie9_bs'] },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -144,7 +144,6 @@ function getCustomLaunchers(){
     edge_bs: {
       base: 'BrowserStack',
       browser: 'edge',
-      browser_version: '14',
       os: 'Windows',
       os_version: '10'
     },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -104,6 +104,7 @@ module.exports = function(config) {
         'chrome_bs',
         'firefox_bs',
         'safari_bs',
+        'edge_bs',
         'ie11_bs',
         'ie10_bs',
         'ie9_bs',
@@ -138,6 +139,14 @@ function getCustomLaunchers(){
       browser: 'safari',
       os: 'OS X',
       os_version: 'Yosemite'
+    },
+
+    edge_bs: {
+      base: 'BrowserStack',
+      browser: 'edge',
+      browser_version: '14',
+      os: 'Windows',
+      os_version: '10'
     },
 
     ie11_bs: {


### PR DESCRIPTION
## Description
Add Edge as a browser to run tests on in browserstack.
