### PR TITLE
Deprecate the use of `starttime` in player.js

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1271,12 +1271,14 @@ class Player extends Component {
    *
    * @fires Player#firstplay
    * @listens Tech#firstplay
+   * @deprecated In 6.0 passing the `starttime` option to the player will be deprecated
    * @private
    */
   handleTechFirstPlay_() {
     // If the first starttime attribute is specified
     // then we will start at the given offset in seconds
     if (this.options_.starttime) {
+      log.warn('Passing the `starttime` option to the player will be deprecated in 6.0');
       this.currentTime(this.options_.starttime);
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1271,7 +1271,7 @@ class Player extends Component {
    *
    * @fires Player#firstplay
    * @listens Tech#firstplay
-   * @deprecated In 6.0 passing the `starttime` option to the player will be deprecated
+   * @deprecated As of 6.0 passing the `starttime` option to the player will be deprecated
    * @private
    */
   handleTechFirstPlay_() {


### PR DESCRIPTION
## Description
Deprecate the use of `starttime` in player.js. It seems like the `startTime` option is actually used in flash so for the time being that will have to stay. Fixes #3781 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors

