### PR TITLE
fix: remove vjs-seeking on src change

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1077,6 +1077,7 @@ class Player extends Component {
     // TODO: Update to use `emptied` event instead. See #1277.
 
     this.removeClass('vjs-ended');
+    this.removeClass('vjs-seeking');
 
     // reset the error state
     this.error(null);


### PR DESCRIPTION
If you're in a seeking state and the source changed, we should no longer
be in a seeking state.

Fixes #3765.