### PR TITLE
Text track button does not hide after remove tracks

### DIFF
--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -38,14 +38,14 @@ class TextTrackButton extends TrackButton {
    *         Array of menu items that were created
    */
   createItems(items = []) {
-    // Add an OFF menu item to turn all tracks off
-    items.push(new OffTextTrackMenuItem(this.player_, {kind: this.kind_}));
-
     const tracks = this.player_.textTracks();
 
-    if (!tracks) {
+    if (!tracks || !tracks.length) {
       return items;
     }
+
+    // Add an OFF menu item to turn all tracks off
+    items.push(new OffTextTrackMenuItem(this.player_, {kind: this.kind_}));
 
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];


### PR DESCRIPTION
Hello! I write own tech that supports text tracks. How to clear text tracks, after load next source in player?

I try to remove **text** (upd) tracks like below:


```js
const tracks = player.textTracks();
tracks.tracks_.forEach(track => tracks.removeTrack_(track));
```

But `TextTrackButton` push OFF `item` for disabling any text tracks and return items with single element.

For the first displaying component it is work because in constructor of `TrackButton` it hides when length of items less than 2:

```js
if (this.items.length <= 1) {
  this.hide();
}
```

But when `TextTracks` updates in `MenuButton` it hides only when length of items is 0:

```js
if (this.items && this.items.length === 0) {
  this.hide();
} else if (this.items && this.items.length > 1) {
  this.show();
}
```

So I think it would better that `TextTrackButton` should return empty array of items if there are no tracks in player. This PR is just example solution.
