### PR TITLE
Log Levels

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -170,10 +170,10 @@ help but are outside of the scope of video.js.
 For content that must be highly secure [videojs-contrib-eme][eme] adds DRM support.
 
 ## Q: Can I turn off video.js logging?
-Yes! This can be achieved by adding the following code _before_ including video.js:
+Yes! This can be achieved by adding the following code _after_ including Video.js, but _before_ creating any player(s):
 
 ```js
-window.VIDEOJS_DEFAULT_LOG_LEVEL = 'off';
+videojs.log.level('off');
 ```
 
 ## Q: What is a plugin?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -169,6 +169,13 @@ help but are outside of the scope of video.js.
 
 For content that must be highly secure [videojs-contrib-eme][eme] adds DRM support.
 
+## Q: Can I turn off video.js logging?
+Yes! This can be achieved by adding the following code _before_ including video.js:
+
+```js
+window.VIDEOJS_DEFAULT_LOG_LEVEL = 'off';
+```
+
 ## Q: What is a plugin?
 
 A plugin is a group of reusable functionality that can be re-used by others. For instance a plugin could add
@@ -197,6 +204,15 @@ the [plugins guide][plugin-guide] for more information.
 ## Q: Where can I find a list of video.js skins?
 
 See the [video.js github wiki][skins-list].
+
+## Q: Can I disable the `<style>` elements video.js adds by default?
+Yes! You can add the following code _before_ including video.js:
+
+```js
+window.VIDEOJS_NO_DYNAMIC_STYLE = true;
+```
+
+For more information, see the [skins guide][skin-style-els].
 
 ## Q: Does video.js work as an audio only player?
 
@@ -307,3 +323,5 @@ Yes! Please [submit an issue or open a pull request][pr-issue-question] if this 
 [semver]: http://semver.org/
 
 [starter-example]: http://jsbin.com/axedog/edit?html,output
+
+[skin-style-els]: /docs/guides/skins.md#additional-style-elements

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -205,15 +205,6 @@ the [plugins guide][plugin-guide] for more information.
 
 See the [video.js github wiki][skins-list].
 
-## Q: Can I disable the `<style>` elements video.js adds by default?
-Yes! You can add the following code _before_ including video.js:
-
-```js
-window.VIDEOJS_NO_DYNAMIC_STYLE = true;
-```
-
-For more information, see the [skins guide][skin-style-els].
-
 ## Q: Does video.js work as an audio only player?
 
 Yes! It can be used to play audio only files in a `<video>` or `<audio>` tag. The
@@ -323,5 +314,3 @@ Yes! Please [submit an issue or open a pull request][pr-issue-question] if this 
 [semver]: http://semver.org/
 
 [starter-example]: http://jsbin.com/axedog/edit?html,output
-
-[skin-style-els]: /docs/guides/skins.md#additional-style-elements

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,7 @@
   * [Q: How can I autoplay a video on a mobile device?](#q-how-can-i-autoplay-a-video-on-a-mobile-device)
 * [Q: How can I play RTMP video in video.js?](#q-how-can-i-play-rtmp-video-in-videojs)
 * [Q: How can I hide the links to my video/subtitles/audio/tracks?](#q-how-can-i-hide-the-links-to-my-videosubtitlesaudiotracks)
+* [Q: Can I turn off video.js logging?](#q-can-i-turn-off-videojs-logging)
 * [Q: What is a plugin?](#q-what-is-a-plugin)
 * [Q: How do I make a plugin for video.js?](#q-how-do-i-make-a-plugin-for-videojs)
 * [Q: Where can I find a list of video.js plugins?](#q-where-can-i-find-a-list-of-videojs-plugins)
@@ -170,11 +171,14 @@ help but are outside of the scope of video.js.
 For content that must be highly secure [videojs-contrib-eme][eme] adds DRM support.
 
 ## Q: Can I turn off video.js logging?
+
 Yes! This can be achieved by adding the following code _after_ including Video.js, but _before_ creating any player(s):
 
 ```js
 videojs.log.level('off');
 ```
+
+For more information, including which logging levels are available, check out the [debugging guide][debug-guide].
 
 ## Q: What is a plugin?
 
@@ -314,3 +318,5 @@ Yes! Please [submit an issue or open a pull request][pr-issue-question] if this 
 [semver]: http://semver.org/
 
 [starter-example]: http://jsbin.com/axedog/edit?html,output
+
+[debug-guide]: ./guides/debug.md

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,0 +1,111 @@
+# Debugging
+
+## Table of Contents
+
+* [Logging](#logging)
+  * [API Overview](#api-overview)
+  * [Log Safely](#log-safely)
+  * [Log Objects Usefully](#log-objects-usefully)
+  * [Log Levels](#log-levels)
+  * [History](#history)
+
+## Logging
+
+Video.js includes a lightweight wrapper - `videojs.log` - around a subset of [the `console` API][console]. The available methods are `videojs.log`, `videojs.log.warn`, and `videojs.log.error`.
+
+### API Overview
+
+Most of these methods should be fairly self-explanatory, but for complete details, see [the API docs][api].
+
+| Method                          | Alias Of        | Matching Level(s) |
+| ------------------------------- | --------------- | ----------------- |
+| `videojs.log()`                 | `console.log`   | all               |
+| `videojs.log.warn()`            | `console.warn`  | all, warn         |
+| `videojs.log.error()`           | `console.error` | all, warn, error  |
+| `videojs.log.level()`           | n/a             | n/a               |
+| `videojs.log.history()`         | n/a             | n/a               |
+| `videojs.log.history.clear()`   | n/a             | n/a               |
+| `videojs.log.history.disable()` | n/a             | n/a               |
+| `videojs.log.history.enable()`  | n/a             | n/a               |
+
+For descriptions of these features, please refer to the sections below.
+
+### Log Safely
+
+Unlike the `console`, it's safe to leave `videojs.log` calls in your code. They won't throw errors when the `console` doesn't exist.
+
+### Log Objects Usefully
+
+Similar to the `console`, any number of mixed-type values can be passed to `videojs.log` methods:
+
+```js
+videojs.log('this is a string', {butThis: 'is an object'});
+```
+
+However, certain browser consoles (namely, IE10 and lower) do not support non-string values. Video.js improves on this situation by passing objects through `JSON.stringify` before logging them in IE10 and below. In other words, instead of the above producing this:
+
+```txt
+VIDEOJS: this is a string [object Object]
+```
+
+it will produce this:
+
+```txt
+VIDEOJS: this is a string {"butThis": "is an object"}
+```
+
+### Log Levels
+
+Unlike the `console`, `videojs.log` includes the concept of logging levels. These levels toggle logging methods on or off.
+
+Levels are exposed through the `videojs.log.level` method. This method acts as both a getter and setter for the current logging level. With no arguments, it returns the current logging level:
+
+```js
+videojs.log.level(); // "all"
+```
+
+By passing a string, the logging level can be changed to one of the available logging levels:
+
+```js
+videojs.log.level('error'); // show only error messages and suppress others
+videojs.log('foo'); // does nothing
+videojs.log.warn('foo'); // does nothing
+videojs.log.error('foo'); // logs "foo" as an error
+```
+
+Available logging levels are:
+
+* **all** (default): enables all logging methods
+* **error**: only show `log.error` messages
+* **off**: disable all logging methods
+* **warn**: only show `log.warn` _and_ `log.error` messages
+
+### History
+
+> **Note:** In Video.js 5, `videojs.log.history` was an array. As of Video.js 6, it is a function which returns an array. This change was made to provide a richer, safer logging history API.
+
+By default, the `videojs.log` module tracks a history of _everything_ passed to it regardless of logging level:
+
+```js
+videojs.log.history(); // an array of everything that's been logged up to now
+```
+
+This will work even when logging is set to **off**.
+
+This can be useful, but it can also be a source of memory leaks. For example, logged objects will be retained in history even if references are removed everywhere else!
+
+To avoid this problem, history can be disabled or enabled via method calls (using the `disable` and `enable` methods respectively). Disabling history is as easy as:
+
+```js
+videojs.log.history.disable();
+```
+
+Finally, the history (if enabled) can be cleared at any time via:
+
+```js
+videojs.log.history.clear();
+```
+
+[api]: http://docs.videojs.com/docs/api/index.html
+
+[console]: https://developer.mozilla.org/en-US/docs/Web/API/Console

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -7,6 +7,7 @@
   * [Log Safely](#log-safely)
   * [Log Objects Usefully](#log-objects-usefully)
   * [Log Levels](#log-levels)
+  * [Available Log Levels](#available-log-levels)
   * [History](#history)
 
 ## Logging
@@ -73,7 +74,7 @@ videojs.log.warn('foo'); // does nothing
 videojs.log.error('foo'); // logs "foo" as an error
 ```
 
-Available logging levels are:
+### Available Log Levels
 
 * **all** (default): enables all logging methods
 * **error**: only show `log.error` messages

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -178,10 +178,10 @@ if (Object.defineProperty) {
  * {@link log.levels} is provided, acts as a setter. Regardless of argument,
  * returns the current logging level.
  *
- * @param  {String} [lvl]
+ * @param  {string} [lvl]
  *         Pass to set a new logging level.
  *
- * @return {String}
+ * @return {string}
  *         The current logging level.
  */
 log.level = (lvl) => {

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -9,7 +9,7 @@ import {isObject} from './obj';
 let log;
 
 // This is the private tracking variable for logging level.
-let level;
+let level = 'all';
 
 /**
  * Log messages to the console and history based on the type of message
@@ -124,54 +124,14 @@ log.history = [];
  *
  * @type {Object}
  */
-log.levels = {};
-
-if (Object.defineProperties) {
-  Object.defineProperties(log.levels, {
-    all: {
-      enumerable: true,
-      value: 'log|warn|error'
-    },
-    error: {
-      enumerable: true,
-      value: 'error'
-    },
-    log: {
-      enumerable: true,
-      value: 'log'
-    },
-    off: {
-      enumerable: true,
-      value: ''
-    },
-    warn: {
-      enumerable: true,
-      value: 'warn|error'
-    }
-  });
-} else {
-  log.levels = {
-    all: 'log|warn|error',
-    error: 'error',
-    log: 'log',
-    off: '',
-    warn: 'warn|error'
-  };
-}
-
-// Determine the default logging level.
-level = 'all';
-
-if (window.VIDEOJS_DEFAULT_LOG_LEVEL &&
-    log.levels.hasOwnProperty(window.VIDEOJS_DEFAULT_LOG_LEVEL)) {
-  level = window.VIDEOJS_DEFAULT_LOG_LEVEL;
-}
-
-if (Object.defineProperty) {
-  Object.defineProperty(log.levels, 'DEFAULT', {value: level});
-} else {
-  log.levels.DEFAULT = level;
-}
+log.levels = {
+  all: 'log|warn|error',
+  error: 'error',
+  log: 'log',
+  off: '',
+  warn: 'warn|error',
+  DEFAULT: level
+};
 
 /**
  * Get or set the current logging level. If a string matching a key from

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -9,7 +9,7 @@ import {isObject} from './obj';
 let log;
 
 // This is the private tracking variable for logging level.
-let level = 'all';
+let level;
 
 /**
  * Log messages to the console and history based on the type of message
@@ -158,6 +158,9 @@ if (Object.defineProperties) {
     warn: 'warn|error'
   };
 }
+
+// Determine the default logging level.
+level = 'all';
 
 if (window.VIDEOJS_DEFAULT_LOG_LEVEL &&
     log.levels.hasOwnProperty(window.VIDEOJS_DEFAULT_LOG_LEVEL)) {

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -127,7 +127,7 @@ QUnit.test('setting the log level changes what is actually logged', function(ass
 
   assert.throws(
     () => log.level('foobar'),
-    new Error(`"foobar" in not a valid log level. try one of: "${Object.keys(log.levels).join('", "')}"`),
+    new Error('"foobar" in not a valid log level'),
     'log.level() only accepts valid log levels when used as a setter'
   );
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -124,4 +124,10 @@ QUnit.test('setting the log level changes what is actually logged', function(ass
   assert.notOk(window.console.log.called, 'console.log was not called');
   assert.notOk(window.console.warn.called, 'console.warn was not called');
   assert.strictEqual(window.console.error.callCount, 1, 'console.error was not called again');
+
+  assert.throws(
+    () => log.level('foobar'),
+    new Error(`"foobar" in not a valid log level. try one of: "${Object.keys(log.levels).join('", "')}"`),
+    'log.level() only accepts valid log levels when used as a setter'
+  );
 });

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -5,7 +5,7 @@ import {logByType} from '../../../src/js/utils/log.js';
 import window from 'global/window';
 import sinon from 'sinon';
 
-QUnit.module('log', {
+QUnit.module('utils/log', {
 
   beforeEach() {
 
@@ -33,7 +33,7 @@ QUnit.module('log', {
     log.level(log.levels.DEFAULT);
 
     // Empty the logger's history.
-    log.history.length = 0;
+    log.history.clear();
   }
 });
 
@@ -44,7 +44,7 @@ QUnit.test('logging functions should work', function(assert) {
 
   // Need to reset history here because there are extra messages logged
   // when running via Karma.
-  log.history.length = 0;
+  log.history.clear();
 
   log('log1', 'log2');
   log.warn('warn1', 'warn2');
@@ -68,17 +68,19 @@ QUnit.test('logging functions should work', function(assert) {
     getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2')
   );
 
-  assert.equal(log.history.length, 3, 'there should be three messages in the log history');
-  assert.deepEqual(log.history[0], ['log1', 'log2'], 'history recorded the correct arguments');
-  assert.deepEqual(log.history[1], ['WARN:', 'warn1', 'warn2'], 'history recorded the correct arguments');
-  assert.deepEqual(log.history[2], ['ERROR:', 'error1', 'error2'], 'history recorded the correct arguments');
+  const history = log.history();
+
+  assert.equal(history.length, 3, 'there should be three messages in the log history');
+  assert.deepEqual(history[0], ['log1', 'log2'], 'history recorded the correct arguments');
+  assert.deepEqual(history[1], ['WARN:', 'warn1', 'warn2'], 'history recorded the correct arguments');
+  assert.deepEqual(history[2], ['ERROR:', 'error1', 'error2'], 'history recorded the correct arguments');
 });
 
 QUnit.test('in IE pre-11 (or when requested) objects and arrays are stringified', function(assert) {
 
   // Need to reset history here because there are extra messages logged
   // when running via Karma.
-  log.history.length = 0;
+  log.history.clear();
 
   // Run a custom log call, explicitly requesting object/array stringification.
   logByType('log', [
@@ -99,7 +101,7 @@ QUnit.test('setting the log level changes what is actually logged', function(ass
 
   // Need to reset history here because there are extra messages logged
   // when running via Karma.
-  log.history.length = 0;
+  log.history.clear();
 
   log.level('error');
 
@@ -111,9 +113,11 @@ QUnit.test('setting the log level changes what is actually logged', function(ass
   assert.notOk(window.console.warn.called, 'console.warn was not called');
   assert.ok(window.console.error.called, 'console.error was called');
 
-  assert.deepEqual(log.history[0], ['log1', 'log2'], 'history is maintained even when logging is not performed');
-  assert.deepEqual(log.history[1], ['WARN:', 'warn1', 'warn2'], 'history is maintained even when logging is not performed');
-  assert.deepEqual(log.history[2], ['ERROR:', 'error1', 'error2'], 'history is maintained even when logging is not performed');
+  const history = log.history();
+
+  assert.deepEqual(history[0], ['log1', 'log2'], 'history is maintained even when logging is not performed');
+  assert.deepEqual(history[1], ['WARN:', 'warn1', 'warn2'], 'history is maintained even when logging is not performed');
+  assert.deepEqual(history[2], ['ERROR:', 'error1', 'error2'], 'history is maintained even when logging is not performed');
 
   log.level('off');
 
@@ -130,4 +134,29 @@ QUnit.test('setting the log level changes what is actually logged', function(ass
     new Error('"foobar" in not a valid log level'),
     'log.level() only accepts valid log levels when used as a setter'
   );
+});
+
+QUnit.test('history can be enabled/disabled', function(assert) {
+
+  // Need to reset history here because there are extra messages logged
+  // when running via Karma.
+  log.history.clear();
+
+  log.history.disable();
+  log('log1');
+  log.warn('warn1');
+  log.error('error1');
+
+  let history = log.history();
+
+  assert.strictEqual(history.length, 0, 'no history was tracked');
+
+  log.history.enable();
+  log('log1');
+  log.warn('warn1');
+  log.error('error1');
+
+  history = log.history();
+
+  assert.strictEqual(history.length, 3, 'history was tracked');
 });


### PR DESCRIPTION
## Description
This adds support for log levels to video.js' logger. Log levels act as a whitelist of logger method(s) that are allowed. The following levels are defined here:

* `off`: Matches none. Any value that can be cast to `false` will have this effect. The most restrictive.
* `all` (default): Matches all Video.js-provided functions (`log`, `log.warn`, and `log.error`).
* `warn`: Matches `log.warn` and `log.error` calls.
* `error`: Matches only `log.error` calls.

Also, this improves the `log.history` handling with the ability to `clear()` it as well as toggle it off and on using `disable()` and `enable()`.

## Specific Changes proposed
- Adds the `log.level()` method which is a getter/setter for log levels.
- Adds the `log.levels` object as a container for the various logging levels.
- **BREAKING CHANGE:** `log.history` is now a function that returns a shallow clone of the internal history array rather than the array itself.
- Adds the `log.history.clear`, `log.history.disable`, `log.history.enable` methods.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors

