### PR TITLE
feat(player): ingest a player div for videojs

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -490,8 +490,15 @@ class Player extends Component {
    *         The DOM element that gets created.
    */
   createEl() {
-    const el = this.el_ = super.createEl('div');
     const tag = this.tag;
+    let el;
+    const playerElIngest = this.playerElIngest_ = tag.parentNode.hasAttribute('data-vjs-player');
+
+    if (playerElIngest) {
+      el = this.el_ = tag.parentNode;
+    } else {
+      el = this.el_ = super.createEl('div');
+    }
 
     // Remove width/height attrs from tag so CSS can make it 100% width/height
     tag.removeAttribute('width');
@@ -505,7 +512,7 @@ class Player extends Component {
       // workaround so we don't totally break IE7
       // http://stackoverflow.com/questions/3653444/css-styles-not-applied-on-dynamic-elements-in-internet-explorer-7
       if (attr === 'class') {
-        el.className = attrs[attr];
+        el.className += ' ' + attrs[attr];
       } else {
         el.setAttribute(attr, attrs[attr]);
       }
@@ -555,7 +562,7 @@ class Player extends Component {
     tag.initNetworkState_ = tag.networkState;
 
     // Wrap video tag in div (el/box) container
-    if (tag.parentNode) {
+    if (tag.parentNode && !playerElIngest) {
       tag.parentNode.insertBefore(el, tag);
     }
 
@@ -836,6 +843,7 @@ class Player extends Component {
       'muted': this.options_.muted,
       'poster': this.poster(),
       'language': this.language(),
+      'playerElIngest': this.playerElIngest_,
       'vtt.js': this.options_['vtt.js']
     }, this.options_[techName.toLowerCase()]);
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -492,7 +492,7 @@ class Player extends Component {
   createEl() {
     const tag = this.tag;
     let el;
-    const playerElIngest = this.playerElIngest_ = tag.parentNode.hasAttribute('data-vjs-player');
+    const playerElIngest = this.playerElIngest_ = tag.parentNode && tag.parentNode.hasAttribute('data-vjs-player');
 
     if (playerElIngest) {
       el = this.el_ = tag.parentNode;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -843,7 +843,7 @@ class Player extends Component {
       'muted': this.options_.muted,
       'poster': this.poster(),
       'language': this.language(),
-      'playerElIngest': this.playerElIngest_,
+      'playerElIngest': this.playerElIngest_ || false,
       'vtt.js': this.options_['vtt.js']
     }, this.options_[techName.toLowerCase()]);
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -185,7 +185,8 @@ class Html5 extends Tech {
     // Check if this browser supports moving the element into the box.
     // On the iPhone video will break if you move the element,
     // So we have to create a brand new element.
-    if (!el || this.movingMediaElementInDOM === false) {
+    // If we ingested the player div, we do not need to move the media element.
+    if (!el || !this.options_.playerElIngest || this.movingMediaElementInDOM === false) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -187,8 +187,8 @@ class Html5 extends Tech {
     // So we have to create a brand new element.
     // If we ingested the player div, we do not need to move the media element.
     if (!el ||
-        ('playerElIngest' in this.options_ && !this.options_.playerElIngest) ||
-        this.movingMediaElementInDOM === false) {
+        !(this.options_.playerElIngest ||
+          this.movingMediaElementInDOM)) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -194,9 +194,12 @@ class Html5 extends Tech {
       if (el) {
         const clone = el.cloneNode(true);
 
-        el.parentNode.insertBefore(clone, el);
+        if (el.parentNode) {
+          el.parentNode.insertBefore(clone, el);
+        }
         Html5.disposeMediaElement(el);
         el = clone;
+
       } else {
         el = document.createElement('video');
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -186,7 +186,9 @@ class Html5 extends Tech {
     // On the iPhone video will break if you move the element,
     // So we have to create a brand new element.
     // If we ingested the player div, we do not need to move the media element.
-    if (!el || !this.options_.playerElIngest || this.movingMediaElementInDOM === false) {
+    if (!el ||
+        ('playerElIngest' in this.options_ && !this.options_.playerElIngest) ||
+        this.movingMediaElementInDOM === false) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -830,6 +830,93 @@ QUnit.test('should restore attributes from the original video tag when creating 
   assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
 });
 
+QUnit.test('if tag exists and movingMediaElementInDOM, re-use the tag', function(assert) {
+  // simulate attributes stored from the original tag
+  const tag = Dom.createEl('video');
+
+  tag.setAttribute('preload', 'auto');
+  tag.setAttribute('autoplay', '');
+  tag.setAttribute('webkit-playsinline', '');
+
+  const html5Mock = {
+    options_: {
+      tag,
+      playerElIngest: false
+    },
+    movingMediaElementInDOM: true
+  };
+
+  // set options that should override tag attributes
+  html5Mock.options_.preload = 'none';
+
+  // create the element
+  const el = Html5.prototype.createEl.call(html5Mock);
+
+  assert.equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
+  assert.equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
+  assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
+
+  assert.equal(el, tag, 'we have re-used the tag as expected');
+});
+
+QUnit.test('if tag exists and *not* movingMediaElementInDOM, create a new tag', function(assert) {
+  // simulate attributes stored from the original tag
+  const tag = Dom.createEl('video');
+
+  tag.setAttribute('preload', 'auto');
+  tag.setAttribute('autoplay', '');
+  tag.setAttribute('webkit-playsinline', '');
+
+  const html5Mock = {
+    options_: {
+      tag,
+      playerElIngest: false
+    },
+    movingMediaElementInDOM: false
+  };
+
+  // set options that should override tag attributes
+  html5Mock.options_.preload = 'none';
+
+  // create the element
+  const el = Html5.prototype.createEl.call(html5Mock);
+
+  assert.equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
+  assert.equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
+  assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
+
+  assert.notEqual(el, tag, 'we have not re-used the tag as expected');
+});
+
+QUnit.test('if tag exists and *not* movingMediaElementInDOM, but playerElIngest re-use tag', function(assert) {
+  // simulate attributes stored from the original tag
+  const tag = Dom.createEl('video');
+
+  tag.setAttribute('preload', 'auto');
+  tag.setAttribute('autoplay', '');
+  tag.setAttribute('webkit-playsinline', '');
+
+  const html5Mock = {
+    options_: {
+      tag,
+      playerElIngest: true
+    },
+    movingMediaElementInDOM: false
+  };
+
+  // set options that should override tag attributes
+  html5Mock.options_.preload = 'none';
+
+  // create the element
+  const el = Html5.prototype.createEl.call(html5Mock);
+
+  assert.equal(el.getAttribute('preload'), 'none', 'attribute was successful overridden by an option');
+  assert.equal(el.getAttribute('autoplay'), '', 'autoplay attribute was set properly');
+  assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
+
+  assert.equal(el, tag, 'we have re-used the tag as expected');
+});
+
 QUnit.test('should honor default inactivity timeout', function(assert) {
   const clock = sinon.useFakeTimers();
 

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -224,7 +224,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   });
 
   assert.equal(player.el(), playerDiv, 'we re-used the given div');
-  assert.equal(player.tech_.el(), vid, 'we re-used the video element');
+  assert.equal(player.$('.vjs-tech'), vid, 'we re-used the video element');
   assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
 
   player.dispose();
@@ -256,7 +256,7 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   });
 
   assert.notEqual(player.el(), playerDiv, 'we used a new div');
-  assert.notEqual(player.tech_.el(), vid, 'we a new video element');
+  assert.notEqual(player.$('.vjs-tech'), vid, 'we a new video element');
 
   player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -204,6 +204,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   const Html5 = videojs.getTech('Html5');
   const oldIS = Html5.isSupported;
   const oldMoving = Html5.prototype.movingMediaElementInDOM;
+  const oldCPT = Html5.nativeSourceHandler.canPlayType;
   const fixture = document.querySelector('#qunit-fixture');
 
   fixture.innerHTML = `
@@ -215,6 +216,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   `;
   Html5.prototype.movingMediaElementInDOM = false;
   Html5.isSupported = () => true;
+  Html5.nativeSourceHandler.canPlayType = () => true;
 
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
@@ -224,17 +226,19 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   });
 
   assert.equal(player.el(), playerDiv, 'we re-used the given div');
-  assert.equal(player.$('.vjs-tech'), vid, 'we re-used the video element');
+  assert.equal(player.tech_.el(), vid, 'we re-used the video element');
   assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
 
   player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
   Html5.isSupported = oldIS;
+  Html5.nativeSourceHandler.canPlayType = oldCPT;
 });
 
 QUnit.test('should create a new tag for movingMediaElementInDOM', function(assert) {
   const Html5 = videojs.getTech('Html5');
   const oldMoving = Html5.prototype.movingMediaElementInDOM;
+  const oldCPT = Html5.nativeSourceHandler.canPlayType;
   const fixture = document.querySelector('#qunit-fixture');
   const oldIS = Html5.isSupported;
 
@@ -247,6 +251,7 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   `;
   Html5.prototype.movingMediaElementInDOM = false;
   Html5.isSupported = () => true;
+  Html5.nativeSourceHandler.canPlayType = () => true;
 
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
@@ -256,9 +261,10 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   });
 
   assert.notEqual(player.el(), playerDiv, 'we used a new div');
-  assert.notEqual(player.$('.vjs-tech'), vid, 'we a new video element');
+  assert.notEqual(player.tech_.el(), vid, 'we a new video element');
 
   player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
   Html5.isSupported = oldIS;
+  Html5.nativeSourceHandler.canPlayType = oldCPT;
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -40,6 +40,9 @@ QUnit.test('should return a video player instance', function(assert) {
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
   assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
+
+  player.dispose();
+  player2.dispose();
 });
 
 QUnit.test('should return a video player instance from el html5 tech', function(assert) {
@@ -66,6 +69,9 @@ QUnit.test('should return a video player instance from el html5 tech', function(
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
   assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
+
+  player.dispose();
+  player2.dispose();
 });
 
 QUnit.test('should return a video player instance from el techfaker', function(assert) {
@@ -91,6 +97,9 @@ QUnit.test('should return a video player instance from el techfaker', function(a
   const player2 = videojs(tag2, { techOrder: ['techFaker'] });
 
   assert.ok(player2.id() === 'test_vid_id2', 'created player from element');
+
+  player.dispose();
+  player2.dispose();
 });
 
 QUnit.test('should add the value to the languages object', function(assert) {

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -173,7 +173,7 @@ QUnit.test('ingest player div if data-vjs-player attribute is present on video p
   fixture.innerHTML = `
     <div data-vjs-player class="foo">
       <video id="test_vid_id">
-        <source type="video/mp4"></source>
+        <source src="http://example.com/video.mp4" type="video/mp4"></source>
       </video>
     </div>
   `;
@@ -187,6 +187,8 @@ QUnit.test('ingest player div if data-vjs-player attribute is present on video p
 
   assert.equal(player.el(), playerDiv, 'we re-used the given div');
   assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
+
+  player.dispose();
 });
 
 QUnit.test('ingested player div should not create a new tag for movingMediaElementInDOM', function(assert) {
@@ -197,7 +199,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   fixture.innerHTML = `
     <div data-vjs-player class="foo">
       <video id="test_vid_id">
-        <source type="video/mp4"></source>
+        <source src="http://example.com/video.mp4" type="video/mp4"></source>
       </video>
     </div>
   `;
@@ -214,6 +216,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   assert.equal(player.tech_.el(), vid, 'we re-used the video element');
   assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
 
+  player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
 });
 
@@ -225,7 +228,7 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   fixture.innerHTML = `
     <div class="foo">
       <video id="test_vid_id">
-        <source type="video/mp4"></source>
+        <source src="http://example.com/video.mp4" type="video/mp4"></source>
       </video>
     </div>
   `;
@@ -241,5 +244,6 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   assert.notEqual(player.el(), playerDiv, 'we used a new div');
   assert.notEqual(player.tech_.el(), vid, 'we a new video element');
 
+  player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -181,7 +181,9 @@ QUnit.test('ingest player div if data-vjs-player attribute is present on video p
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
 
-  const player = videojs(vid, {});
+  const player = videojs(vid, {
+    techOrder: ['html5']
+  });
 
   assert.equal(player.el(), playerDiv, 'we re-used the given div');
   assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
@@ -204,7 +206,9 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
 
-  const player = videojs(vid, {});
+  const player = videojs(vid, {
+    techOrder: ['html5']
+  });
 
   assert.equal(player.el(), playerDiv, 'we re-used the given div');
   assert.equal(player.tech_.el(), vid, 'we re-used the video element');
@@ -230,7 +234,9 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
 
-  const player = videojs(vid, {});
+  const player = videojs(vid, {
+    techOrder: ['html5']
+  });
 
   assert.notEqual(player.el(), playerDiv, 'we used a new div');
   assert.notEqual(player.tech_.el(), vid, 'we a new video element');

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -193,6 +193,7 @@ QUnit.test('ingest player div if data-vjs-player attribute is present on video p
 
 QUnit.test('ingested player div should not create a new tag for movingMediaElementInDOM', function(assert) {
   const Html5 = videojs.getTech('Html5');
+  const oldIS = Html5.isSupported;
   const oldMoving = Html5.prototype.movingMediaElementInDOM;
   const fixture = document.querySelector('#qunit-fixture');
 
@@ -204,6 +205,7 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
     </div>
   `;
   Html5.prototype.movingMediaElementInDOM = false;
+  Html5.isSupported = () => true;
 
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
@@ -218,12 +220,14 @@ QUnit.test('ingested player div should not create a new tag for movingMediaEleme
 
   player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
+  Html5.isSupported = oldIS;
 });
 
 QUnit.test('should create a new tag for movingMediaElementInDOM', function(assert) {
   const Html5 = videojs.getTech('Html5');
   const oldMoving = Html5.prototype.movingMediaElementInDOM;
   const fixture = document.querySelector('#qunit-fixture');
+  const oldIS = Html5.isSupported;
 
   fixture.innerHTML = `
     <div class="foo">
@@ -233,6 +237,7 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
     </div>
   `;
   Html5.prototype.movingMediaElementInDOM = false;
+  Html5.isSupported = () => true;
 
   const playerDiv = document.querySelector('.foo');
   const vid = document.querySelector('#test_vid_id');
@@ -246,4 +251,5 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
 
   player.dispose();
   Html5.prototype.movingMediaElementInDOM = oldMoving;
+  Html5.isSupported = oldIS;
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -166,3 +166,74 @@ QUnit.test('should expose DOM functions', function(assert) {
                       `videojs.${vjsName} is a reference to Dom.${domName}`);
   });
 });
+
+QUnit.test('ingest player div if data-vjs-player attribute is present on video parentNode', function(assert) {
+  const fixture = document.querySelector('#qunit-fixture');
+
+  fixture.innerHTML = `
+    <div data-vjs-player class="foo">
+      <video id="test_vid_id">
+        <source type="video/mp4"></source>
+      </video>
+    </div>
+  `;
+
+  const playerDiv = document.querySelector('.foo');
+  const vid = document.querySelector('#test_vid_id');
+
+  const player = videojs(vid, {});
+
+  assert.equal(player.el(), playerDiv, 'we re-used the given div');
+  assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
+});
+
+QUnit.test('ingested player div should not create a new tag for movingMediaElementInDOM', function(assert) {
+  const Html5 = videojs.getTech('Html5');
+  const oldMoving = Html5.prototype.movingMediaElementInDOM;
+  const fixture = document.querySelector('#qunit-fixture');
+
+  fixture.innerHTML = `
+    <div data-vjs-player class="foo">
+      <video id="test_vid_id">
+        <source type="video/mp4"></source>
+      </video>
+    </div>
+  `;
+  Html5.prototype.movingMediaElementInDOM = false;
+
+  const playerDiv = document.querySelector('.foo');
+  const vid = document.querySelector('#test_vid_id');
+
+  const player = videojs(vid, {});
+
+  assert.equal(player.el(), playerDiv, 'we re-used the given div');
+  assert.equal(player.tech_.el(), vid, 'we re-used the video element');
+  assert.ok(player.hasClass('foo'), 'keeps any classes that were around previously');
+
+  Html5.prototype.movingMediaElementInDOM = oldMoving;
+});
+
+QUnit.test('should create a new tag for movingMediaElementInDOM', function(assert) {
+  const Html5 = videojs.getTech('Html5');
+  const oldMoving = Html5.prototype.movingMediaElementInDOM;
+  const fixture = document.querySelector('#qunit-fixture');
+
+  fixture.innerHTML = `
+    <div class="foo">
+      <video id="test_vid_id">
+        <source type="video/mp4"></source>
+      </video>
+    </div>
+  `;
+  Html5.prototype.movingMediaElementInDOM = false;
+
+  const playerDiv = document.querySelector('.foo');
+  const vid = document.querySelector('#test_vid_id');
+
+  const player = videojs(vid, {});
+
+  assert.notEqual(player.el(), playerDiv, 'we used a new div');
+  assert.notEqual(player.tech_.el(), vid, 'we a new video element');
+
+  Html5.prototype.movingMediaElementInDOM = oldMoving;
+});


### PR DESCRIPTION
If the videojs embed code (a video element) is wrapped in a div with the
'data-vjs-player' attribute on it, that element will be used for the
player div and a new one will not be created. In addition, on browsers
like iOS that don't support moving the media element inside the DOM, we
will not need to clone the element and we could continue to re-use the
same video element give to us in the embed code.

This could also be extended in the future to change our embed code to a
div-only approach if we so choose.