### PR TITLE
test: stub/restore window.console properly

### DIFF
--- a/test/unit/plugins.test.js
+++ b/test/unit/plugins.test.js
@@ -178,6 +178,8 @@ QUnit.test('Plugins should not get events after stopImmediatePropagation is call
 
 QUnit.test('Plugin that does not exist logs an error', function(assert) {
 
+  const origConsole = window.console;
+
   // stub the global log functions
   const console = window.console = {
     log() {},
@@ -186,7 +188,6 @@ QUnit.test('Plugin that does not exist logs an error', function(assert) {
   };
   const log = sinon.stub(console, 'log');
   const error = sinon.stub(console, 'error');
-  const origConsole = window.console;
 
   // enable a non-existing plugin
   TestHelpers.makePlayer({


### PR DESCRIPTION
## Description
We were accidentally stubbing console.log forever in our tests.

## Specific Changes proposed
Move the storing of the default `window.console` to before we stub it out.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [x] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

