### PR TITLE
do not allow adding children with options passed in as a boolean

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -429,21 +429,6 @@ class Component {
     if (typeof child === 'string') {
       componentName = toTitleCase(child);
 
-      // Options can also be specified as a boolean,
-      // so convert to an empty object if false.
-      if (!options) {
-        options = {};
-      }
-
-      // Same as above, but true is deprecated so show a warning.
-      if (options === true) {
-        log.warn('Initializing a child component with `true` is deprecated.' +
-          'Children should be defined in an array when possible, ' +
-          'but if necessary use an object instead of `true`.'
-        );
-        options = {};
-      }
-
       const componentClassName = options.componentClass || componentName;
 
       // Set name through options


### PR DESCRIPTION
## Description
do not allow adding children with options passed in as a boolean


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors

