### PR TITLE
Correcting NativeControls + Taps.

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -146,8 +146,10 @@ class Tech extends Component {
     this.initTextTrackListeners();
     this.initTrackListeners();
 
-    // Turn on component tap events
-    this.emitTapEvents();
+    // Turn on component tap events only if not using native controls
+    if (!options.nativeControlsForTouch) {
+      this.emitTapEvents();
+    }
   }
 
   /* Fallbacks for unsupported event types


### PR DESCRIPTION
Skipping browser bugfix for changing cursor as that stops tap events
from propagating to native controls. Also enabled option that disables
converting events to 'tap'. The 'tap' event does not cause native
controls to appear on devices like android.

## Description
When using nativeControlsForTouch - taps appear to be stalled and don't go through to the native video element, therefore the controls never appear again when tapping as would be expected.  On Android you have to tap and hold to bring up the controls, which is not as users would typically expect.

Additionally, added option for disableEmitTapEvents which when enabled, doesn't attempt to convert / check taps and allows the browser to natively interpret taps as clicks instead.

## Specific Changes proposed
Added option disableEmitTapEvents to stop converting taps to manually.
Don't call stopPropagation and preventDefault on mousemove when TOUCH_ENABLED is true and we're using nativeControls.


This particular change has been in production for us for a while now as we rely on native controls for touch users.
