### PR TITLE
improve test for no tracks

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -462,7 +462,7 @@ class Tech extends Component {
 
     const tracks = this.textTracks();
 
-    if (!tracks) {
+    if (!tracks || !tracks.length) {
       return;
     }
 
@@ -564,7 +564,7 @@ class Tech extends Component {
   emulateTextTracks() {
     const tracks = this.textTracks();
 
-    if (!tracks) {
+    if (!tracks || !tracks.length) {
       return;
     }
 


### PR DESCRIPTION
## Description
Bug Fix:
textTracks() returns an object, therefore previous test was truthy if it returned successfully. Need to test the length of the returned object to correctly identify if we have tracks or not.

should help with: [https://github.com/videojs/video.js/issues/2135](https://github.com/videojs/video.js/issues/2135)

However above may have other issues which occur when player does utilise tracks

## Specific Changes proposed
Improve test for tracks to utilise the length property returned by `this.textTracks()`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
