### PR TITLE
fix(seeking): don't always pause in mouse down

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -127,7 +127,10 @@ class SeekBar extends Slider {
     this.player_.scrubbing(true);
 
     this.videoWasPlaying = !this.player_.paused();
-    this.player_.pause();
+
+    this.pauseTimer_ = this.setTimeout(function() {
+      this.player_.pause();
+    }, 100);
   }
 
   /**
@@ -148,6 +151,11 @@ class SeekBar extends Slider {
 
     // Set new time (tell player to seek to new time)
     this.player_.currentTime(newTime);
+
+    if (event.type === 'mousemove') {
+      this.clearTimeout(this.pauseTimer_);
+      this.player_.pause();
+    }
   }
 
   /**
@@ -160,6 +168,8 @@ class SeekBar extends Slider {
    */
   handleMouseUp(event) {
     super.handleMouseUp(event);
+
+    this.clearTimeout(this.pauseTimer_);
 
     this.player_.scrubbing(false);
     if (this.videoWasPlaying) {


### PR DESCRIPTION
In chrome 55, something changed which introduced a bug in videojs where
if you seeked back, it wouldn't work. This is because we always paused
the video in the mousedown handler.

Instead, we should create a timer for pausing that is cleared in the
mouseup handler or in the mouse move handler. This is so that if someone
is seeking by clicking and waiting the video pauses. As soon as we start
moving and we get a mousemove event, we can know that it's safe to pause
as well.

Fixes #3839.