### PR TITLE
Fix extra warn logs on already initialized player references

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -80,7 +80,7 @@ function videojs(id, options, ready) {
     if (videojs.getPlayers()[id]) {
 
       // If options or ready funtion are passed, warn
-      if (options) {
+      if (Object.keys(options).length) {
         log.warn(`Player "${id}" is already initialised. Options will not be applied.`);
       }
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -65,8 +65,6 @@ if (typeof HTMLVideoElement === 'undefined' &&
 function videojs(id, options, ready) {
   let tag;
 
-  options = options || {};
-
   // Allow for element or ID to be passed in
   // String ID
   if (typeof id === 'string') {
@@ -80,7 +78,7 @@ function videojs(id, options, ready) {
     if (videojs.getPlayers()[id]) {
 
       // If options or ready funtion are passed, warn
-      if (Object.keys(options).length) {
+      if (options) {
         log.warn(`Player "${id}" is already initialised. Options will not be applied.`);
       }
 
@@ -110,6 +108,8 @@ function videojs(id, options, ready) {
   if (tag.player || Player.players[tag.playerId]) {
     return tag.player || Player.players[tag.playerId];
   }
+
+  options = options || {};
 
   videojs.hooks('beforesetup').forEach(function(hookFunction) {
     const opts = hookFunction(tag, mergeOptions(options));

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -61,25 +61,27 @@ function(assert) {
   const player = videojs('test_vid_id', { techOrder: ['techFaker'] });
 
   assert.ok(player, 'created player from tag');
-  assert.ok(player.id() === 'test_vid_id');
-  assert.ok(!warnLogs.length, 'no warn logs');
+  assert.equal(player.id(), 'test_vid_id', 'player has the right ID');
+  assert.equal(warnLogs.length, 0, 'no warn logs');
 
   const playerAgain = videojs('test_vid_id');
 
-  assert.ok(player === playerAgain, 'did not create a second player from same tag');
-  assert.ok(!warnLogs.length, 'no warn logs');
+  assert.equal(player, playerAgain, 'did not create a second player from same tag');
+  assert.equal(warnLogs.length, 0, 'no warn logs');
 
   const playerAgainWithOptions = videojs('test_vid_id', { techOrder: ['techFaker'] });
 
-  assert.ok(player === playerAgainWithOptions,
-            'did not create a second player from same tag');
+  assert.equal(player,
+               playerAgainWithOptions,
+               'did not create a second player from same tag');
   assert.equal(warnLogs.length, 1, 'logged a warning');
   assert.equal(warnLogs[0],
-               'Player "test_vid_id" is already initialised. ' +
-                 'Options will not be applied.',
+               'Player "test_vid_id" is already initialised. Options will not be applied.',
                'logged the right message');
 
   log.warn = origWarnLog;
+
+  player.dispose();
 });
 
 QUnit.test('should return a video player instance from el html5 tech', function(assert) {


### PR DESCRIPTION
## Description
Extra warnings were being logged when getting a reference to a player via videojs('player_id').

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
