### PR TITLE
ignore: Prevent test failures in IE8

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1030,9 +1030,6 @@ const mpegurlRE = /^application\/(?:x-|vnd\.apple\.)mpegurl/i;
 const mp4RE = /^video\/mp4/i;
 
 Html5.patchCanPlayType = function() {
-  if (!canPlayType) {
-    return;
-  }
 
   // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
   if (browser.ANDROID_VERSION >= 4.0 && !browser.IS_FIREFOX) {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -61,7 +61,14 @@ function classRegExp(className) {
  * @return {Boolean}
  */
 export function isReal() {
-  return document === window.document && typeof document.createElement === 'function';
+  return (
+
+    // Both document and window will never be undefined thanks to `global`.
+    document === window.document &&
+
+    // In IE < 9, DOM methods return "object" as their type, so all we can
+    // confidently check is that it exists.
+    typeof document.createElement !== 'undefined');
 }
 
 /**


### PR DESCRIPTION
This prevents test failures (and fixes some issues introduced by the Node support PR) in IE8.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
