### PR TITLE
Show big play button on pause if specified

### DIFF
--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -50,3 +50,8 @@
 .vjs-error .vjs-big-play-button {
   display: none;
 }
+
+// Show big play button if video is paused and .vjs-show-big-play-button-on-pause is set on video element
+.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause .vjs-big-play-button{
+  display: block;
+}

--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -52,6 +52,6 @@
 }
 
 // Show big play button if video is paused and .vjs-show-big-play-button-on-pause is set on video element
-.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause .vjs-big-play-button{
+.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause .vjs-big-play-button {
   display: block;
 }


### PR DESCRIPTION
Show big play button if video is paused and
.vjs-show-big-play-button-on-pause is set on video element

## Description
If you pause a video-js video, the play button isn't shown like most users expect from UIs like youbtube or iPhone video behavior.
This patch implements a play button after pause if needed via an additional CSS class on the video-js video elemetn.

## Specific Changes proposed


## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
