### PR TITLE
chore: better dev experience

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -127,6 +127,15 @@ module.exports = function(grunt) {
     },
     dist: {},
     watch: {
+      dist: {
+        files: [
+          'build/temp/video.js',
+          'build/temp/alt/video.novtt.js',
+          'build/temp/video-js.css',
+          'build/temp/alt/video-js-cdn.css'
+        ],
+        tasks: ['copy:dist']
+      },
       novtt: {
         files: ['build/temp/video.js'],
         tasks: ['concat:novtt']
@@ -142,10 +151,6 @@ module.exports = function(grunt) {
       babel: {
         files: ['src/js/**/*.js'],
         tasks: ['babel:es5']
-      },
-      jshint: {
-        files: ['src/**/*', 'test/unit/**/*.js', 'Gruntfile.js'],
-        tasks: 'jshint'
       }
     },
     connect: {
@@ -405,6 +410,14 @@ module.exports = function(grunt) {
         'watch:babel',
         'browserify:tests'
       ],
+      dev: [
+        'browserify:watch',
+        'browserify:tests',
+        'watch:novtt',
+        'watch:skin',
+        'watch:dist',
+        'shell:babel'
+      ],
       // Run multiple watch tasks in parallel
       // Needed so watchify can cache intelligently
       watchAll: [
@@ -437,6 +450,12 @@ module.exports = function(grunt) {
       }
     },
     shell: {
+      babel: {
+        command: 'npm run babel -- --w',
+        options: {
+          preferLocal: true
+        }
+      },
       lint: {
         command: 'npm run lint',
         options: {
@@ -541,7 +560,7 @@ module.exports = function(grunt) {
     'test-a11y'].concat(process.env.TRAVIS && 'coveralls').filter(Boolean));
 
   // Run while developing
-  grunt.registerTask('dev', ['build', 'connect:dev', 'concurrent:watchSandbox']);
+  grunt.registerTask('dev', ['connect:dev', 'concurrent:dev']);
 
   grunt.registerTask('watchAll', ['build', 'connect:dev', 'concurrent:watchAll']);
 

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
     "clean": "grunt clean",
     "grunt": "grunt",
     "lint": "vjsstandard",
-    "start": "grunt watchAll",
+    "start": "grunt dev",
     "test": "grunt test",
     "docs": "npm run docs:lint && npm run docs:api",
     "docs:api": "jsdoc -r src/js -d docs/api -c .jsdoc.json",
     "docs:lint": "remark -- './**/*.md'",
-    "docs:fix": "remark --output -- './**/*.md'"
+    "docs:fix": "remark --output -- './**/*.md'",
+    "babel": "babel src/js -d es5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm start now runs `grunt dev` which in turn runs the connect server,
sets up babel watching, browserify watching (for both src and test
files), and css and alternate builds watching.

Additionally, it will copy over the dev build files into the dist folder
so that if you're linking videojs and you have a project that gets
video.js from the dist, you can link and develop with more easy without
rerunning all of `grunt dist` each time.

Additionally, this specifically does not run more time consumming
operations like minification.