### PR TITLE
remove special loadstart handling

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1122,38 +1122,12 @@ Tech.withSourceHandlers = function(_Tech) {
 
     if (sh !== _Tech.nativeSourceHandler) {
       this.currentSource_ = source;
-
-      // Catch if someone replaced the src without calling setSource.
-      // If they do, set currentSource_ to null and dispose our source handler.
-      this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
-      this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
-      this.one(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
     }
 
     this.sourceHandler_ = sh.handleSource(source, this, this.options_);
     this.on('dispose', this.disposeSourceHandler);
 
     return this;
-  };
-
-  /**
-   * Called once for the first loadstart of a video.
-   *
-   * @listens Tech#loadstart
-   */
-  _Tech.prototype.firstLoadStartListener_ = function() {
-    this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
-  };
-
-  // On successive loadstarts when setSource has not been called again
-  /**
-   * Called after the first loadstart for a video occurs.
-   *
-   * @listens Tech#loadstart
-   */
-  _Tech.prototype.successiveLoadStartListener_ = function() {
-    this.disposeSourceHandler();
-    this.one(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
   };
 
   /**
@@ -1174,8 +1148,6 @@ Tech.withSourceHandlers = function(_Tech) {
     this.cleanupAutoTextTracks();
 
     if (this.sourceHandler_) {
-      this.off(this.el_, 'loadstart', _Tech.prototype.firstLoadStartListener_);
-      this.off(this.el_, 'loadstart', _Tech.prototype.successiveLoadStartListener_);
 
       if (this.sourceHandler_.dispose) {
         this.sourceHandler_.dispose();

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -506,50 +506,6 @@ QUnit.test('Tech.isTech returns correct answers for techs and components', funct
   assert.ok(!isTech(isTech), 'A function is not a Tech');
 });
 
-QUnit.test('Tech#setSource clears currentSource_ after repeated loadstart', function(assert) {
-  let disposed = false;
-  const MyTech = extendFn(Tech);
-
-  Tech.withSourceHandlers(MyTech);
-  const tech = new MyTech();
-
-  const sourceHandler = {
-    canPlayType(type) {
-      return true;
-    },
-    canHandleSource(source, options) {
-      return true;
-    },
-    handleSource(source, tech_, options) {
-      return {
-        dispose() {
-          disposed = true;
-        }
-      };
-    }
-  };
-
-  // Test registering source handlers
-  MyTech.registerSourceHandler(sourceHandler);
-
-  // First loadstart
-  tech.setSource('test');
-  tech.currentSource_ = 'test';
-  tech.trigger('loadstart');
-  assert.equal(tech.currentSource_, 'test', 'Current source is test');
-
-  // Second loadstart
-  tech.trigger('loadstart');
-  assert.equal(tech.currentSource_, null, 'Current source is null');
-  assert.equal(disposed, true, 'disposed is true');
-
-  // Third loadstart
-  tech.currentSource_ = 'test';
-  tech.trigger('loadstart');
-  assert.equal(tech.currentSource_, null, 'Current source is still null');
-
-});
-
 QUnit.test('setSource after tech dispose should dispose source handler once', function(assert) {
   const MyTech = extendFn(Tech);
 


### PR DESCRIPTION
## Description
Remove all special `loadstart` handling for source handlers.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
