### PR TITLE
Return the native Promise from play()

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1580,13 +1580,15 @@ class Player extends Component {
       return this.techGet_('play');
     }
 
-    this.tech_.one('loadstart', function() {
-      const retval = this.play();
+    this.ready(function() {
+      this.tech_.one('loadstart', function() {
+        const retval = this.play();
 
-      // silence errors (unhandled promise from play)
-      if (retval !== undefined && typeof retval.then === 'function') {
-        retval.then(null, (e) => {});
-      }
+        // silence errors (unhandled promise from play)
+        if (retval !== undefined && typeof retval.then === 'function') {
+          retval.then(null, (e) => {});
+        }
+      });
     });
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1571,35 +1571,23 @@ class Player extends Component {
    * start media playback
    *
    * @return {Promise|undefined}
-   *         Returns a `Promise` if the browser supports it or a Promise library was
-   *         passed in as an option. This will return the native play `Promise` if play()
-   *         returns a `Promise` for this browser.
+   *         Returns a `Promise` if the browser returns one, for most browsers this will
+   *         return undefined.
    */
   play() {
-    const Promise_ = this.options_.Promise || window.Promise;
-
-    const play_ = (resolve) => {
-      // Only calls the tech's play if we already have a src loaded
-      if (this.src() || this.currentSrc()) {
-        return resolve(this.techGet_('play'));
-      }
-
-      this.tech_.one('loadstart', function() {
-        // if resolve is actually the resolution to a promise
-        // it will resolve here, otherwise this will do nothing
-        resolve(this.play());
-      });
-    };
-
-    // return a Promise if the browser supports it
-    if (typeof Promise_ === 'function') {
-      return new Promise_((resolve, reject) => {
-        play_(resolve);
-      });
+    // Only calls the tech's play if we already have a src loaded
+    if (this.src() || this.currentSrc()) {
+      return this.techGet_('play');
     }
 
-    // return the native value of play, which is probably undefined
-    return play_((val) => val);
+    this.tech_.one('loadstart', function() {
+      const retval = this.play();
+
+      // silence errors (unhandled promise from play)
+      if (retval !== undefined && typeof retval.then === 'function') {
+        retval.then(null, (e) => {});
+      }
+    });
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -457,19 +457,6 @@ class Html5 extends Tech {
   }
 
   /**
-   * Called by {@link Player#play} to play using the `Html5` `Tech`.
-   */
-  play() {
-    const playPromise = this.el_.play();
-
-    // Catch/silence error when a pause interrupts a play request
-    // on browsers which return a promise
-    if (playPromise !== undefined && typeof playPromise.then === 'function') {
-      playPromise.then(null, (e) => {});
-    }
-  }
-
-  /**
    * Set current time for the `HTML5` tech.
    *
    * @param {number} seconds
@@ -1571,7 +1558,16 @@ Html5.resetMediaElement = function(el) {
    * @method Html5#load
    * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-load}
    */
-  'load'
+  'load',
+
+  /**
+   * A wrapper around the media elements `play` function. This will call the `HTML5`s
+   * media element `play` function.
+   *
+   * @method Html5#play
+   * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-play}
+   */
+  'play'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
     return this.el_[prop]();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1066,6 +1066,84 @@ QUnit.test('should be scrubbing while seeking', function(assert) {
   player.dispose();
 });
 
+if (typeof window.Promise !== 'undefined') {
+  QUnit.test('play should return a promise if they are supported', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+
+    player.dispose();
+  });
+
+  QUnit.test('play promise should resolve to native promise if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => window.Promise.resolve('foo');
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, 'foo', 'should resolve to native promise value');
+
+      player.dispose();
+      done();
+    });
+
+  });
+
+  QUnit.test('play promise should resolve to native value if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => 'foo';
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, 'foo', 'should resolve to native promise value');
+
+      player.dispose();
+      done();
+    });
+  });
+
+  QUnit.test('play promise should resolve to undefined value if returned', function(assert) {
+    const player = TestHelpers.makePlayer({});
+    const done = assert.async();
+
+    player.tech_.play = () => undefined;
+    const p = player.play();
+
+    assert.ok(p, 'play returns something');
+    assert.equal(typeof p.then, 'function', 'play returns a promise');
+    p.then(function(val) {
+      assert.equal(val, undefined, 'should resolve to undefined');
+
+      player.dispose();
+      done();
+    });
+  });
+}
+
+QUnit.test('play should not return a promise if they are not supported', function(assert) {
+  const oldPromise = window.Promise;
+
+  window.Promise = null;
+
+  const player = TestHelpers.makePlayer({});
+  const p = player.play();
+
+  assert.notOk(p, 'play returns nothing');
+
+  player.dispose();
+  window.Promise = oldPromise;
+});
+
 QUnit.test('should throw on startup no techs are specified', function(assert) {
   const techOrder = videojs.options.techOrder;
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1066,17 +1066,7 @@ QUnit.test('should be scrubbing while seeking', function(assert) {
   player.dispose();
 });
 
-if (typeof window.Promise !== 'undefined') {
-  QUnit.test('play should return a promise if they are supported', function(assert) {
-    const player = TestHelpers.makePlayer({});
-    const p = player.play();
-
-    assert.ok(p, 'play returns something');
-    assert.equal(typeof p.then, 'function', 'play returns a promise');
-
-    player.dispose();
-  });
-
+if (window.Promise) {
   QUnit.test('play promise should resolve to native promise if returned', function(assert) {
     const player = TestHelpers.makePlayer({});
     const done = assert.async();
@@ -1092,56 +1082,16 @@ if (typeof window.Promise !== 'undefined') {
       player.dispose();
       done();
     });
-
-  });
-
-  QUnit.test('play promise should resolve to native value if returned', function(assert) {
-    const player = TestHelpers.makePlayer({});
-    const done = assert.async();
-
-    player.tech_.play = () => 'foo';
-    const p = player.play();
-
-    assert.ok(p, 'play returns something');
-    assert.equal(typeof p.then, 'function', 'play returns a promise');
-    p.then(function(val) {
-      assert.equal(val, 'foo', 'should resolve to native promise value');
-
-      player.dispose();
-      done();
-    });
-  });
-
-  QUnit.test('play promise should resolve to undefined value if returned', function(assert) {
-    const player = TestHelpers.makePlayer({});
-    const done = assert.async();
-
-    player.tech_.play = () => undefined;
-    const p = player.play();
-
-    assert.ok(p, 'play returns something');
-    assert.equal(typeof p.then, 'function', 'play returns a promise');
-    p.then(function(val) {
-      assert.equal(val, undefined, 'should resolve to undefined');
-
-      player.dispose();
-      done();
-    });
   });
 }
 
-QUnit.test('play should not return a promise if they are not supported', function(assert) {
-  const oldPromise = window.Promise;
-
-  window.Promise = null;
-
+QUnit.test('play promise should resolve to native value if returned', function(assert) {
   const player = TestHelpers.makePlayer({});
+
+  player.tech_.play = () => 'foo';
   const p = player.play();
 
-  assert.notOk(p, 'play returns nothing');
-
-  player.dispose();
-  window.Promise = oldPromise;
+  assert.equal(p, 'foo', 'play returns foo');
 });
 
 QUnit.test('should throw on startup no techs are specified', function(assert) {


### PR DESCRIPTION
## Description
Return a Promise from `play()` originally this was a PR off of #3860 (https://github.com/BrandonOCasey/video.js/pull/4). This has been changed to be standalone.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
