### PR TITLE
chore: don't run tests on travis if only docs were changed

### DIFF
--- a/build/docs-only.js
+++ b/build/docs-only.js
@@ -1,0 +1,19 @@
+import sh from 'shelljs';
+import path from 'path';
+
+
+export default function(commit, commitRange) {
+  const SINGLE_COMMIT = `git diff-tree --no-commit-id --name-only -r ${commit}`;
+  const COMMIT_RANGE = `git diff --name-only ${commitRange}`;
+
+  let command = SINGLE_COMMIT;
+
+  if (commitRange) {
+    command = COMMIT_RANGE
+  }
+
+  const output = sh.exec(command, {async: false, silent: true}).stdout;
+
+  const files = output.split('\n').filter(Boolean);
+  return files.every((file) => file.startsWith('docs') || path.extname(file) === '.md');
+};

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "remark-lint": "^5.2.0",
     "remark-toc": "^3.1.0",
     "remark-validate-links": "^5.0.0",
+    "shelljs": "^0.7.5",
     "sinon": "^1.16.1",
     "time-grunt": "^1.1.1",
     "uglify-js": "~2.7.3",


### PR DESCRIPTION
Check to see if we're on travis and if the changes that we're running against only include files in the `docs/` folder or are `.md` files and if so, don't run any tests. Locally, or, if non-doc changes, tests will still run.