### PR TITLE
docs(troubleshooting): Fix a title

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,13 +6,13 @@
   * [Choosing a video format](#choosing-a-video-format)
     * [I want to have a single source and don't care about live/adaptive streaming:](#i-want-to-have-a-single-source-and-dont-care-about-liveadaptive-streaming)
     * [I need adaptive streaming or live streaming](#i-need-adaptive-streaming-or-live-streaming)
-  * [Make sure you are using formats that video.js can play:](#make-sure-you-are-using-formats-that-videojs-can-play)
-  * [Make sure that the codec for that is being used in the file container is supported:](#make-sure-that-the-codec-for-that-is-being-used-in-the-file-container-is-supported)
+  * [Make sure you are using formats that Video.js can play:](#make-sure-you-are-using-formats-that-videojs-can-play)
+  * [Make sure that the codec used in the file container is supported:](#make-sure-that-the-codec-used-in-the-file-container-is-supported)
   * [If you are using Flash videos:](#if-you-are-using-flash-videos)
 * [Problems when hosting media](#problems-when-hosting-media)
-* [Problems with Fullscreen](#problems-with-fullscreen)
+* [Problems with fullscreen](#problems-with-fullscreen)
 * [Problems with playback](#problems-with-playback)
-* [video.js Errors](#videojs-errors)
+* [Video.js Errors](#videojs-errors)
   * [vdata123456 errors](#vdata123456-errors)
 
 ## Problems with media formats
@@ -22,7 +22,7 @@
 #### I want to have a single source and don't care about live/adaptive streaming:
 
 Most browsers now play MP4 with h264 video. If you want to have a single source, and neither live streaming
-nor adaptive streaming is a consideration, MP4 is a good choice.
+nor adaptive streaming is a consideration, MP4 with h264 video and acc audio is a good choice.
 
 #### I need adaptive streaming or live streaming
 
@@ -30,17 +30,17 @@ Use HLS with [videojs-contrib-hls][hls] or
 Use Dash with [videojs-contrib-dash][dash].
 HLS is more convenient as mobile browsers have native support.
 
-### Make sure you are using formats that video.js can play:
+### Make sure you are using formats that Video.js can play:
 
 * Does your browser/OS support the type of media that you are trying to play?
-* Do you have a video.js plugin that will add support for a media format to video.js? For Example:
+* Do you have a Video.js plugin that will add support for a media format to Video.js? For example:
   * [videojs-youtube][youtube]
   * [videojs-contrib-hls][hls]
   * [videojs-contrib-dash][dash]
 * Verify that you are using the correct [mime-type/content-type][media-types] for your videos.
-  This is used to determine if video.js can play a certain type of media.
+  This is used to determine if Video.js can play a certain type of media.
 
-### Make sure that the codec for that is being used in the file container is supported:
+### Make sure that the codec used in the file container is supported:
 
 * MP4 in browsers typically only supports h264 video and MP3 or AAC audio
 * Some low end phones save video in 3GP format but give it an MP4 extension. These files will not play.
@@ -48,7 +48,7 @@ HLS is more convenient as mobile browsers have native support.
 ### If you are using Flash videos:
 
 * Make sure that Flash is installed
-* Make sure the Flash tech is included with video.js (in `video.js >= v6.0.0` it won't be, see [videojs-flash][flash])
+* Make sure the Flash tech is included with Video.js (in `video.js >= v6.0.0` it won't be by default, see [videojs-flash][flash])
 * Flash media include RTMP streams and FLV format media.
 * SWF is not a media format
 
@@ -63,7 +63,7 @@ HLS is more convenient as mobile browsers have native support.
   * You are using [videojs-contrib-hls][hls], [videojs-contrib-dash][dash] and your media is served from a different domain than your page.
   * You are using [text tracks][text-tracks] (captions, subtitles, etc.) and they are being served from a different domain than your page.
 
-## Problems with Fullscreen
+## Problems with fullscreen
 
 * If your player is in an iframe, the parent iframes must have the following attributes for fullscreen to be allowed:
   * `allowfullscreen`
@@ -72,13 +72,13 @@ HLS is more convenient as mobile browsers have native support.
 
 ## Problems with playback
 
-* Make sure that the media host supports byte-range requests, this could be breaking playback. See [Problems when Hosting media][hosting-media] for more info.
+* Make sure that the media host supports byte-range requests, this could be breaking playback. See [Problems when hosting media][hosting-media] for more info.
 * If your media is taking a long time to start playback or the entire mediadownloads before playback:
   * It is likely that metadata for the media has not been included at the start of the media. In MP4 terms this is called
     the "moov atom". Many encoders are configured to do this by default, others may require you to choose
     a "fast start" or "optimize for streaming" option.
 
-## video.js Errors
+## Video.js Errors
 
 ### vdata123456 errors
 


### PR DESCRIPTION
- Fixed (and simplified) the codecs header; and while I'm at it:
- Elaborated slightly on codecs and flash in v6
- Changed case of 'Video.js' throughout and some other capilatisation to be consistent with the doc