### PR TITLE
Remove unused defaultVolume option default

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3205,9 +3205,6 @@ Player.prototype.options_ = {
   html5: {},
   flash: {},
 
-  // defaultVolume: 0.85,
-  defaultVolume: 0.00,
-
   // default inactivity timeout
   inactivityTimeout: 2000,
 


### PR DESCRIPTION
There is a default value for a `defaultVolume` option in the `Player`. It's never used; so, might as well remove it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
