### PR TITLE
Pause player before seeking in seek bar mousedown

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -122,12 +122,12 @@ class SeekBar extends Slider {
    * @listens mousedown
    */
   handleMouseDown(event) {
-    super.handleMouseDown(event);
-
     this.player_.scrubbing(true);
 
     this.videoWasPlaying = !this.player_.paused();
     this.player_.pause();
+
+    super.handleMouseDown(event);
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -127,10 +127,7 @@ class SeekBar extends Slider {
     this.player_.scrubbing(true);
 
     this.videoWasPlaying = !this.player_.paused();
-
-    this.pauseTimer_ = this.setTimeout(function() {
-      this.player_.pause();
-    }, 100);
+    this.player_.pause();
   }
 
   /**
@@ -151,11 +148,6 @@ class SeekBar extends Slider {
 
     // Set new time (tell player to seek to new time)
     this.player_.currentTime(newTime);
-
-    if (event.type === 'mousemove') {
-      this.clearTimeout(this.pauseTimer_);
-      this.player_.pause();
-    }
   }
 
   /**
@@ -168,8 +160,6 @@ class SeekBar extends Slider {
    */
   handleMouseUp(event) {
     super.handleMouseUp(event);
-
-    this.clearTimeout(this.pauseTimer_);
 
     this.player_.scrubbing(false);
     if (this.videoWasPlaying) {


### PR DESCRIPTION
## Description
I ran into the backwards seeking problem with Chrome 55, as previously reported in #3839. After some investigation, I found it was also reported in the Chromium bug tracker as [bug 675556](https://bugs.chromium.org/p/chromium/issues/detail?id=675556), and it should be fixed in Chrome 57.

I noticed that video.js 5.15.0 fixes this in #3886 by delaying the pause until the first `mousemove` or after 100ms (whichever happens first). However, the comments from the Chromium bug indicate that there is a simpler solution. The problem occurs when you call when you call `video.pause()` immediately after setting `video.currentTime`, however it does not occur when you pause **before** seeking.

## Specific Changes proposed
This change reverts #3886. Instead, it ensures that `SeekBar.handleMouseDown` first pauses the player before calling its super method (which in turn calls `handleMouseMove` which seeks the player).

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
