### PR TITLE
Fix `npm start` file watching

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -452,7 +452,7 @@ module.exports = function(grunt) {
     },
     shell: {
       babel: {
-        command: 'npm run babel -- --w',
+        command: 'npm run babel -- --watch',
         options: {
           preferLocal: true
         }


### PR DESCRIPTION
## Description
Fix `npm start` file watching

## Specific Changes proposed
Pass the babel cli a valid command for watch rather than --w.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual terminal
 - [ ] Reviewed by Two Core Contributors
