### PR TITLE
Add check to ensure `hasAttribute` is a function

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -473,7 +473,7 @@ class Player extends Component {
   createEl() {
     const tag = this.tag;
     let el;
-    const playerElIngest = this.playerElIngest_ = tag.parentNode && tag.parentNode.hasAttribute('data-vjs-player');
+    const playerElIngest = this.playerElIngest_ = tag.parentNode && tag.parentNode.hasAttribute && tag.parentNode.hasAttribute('data-vjs-player');
 
     if (playerElIngest) {
       el = this.el_ = tag.parentNode;


### PR DESCRIPTION
## Description
For elements which parent doesn't have `hasAttribute` it needs do another check to prevent erroring out.

## Specific Changes proposed
Added a check to ensure the tag's parentNode has the `hasAttribute` function

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
