### PR TITLE
fix: showing custom poster with controls disabled

### DIFF
--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -36,12 +36,6 @@
   display: block;
 }
 
-// Hide the poster when controls are disabled because it's clickable
-// and the native poster can take over
-.vjs-controls-disabled .vjs-poster {
-  display: none;
-}
-
 // Hide the poster when native controls are used otherwise it covers them
 .vjs-using-native-controls .vjs-poster {
   display: none;

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -121,7 +121,10 @@ class PosterImage extends ClickableComponent {
    */
   handleClick(event) {
     // We don't want a click to trigger playback when controls are disabled
-    // but CSS should be hiding the poster to prevent that from happening
+    if (!this.player_.controls()) {
+      return;
+    }
+
     if (this.player_.paused()) {
       this.player_.play();
     } else {


### PR DESCRIPTION
We previously hid the poster image when controls were disabled because
the poster image had a click handler on it. However, this meant that in
the case of Flash, which doesn't have a native poster image ability, we
lost the poster.

Fixes #1625.