### PR TITLE
fix: give techs a name

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -145,6 +145,10 @@ class Tech extends Component {
     if (!options.nativeControlsForTouch) {
       this.emitTapEvents();
     }
+
+    if (this.constructor) {
+      this.name_ = this.constructor.name || 'Unknown Tech';
+    }
   }
 
   /* Fallbacks for unsupported event types


### PR DESCRIPTION
This helps with debugging to know what a component's name is.
We try to look up the tech's name via the constructor's name property,
otherwise, we set it to 'Unknown Tech'. Can be overridden by setting
`this.name_` after calling `super()` in the constructor.

Fixes #1786.