### PR TITLE
Improve mute button usability

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -53,7 +53,15 @@ class MuteToggle extends Button {
    * @listens click
    */
   handleClick(event) {
-    this.player_.muted(this.player_.muted() ? false : true);
+    const vol = this.player_.volume();
+    const lastVolume = this.player_.lastVolume();
+
+    if (vol === 0) {
+      this.player_.volume(lastVolume);
+      this.player_.muted(false);
+    } else {
+      this.player_.muted(this.player_.muted() ? false : true);
+    }
   }
 
   /**

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -54,7 +54,7 @@ class MuteToggle extends Button {
    */
   handleClick(event) {
     const vol = this.player_.volume();
-    const lastVolume = this.player_.lastVolume();
+    const lastVolume = this.player_.lastVolume_();
 
     if (vol === 0) {
       this.player_.volume(lastVolume);

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -25,7 +25,8 @@ class VolumeBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
-
+    this.on('slideractive', this.updateVolumeBeforeDrag);
+    this.on('sliderinactive', this.updateLastVolume);
     this.on(player, 'volumechange', this.updateARIAAttributes);
     player.ready(() => this.updateARIAAttributes);
   }
@@ -110,6 +111,39 @@ class VolumeBar extends Slider {
 
     this.el_.setAttribute('aria-valuenow', volume);
     this.el_.setAttribute('aria-valuetext', volume + '%');
+  }
+
+  /**
+   * Store value of volume in `volumeBeforeDrag` when user begins dragging the
+   * VolumeBar (so long as volume is above zero). This is used to restore
+   * volume to its starting level after dragging volume to zero and clicking
+   * MuteToggle.
+   *
+   * @listens slideractive
+   */
+  updateVolumeBeforeDrag() {
+    const vol = this.player_.volume();
+
+    if (vol > 0) {
+      this.player_.volumeBeforeDrag(vol);
+    }
+  }
+
+  /**
+   * After user finishes dragging the VolumeBar, if volume is zero, set
+   * `lastVolume` (the value used in setting the volume after clicking
+   * MuteToggle when volume is zero) to `volumeBeforeDrag`, so that volume will
+   * be restored to its starting level before the drag.
+   *
+   * @listens sliderinactive
+   */
+  updateLastVolume() {
+    const vol = this.player_.volume();
+    const volumeBeforeDrag = this.player_.volumeBeforeDrag();
+
+    if (vol === 0) {
+      this.player_.lastVolume(volumeBeforeDrag);
+    }
   }
 
 }

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -25,8 +25,7 @@ class VolumeBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
-    this.on('slideractive', this.updateVolumeBeforeDrag);
-    this.on('sliderinactive', this.updateLastVolume);
+    this.on('slideractive', this.updateLastVolume);
     this.on(player, 'volumechange', this.updateARIAAttributes);
     player.ready(() => this.updateARIAAttributes);
   }
@@ -114,36 +113,21 @@ class VolumeBar extends Slider {
   }
 
   /**
-   * Store value of volume in `volumeBeforeDrag` when user begins dragging the
-   * VolumeBar (so long as volume is above zero). This is used to restore
-   * volume to its starting level after dragging volume to zero and clicking
-   * MuteToggle.
+   * When user starts dragging the VolumeBar, store the volume and listen for
+   * the end of the drag. When the drag ends, if the volume was set to zero,
+   * set lastVolume to the stored volume.
    *
    * @listens slideractive
    */
-  updateVolumeBeforeDrag() {
-    const vol = this.player_.volume();
-
-    if (vol > 0) {
-      this.player_.volumeBeforeDrag(vol);
-    }
-  }
-
-  /**
-   * After user finishes dragging the VolumeBar, if volume is zero, set
-   * `lastVolume` (the value used in setting the volume after clicking
-   * MuteToggle when volume is zero) to `volumeBeforeDrag`, so that volume will
-   * be restored to its starting level before the drag.
-   *
-   * @listens sliderinactive
-   */
   updateLastVolume() {
-    const vol = this.player_.volume();
-    const volumeBeforeDrag = this.player_.volumeBeforeDrag();
+    const volumeBeforeDrag = this.player_.volume();
 
-    if (vol === 0) {
-      this.player_.lastVolume(volumeBeforeDrag);
-    }
+    this.on('sliderinactive', function setLastVolume() {
+      if (this.player_.volume() === 0) {
+        this.player_.lastVolume(volumeBeforeDrag);
+      }
+      this.off('sliderinactive', setLastVolume);
+    });
   }
 
 }

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -123,11 +123,10 @@ class VolumeBar extends Slider {
   updateLastVolume_() {
     const volumeBeforeDrag = this.player_.volume();
 
-    this.on('sliderinactive', function setLastVolume() {
+    this.one('sliderinactive', () => {
       if (this.player_.volume() === 0) {
         this.player_.lastVolume_(volumeBeforeDrag);
       }
-      this.off('sliderinactive', setLastVolume);
     });
   }
 

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -124,7 +124,7 @@ class VolumeBar extends Slider {
 
     this.on('sliderinactive', function setLastVolume() {
       if (this.player_.volume() === 0) {
-        this.player_.lastVolume(volumeBeforeDrag);
+        this.player_.lastVolume_(volumeBeforeDrag);
       }
       this.off('sliderinactive', setLastVolume);
     });

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -118,6 +118,7 @@ class VolumeBar extends Slider {
    * set lastVolume to the stored volume.
    *
    * @listens slideractive
+   * @private
    */
   updateLastVolume_() {
     const volumeBeforeDrag = this.player_.volume();

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -25,7 +25,7 @@ class VolumeBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
-    this.on('slideractive', this.updateLastVolume);
+    this.on('slideractive', this.updateLastVolume_);
     this.on(player, 'volumechange', this.updateARIAAttributes);
     player.ready(() => this.updateARIAAttributes);
   }
@@ -119,7 +119,7 @@ class VolumeBar extends Slider {
    *
    * @listens slideractive
    */
-  updateLastVolume() {
+  updateLastVolume_() {
     const volumeBeforeDrag = this.player_.volume();
 
     this.on('sliderinactive', function setLastVolume() {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1890,6 +1890,8 @@ class Player extends Component {
    *
    * @return {number}
    *         the current value of lastVolume as a percent when getting
+   *
+   * @private
    */
   lastVolume_(percentAsDecimal) {
     if (percentAsDecimal !== undefined && percentAsDecimal !== 0) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -335,9 +335,8 @@ class Player extends Component {
     // Set controls
     this.controls_ = !!options.controls;
 
-    // Set default values for lastVolume and volumeBeforeDrag
-    this.lastVolume_ = 1;
-    this.volumeBeforeDrag_ = 1;
+    // Set default values for lastVolume
+    this.cache_.lastVolume = 1;
 
     // Original tag settings stored in options
     // now remove immediately so native controls don't flash.
@@ -1817,7 +1816,7 @@ class Player extends Component {
       this.techCall_('setVolume', vol);
 
       if (vol > 0) {
-        this.lastVolume(vol);
+        this.lastVolume_(vol);
       }
 
       return;
@@ -1889,16 +1888,15 @@ class Player extends Component {
    *         - 1.0 is 100%/full
    *         - 0.5 is half volume or 50%
    *
-   * @return {Player|number}
-   *         a reference to the calling player when setting and the
-   *         current volume as a percent when getting
+   * @return {number}
+   *         the current value of lastVolume as a percent when getting
    */
-  lastVolume(percentAsDecimal) {
+  lastVolume_(percentAsDecimal) {
     if (percentAsDecimal !== undefined && percentAsDecimal !== 0) {
-      this.lastVolume_ = percentAsDecimal;
-      return this;
+      this.cache_.lastVolume = percentAsDecimal;
+      return;
     }
-    return this.lastVolume_;
+    return this.cache_.lastVolume;
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -335,6 +335,10 @@ class Player extends Component {
     // Set controls
     this.controls_ = !!options.controls;
 
+    // Set default values for lastVolume and volumeBeforeDrag
+    this.lastVolume_ = 1;
+    this.volumeBeforeDrag_ = 1;
+
     // Original tag settings stored in options
     // now remove immediately so native controls don't flash.
     // May be turned back on by HTML5 tech if nativeControlsForTouch is true
@@ -1812,6 +1816,10 @@ class Player extends Component {
       this.cache_.volume = vol;
       this.techCall_('setVolume', vol);
 
+      if (vol > 0) {
+        this.lastVolume(vol);
+      }
+
       return;
     }
 
@@ -1870,6 +1878,48 @@ class Player extends Component {
       return this.techCall_('setDefaultMuted', defaultMuted);
     }
     return this.techGet_('defaultMuted') || false;
+  }
+
+  /**
+   * Get the last volume, or set it
+   *
+   * @param  {number} [percentAsDecimal]
+   *         The new last volume as a decimal percent:
+   *         - 0 is muted/0%/off
+   *         - 1.0 is 100%/full
+   *         - 0.5 is half volume or 50%
+   *
+   * @return {Player|number}
+   *         a reference to the calling player when setting and the
+   *         current volume as a percent when getting
+   */
+  lastVolume(percentAsDecimal) {
+    if (percentAsDecimal !== undefined) {
+      this.lastVolume_ = percentAsDecimal;
+      return this;
+    }
+    return this.lastVolume_;
+  }
+
+   /**
+    * Get the last volume before dragging the VolumeBar, or set it
+    *
+    * @param  {number} [percentAsDecimal]
+    *         The new last volume as a decimal percent:
+    *         - 0 is muted/0%/off
+    *         - 1.0 is 100%/full
+    *         - 0.5 is half volume or 50%
+    *
+    * @return {Player|number}
+    *         a reference to the calling player when setting and the
+    *         current volume as a percent when getting
+    */
+  volumeBeforeDrag(percentAsDecimal) {
+    if (percentAsDecimal !== undefined) {
+      this.volumeBeforeDrag_ = percentAsDecimal;
+      return this;
+    }
+    return this.volumeBeforeDrag_;
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1894,7 +1894,7 @@ class Player extends Component {
    *         current volume as a percent when getting
    */
   lastVolume(percentAsDecimal) {
-    if (percentAsDecimal !== undefined) {
+    if (percentAsDecimal !== undefined && percentAsDecimal !== 0) {
       this.lastVolume_ = percentAsDecimal;
       return this;
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1901,27 +1901,6 @@ class Player extends Component {
     return this.lastVolume_;
   }
 
-   /**
-    * Get the last volume before dragging the VolumeBar, or set it
-    *
-    * @param  {number} [percentAsDecimal]
-    *         The new last volume as a decimal percent:
-    *         - 0 is muted/0%/off
-    *         - 1.0 is 100%/full
-    *         - 0.5 is half volume or 50%
-    *
-    * @return {Player|number}
-    *         a reference to the calling player when setting and the
-    *         current volume as a percent when getting
-    */
-  volumeBeforeDrag(percentAsDecimal) {
-    if (percentAsDecimal !== undefined) {
-      this.volumeBeforeDrag_ = percentAsDecimal;
-      return this;
-    }
-    return this.volumeBeforeDrag_;
-  }
-
   /**
    * Check if current tech can support native fullscreen
    * (e.g. with built in controls like iOS, so not our flash swf)

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -111,7 +111,7 @@ QUnit.test('Clicking MuteToggle when volume is 0 and muted is false should set v
   const muteToggle = new MuteToggle(player);
 
   player.volume(0);
-  assert.equal(player.lastVolume(), 1, 'lastVolume is set');
+  assert.equal(player.lastVolume_(), 1, 'lastVolume is set');
   assert.equal(player.muted(), false, 'player is muted');
 
   muteToggle.handleClick();
@@ -126,7 +126,7 @@ QUnit.test('Clicking MuteToggle when volume is 0 and muted is true should set vo
 
   player.volume(0);
   player.muted(true);
-  player.lastVolume(0.5);
+  player.lastVolume_(0.5);
 
   muteToggle.handleClick();
 

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -98,12 +98,12 @@ QUnit.test('Clicking MuteToggle when volume is above 0 should toggle muted prope
   const muteToggle = new MuteToggle(player);
 
   assert.equal(player.volume(), 1, 'volume is above 0');
-  assert.equal(player.muted(), false, 'player is muted');
+  assert.equal(player.muted(), false, 'player is not muted');
 
   muteToggle.handleClick();
 
   assert.equal(player.volume(), 1, 'volume is same');
-  assert.equal(player.muted(), true, 'player is not muted');
+  assert.equal(player.muted(), true, 'player is muted');
 });
 
 QUnit.test('Clicking MuteToggle when volume is 0 and muted is false should set volume to lastVolume and keep muted false', function(assert) {

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -92,3 +92,44 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
   QUnit.equal(fullscreentoggle.controlText(), 'Fullscreen', 'Control Text is correct while switching back to normal mode');
   player.dispose();
 });
+
+QUnit.test('Clicking MuteToggle when volume is above 0 should toggle muted property and not change volume', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+  const muteToggle = new MuteToggle(player);
+
+  assert.equal(player.volume(), 1, 'volume is above 0');
+  assert.equal(player.muted(), false, 'player is muted');
+
+  muteToggle.handleClick();
+
+  assert.equal(player.volume(), 1, 'volume is same');
+  assert.equal(player.muted(), true, 'player is not muted');
+});
+
+QUnit.test('Clicking MuteToggle when volume is 0 and muted is false should set volume to lastVolume and keep muted false', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+  const muteToggle = new MuteToggle(player);
+
+  player.volume(0);
+  assert.equal(player.lastVolume(), 1, 'lastVolume is set');
+  assert.equal(player.muted(), false, 'player is muted');
+
+  muteToggle.handleClick();
+
+  assert.equal(player.volume(), 1, 'volume is set to lastVolume');
+  assert.equal(player.muted(), false, 'muted remains false');
+});
+
+QUnit.test('Clicking MuteToggle when volume is 0 and muted is true should set volume to lastVolume and sets muted to false', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+  const muteToggle = new MuteToggle(player);
+
+  player.volume(0);
+  player.muted(true);
+  player.lastVolume(0.5);
+
+  muteToggle.handleClick();
+
+  assert.equal(player.volume(), 0.5, 'volume is set to lastVolume');
+  assert.equal(player.muted(), false, 'muted is set to false');
+});


### PR DESCRIPTION
Clicking `MuteToggle` when `volume` is 0 now has more user-friendly behavior. Previously, clicking MuteToggle when `volume` was 0 had no user-visible effect (as discussed in https://github.com/videojs/video.js/issues/3909, which this PR addresses).

There are three possible scenarios I'm aware of for setting the volume to 0 and then dealing with a click on `MuteToggle` that need to be taken into account:

1. **User drags `VolumeBar` to 0 with mouse or finger.** In this case, `volume` should be restored to the level it was at when the user started dragging `VolumeBar`.
1. **User steps `volume` to 0 with keyboard.** In this case, clicking `MuteToggle` should restore the volume to its last value before it reached 0.
1. **`volume` is set directly to 0 with external JS, by a plugin, etc.** In this case, it should be up to the programmer to control what level the volume should be set to when the user clicks `MuteToggle`, but it should never remain at 0.

How this solution works:

- Clicking `MuteToggle` when volume is zero sets `volume` to the value of a new property, `lastVolume`.
- `lastVolume` is updated to match `volume` when `Player#volume` sets a new value for `volume`, unless the new value of `volume` is 0.
- When a user starts to drag `VolumeBar`, `volume` is saved into another new property, `volumeBeforeDrag`. When the user finishes dragging `VolumeBar`, if `volume` is 0, `lastVolume` is updated to match `volumeBeforeDrag`.

**Note:** This should not be merged until https://github.com/videojs/video.js/issues/3918 is fixed. As explained in that bug report: 

> If clicking `MuteToggle` when `volume` is zero sets `volume` to something greater than zero, then users will be able to accidentally trigger that behavior by `mouseup`ing over `MuteToggle` after dragging `VolumeBar` to zero.