### PR TITLE
Minor fix to currentTime() comment: "setting" not "getting"

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1645,8 +1645,7 @@ class Player extends Component {
    *
    * @return {Player|number}
    *         - the current time in seconds when getting
-   *         - a reference to the current player object when
-   *           getting
+   *         - a reference to the current player object when setting
    */
   currentTime(seconds) {
     if (seconds !== undefined) {


### PR DESCRIPTION
## Description
This is an extremely minor fix to a mistake/type comment on the `currentTime()` method. But I think it's important that it be fixed - I found it confusing.

## Specific Changes proposed
It's basically a one character change to a comment.

## Requirements Checklist
- **N/A** Feature implemented / Bug fixed
- **N/A** If necessary, more likely in a feature request than a bug fix
  - **N/A** Change has been verified in an actual browser (Chome, Firefox, IE)
  - **N/A** Unit Tests updated or fixed
  - [x] Docs/guides updated
  - **N/A** Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
