### PR TITLE
Fix CSS for Accessible Volume Control & IE <= 9

### DIFF
--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -115,3 +115,11 @@
   @extend %fill-parent;
   text-align: center;
 }
+
+// don't wrap whitespace for the time control and make the text container 0 width
+// fixes a bug with 'width: auto' in IE 8/9
+.vjs-ie-auto-width-fix {
+  width: 0px !important;
+  white-space: nowrap;
+}
+

--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -17,6 +17,8 @@
   -webkit-transition: $string;
   -moz-transition: $string;
   -o-transition: $string;
+  // added for ie10
+  -ms-transition: $string;
   transition: $string;
 }
 

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -45,6 +45,7 @@
   padding: 0;
   overflow: hidden;
   opacity: 0;
+  margin-top: -1px;
 }
 
 // visually hide a control-bar component without changing the position
@@ -56,7 +57,6 @@
   padding: 0;
   overflow: hidden;
   opacity: 0;
+  margin-left: -1px;
 }
-
-
 

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -19,13 +19,16 @@
   @extend .vjs-icon-volume-mid;
 }
 
-
 .video-js .vjs-volume-control {
   width: auto;
   margin-right: 1em;
   @include flex(none);
   @include display-flex(center);
-  @include transition(all 0.4s);
+
+  transition-property: height, opacity, margin-right;
+  transition-duration: 0.4s;
+  transition-timing-function: initial;
+  transition-delay: initial;
 }
 
 .video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -2,6 +2,11 @@
   cursor: pointer;
   @include flex(none);
   @extend .vjs-icon-volume-high;
+  // padding here is for IE < 9, it doesn't do width: auto from
+  // another style correctly
+  padding-left: 2em;
+  padding-right: 2em;
+  padding-bottom: 3em;
 }
 
 .video-js .vjs-mute-control.vjs-vol-0 {
@@ -21,6 +26,12 @@
   @include flex(none);
   @include display-flex(center);
   @include transition(all 0.4s);
+}
+
+.video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {
+  left: 0.6em;
+  bottom: 3em;
+  position: absolute;
 }
 
 .video-js .vjs-volume-panel {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -25,10 +25,9 @@
   @include flex(none);
   @include display-flex(center);
 
-  transition-property: height, opacity, margin-right;
-  transition-duration: 0.4s;
-  transition-timing-function: initial;
-  transition-delay: initial;
+  // var needed due to comma
+  $transition-property: height 0.4s, opacity 0.4s, margin-right 0.4s;
+  @include transition($transition-property)
 }
 
 .video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -4,6 +4,7 @@
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import formatTime from '../../utils/format-time.js';
+import {IE_VERSION} from '../../utils/browser';
 
 /**
  * Displays the time left in the video
@@ -35,8 +36,14 @@ class RemainingTimeDisplay extends Component {
    *         The element that was created.
    */
   createEl() {
+    let ieFixClass = '';
+
+    if (IE_VERSION && IE_VERSION <= 9) {
+      ieFixClass = 'vjs-ie-auto-width-fix';
+    }
+
     const el = super.createEl('div', {
-      className: 'vjs-remaining-time vjs-time-control vjs-control'
+      className: `vjs-remaining-time vjs-time-control vjs-control ${ieFixClass}`
     });
 
     this.contentEl_ = Dom.createEl('div', {

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -41,8 +41,8 @@ class VolumeControl extends Component {
     checkVolumeSupport(this, player);
 
     // while the slider is active (the mouse has been pressed down and
-    // is dragging) we do not want to hide the VolumeBar
-    this.on(this.volumeBar, ['slideractive'], () => {
+    // is dragging) or in focus we do not want to hide the VolumeBar
+    this.on(this.volumeBar, ['focus', 'slideractive'], () => {
       this.volumeBar.addClass('vjs-slider-active');
       this.lockShowing_ = true;
     });
@@ -50,7 +50,7 @@ class VolumeControl extends Component {
     // when the slider becomes inactive again we want to hide
     // the VolumeBar, but only if we tried to hide when
     // lockShowing_ was true. see the VolumeBar#hide function.
-    this.on(this.volumeBar, ['sliderinactive'], () => {
+    this.on(this.volumeBar, ['blur', 'sliderinactive'], () => {
       this.volumeBar.removeClass('vjs-slider-active');
       this.lockShowing_ = false;
 

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -77,7 +77,7 @@ class VolumeControl extends Component {
     // animate hiding the bar via transitions
     let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.inline === false) {
+    if (this.options_.vertical) {
       hideClass = 'vjs-visual-hide-vertical';
     }
 
@@ -109,7 +109,7 @@ class VolumeControl extends Component {
     // animate hiding the bar via transitions
     let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.inline === false) {
+    if (this.options_.vertical) {
       hideClass = 'vjs-visual-hide-vertical';
     }
 

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -4,6 +4,7 @@
 import Component from '../../component.js';
 import checkVolumeSupport from './check-volume-support';
 import {isPlain} from '../../utils/obj';
+import {IE_VERSION} from '../../utils/browser';
 
 // Required children
 import './volume-bar.js';
@@ -63,6 +64,8 @@ class VolumeControl extends Component {
     // VolumeBar by itself we will need this
     this.on(this.volumeBar, ['focus'], () => this.show());
     this.on(this.volumeBar, ['blur'], () => this.hide());
+
+    this.hide();
   }
 
   /**
@@ -71,12 +74,22 @@ class VolumeControl extends Component {
   show() {
     this.shouldHide_ = false;
 
-    if (this.options_.vertical) {
-      this.removeClass('vjs-visual-hide-vertical');
-    } else {
-      this.removeClass('vjs-visual-hide-horizontal');
+    // animate hiding the bar via transitions
+    let hideClass = 'vjs-visual-hide-horizontal';
+
+    if (this.options_.inline === false) {
+      hideClass = 'vjs-visual-hide-vertical';
     }
 
+    this.removeClass(hideClass);
+
+    // IE < 9 doesn't calculate width correctly if everything inside
+    // the parent element is not hidden as well
+    if (IE_VERSION && IE_VERSION <= 9) {
+      this.children().forEach(function(child) {
+        child.removeClass(hideClass);
+      });
+    }
   }
 
   /**
@@ -94,10 +107,20 @@ class VolumeControl extends Component {
     }
 
     // animate hiding the bar via transitions
-    if (this.options_.vertical) {
-      this.addClass('vjs-visual-hide-vertical');
-    } else {
-      this.addClass('vjs-visual-hide-horizontal');
+    let hideClass = 'vjs-visual-hide-horizontal';
+
+    if (this.options_.inline === false) {
+      hideClass = 'vjs-visual-hide-vertical';
+    }
+
+    this.addClass(hideClass);
+
+    // IE < 9 doesn't calculate width correctly if everything inside
+    // the parent element is not hidden as well
+    if (IE_VERSION && IE_VERSION <= 9) {
+      this.children().forEach(function(child) {
+        child.addClass(hideClass);
+      });
     }
   }
 
@@ -108,10 +131,10 @@ class VolumeControl extends Component {
    *         The element that was created.
    */
   createEl() {
-    let orientationClass = 'vjs-volume-horizonal vjs-visual-hide-horizontal';
+    let orientationClass = 'vjs-volume-horizonal';
 
     if (this.options_.vertical) {
-      orientationClass = 'vjs-volume-vertical vjs-visual-hide-vertical';
+      orientationClass = 'vjs-volume-vertical';
     }
 
     return super.createEl('div', {

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -4,6 +4,7 @@
 import Component from '../component.js';
 import checkVolumeSupport from './volume-control/check-volume-support';
 import {isPlain} from '../utils/obj';
+import {IE_VERSION} from '../utils/browser';
 
 // Required children
 import './volume-control/volume-control.js';
@@ -64,6 +65,12 @@ class VolumePanel extends Component {
    *         The element that was created.
    */
   createEl() {
+    let ieFixClass = '';
+
+    if (IE_VERSION && IE_VERSION <= 9) {
+      ieFixClass = 'vjs-ie-auto-width-fix';
+    }
+
     let orientationClass = 'vjs-volume-panel-horizontal';
 
     if (!this.options_.inline) {
@@ -71,7 +78,7 @@ class VolumePanel extends Component {
     }
 
     return super.createEl('div', {
-      className: `vjs-volume-panel vjs-control ${orientationClass}`
+      className: `vjs-volume-panel vjs-control ${orientationClass} ${ieFixClass}`
     });
   }
 


### PR DESCRIPTION
## Description
* Fix IE8/IE9 styles for volume control
* Fix IE8/IE9 styles for remaining time display (Fixes #3952)
* ~~This PR is based upon #3935~~ (Merged)
* Fixes IE10 transitions which were not implemented previously

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - Change has been verified in:
    - [x] Safari
    - [x] Chrome
    - [x] Firefox
    - [x] IE8
    - [x] IE9
    - [x] IE10
    - [x] IE11
    - [x] Edge
- [ ] Reviewed by Two Core Contributors
