### PR TITLE
refactor: Evented Components

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -7,6 +7,7 @@ import Component from './component.js';
 import document from 'global/document';
 import window from 'global/window';
 import tsml from 'tsml';
+import evented from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
@@ -348,6 +349,9 @@ class Player extends Component {
     this.scrubbing_ = false;
 
     this.el_ = this.createEl();
+
+    // Make this an evented object and use `el_` as its event bus.
+    evented(this, {eventBusKey: 'el_'});
 
     // We also want to pass the original player options to each component and plugin
     // as well so they don't need to reach back into the player for options later.

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -38,7 +38,10 @@ class Slider extends Component {
     this.on('click', this.handleClick);
 
     this.on(player, 'controlsvisible', this.update);
-    this.on(player, this.playerEvent, this.update);
+
+    if (this.playerEvent) {
+      this.on(player, this.playerEvent, this.update);
+    }
   }
 
   /**

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -11,49 +11,23 @@ QUnit.module('Controls');
 
 QUnit.test('should hide volume control if it\'s not supported', function(assert) {
   assert.expect(2);
-  const noop = function() {};
-  const player = {
-    id: noop,
-    on: noop,
-    ready: noop,
-    tech_: {
-      featuresVolumeControl: false
-    },
-    volume() {},
-    muted() {},
-    reportUserActivity() {}
-  };
+
+  const player = TestHelpers.makePlayer();
+
+  player.tech_.featuresVolumeControl = false;
 
   const volumeControl = new VolumeControl(player);
   const muteToggle = new MuteToggle(player);
 
-  assert.ok(volumeControl.el().className.indexOf('vjs-hidden') >= 0, 'volumeControl is not hidden');
-  assert.ok(muteToggle.el().className.indexOf('vjs-hidden') >= 0, 'muteToggle is not hidden');
+  assert.ok(volumeControl.hasClass('vjs-hidden'), 'volumeControl is not hidden');
+  assert.ok(muteToggle.hasClass('vjs-hidden'), 'muteToggle is not hidden');
+  player.dispose();
 });
 
 QUnit.test('should test and toggle volume control on `loadstart`', function(assert) {
-  const noop = function() {};
-  const listeners = [];
-  const player = {
-    id: noop,
-    on(event, callback) {
-      // don't fire dispose listeners
-      if (event !== 'dispose') {
-        listeners.push(callback);
-      }
-    },
-    ready: noop,
-    volume() {
-      return 1;
-    },
-    muted() {
-      return false;
-    },
-    tech_: {
-      featuresVolumeControl: true
-    },
-    reportUserActivity() {}
-  };
+  const player = TestHelpers.makePlayer();
+
+  player.tech_.featuresVolumeControl = true;
 
   const volumeControl = new VolumeControl(player);
   const muteToggle = new MuteToggle(player);
@@ -62,30 +36,23 @@ QUnit.test('should test and toggle volume control on `loadstart`', function(asse
   assert.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle is hidden initially');
 
   player.tech_.featuresVolumeControl = false;
-  for (let i = 0; i < listeners.length; i++) {
-    listeners[i]();
-  }
+  player.trigger('loadstart');
 
   assert.equal(volumeControl.hasClass('vjs-hidden'), true, 'volumeControl does not hide itself');
   assert.equal(muteToggle.hasClass('vjs-hidden'), true, 'muteToggle does not hide itself');
 
   player.tech_.featuresVolumeControl = true;
-  for (let i = 0; i < listeners.length; i++) {
-    listeners[i]();
-  }
+  player.trigger('loadstart');
 
   assert.equal(volumeControl.hasClass('vjs-hidden'), false, 'volumeControl does not show itself');
   assert.equal(muteToggle.hasClass('vjs-hidden'), false, 'muteToggle does not show itself');
 });
 
 QUnit.test('calculateDistance should use changedTouches, if available', function(assert) {
-  const noop = function() {};
-  const player = {
-    id: noop,
-    on: noop,
-    ready: noop,
-    reportUserActivity: noop
-  };
+  const player = TestHelpers.makePlayer();
+
+  player.tech_.featuresVolumeControl = true;
+
   const slider = new Slider(player);
 
   document.body.appendChild(slider.el_);


### PR DESCRIPTION
## Description
The PR for advanced plugins introduced the concept of mixins and added two: evented and stateful.

This PR refactors `Component` to use the evented mixin, granting it event broadcast/handling capabilities.

I will open a second PR for implementing stateful components.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - ~~Docs/guides updated~~
  - ~~Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))~~
- [ ] Reviewed by Two Core Contributors
