### PR TITLE
feat: Stateful Components

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -4,6 +4,7 @@
  * @file component.js
  */
 import window from 'global/window';
+import stateful from './mixins/stateful';
 import * as Dom from './utils/dom.js';
 import * as DomData from './utils/dom-data';
 import * as Fn from './utils/fn.js';
@@ -82,6 +83,8 @@ class Component {
     } else if (options.createEl !== false) {
       this.el_ = this.createEl();
     }
+
+    stateful(this, this.constructor.defaultState);
 
     this.children_ = [];
     this.childIndex_ = {};

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -4,6 +4,7 @@ import Component from '../../src/js/component.js';
 import * as Dom from '../../src/js/utils/dom.js';
 import * as DomData from '../../src/js/utils/dom-data';
 import * as Events from '../../src/js/utils/events.js';
+import * as Obj from '../../src/js/utils/obj';
 import * as browser from '../../src/js/utils/browser.js';
 import document from 'global/document';
 import sinon from 'sinon';
@@ -905,4 +906,14 @@ QUnit.test('$ and $$ functions', function(assert) {
 
   assert.strictEqual(comp.$('div'), children[0], '$ defaults to contentEl as scope');
   assert.strictEqual(comp.$$('div').length, children.length, '$$ defaults to contentEl as scope');
+});
+
+QUnit.test('should use the stateful mixin', function(assert) {
+  const comp = new Component(getFakePlayer(), {});
+
+  assert.ok(Obj.isPlain(comp.state), '`state` is a plain object');
+  assert.strictEqual(typeof comp.setState, 'function', '`setState` is a function');
+
+  comp.setState({foo: 'bar'});
+  assert.strictEqual(comp.state.foo, 'bar', 'the component passes a basic stateful test');
 });

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -912,7 +912,7 @@ QUnit.test('should use the stateful mixin', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 
   assert.ok(Obj.isPlain(comp.state), '`state` is a plain object');
-  assert.strictEqual(typeof comp.setState, 'function', '`setState` is a function');
+  assert.strictEqual(Object.prototype.toString.call(comp.setState), '[object Function]', '`setState` is a function');
 
   comp.setState({foo: 'bar'});
   assert.strictEqual(comp.state.foo, 'bar', 'the component passes a basic stateful test');

--- a/test/unit/mixins/stateful.test.js
+++ b/test/unit/mixins/stateful.test.js
@@ -9,13 +9,13 @@ QUnit.module('mixins: stateful');
 QUnit.test('stateful() mutates an object as expected', function(assert) {
   const target = {};
 
-  assert.strictEqual(typeof stateful, 'function', 'the mixin is a function');
+  assert.strictEqual(Object.prototype.toString.call(stateful), '[object Function]', 'the mixin is a function');
   assert.strictEqual(stateful(target), target, 'returns the target object');
 
   assert.ok(Obj.isObject(target), 'the target is still an object');
   assert.ok(Obj.isPlain(target.state), 'the target has a state');
   assert.strictEqual(Object.keys(target.state).length, 0, 'the target state is empty by default');
-  assert.strictEqual(typeof target.setState, 'function', 'the target has a setState method');
+  assert.strictEqual(Object.prototype.toString.call(target.setState), '[object Function]', 'the target has a setState method');
 });
 
 QUnit.test('stateful() with default state passed in', function(assert) {


### PR DESCRIPTION
## Description
The PR for advanced plugins introduced the concept of mixins and added two: evented and stateful.

This PR follows #3959 by providing `Component`s with the benefits of the stateful mixin.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - ~~Docs/guides updated~~
  - ~~Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))~~
- [ ] Reviewed by Two Core Contributors
