### PR TITLE
Update MW to require a factory, add *-mw

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2208,7 +2208,7 @@ class Player extends Component {
 
     this.currentType_ = src.type;
 
-    middleware.setSource(Fn.bind(this, this.setTimeout), src, (src_, mws) => {
+    middleware.setSource(this, Fn.bind(this, this.setTimeout), src, (src_, mws) => {
       this.middleware_ = mws;
 
       const err = this.src_(src_);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2208,7 +2208,7 @@ class Player extends Component {
 
     this.currentType_ = src.type;
 
-    middleware.setSource(this, Fn.bind(this, this.setTimeout), src, (src_, mws) => {
+    middleware.setSource(this, src, (src_, mws) => {
       this.middleware_ = mws;
 
       const err = this.src_(src_);

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -32,8 +32,11 @@ export function set(middleware, tech, method, arg) {
 }
 
 export const allowedGetters = {
+  buffered: 1,
   currentTime: 1,
-  duration: 1
+  duration: 1,
+  seekable: 1,
+  played: 1
 };
 
 export const allowedSetters = {

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -61,6 +61,7 @@ function setSourceHelper(src = {}, middleware = [], next, player, acc = [], last
   // then call the mw's setSource method
   } else if (mwFactory) {
     const mw = mwFactory(player);
+
     mw.setSource(assign({}, src), function(err, _src) {
 
       // something happened, try the next middleware on the current level

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -15,8 +15,8 @@ export function getMiddleware(type) {
   return middlewares;
 }
 
-export function setSource(setTimeout, src, next) {
-  setTimeout(() => setSourceHelper(src, middlewares[src.type], next), 1);
+export function setSource(player, setTimeout, src, next) {
+  setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
 }
 
 export function setTech(middleware, tech) {
@@ -50,21 +50,23 @@ function middlewareIterator(method) {
   };
 }
 
-function setSourceHelper(src = {}, middleware = [], next, acc = []) {
-  const [mw, ...mwrest] = middleware;
+function setSourceHelper(src = {}, middleware = [], next, player, acc = [], lastRun = false) {
+  const [mwFactory, ...mwrest] = middleware;
 
-  // if mw is a string, then we're at a fork in the road
-  if (typeof mw === 'string') {
-    setSourceHelper(src, middlewares[mw], next, acc);
+  // if mwFactory is a string, then we're at a fork in the road
+  if (typeof mwFactory === 'string') {
+    setSourceHelper(src, middlewares[mwFactory], next, player, acc, lastRun);
 
-  // if we have an mw, call its setSource method
-  } else if (mw) {
+  // if we have an mwFactory, call it with the player to get the mw,
+  // then call the mw's setSource method
+  } else if (mwFactory) {
+    const mw = mwFactory(player);
     mw.setSource(assign({}, src), function(err, _src) {
 
       // something happened, try the next middleware on the current level
       // make sure to use the old src
       if (err) {
-        return setSourceHelper(src, mwrest, next, acc);
+        return setSourceHelper(src, mwrest, next, player, acc, lastRun);
       }
 
       // we've succeeded, now we need to go deeper
@@ -75,11 +77,15 @@ function setSourceHelper(src = {}, middleware = [], next, acc = []) {
       setSourceHelper(_src,
           src.type === _src.type ? mwrest : middlewares[_src.type],
           next,
-          acc);
+          player,
+          acc,
+          lastRun);
     });
   } else if (mwrest.length) {
-    setSourceHelper(src, mwrest, next, acc);
-  } else {
+    setSourceHelper(src, mwrest, next, player, acc, lastRun);
+  } else if (lastRun) {
     next(src, acc);
+  } else {
+    setSourceHelper(src, middlewares['*'], next, player, acc, true);
   }
 }

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -15,8 +15,8 @@ export function getMiddleware(type) {
   return middlewares;
 }
 
-export function setSource(player, setTimeout, src, next) {
-  setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
+export function setSource(player, src, next) {
+  player.setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
 }
 
 export function setTech(middleware, tech) {

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -11,7 +11,6 @@ import { bufferedPercent } from '../utils/buffer.js';
 import MediaError from '../media-error.js';
 import window from 'global/window';
 import document from 'global/document';
-import * as middleware from './middleware.js';
 import {isPlain} from '../utils/obj';
 import * as TRACK_TYPES from '../tracks/track-types';
 
@@ -798,8 +797,6 @@ class Tech extends Component {
     if (!Tech.canPlaySource) {
       throw new Error('Techs must have a static canPlaySource method on them');
     }
-
-    middleware.use('*', {name, tech});
 
     Tech.techs_[name] = tech;
     return tech;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1411,7 +1411,7 @@ QUnit.test('techGet runs through middleware if allowedGetter', function(assert) 
   let durs = 0;
   let ps = 0;
 
-  videojs.use('video/foo', {
+  videojs.use('video/foo', () => ({
     currentTime() {
       cts++;
     },
@@ -1421,14 +1421,14 @@ QUnit.test('techGet runs through middleware if allowedGetter', function(assert) 
     paused() {
       ps++;
     }
-  });
+  }));
 
   const tag = TestHelpers.makeTag();
   const player = videojs(tag, {
     techOrder: ['techFaker']
   });
 
-  player.middleware_ = middleware.getMiddleware('video/foo');
+  player.middleware_ = [middleware.getMiddleware('video/foo')[0](player)];
 
   player.techGet_('currentTime');
   player.techGet_('duration');
@@ -1446,7 +1446,7 @@ QUnit.test('techCall runs through middleware if allowedSetter', function(assert)
   let cts = 0;
   let vols = 0;
 
-  videojs.use('video/foo', {
+  videojs.use('video/foo', () => ({
     setCurrentTime(ct) {
       cts++;
       return ct;
@@ -1454,14 +1454,14 @@ QUnit.test('techCall runs through middleware if allowedSetter', function(assert)
     setVolume() {
       vols++;
     }
-  });
+  }));
 
   const tag = TestHelpers.makeTag();
   const player = videojs(tag, {
     techOrder: ['techFaker']
   });
 
-  player.middleware_ = middleware.getMiddleware('video/foo');
+  player.middleware_ = [middleware.getMiddleware('video/foo')[0](player)];
 
   this.clock.tick(1);
 
@@ -1492,23 +1492,23 @@ QUnit.test('src selects tech based on middleware', function(assert) {
   videojs.registerTech('FooTech', FooTech);
   videojs.registerTech('BarTech', BarTech);
 
-  videojs.use('video/foo', {
+  videojs.use('video/foo', () => ({
     setSource(src, next) {
       next(null, {
         src: 'http://example.com/video.mp4',
         type: 'video/mp4'
       });
     }
-  });
+  }));
 
-  videojs.use('video/bar', {
+  videojs.use('video/bar', () => ({
     setSource(src, next) {
       next(null, {
         src: 'http://example.com/video.flv',
         type: 'video/flv'
       });
     }
-  });
+  }));
 
   const tag = TestHelpers.makeTag();
   const player = videojs(tag, {

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -148,7 +148,9 @@ QUnit.test('setSource is run asynchronously', function(assert) {
   let src;
   let acc;
 
-  middleware.setSource({}, window.setTimeout, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
+  middleware.setSource({
+    setTimeout: window.setTimeout
+  }, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -177,7 +179,9 @@ QUnit.test('setSource selects a source based on the middleware given', function(
 
   middleware.use('video/foo', fooFactory);
 
-  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({
+    setTimeout: window.setTimeout
+  }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -217,7 +221,9 @@ QUnit.test('setSource can select multiple middleware from multiple types', funct
   middleware.use('video/foo', fooFactory);
   middleware.use('video/bar', barFactory);
 
-  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({
+    setTimeout: window.setTimeout
+  }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -269,7 +275,9 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
   middleware.use('video/foo', fooFactory2);
   middleware.use('video/foo', fooFactory3);
 
-  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({
+    setTimeout: window.setTimeout
+  }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -263,7 +263,7 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
   };
   const fooFactory1 = () => foomw1;
   const fooFactory2 = () => foomw2;
-  const fooFactory3 = () => foomw1;
+  const fooFactory3 = () => foomw3;
 
   middleware.use('video/foo', fooFactory1);
   middleware.use('video/foo', fooFactory2);

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -14,10 +14,11 @@ QUnit.module('Middleware', {
 
 QUnit.test('middleware can be added with the use method', function(assert) {
   const myMw = {};
+  const mwFactory = () => myMw;
 
-  middleware.use('foo', myMw);
+  middleware.use('foo', mwFactory);
 
-  assert.equal(middleware.getMiddleware('foo').pop(), myMw, 'we are able to add middleware');
+  assert.equal(middleware.getMiddleware('foo').pop(), mwFactory, 'we are able to add middleware');
 });
 
 QUnit.test('middleware get iterates through the middleware array the right order', function(assert) {
@@ -147,7 +148,7 @@ QUnit.test('setSource is run asynchronously', function(assert) {
   let src;
   let acc;
 
-  middleware.setSource(window.setTimeout, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
+  middleware.setSource({}, window.setTimeout, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -172,10 +173,11 @@ QUnit.test('setSource selects a source based on the middleware given', function(
       });
     }
   };
+  const fooFactory = () => mw;
 
-  middleware.use('video/foo', mw);
+  middleware.use('video/foo', fooFactory);
 
-  middleware.setSource(window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -209,11 +211,13 @@ QUnit.test('setSource can select multiple middleware from multiple types', funct
       });
     }
   };
+  const fooFactory = () => foomw;
+  const barFactory = () => barmw;
 
-  middleware.use('video/foo', foomw);
-  middleware.use('video/bar', barmw);
+  middleware.use('video/foo', fooFactory);
+  middleware.use('video/bar', barFactory);
 
-  middleware.setSource(window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });
@@ -257,12 +261,15 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
       });
     }
   };
+  const fooFactory1 = () => foomw1;
+  const fooFactory2 = () => foomw2;
+  const fooFactory3 = () => foomw1;
 
-  middleware.use('video/foo', foomw1);
-  middleware.use('video/foo', foomw2);
-  middleware.use('video/foo', foomw3);
+  middleware.use('video/foo', fooFactory1);
+  middleware.use('video/foo', fooFactory2);
+  middleware.use('video/foo', fooFactory3);
 
-  middleware.setSource(window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
+  middleware.setSource({}, window.setTimeout, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
     acc = _acc;
   });


### PR DESCRIPTION
## Description
As I was playing around with middleware, in the first RC, I realized that the current way of `videojs.use` with an object was lacking. Specifically, if you have multiple players on the page, the middleware would need to be able to handle tech management itself, which doesn't seem right. Also, the mw didn't know about what player it was attached to.
Now, `videojs.use` takes in a function that given a player, returns a middleware object. The middleware object looks the same as the current object we use for registration. This allows us to have per-player instances of middleware and because it's a factory, a user can use a class or Component or Plugin object for managing their middleware if they want, as long as the methods are available.
For example:
```js
videojs.use('video/foo', (player) => ({
  setSource(src, next) {
    if (player.playbackRate() > 1) {
      next(null, {
       src:  'foo',
       type: 'video/mp4'
      });
    } else {
      next(new Error('we don't support this));
    }
  }
}));
```

Also, this PR adds the ability to register "star middleware" (* mw),  which will always be run through right before selecting the tech.