### PR TITLE
docs(guides): add basic ReactJS integration example

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -38,6 +38,7 @@
 * [Q: Does video.js have any support for advertisement integrations?](#q-does-videojs-have-any-support-for-advertisement-integrations)
 * [Q: Can video.js be required in node.js?](#q-can-videojs-be-required-in-nodejs)
 * [Q: Does video.js work with webpack?](#q-does-videojs-work-with-webpack)
+* [Q: Does video.js work with react?](#q-does-videojs-work-with-react)
 
 ## Q: What is video.js?
 
@@ -268,6 +269,12 @@ Yes! Please [submit an issue or open a pull request][pr-issue-question] if this 
 ## Q: Does video.js work with webpack?
 
 Yes! Please [submit an issue or open a pull request][pr-issue-question] if this does not work.
+
+Use `require('!style-loader!css-loader!video.js/dist/video-js.css')` to inject video.js CSS.
+
+## Q: Does video.js work with react?
+
+Yes! See [ReactJS integration example](./guides/react.md).
 
 [plugin-guide]: plugins.md
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -270,7 +270,7 @@ Yes! Please [submit an issue or open a pull request][pr-issue-question] if this 
 
 Yes! Please [submit an issue or open a pull request][pr-issue-question] if this does not work.
 
-Use `require('!style-loader!css-loader!video.js/dist/video-js.css')` to inject video.js CSS.
+Be sure to use `require('!style-loader!css-loader!video.js/dist/video-js.css')` to inject video.js CSS.
 
 ## Q: Does video.js work with react?
 

--- a/docs/guides/player-workflows.md
+++ b/docs/guides/player-workflows.md
@@ -367,6 +367,8 @@ Coming soon...
 
 ### React
 
+See [ReactJS integration example](./react.md)
+
 ### Ember
 
 ### Angular

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -1,0 +1,61 @@
+# video.js and ReactJS integration
+
+Here's a basic ReactJS player implementation.
+
+It just instantiate the video.js player on `componentDidMount` and destroy it on `componentWillUnmount`.
+
+```jsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import videojs from 'video.js'
+
+// this loads video.js CSS using webpack loaders
+require('!style-loader!css-loader!video.js/dist/video-js.css')
+
+export default class VideoPlayer extends React.Component {
+  componentDidMount() {
+    // get the <video> DOM node
+    const videoNode = ReactDOM.findDOMNode(this).querySelector('video');
+
+    // instantiate video.js
+    this.player = videojs(videoNode, this.props, function onPlayerReady() {
+      console.log('onPlayerReady', this)
+    });
+  }
+
+  // destroy player on unmount
+  componentWillUnmount() {
+    if (this.player) {
+      this.player.dispose()
+    }
+  }
+
+  // wrap the player in a div with a `data-vjs-player` attribute
+  // so videojs won't create additional wrapper in the DOM
+  // see https://github.com/videojs/video.js/pull/3856
+  render() {
+    return (
+      <div data-vjs-player>
+        <video className="video-js"></video>
+      </div>
+    )
+  }
+}
+```
+
+You can then use it like this :
+
+```jsx
+// see https://github.com/videojs/video.js/blob/master/docs/guides/options.md
+const videoJsOptions = {
+  autoPlay: true,
+  controls: true,
+  sources: [{
+    src: '/path/to/video.mp4',
+    type: 'video/mp4'
+  }]
+}
+
+return <VideoPlayer { ...videoJsOptions } />
+```

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -6,17 +6,12 @@ It just instantiates the video.js player on `componentDidMount` and destroys it 
 
 ```jsx
 import React from 'react';
-import ReactDOM from 'react-dom';
-
 import videojs from 'video.js'
 
 export default class VideoPlayer extends React.Component {
   componentDidMount() {
-    // get the <video> DOM node
-    const videoNode = ReactDOM.findDOMNode(this).querySelector('video');
-
     // instantiate video.js
-    this.player = videojs(videoNode, this.props, function onPlayerReady() {
+    this.player = videojs(this.videoNode, this.props, function onPlayerReady() {
       console.log('onPlayerReady', this)
     });
   }
@@ -34,7 +29,7 @@ export default class VideoPlayer extends React.Component {
   render() {
     return (
       <div data-vjs-player>
-        <video className="video-js"></video>
+        <video ref={ node => this.videoNode = node } className="video-js"></video>
       </div>
     )
   }

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -2,16 +2,13 @@
 
 Here's a basic ReactJS player implementation.
 
-It just instantiate the video.js player on `componentDidMount` and destroy it on `componentWillUnmount`.
+It just instantiates the video.js player on `componentDidMount` and destroys it on `componentWillUnmount`.
 
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import videojs from 'video.js'
-
-// this loads video.js CSS using webpack loaders
-require('!style-loader!css-loader!video.js/dist/video-js.css')
 
 export default class VideoPlayer extends React.Component {
   componentDidMount() {
@@ -44,7 +41,7 @@ export default class VideoPlayer extends React.Component {
 }
 ```
 
-You can then use it like this :
+You can then use it like this:
 
 ```jsx
 // see https://github.com/videojs/video.js/blob/master/docs/guides/options.md
@@ -59,3 +56,7 @@ const videoJsOptions = {
 
 return <VideoPlayer { ...videoJsOptions } />
 ```
+
+If you use webpack, you can embed video.js CSS like this:
+
+`require('!style-loader!css-loader!video.js/dist/video-js.css')`

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -52,6 +52,4 @@ const videoJsOptions = {
 return <VideoPlayer { ...videoJsOptions } />
 ```
 
-If you use webpack, you can embed video.js CSS like this:
-
-`require('!style-loader!css-loader!video.js/dist/video-js.css')`
+Dont forget to include the video.js CSS, located at `video.js/dist/video-js.css`.


### PR DESCRIPTION
## Description

Just some doc for a clean ReactJS integration

## Specific Changes proposed

add `guides/react.md `

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
