### PR TITLE
fix: Patch a memory leak caused by un-removed track listener(s).

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -589,13 +589,12 @@ class Tech extends Component {
       return;
     }
 
-    this.remoteTextTracks().on('addtrack', (e) => {
-      this.textTracks().addTrack_(e.track);
-    });
+    const remoteTracks = this.remoteTextTracks();
+    const handleAddTrack = (e) => tracks.addTrack_(e.track);
+    const handleRemoveTrack = (e) => tracks.removeTrack_(e.track);
 
-    this.remoteTextTracks().on('removetrack', (e) => {
-      this.textTracks().removeTrack_(e.track);
-    });
+    remoteTracks.on('addtrack', handleAddTrack);
+    remoteTracks.on('removetrack', handleRemoveTrack);
 
     // Initially, Tech.el_ is a child of a dummy-div wait until the Component system
     // signals that the Tech is ready at which point Tech.el_ is part of the DOM
@@ -603,6 +602,7 @@ class Tech extends Component {
     this.on('ready', this.addWebVttScript_);
 
     const updateDisplay = () => this.trigger('texttrackchange');
+
     const textTracksChanges = () => {
       updateDisplay();
 
@@ -620,7 +620,15 @@ class Tech extends Component {
     tracks.addEventListener('change', textTracksChanges);
 
     this.on('dispose', function() {
+      remoteTracks.off('addtrack', handleAddTrack);
+      remoteTracks.off('removetrack', handleRemoveTrack);
       tracks.removeEventListener('change', textTracksChanges);
+
+      for (let i = 0; i < tracks.length; i++) {
+        const track = tracks[i];
+
+        track.removeEventListener('cuechange', updateDisplay);
+      }
     });
   }
 


### PR DESCRIPTION
In investigating some memory issues in our player, I found this one in Video.js. Some of these listener(s) could be left behind leaving `TextTrackList` objects (and other related references) hanging around after player disposal.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
