### PR TITLE
fix: Patch a memory leak caused by un-removed track listener(s).

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -560,8 +560,8 @@ class Tech extends Component {
   emulateTextTracks() {
     const tracks = this.textTracks();
     const remoteTracks = this.remoteTextTracks();
-    const handleAddTrack = (e) => tracks.addTrack_(e.track);
-    const handleRemoveTrack = (e) => tracks.removeTrack_(e.track);
+    const handleAddTrack = (e) => tracks.addTrack(e.track);
+    const handleRemoveTrack = (e) => tracks.removeTrack(e.track);
 
     remoteTracks.on('addtrack', handleAddTrack);
     remoteTracks.on('removetrack', handleRemoveTrack);


### PR DESCRIPTION
#3975 as applied to Video.js 6.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
