### PR TITLE
Expose Tech#resize as Player#resize

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -790,7 +790,7 @@ class Component {
    *        The width that you want to set postfixed with '%', 'px' or nothing.
    *
    * @param {boolean} [skipListeners]
-   *        Skip the resize event trigger
+   *        Skip the componentresize event trigger
    *
    * @return {number|string}
    *         The width when getting, zero if there is no width. Can be a string
@@ -808,7 +808,7 @@ class Component {
    *        The height that you want to set postfixed with '%', 'px' or nothing.
    *
    * @param {boolean} [skipListeners]
-   *        Skip the resize event trigger
+   *        Skip the componentresize event trigger
    *
    * @return {number|string}
    *         The width when getting, zero if there is no width. Can be a string
@@ -828,7 +828,7 @@ class Component {
    *         Height to set the `Component`s element to.
    */
   dimensions(width, height) {
-    // Skip resize listeners on width for optimization
+    // Skip componentresize listeners on width for optimization
     this.width(width, true);
     this.height(height);
   }
@@ -847,7 +847,7 @@ class Component {
    * - If you want the computed style of the component, use {@link Component#currentWidth}
    *   and {@link {Component#currentHeight}
    *
-   * @fires Component#resize
+   * @fires Component#componentresize
    *
    * @param {string} widthOrHeight
    8        'width' or 'height'
@@ -856,7 +856,7 @@ class Component {
    8         New dimension
    *
    * @param  {boolean} [skipListeners]
-   *         Skip resize event trigger
+   *         Skip componentresize event trigger
    *
    * @return {number}
    *         The dimension when getting or 0 if unset
@@ -882,10 +882,10 @@ class Component {
         /**
          * Triggered when a component is resized.
          *
-         * @event Component#resize
+         * @event Component#componentresize
          * @type {EventTarget~Event}
          */
-        this.trigger('resize');
+        this.trigger('componentresize');
       }
 
       return;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -192,13 +192,13 @@ const TECH_EVENTS_RETRIGGER = [
   'ratechange',
 
   /**
-   * Fires when the playing speed of the audio/video is changed
+   * Fires when the video's intrinsic dimensions change
    *
    * @event Player#resize
    * @type {event}
    */
   /**
-   * Retrigger the `ratechange` event that was triggered by the {@link Tech}.
+   * Retrigger the `resize` event that was triggered by the {@link Tech}.
    *
    * @private
    * @method Player#handleTechResize_

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -192,6 +192,22 @@ const TECH_EVENTS_RETRIGGER = [
   'ratechange',
 
   /**
+   * Fires when the playing speed of the audio/video is changed
+   *
+   * @event Player#resize
+   * @type {event}
+   */
+  /**
+   * Retrigger the `ratechange` event that was triggered by the {@link Tech}.
+   *
+   * @private
+   * @method Player#handleTechResize_
+   * @fires Player#resize
+   * @listens Tech#resize
+   */
+  'resize',
+
+  /**
    * Fires when the volume has been changed
    *
    * @event player#volumechange
@@ -890,29 +906,6 @@ class Player extends Component {
     this.on(this.tech_, 'loadedmetadata', this.updateStyleEl_);
     this.on(this.tech_, 'posterchange', this.handleTechPosterChange_);
     this.on(this.tech_, 'textdata', this.handleTechTextData_);
-
-    /**
-     * Fires when the video's intrinsic width and/or height has changed.
-     * This differs from Player#resize, which is triggered when the player
-     * is resized.
-     *
-     * @event player#videoresize
-     * @type {event}
-     */
-    /**
-     * Retrigger the `resize` event that was triggered by the {@link Tech}
-     * as `videoresize`.
-     *
-     * @private
-     * @method Player#handleTechResize_
-     * @fires Player#videoresize
-     * @listens Tech#resize
-     */
-    Player.prototype.handleTechResize_ = function(event) {
-      event.type = 'videoresize';
-      return this.trigger(event);
-    };
-    this.on(this.tech_, 'resize', this.handleTechResize_);
 
     this.usingNativeControls(this.techGet_('controls'));
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -891,6 +891,29 @@ class Player extends Component {
     this.on(this.tech_, 'posterchange', this.handleTechPosterChange_);
     this.on(this.tech_, 'textdata', this.handleTechTextData_);
 
+    /**
+     * Fires when the video's intrinsic width and/or height has changed.
+     * This differs from Player#resize, which is triggered when the player
+     * is resized.
+     *
+     * @event player#videoresize
+     * @type {event}
+     */
+    /**
+     * Retrigger the `resize` event that was triggered by the {@link Tech}
+     * as `videoresize`.
+     *
+     * @private
+     * @method Player#handleTechResize_
+     * @fires Player#videoresize
+     * @listens Tech#resize
+     */
+    Player.prototype.handleTechResize_ = function(event) {
+      event.type = 'videoresize';
+      return this.trigger(event);
+    };
+    this.on(this.tech_, 'resize', this.handleTechResize_);
+
     this.usingNativeControls(this.techGet_('controls'));
 
     if (this.controls() && !this.usingNativeControls()) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -848,6 +848,7 @@ Html5.Events = [
   'play',
   'pause',
   'ratechange',
+  'resize',
   'volumechange'
 ];
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1580,3 +1580,17 @@ QUnit.test('options: plugins', function(assert) {
   player.dispose();
   Plugin.deregisterPlugin('foo');
 });
+
+QUnit.test('should fire videoresize when tech fires resize', function(assert) {
+  assert.expect(1);
+
+  const player = TestHelpers.makePlayer({});
+
+  player.on('videoresize', function() {
+    assert.ok(true, 'videoresize event triggered');
+  });
+
+  // init firstplay listeners
+  player.tech_.trigger('resize');
+  player.dispose();
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1580,17 +1580,3 @@ QUnit.test('options: plugins', function(assert) {
   player.dispose();
   Plugin.deregisterPlugin('foo');
 });
-
-QUnit.test('should fire videoresize when tech fires resize', function(assert) {
-  assert.expect(1);
-
-  const player = TestHelpers.makePlayer({});
-
-  player.on('videoresize', function() {
-    assert.ok(true, 'videoresize event triggered');
-  });
-
-  // init firstplay listeners
-  player.tech_.trigger('resize');
-  player.dispose();
-});


### PR DESCRIPTION
## Description
The HTML5 tech has a [resize](https://html.spec.whatwg.org/multipage/embedded-content.html#event-media-resize) which fires when the video's intrinsic dimensions change. ~`Player` has a `resize` event when the player dimensions change.~ This can be confusing, and the tech's `resize` is useful.

`Player` had a `resize` event, but currently does not. 

## Specific Changes proposed
~Trigger a `videoresize` event on `Player` when `Tech` emits `resize`. The existing `Player#resize` does not change.~

Retrigger tech `resize` on `Player`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated (jsdoc)
- [ ] Reviewed by Two Core Contributors
