### PR TITLE
move most volume panel functionality into css state

### DIFF
--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -16,9 +16,8 @@
 @mixin transition($string: $transition--default) {
   -webkit-transition: $string;
   -moz-transition: $string;
-  -o-transition: $string;
-  // added for ie10
   -ms-transition: $string;
+  -o-transition: $string;
   transition: $string;
 }
 
@@ -117,11 +116,3 @@
   @extend %fill-parent;
   text-align: center;
 }
-
-// don't wrap whitespace for the time control and make the text container 0 width
-// fixes a bug with 'width: auto' in IE 8/9
-.vjs-ie-auto-width-fix {
-  width: 0px !important;
-  white-space: nowrap;
-}
-

--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -115,3 +115,11 @@
   @extend %fill-parent;
   text-align: center;
 }
+
+// don't wrap whitespace for the time control and make the text container 0 width
+// fixes a bug with 'width: auto' in IE 8/9
+.vjs-ie-auto-width-fix {
+  width: 0px !important;
+  white-space: nowrap;
+}
+

--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -17,6 +17,8 @@
   -webkit-transition: $string;
   -moz-transition: $string;
   -o-transition: $string;
+  // added for ie10
+  -ms-transition: $string;
   transition: $string;
 }
 

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -35,28 +35,3 @@
   display: table-cell;
   vertical-align: middle;
 }
-
-// visually hide a control-bar component without changing the position
-// and without hiding it from screen readers. This also preserves
-// a transition animation.
-.video-js .vjs-control .vjs-visual-hide-vertical {
-  height: 1px;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  opacity: 0;
-  margin-top: -1px;
-}
-
-// visually hide a control-bar component without changing the position
-// and without hiding it from screen readers. This also preserves
-// a transition animation.
-.video-js .vjs-control .vjs-visual-hide-horizontal {
-  width: 1px;
-  margin: 0;
-  padding: 0;
-  overflow: hidden;
-  opacity: 0;
-  margin-left: -1px;
-}
-

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -45,6 +45,7 @@
   padding: 0;
   overflow: hidden;
   opacity: 0;
+  margin-top: -1px;
 }
 
 // visually hide a control-bar component without changing the position
@@ -56,7 +57,6 @@
   padding: 0;
   overflow: hidden;
   opacity: 0;
+  margin-left: -1px;
 }
-
-
 

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -86,6 +86,17 @@
   @include transition($transition-property)
 }
 
+.video-js.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
+  width: 5em;
+  height: 3em;
+
+  visibility: visible;
+  opacity: 1;
+  position: relative;
+
+  @include transition(none);
+}
+
 .video-js.vjs-no-flex .vjs-volume-control.vjs-volume-vertical,
 .video-js.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
   position: absolute;

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -22,12 +22,37 @@
 .video-js .vjs-volume-control {
   width: auto;
   margin-right: 1em;
-  @include flex(none);
-  @include display-flex(center);
+  @include display-flex;
+
+  visibility: visible;
+  opacity: 1;
 
   // var needed due to comma
-  $transition-property: height 0.4s, opacity 0.4s, margin-right 0.4s;
+  /*$transition-property: height 0.1s, width 0.1s, opacity 0.1s, margin-right 0.1s;*/
+  /*@include transition($transition-property)*/
+  $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s;
   @include transition($transition-property)
+}
+
+.video-js .vjs-volume-hide {
+  visibility: visible;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+.video-js .vjs-volume-vertical.vjs-volume-hide {
+  $transition-property: visibility 1s, opacity 1s, height 1s, width 1s 1s;
+  @include transition($transition-property)
+}
+.video-js .vjs-volume-horizontal.vjs-volume-hide {
+  $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s;
+  @include transition($transition-property)
+}
+
+.video-js .vjs-volume-control.vjs-visual-hide {
+  /*$transition-property: height 5s, width 5s, opacity 5s 5s, margin-top 5s 5s, margin-left 5s 5s, padding 5s 5s, visibility 5s 5s;*/
+  /*$transition-property: width 5s;*/
+  /*@include transition($transition-property)*/
 }
 
 .video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -20,51 +20,74 @@
 }
 
 .video-js .vjs-volume-control {
-  width: auto;
   margin-right: 1em;
   @include display-flex;
-
-  visibility: visible;
-  opacity: 1;
-
-  // var needed due to comma
-  /*$transition-property: height 0.1s, width 0.1s, opacity 0.1s, margin-right 0.1s;*/
-  /*@include transition($transition-property)*/
-  $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s;
-  @include transition($transition-property)
+}
+.video-js .vjs-volume-control.vjs-volume-horizontal {
+  width: 5em;
 }
 
-.video-js .vjs-volume-hide {
+.video-js .vjs-volume-panel .vjs-volume-control {
   visibility: visible;
   opacity: 0;
   width: 1px;
   height: 1px;
-}
-.video-js .vjs-volume-vertical.vjs-volume-hide {
-  $transition-property: visibility 1s, opacity 1s, height 1s, width 1s 1s;
-  @include transition($transition-property)
-}
-.video-js .vjs-volume-horizontal.vjs-volume-hide {
-  $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s;
-  @include transition($transition-property)
-}
-
-.video-js .vjs-volume-control.vjs-visual-hide {
-  /*$transition-property: height 5s, width 5s, opacity 5s 5s, margin-top 5s 5s, margin-left 5s 5s, padding 5s 5s, visibility 5s 5s;*/
-  /*$transition-property: width 5s;*/
-  /*@include transition($transition-property)*/
-}
-
-.video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {
-  left: 0.6em;
-  bottom: 3em;
-  position: absolute;
+  margin-left: -1px;
 }
 
 .video-js .vjs-volume-panel {
-  width: auto;
-  @include flex(none);
-  @include display-flex(center);
+  &:hover  .vjs-volume-control,
+  &:active .vjs-volume-control,
+  &:focus  .vjs-volume-control,
+  & .vjs-volume-control:hover  ,
+  & .vjs-volume-control:active ,
+  & .vjs-volume-control:focus  ,
+  & .vjs-mute-control:hover  ~ .vjs-volume-control,
+  & .vjs-mute-control:active ~ .vjs-volume-control,
+  & .vjs-mute-control:focus  ~ .vjs-volume-control,
+  & .vjs-volume-control.vjs-slider-active {
+    &.vjs-volume-horizontal {
+      width: 5em;
+      height: 3em;
+    }
+
+    visibility: visible;
+    opacity: 1;
+    position: relative;
+
+    $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
+    @include transition($transition-property);
+  }
+
+  &.vjs-volume-panel-horizontal {
+    &:hover,
+    &:focus,
+    &:active,
+    &.vjs-slider-active {
+      width: 9em;
+
+      @include transition(width 0.1s);
+    }
+  }
+
+  @include transition(width 1s);
+}
+
+.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical  {
+  height: 8em;
+  width: 3em;
+  left: -3.5em;
+
+  $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
+  @include transition($transition-property)
+}
+.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
+  $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s, top 1s 1s;
+  @include transition($transition-property)
+}
+
+.video-js .vjs-volume-panel {
+  @include display-flex;
 }
 
 .video-js .vjs-volume-bar {
@@ -131,10 +154,9 @@
 }
 
 .video-js .vjs-volume-vertical {
-  width: 2.9em;
+  width: 3em;
   height: 8em;
-  bottom: 5.5em;
-  left: -3.5em;
+  bottom: 7.5em;
 
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -33,6 +33,14 @@
   width: 1px;
   height: 1px;
   margin-left: -1px;
+
+}
+.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  & .vjs-volume-bar,
+  & .vjs-volume-level {
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  }
 }
 
 .video-js .vjs-volume-panel {
@@ -54,6 +62,14 @@
     visibility: visible;
     opacity: 1;
     position: relative;
+
+    &.vjs-volume-vertical {
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+      & .vjs-volume-bar,
+      & .vjs-volume-level {
+        -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+      }
+    }
 
     $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
     @include transition($transition-property);

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -73,7 +73,7 @@
   @include transition(width 1s);
 }
 
-.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical  {
+.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
   height: 8em;
   width: 3em;
   left: -3.5em;
@@ -84,6 +84,13 @@
 .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
   $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s, top 1s 1s;
   @include transition($transition-property)
+}
+
+.video-js.vjs-no-flex .vjs-volume-control.vjs-volume-vertical,
+.video-js.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+  position: absolute;
+  bottom: 3em;
+  left: 0.5em;
 }
 
 .video-js .vjs-volume-panel {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -156,7 +156,7 @@
 .video-js .vjs-volume-vertical {
   width: 3em;
   height: 8em;
-  bottom: 7.5em;
+  bottom: 8em;
 
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -19,13 +19,16 @@
   @extend .vjs-icon-volume-mid;
 }
 
-
 .video-js .vjs-volume-control {
   width: auto;
   margin-right: 1em;
   @include flex(none);
   @include display-flex(center);
-  @include transition(all 0.4s);
+
+  transition-property: height, opacity, margin-right;
+  transition-duration: 0.4s;
+  transition-timing-function: initial;
+  transition-delay: initial;
 }
 
 .video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -2,6 +2,11 @@
   cursor: pointer;
   @include flex(none);
   @extend .vjs-icon-volume-high;
+  // padding here is for IE < 9, it doesn't do width: auto from
+  // another style correctly
+  padding-left: 2em;
+  padding-right: 2em;
+  padding-bottom: 3em;
 }
 
 .video-js .vjs-mute-control.vjs-vol-0 {
@@ -21,6 +26,12 @@
   @include flex(none);
   @include display-flex(center);
   @include transition(all 0.4s);
+}
+
+.video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {
+  left: 0.6em;
+  bottom: 3em;
+  position: absolute;
 }
 
 .video-js .vjs-volume-panel {

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -25,10 +25,9 @@
   @include flex(none);
   @include display-flex(center);
 
-  transition-property: height, opacity, margin-right;
-  transition-duration: 0.4s;
-  transition-timing-function: initial;
-  transition-delay: initial;
+  // var needed due to comma
+  $transition-property: height 0.4s, opacity 0.4s, margin-right 0.4s;
+  @include transition($transition-property)
 }
 
 .video-js .vjs-volume-control.vjs-control.vjs-volume-vertical {

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -4,7 +4,6 @@
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import formatTime from '../../utils/format-time.js';
-import {IE_VERSION} from '../../utils/browser';
 
 /**
  * Displays the time left in the video
@@ -36,14 +35,8 @@ class RemainingTimeDisplay extends Component {
    *         The element that was created.
    */
   createEl() {
-    let ieFixClass = '';
-
-    if (IE_VERSION && IE_VERSION <= 9) {
-      ieFixClass = 'vjs-ie-auto-width-fix';
-    }
-
     const el = super.createEl('div', {
-      className: `vjs-remaining-time vjs-time-control vjs-control ${ieFixClass}`
+      className: 'vjs-remaining-time vjs-time-control vjs-control'
     });
 
     this.contentEl_ = Dom.createEl('div', {

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -4,6 +4,7 @@
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import formatTime from '../../utils/format-time.js';
+import {IE_VERSION} from '../../utils/browser';
 
 /**
  * Displays the time left in the video
@@ -35,8 +36,14 @@ class RemainingTimeDisplay extends Component {
    *         The element that was created.
    */
   createEl() {
+    let ieFixClass = '';
+
+    if (IE_VERSION && IE_VERSION <= 9) {
+      ieFixClass = 'vjs-ie-auto-width-fix';
+    }
+
     const el = super.createEl('div', {
-      className: 'vjs-remaining-time vjs-time-control vjs-control'
+      className: `vjs-remaining-time vjs-time-control vjs-control ${ieFixClass}`
     });
 
     this.contentEl_ = Dom.createEl('div', {

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -41,8 +41,8 @@ class VolumeControl extends Component {
     checkVolumeSupport(this, player);
 
     // while the slider is active (the mouse has been pressed down and
-    // is dragging) we do not want to hide the VolumeBar
-    this.on(this.volumeBar, ['slideractive'], () => {
+    // is dragging) or in focus we do not want to hide the VolumeBar
+    this.on(this.volumeBar, ['focus', 'slideractive'], () => {
       this.volumeBar.addClass('vjs-slider-active');
       this.lockShowing_ = true;
     });
@@ -50,7 +50,7 @@ class VolumeControl extends Component {
     // when the slider becomes inactive again we want to hide
     // the VolumeBar, but only if we tried to hide when
     // lockShowing_ was true. see the VolumeBar#hide function.
-    this.on(this.volumeBar, ['sliderinactive'], () => {
+    this.on(this.volumeBar, ['blur', 'sliderinactive'], () => {
       this.volumeBar.removeClass('vjs-slider-active');
       this.lockShowing_ = false;
 

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -4,7 +4,6 @@
 import Component from '../../component.js';
 import checkVolumeSupport from './check-volume-support';
 import {isPlain} from '../../utils/obj';
-import {IE_VERSION} from '../../utils/browser';
 
 // Required children
 import './volume-bar.js';

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -77,7 +77,7 @@ class VolumeControl extends Component {
     // animate hiding the bar via transitions
     let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.inline === false) {
+    if (this.options_.vertical) {
       hideClass = 'vjs-visual-hide-vertical';
     }
 
@@ -109,7 +109,7 @@ class VolumeControl extends Component {
     // animate hiding the bar via transitions
     let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.inline === false) {
+    if (this.options_.vertical) {
       hideClass = 'vjs-visual-hide-vertical';
     }
 

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -4,6 +4,7 @@
 import Component from '../../component.js';
 import checkVolumeSupport from './check-volume-support';
 import {isPlain} from '../../utils/obj';
+import {IE_VERSION} from '../../utils/browser';
 
 // Required children
 import './volume-bar.js';
@@ -63,6 +64,8 @@ class VolumeControl extends Component {
     // VolumeBar by itself we will need this
     this.on(this.volumeBar, ['focus'], () => this.show());
     this.on(this.volumeBar, ['blur'], () => this.hide());
+
+    this.hide();
   }
 
   /**
@@ -71,12 +74,22 @@ class VolumeControl extends Component {
   show() {
     this.shouldHide_ = false;
 
-    if (this.options_.vertical) {
-      this.removeClass('vjs-visual-hide-vertical');
-    } else {
-      this.removeClass('vjs-visual-hide-horizontal');
+    // animate hiding the bar via transitions
+    let hideClass = 'vjs-visual-hide-horizontal';
+
+    if (this.options_.inline === false) {
+      hideClass = 'vjs-visual-hide-vertical';
     }
 
+    this.removeClass(hideClass);
+
+    // IE < 9 doesn't calculate width correctly if everything inside
+    // the parent element is not hidden as well
+    if (IE_VERSION && IE_VERSION <= 9) {
+      this.children().forEach(function(child) {
+        child.removeClass(hideClass);
+      });
+    }
   }
 
   /**
@@ -94,10 +107,20 @@ class VolumeControl extends Component {
     }
 
     // animate hiding the bar via transitions
-    if (this.options_.vertical) {
-      this.addClass('vjs-visual-hide-vertical');
-    } else {
-      this.addClass('vjs-visual-hide-horizontal');
+    let hideClass = 'vjs-visual-hide-horizontal';
+
+    if (this.options_.inline === false) {
+      hideClass = 'vjs-visual-hide-vertical';
+    }
+
+    this.addClass(hideClass);
+
+    // IE < 9 doesn't calculate width correctly if everything inside
+    // the parent element is not hidden as well
+    if (IE_VERSION && IE_VERSION <= 9) {
+      this.children().forEach(function(child) {
+        child.addClass(hideClass);
+      });
     }
   }
 
@@ -108,10 +131,10 @@ class VolumeControl extends Component {
    *         The element that was created.
    */
   createEl() {
-    let orientationClass = 'vjs-volume-horizonal vjs-visual-hide-horizontal';
+    let orientationClass = 'vjs-volume-horizonal';
 
     if (this.options_.vertical) {
-      orientationClass = 'vjs-volume-vertical vjs-visual-hide-vertical';
+      orientationClass = 'vjs-volume-vertical';
     }
 
     return super.createEl('div', {

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -75,11 +75,13 @@ class VolumeControl extends Component {
     this.shouldHide_ = false;
 
     // animate hiding the bar via transitions
-    let hideClass = 'vjs-visual-hide-horizontal';
+    // let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.vertical) {
-      hideClass = 'vjs-visual-hide-vertical';
-    }
+    // if (this.options_.vertical) {
+      // hideClass = 'vjs-visual-hide-vertical';
+    // }
+
+    const hideClass = 'vjs-volume-hide';
 
     this.removeClass(hideClass);
 
@@ -107,11 +109,13 @@ class VolumeControl extends Component {
     }
 
     // animate hiding the bar via transitions
-    let hideClass = 'vjs-visual-hide-horizontal';
+    // let hideClass = 'vjs-visual-hide-horizontal';
 
-    if (this.options_.vertical) {
-      hideClass = 'vjs-visual-hide-vertical';
-    }
+    // if (this.options_.vertical) {
+      // hideClass = 'vjs-visual-hide-vertical';
+    // }
+
+    const hideClass = 'vjs-volume-hide';
 
     this.addClass(hideClass);
 
@@ -131,7 +135,7 @@ class VolumeControl extends Component {
    *         The element that was created.
    */
   createEl() {
-    let orientationClass = 'vjs-volume-horizonal';
+    let orientationClass = 'vjs-volume-horizontal';
 
     if (this.options_.vertical) {
       orientationClass = 'vjs-volume-vertical';

--- a/src/js/control-bar/volume-control/volume-control.js
+++ b/src/js/control-bar/volume-control/volume-control.js
@@ -44,88 +44,15 @@ class VolumeControl extends Component {
     // is dragging) or in focus we do not want to hide the VolumeBar
     this.on(this.volumeBar, ['focus', 'slideractive'], () => {
       this.volumeBar.addClass('vjs-slider-active');
-      this.lockShowing_ = true;
+      this.addClass('vjs-slider-active');
+      this.trigger('slideractive');
     });
 
-    // when the slider becomes inactive again we want to hide
-    // the VolumeBar, but only if we tried to hide when
-    // lockShowing_ was true. see the VolumeBar#hide function.
     this.on(this.volumeBar, ['blur', 'sliderinactive'], () => {
       this.volumeBar.removeClass('vjs-slider-active');
-      this.lockShowing_ = false;
-
-      if (this.shouldHide_) {
-        this.hide();
-      }
+      this.removeClass('vjs-slider-active');
+      this.trigger('sliderinactive');
     });
-
-    // show/hide the VolumeBar on focus/blur
-    // happens in VolumeControl but if we want to use the
-    // VolumeBar by itself we will need this
-    this.on(this.volumeBar, ['focus'], () => this.show());
-    this.on(this.volumeBar, ['blur'], () => this.hide());
-
-    this.hide();
-  }
-
-  /**
-   * Remove the visual hidden state from the `VolumeControl`.
-   */
-  show() {
-    this.shouldHide_ = false;
-
-    // animate hiding the bar via transitions
-    // let hideClass = 'vjs-visual-hide-horizontal';
-
-    // if (this.options_.vertical) {
-      // hideClass = 'vjs-visual-hide-vertical';
-    // }
-
-    const hideClass = 'vjs-volume-hide';
-
-    this.removeClass(hideClass);
-
-    // IE < 9 doesn't calculate width correctly if everything inside
-    // the parent element is not hidden as well
-    if (IE_VERSION && IE_VERSION <= 9) {
-      this.children().forEach(function(child) {
-        child.removeClass(hideClass);
-      });
-    }
-  }
-
-  /**
-   * Hide the `VolumeControl` visually but not from screen-readers unless
-   * showing is locked (due to the slider being active). If showing is locked
-   * hide will be called when the slider becomes inactive.
-   */
-  hide() {
-    // if we are currently locked to the showing state
-    // don't hide, but store that we should hide when
-    // lockShowing_ turns to a false value.
-    if (this.lockShowing_) {
-      this.shouldHide_ = true;
-      return;
-    }
-
-    // animate hiding the bar via transitions
-    // let hideClass = 'vjs-visual-hide-horizontal';
-
-    // if (this.options_.vertical) {
-      // hideClass = 'vjs-visual-hide-vertical';
-    // }
-
-    const hideClass = 'vjs-volume-hide';
-
-    this.addClass(hideClass);
-
-    // IE < 9 doesn't calculate width correctly if everything inside
-    // the parent element is not hidden as well
-    if (IE_VERSION && IE_VERSION <= 9) {
-      this.children().forEach(function(child) {
-        child.addClass(hideClass);
-      });
-    }
   }
 
   /**

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -46,16 +46,20 @@ class VolumePanel extends Component {
     // hide this control if volume support is missing
     checkVolumeSupport(this, player);
 
-    // when the mouse leaves the VolumePanel area hide the VolumeControl (slider/bar)
-    this.on(['mouseenter', 'touchstart'], () => this.volumeControl.show());
-    this.on(['mouseleave', 'touchend'], () => this.volumeControl.hide());
+    // while the slider is active (the mouse has been pressed down and
+    // is dragging) or in focus we do not want to hide the VolumeBar
+    this.on(this.volumeControl, ['slideractive'], this.sliderActive_);
+    this.on(this.muteToggle, 'focus', this.sliderActive_);
 
-    // when any child of the VolumePanel gets or loses focus
-    // show/hide the VolumeControl (slider/bar)
-    this.children().forEach((child) => {
-      this.on(child, ['focus'], () => this.volumeControl.show());
-      this.on(child, ['blur'], () => this.volumeControl.hide());
-    });
+    this.on(this.volumeControl, ['sliderinactive'], this.sliderInactive_);
+    this.on(this.muteToggle, 'blur', this.sliderInactive_);
+  }
+
+  sliderActive_() {
+    this.addClass('vjs-slider-active');
+  }
+  sliderInactive_() {
+    this.removeClass('vjs-slider-active');
   }
 
   /**

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -54,9 +54,22 @@ class VolumePanel extends Component {
     this.on(this.muteToggle, 'blur', this.sliderInactive_);
   }
 
+  /**
+   * Add vjs-slider-active class to the VolumePanel
+   *
+   * @listens VolumeControl#slideractive
+   * @private
+   */
   sliderActive_() {
     this.addClass('vjs-slider-active');
   }
+
+  /**
+   * Removes vjs-slider-active class to the VolumePanel
+   *
+   * @listens VolumeControl#sliderinactive
+   * @private
+   */
   sliderInactive_() {
     this.removeClass('vjs-slider-active');
   }

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -4,6 +4,7 @@
 import Component from '../component.js';
 import checkVolumeSupport from './volume-control/check-volume-support';
 import {isPlain} from '../utils/obj';
+import {IE_VERSION} from '../utils/browser';
 
 // Required children
 import './volume-control/volume-control.js';
@@ -64,6 +65,12 @@ class VolumePanel extends Component {
    *         The element that was created.
    */
   createEl() {
+    let ieFixClass = '';
+
+    if (IE_VERSION && IE_VERSION <= 9) {
+      ieFixClass = 'vjs-ie-auto-width-fix';
+    }
+
     let orientationClass = 'vjs-volume-panel-horizontal';
 
     if (!this.options_.inline) {
@@ -71,7 +78,7 @@ class VolumePanel extends Component {
     }
 
     return super.createEl('div', {
-      className: `vjs-volume-panel vjs-control ${orientationClass}`
+      className: `vjs-volume-panel vjs-control ${orientationClass} ${ieFixClass}`
     });
   }
 

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -4,7 +4,6 @@
 import Component from '../component.js';
 import checkVolumeSupport from './volume-control/check-volume-support';
 import {isPlain} from '../utils/obj';
-import {IE_VERSION} from '../utils/browser';
 
 // Required children
 import './volume-control/volume-control.js';
@@ -69,12 +68,6 @@ class VolumePanel extends Component {
    *         The element that was created.
    */
   createEl() {
-    let ieFixClass = '';
-
-    if (IE_VERSION && IE_VERSION <= 9) {
-      ieFixClass = 'vjs-ie-auto-width-fix';
-    }
-
     let orientationClass = 'vjs-volume-panel-horizontal';
 
     if (!this.options_.inline) {
@@ -82,7 +75,7 @@ class VolumePanel extends Component {
     }
 
     return super.createEl('div', {
-      className: `vjs-volume-panel vjs-control ${orientationClass} ${ieFixClass}`
+      className: `vjs-volume-panel vjs-control ${orientationClass}`
     });
   }
 


### PR DESCRIPTION
## Description
Built from https://github.com/videojs/video.js/pull/3958
Moves as much transition and "logic" into CSS as possible.
Use some javascript to make sure that things are sized properly when tabbing with the keyboard.