### PR TITLE
Make `registerTech` add that tech to the default `techOrder`

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3221,7 +3221,7 @@ const navigator = window.navigator;
  */
 Player.prototype.options_ = {
   // Default order of fallback technology
-  techOrder: ['html5'],
+  techOrder: Tech.defaultTechs_,
 
   html5: {},
   flash: {},

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -802,6 +802,9 @@ class Tech extends Component {
     middleware.use('*', {name, tech});
 
     Tech.techs_[name] = tech;
+    if (name !== 'Tech') {
+      Tech.defaultTechs_.push(name.toLowerCase());
+    }
     return tech;
   }
 
@@ -1170,5 +1173,12 @@ Tech.withSourceHandlers = function(_Tech) {
 // Tech that can be registered as a Component.
 Component.registerComponent('Tech', Tech);
 Tech.registerTech('Tech', Tech);
+
+/**
+ * A list of techs that should be added to techOrder on Players
+ *
+ * @private
+ */
+Tech.defaultTechs_ = [];
 
 export default Tech;

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -803,7 +803,8 @@ class Tech extends Component {
 
     Tech.techs_[name] = tech;
     if (name !== 'Tech') {
-      Tech.defaultTechs_.push(name.toLowerCase());
+      // camel case the techName for use in techOrder
+      Tech.defaultTechs_.push(name.charAt(0).toLowerCase() + name.slice(1));
     }
     return tech;
   }


### PR DESCRIPTION
## Description
Make `registerTech` add that tech to the default `techOrder`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
 - [ ] Reviewed by Two Core Contributors
