### PR TITLE
make techCall_ sync again

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1519,7 +1519,7 @@ class Player extends Component {
         log(e);
         throw e;
       }
-    });
+    }, true);
   }
 
   /**


### PR DESCRIPTION
## Description
[`techCall_` used to be synchronous](https://github.com/videojs/video.js/blob/stable/src/js/player.js#L1264) and is now async. This causes weird behavior for scenarios like this:

1. player.muted(true);
2. player.muted() === true // this will fail sometimes as setting muted is async

## Specific Changes proposed
Make `techCall_` async again

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
