### PR TITLE
fix: EventTarget is also evented

### DIFF
--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -6,6 +6,7 @@ import * as Dom from '../utils/dom';
 import * as Events from '../utils/events';
 import * as Fn from '../utils/fn';
 import * as Obj from '../utils/obj';
+import EventTarget from '../event-target';
 
 /**
  * Returns whether or not an object has had the evented mixin applied.
@@ -17,6 +18,7 @@ import * as Obj from '../utils/obj';
  *         Whether or not the object appears to be evented.
  */
 const isEvented = (object) =>
+  object instanceof EventTarget ||
   !!object.eventBusEl_ &&
   ['on', 'one', 'off', 'trigger'].every(k => typeof object[k] === 'function');
 


### PR DESCRIPTION
If you try to delegate an to an EventTarget from an evented component, you'll end up failing because it didn't think that an EventTarget object worked. But it should and does. This adds a check for it in the `isEvented` function.