### PR TITLE
fix(MenuButton) Implement unified method of showing/hiding MenuButton

### DIFF
--- a/src/js/control-bar/text-track-controls/captions-button.js
+++ b/src/js/control-bar/text-track-controls/captions-button.js
@@ -40,33 +40,6 @@ class CaptionsButton extends TextTrackButton {
   }
 
   /**
-   * Update caption menu items
-   *
-   * @param {EventTarget~Event} [event]
-   *        The `addtrack` or `removetrack` event that caused this function to be
-   *        called.
-   *
-   * @listens TextTrackList#addtrack
-   * @listens TextTrackList#removetrack
-   */
-  update(event) {
-    let threshold = 2;
-
-    super.update();
-
-    // if native, then threshold is 1 because no settings button
-    if (this.player().tech_ && this.player().tech_.featuresNativeTextTracks) {
-      threshold = 1;
-    }
-
-    if (this.items && this.items.length > threshold) {
-      this.show();
-    } else {
-      this.hide();
-    }
-  }
-
-  /**
    * Create caption menu items
    *
    * @return {CaptionSettingsMenuItem[]}
@@ -77,6 +50,8 @@ class CaptionsButton extends TextTrackButton {
 
     if (!(this.player().tech_ && this.player().tech_.featuresNativeTextTracks)) {
       items.push(new CaptionSettingsMenuItem(this.player_, {kind: this.kind_}));
+
+      this.hideThreshold_ += 1;
     }
 
     return super.createItems(items);

--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -40,6 +40,7 @@ class TextTrackButton extends TrackButton {
   createItems(items = []) {
     // Add an OFF menu item to turn all tracks off
     items.push(new OffTextTrackMenuItem(this.player_, {kind: this.kind_}));
+    this.hideThreshold_ += 1;
 
     const tracks = this.player_.textTracks();
 

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -58,9 +58,9 @@ class MenuButton extends ClickableComponent {
     this.buttonPressed_ = false;
     this.el_.setAttribute('aria-expanded', 'false');
 
-    if (this.items && this.items.length === 0) {
+    if (this.items && this.items.length <= this.hideThreshold_) {
       this.hide();
-    } else if (this.items && this.items.length > 1) {
+    } else {
       this.show();
     }
   }
@@ -74,6 +74,16 @@ class MenuButton extends ClickableComponent {
   createMenu() {
     const menu = new Menu(this.player_);
 
+    /**
+     * Hide the menu if the number of items is less than or equal to this threshold. This defaults
+     * to 0 and whenever we add items which can be hidden to the menu we'll increment it. We list
+     * it here because every time we run `createMenu` we need to reset the value.
+     *
+     * @protected
+     * @type {Number}
+     */
+    this.hideThreshold_ = 0;
+
     // Add a title list item to the top
     if (this.options_.title) {
       const title = Dom.createEl('li', {
@@ -81,6 +91,8 @@ class MenuButton extends ClickableComponent {
         innerHTML: toTitleCase(this.options_.title),
         tabIndex: -1
       });
+
+      this.hideThreshold_ += 1;
 
       menu.children_.unshift(title);
       Dom.insertElFirst(title, menu.contentEl());


### PR DESCRIPTION
## Description
When remote subtitle text tracks are removed and there are none left, the subtitle button button persists in the menu bar. This also applies to the descriptions button as seen in #3994.

Reduced test case created by @mctep: http://jsbin.com/navoruk/1/edit?html,js,output

Addresses #3890, #3994

## Specific Changes proposed

- Implement a `getHideThreshold` function in `menu-button` and override it in `captions-button`.
- Remove `menu-button` descendants' update methods

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
