### PR TITLE
Let font import be relative if possible

### DIFF
--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -2,7 +2,7 @@
 @import "private-variables";
 @import "utilities";
 
-@import "node_modules/videojs-font/scss/icons";
+@import "~videojs-font/scss/icons";
 
 @import "components/layout";
 @import "components/big-play";


### PR DESCRIPTION
## Description
This would allow the font import to pull from the node_modules directory relatively, instead of absolutely, for projects that use a bundler, and bundle this on their own 

## Specific Changes proposed
Changed import to use `~`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
