### PR TITLE
chore(package): pin karma to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "in-publish": "^2.0.0",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.2",
-    "karma": "^1.2.0",
+    "karma": "1.3.0",
     "karma-browserify": "^5.1.0",
     "karma-browserstack-launcher": "^1.0.1",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
Karma 1.4.0 indavertantely broke IE8 when updating socket.io.
This pins karma to 1.3.0 a version that is known to work on IE8.

See https://github.com/karma-runner/karma/issues/2556
See https://github.com/socketio/socket.io-client/issues/1063