### PR TITLE
Disable title attribute on menu items, fixes #3699 (same as #4009, but on master branch)

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -121,7 +121,10 @@ class ClickableComponent extends Component {
 
     this.controlText_ = text;
     this.controlTextEl_.innerHTML = localizedText;
-    el.setAttribute('title', localizedText);
+    if (!this.nonIconControl) {
+      // Set title attribute if only an icon is shown
+      el.setAttribute('title', localizedText);
+    }
   }
 
   /**

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -54,6 +54,9 @@ class MenuItem extends ClickableComponent {
    *         The element that gets created.
    */
   createEl(type, props, attrs) {
+    // The control is textual, not just an icon
+    this.nonIconControl = true;
+
     return super.createEl('li', assign({
       className: 'vjs-menu-item',
       innerHTML: this.localize(this.options_.label),


### PR DESCRIPTION
## Description
Prevents a title attribute from being applied to `MenuItem`s. Fixes #3699 

## Specific Changes proposed
MenuItem indicates to ClickableComponent that the control is not just an icon, so it shouldn't have a title attribute.

## Requirements Checklist
- [x] Feature implemented
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
