### PR TITLE
fix: accessibility bugs with the VolumeBar

### DIFF
--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -27,7 +27,7 @@ class VolumeBar extends Slider {
     super(player, options);
     this.on('slideractive', this.updateLastVolume_);
     this.on(player, 'volumechange', this.updateARIAAttributes);
-    player.ready(() => this.updateARIAAttributes);
+    player.ready(() => this.updateARIAAttributes());
   }
 
   /**
@@ -106,7 +106,7 @@ class VolumeBar extends Slider {
    */
   updateARIAAttributes(event) {
     // Current value of volume bar as a percentage
-    const volume = (this.player_.volume() * 100).toFixed(2);
+    const volume = Math.round((this.player_.volume() * 100)).toString();
 
     this.el_.setAttribute('aria-valuenow', volume);
     this.el_.setAttribute('aria-valuetext', volume + '%');


### PR DESCRIPTION
## Description
* Fixes #4021: `aria-valuenow` and `aria-valuetext` not set initially
* Fixes #4022: drop the decimal places on `aria-valuenow` and `aria-valuetext`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
