### PR TITLE
Filter the source given to `Player#src` before use

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2219,28 +2219,27 @@ class Player extends Component {
    *         The current video source when getting
    */
   src(source) {
+    // getter usage
+    if (typeof source !== 'undefined') {
+      return this.cache_.src;
+    }
     let src = source;
 
     // filter out invalid sources and turn our source into
     // an array of source objects
     src = filterSource(src);
 
-    // no valid sources, return the current source
+    // if a source was passed in then it is invalid because
+    // it was filtered to a zero length Array. So we have to
+    // show an error
     if (!src.length) {
-      // if a source was passed in then it is invalid because
-      // it was filtered to a zero length Array. So we have to
-      // show an error
-      if (typeof source !== 'undefined') {
-        this.setTimeout(function() {
-          this.error({ code: 4, message: this.localize(this.options_.notSupportedMessage) });
-        }, 0);
-        return;
-      }
-      return this.cache_.src;
+      this.setTimeout(function() {
+        this.error({ code: 4, message: this.localize(this.options_.notSupportedMessage) });
+      }, 0);
+      return;
     }
 
     this.cache_.sources = src;
-
     this.changingSrc_ = true;
     this.cache_.source = src[0];
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2221,24 +2221,18 @@ class Player extends Component {
   src(source) {
     let src = source;
 
-    // remove invalid values from here and turn the source into an object
+    // filter out invalid sources and turn our source into
+    // an array of source objects
     src = filterSource(src);
 
-    // if they pass a zero length array, or
-    // an undefined value, return the current source.
-    // aka make this function work as a getter
-    if ((Array.isArray(src) && !src.length) || !src) {
+    if (!src.length) {
       return this.cache_.src;
     }
 
-    this.changingSrc_ = true;
+    this.cache_.sources = src;
+    src = src[0];
 
-    if (Array.isArray(src)) {
-      this.cache_.sources = src;
-      src = src[0];
-    } else {
-      this.cache_.sources = [src];
-    }
+    this.changingSrc_ = true;
 
     this.cache_.source = src;
     this.currentType_ = src.type;
@@ -2249,8 +2243,6 @@ class Player extends Component {
       const err = this.src_(src_);
 
       if (err) {
-        // if there was an error with this src
-        // try another
         if (Array.isArray(source) && source.length > 1) {
           return this.src(source.slice(1));
         }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -28,7 +28,7 @@ import ModalDialog from './modal-dialog';
 import Tech from './tech/tech.js';
 import * as middleware from './tech/middleware.js';
 import {ALL as TRACK_TYPES} from './tracks/track-types';
-import {filterSource} from './utils/filter-source';
+import filterSource from './utils/filter-source';
 
 // The following imports are used only to ensure that the corresponding modules
 // are always included in the video.js package. Importing the modules will
@@ -2215,7 +2215,7 @@ class Player extends Component {
    * @param {Tech~SourceObject|Tech~SourceObject[]} [source]
    *        One SourceObject or an array of SourceObjects
    *
-   * @return {String}
+   * @return {string}
    *         The current video source when getting
    */
   src(source) {
@@ -2225,6 +2225,7 @@ class Player extends Component {
     // an array of source objects
     src = filterSource(src);
 
+    // no valid sources, return the current source
     if (!src.length) {
       return this.cache_.src;
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2220,7 +2220,7 @@ class Player extends Component {
    */
   src(source) {
     // getter usage
-    if (typeof source !== 'undefined') {
+    if (typeof source === 'undefined') {
       return this.cache_.src;
     }
     let src = source;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2273,6 +2273,19 @@ class Player extends Component {
     });
   }
 
+  /**
+   * Set the source object on the tech, returns a boolean that indicates wether
+   * there is a tech that can play the source or not
+   *
+   * @param {Tech~SourceObject} source
+   *        The source object to set on the Tech
+   *
+   * @return {Boolean}
+   *         - True if there is no Tech to playback this source
+   *         - False otherwise
+   *
+   * @private
+   */
   src_(source) {
     const sourceTech = this.selectSource([source]);
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2223,34 +2223,36 @@ class Player extends Component {
     if (typeof source === 'undefined') {
       return this.cache_.src;
     }
-    let src = source;
-
     // filter out invalid sources and turn our source into
     // an array of source objects
-    src = filterSource(src);
+    const sources = filterSource(source);
 
     // if a source was passed in then it is invalid because
     // it was filtered to a zero length Array. So we have to
     // show an error
-    if (!src.length) {
+    if (!sources.length) {
       this.setTimeout(function() {
         this.error({ code: 4, message: this.localize(this.options_.notSupportedMessage) });
       }, 0);
       return;
     }
 
-    this.cache_.sources = src;
+    // intial sources
+    this.cache_.sources = sources;
     this.changingSrc_ = true;
-    this.cache_.source = src[0];
 
-    middleware.setSource(this, src[0], (src_, mws) => {
+    // intial source
+    this.cache_.source = sources[0];
+
+    // middlewareSource is the source after it has been changed by middleware
+    middleware.setSource(this, sources[0], (middlewareSource, mws) => {
       this.middleware_ = mws;
 
-      const err = this.src_(src_);
+      const err = this.src_(middlewareSource);
 
       if (err) {
-        if (src.length > 1) {
-          return this.src(src.slice(1));
+        if (sources.length > 1) {
+          return this.src(sources.slice(1));
         }
 
         // We need to wrap this in a timeout to give folks a chance to add error event handlers
@@ -2266,8 +2268,8 @@ class Player extends Component {
       }
 
       this.changingSrc_ = false;
-      this.cache_.source = src_.src;
-      this.cache_.src = src_;
+      // video element listed source
+      this.cache_.src = middlewareSource.src;
 
       middleware.setTech(mws, this.tech_);
     });

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2266,7 +2266,7 @@ class Player extends Component {
       }
 
       this.changingSrc_ = false;
-      this.cache_.source = src[0];
+      this.cache_.source = src_.src;
       this.cache_.src = src_;
 
       middleware.setTech(mws, this.tech_);

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -1,0 +1,27 @@
+import {isObject} from './obj';
+
+export const filterSource = function(src) {
+  if (Array.isArray(src)) {
+    let i = src.length;
+
+    while (i--) {
+      src[i] = filterSource(src[i]);
+
+      if (!isObject(src[i])) {
+        src.splice(i, 1);
+      }
+    }
+    if (src.length === 0) {
+      src = null;
+    }
+  } else if (typeof src === 'string' && src) {
+    src = {src};
+  } else if (isObject(src) && typeof src.src === 'string' && src.src) {
+    src = src;
+  } else {
+    // invalid source
+    src = null;
+  }
+
+  return src;
+};

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -1,5 +1,16 @@
 import {isObject} from './obj';
 
+/**
+ * Filter out single bad source objects or multiple source objects in an
+ * array. Also flattens nested source object arrays into a 1 dimensional
+ * array of source objects.
+ *
+ * @param {Tech~SourceObject|Tech~SourceObject[]} src
+ *        The src object to filter
+ *
+ * @return {Tech~SourceObject[]}
+ *         An array of sourceobjects containing only valid sources
+ */
 export const filterSource = function(src) {
   // traverse array
   if (Array.isArray(src)) {
@@ -15,19 +26,16 @@ export const filterSource = function(src) {
       }
     });
 
-    if (newsrc.length === 0) {
-      src = null;
-    } else {
-      src = newsrc;
-    }
+    src = newsrc;
   } else if (typeof src === 'string' && src) {
     // convert string into object
-    src = {src};
+    src = [{src}];
   } else if (isObject(src) && typeof src.src === 'string' && src.src) {
-    // do nothing, src is already valid
+    // src is already valid
+    src = [src];
   } else {
-    // invalid source
-    src = null;
+    // invalid source, turn it into an empty array
+    src = [];
   }
 
   return src;

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -1,23 +1,30 @@
 import {isObject} from './obj';
 
 export const filterSource = function(src) {
+  // traverse array
   if (Array.isArray(src)) {
-    let i = src.length;
+    let newsrc = [];
 
-    while (i--) {
-      src[i] = filterSource(src[i]);
+    src.forEach(function(srcobj) {
+      srcobj = filterSource(srcobj);
 
-      if (!isObject(src[i])) {
-        src.splice(i, 1);
+      if (Array.isArray(srcobj)) {
+        newsrc = newsrc.concat(srcobj);
+      } else if (isObject(srcobj)) {
+        newsrc.push(srcobj);
       }
-    }
-    if (src.length === 0) {
+    });
+
+    if (newsrc.length === 0) {
       src = null;
+    } else {
+      src = newsrc;
     }
   } else if (typeof src === 'string' && src) {
+    // convert string into object
     src = {src};
   } else if (isObject(src) && typeof src.src === 'string' && src.src) {
-    src = src;
+    // do nothing, src is already valid
   } else {
     // invalid source
     src = null;

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -32,10 +32,10 @@ const filterSource = function(src) {
     });
 
     src = newsrc;
-  } else if (typeof src === 'string' && src) {
+  } else if (typeof src === 'string' && src.trim()) {
     // convert string into object
     src = [{src}];
-  } else if (isObject(src) && typeof src.src === 'string' && src.src) {
+  } else if (isObject(src) && typeof src.src === 'string' && src.src && src.src.trim()) {
     // src is already valid
     src = [src];
   } else {

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -1,3 +1,6 @@
+/**
+ * @module filter-source
+ */
 import {isObject} from './obj';
 
 /**
@@ -10,8 +13,10 @@ import {isObject} from './obj';
  *
  * @return {Tech~SourceObject[]}
  *         An array of sourceobjects containing only valid sources
+ *
+ * @private
  */
-export const filterSource = function(src) {
+const filterSource = function(src) {
   // traverse array
   if (Array.isArray(src)) {
     let newsrc = [];
@@ -40,3 +45,5 @@ export const filterSource = function(src) {
 
   return src;
 };
+
+export default filterSource;

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -4,35 +4,35 @@ import {filterSource} from '../../../src/js/utils/filter-source';
 QUnit.module('utils/filter-source');
 
 QUnit.test('invalid sources', function(assert) {
-  assert.equal(filterSource(null), null, 'null source is filtered to null');
-  assert.equal(filterSource(undefined), null, 'undefined source is filtered to null');
-  assert.equal(filterSource(''), null, 'empty string source is filtered to null');
-  assert.equal(filterSource(1), null, 'number source is filtered to null');
-  assert.equal(filterSource([]), null, 'empty array source is filtered to null');
-  assert.equal(filterSource([[]]), null, 'empty array source is filtered to null');
-  assert.equal(filterSource(new Date()), null, 'Date source is filtered to null');
-  assert.equal(filterSource(new RegExp()), null, 'RegExp source is filtered to null');
-  assert.equal(filterSource(true), null, 'true boolean source is filtered to null');
-  assert.equal(filterSource(false), null, 'false boolean source is filtered to null');
-  assert.equal(filterSource([null]), null, 'invalid array source is filtered to null');
-  assert.equal(filterSource([undefined]), null, 'invalid array source is filtered to null');
-  assert.equal(filterSource([{src: 1}]), null, 'invalid array source is filtered to null');
-  assert.equal(filterSource({}), null, 'empty object source is filtered to null');
-  assert.equal(filterSource({src: 1}), null, 'invalid object source is filtered to null');
-  assert.equal(filterSource({src: ''}), null, 'invalid object source is filtered to null');
-  assert.equal(filterSource({src: null}), null, 'invalid object source is filtered to null');
-  assert.equal(filterSource({url: 1}), null, 'invalid object source is filtered to null');
+  assert.deepEqual(filterSource(null), [], 'null source is filtered to []');
+  assert.deepEqual(filterSource(undefined), [], 'undefined source is filtered to []');
+  assert.deepEqual(filterSource(''), [], 'empty string source is filtered to []');
+  assert.deepEqual(filterSource(1), [], 'number source is filtered to []');
+  assert.deepEqual(filterSource([]), [], 'empty array source is filtered to []');
+  assert.deepEqual(filterSource([[]]), [], 'empty array source is filtered to []');
+  assert.deepEqual(filterSource(new Date()), [], 'Date source is filtered to []');
+  assert.deepEqual(filterSource(new RegExp()), [], 'RegExp source is filtered to []');
+  assert.deepEqual(filterSource(true), [], 'true boolean source is filtered to []');
+  assert.deepEqual(filterSource(false), [], 'false boolean source is filtered to []');
+  assert.deepEqual(filterSource([null]), [], 'invalid array source is filtered to []');
+  assert.deepEqual(filterSource([undefined]), [], 'invalid array source is filtered to []');
+  assert.deepEqual(filterSource([{src: 1}]), [], 'invalid array source is filtered to []');
+  assert.deepEqual(filterSource({}), [], 'empty object source is filtered to []');
+  assert.deepEqual(filterSource({src: 1}), [], 'invalid object source is filtered to []');
+  assert.deepEqual(filterSource({src: ''}), [], 'invalid object source is filtered to []');
+  assert.deepEqual(filterSource({src: null}), [], 'invalid object source is filtered to []');
+  assert.deepEqual(filterSource({url: 1}), [], 'invalid object source is filtered to []');
 });
 
 QUnit.test('valid sources', function(assert) {
   assert.deepEqual(
     filterSource('some-url'),
-    {src: 'some-url'},
+    [{src: 'some-url'}],
     'string source filters to object'
   );
   assert.deepEqual(
     filterSource({src: 'some-url'}),
-    {src: 'some-url'},
+    [{src: 'some-url'}],
     'valid source filters to itself'
   );
   assert.deepEqual(
@@ -104,13 +104,13 @@ QUnit.test('Order is maintained', function(assert) {
 QUnit.test('Dont filter extra object properties', function(assert) {
   assert.deepEqual(
     filterSource({src: 'some-url', type: 'some-type'}),
-    {src: 'some-url', type: 'some-type'},
+    [{src: 'some-url', type: 'some-type'}],
     'type key is maintained'
   );
 
   assert.deepEqual(
     filterSource({src: 'some-url', type: 'some-type', foo: 'bar'}),
-    {src: 'some-url', type: 'some-type', foo: 'bar'},
+    [{src: 'some-url', type: 'some-type', foo: 'bar'}],
     'foo and bar keys are maintained'
   );
 

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -9,6 +9,7 @@ QUnit.test('invalid sources', function(assert) {
   assert.equal(filterSource(''), null, 'empty string source is filtered to null');
   assert.equal(filterSource(1), null, 'number source is filtered to null');
   assert.equal(filterSource([]), null, 'empty array source is filtered to null');
+  assert.equal(filterSource([[]]), null, 'empty array source is filtered to null');
   assert.equal(filterSource(new Date()), null, 'Date source is filtered to null');
   assert.equal(filterSource(new RegExp()), null, 'RegExp source is filtered to null');
   assert.equal(filterSource(true), null, 'true boolean source is filtered to null');
@@ -24,18 +25,99 @@ QUnit.test('invalid sources', function(assert) {
 });
 
 QUnit.test('valid sources', function(assert) {
-  assert.deepEqual(filterSource('some-url'), {src: 'some-url'}, 'string source filters to object');
-  assert.deepEqual(filterSource({src: 'some-url'}), {src: 'some-url'}, 'valid source filters to itself');
-  assert.deepEqual(filterSource([{src: 'some-url'}]), [{src: 'some-url'}], 'valid source filters to itself');
-  assert.deepEqual(filterSource([{src: 'some-url'}, {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'valid source filters to itself');
-  assert.deepEqual(filterSource(['some-url', {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'mixed array filters to object array');
-  assert.deepEqual(filterSource(['some-url', undefined, {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'mostly-valid array filters to valid object array');
+  assert.deepEqual(
+    filterSource('some-url'),
+    {src: 'some-url'},
+    'string source filters to object'
+  );
+  assert.deepEqual(
+    filterSource({src: 'some-url'}),
+    {src: 'some-url'},
+    'valid source filters to itself'
+  );
+  assert.deepEqual(
+    filterSource([{src: 'some-url'}]),
+    [{src: 'some-url'}],
+    'valid source filters to itself'
+  );
+  assert.deepEqual(
+    filterSource([{src: 'some-url'}, {src: 'some-url2'}]),
+    [{src: 'some-url'}, {src: 'some-url2'}],
+    'valid source filters to itself'
+  );
+  assert.deepEqual(
+    filterSource(['some-url', {src: 'some-url2'}]),
+    [{src: 'some-url'}, {src: 'some-url2'}],
+    'mixed array filters to object array'
+  );
+  assert.deepEqual(
+    filterSource(['some-url', undefined, {src: 'some-url2'}]),
+    [{src: 'some-url'}, {src: 'some-url2'}],
+    'mostly-valid array filters to valid object array'
+  );
+  assert.deepEqual(
+    filterSource([[{src: 'some-url'}]]),
+    [{src: 'some-url'}],
+    'nested array filters to flattened array itself'
+  );
+
+  assert.deepEqual(
+    filterSource([[[{src: 'some-url'}]]]),
+    [{src: 'some-url'}],
+    'double nested array filters to flattened array'
+  );
+
+  assert.deepEqual(
+    filterSource([{src: 'some-url2'}, [{src: 'some-url'}], undefined]),
+    [{src: 'some-url2'}, {src: 'some-url'}],
+    'nested array filters to flattened array'
+  );
+
+  assert.deepEqual(
+    filterSource([[{src: 'some-url2'}], [[[{src: 'some-url'}]]], [undefined]]),
+    [{src: 'some-url2'}, {src: 'some-url'}],
+    'nested array filters to flattened array in correct order'
+  );
+});
+
+QUnit.test('Order is maintained', function(assert) {
+  assert.deepEqual(
+    filterSource([{src: 'one'}, {src: 'two'}, {src: 'three'}, undefined]),
+    [{src: 'one'}, {src: 'two'}, {src: 'three'}],
+    'source order is maintained for array'
+  );
+
+  assert.deepEqual(
+    filterSource([{src: 'one'}, {src: 'two'}, {src: 'three'}, undefined]),
+    [{src: 'one'}, {src: 'two'}, {src: 'three'}],
+    'source order is maintained for array'
+  );
+
+  assert.deepEqual(
+    filterSource([null, [{src: 'one'}], [[[{src: 'two'}]]], {src: 'three'}, undefined]),
+    [{src: 'one'}, {src: 'two'}, {src: 'three'}],
+    'source order is maintained for mixed nested arrays'
+  );
+
 });
 
 QUnit.test('Dont filter extra object properties', function(assert) {
   assert.deepEqual(
     filterSource({src: 'some-url', type: 'some-type'}),
     {src: 'some-url', type: 'some-type'},
-    'string source filters to object'
+    'type key is maintained'
   );
+
+  assert.deepEqual(
+    filterSource({src: 'some-url', type: 'some-type', foo: 'bar'}),
+    {src: 'some-url', type: 'some-type', foo: 'bar'},
+    'foo and bar keys are maintained'
+  );
+
+  assert.deepEqual(
+    filterSource([{src: 'some-url', type: 'some-type', foo: 'bar'}]),
+    [{src: 'some-url', type: 'some-type', foo: 'bar'}],
+    'foo and bar keys are not removed'
+  );
+
 });

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -1,5 +1,5 @@
 /* eslint-env qunit */
-import {filterSource} from '../../../src/js/utils/filter-source';
+import filterSource from '../../../src/js/utils/filter-source';
 
 QUnit.module('utils/filter-source');
 

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -7,6 +7,7 @@ QUnit.test('invalid sources', function(assert) {
   assert.deepEqual(filterSource(null), [], 'null source is filtered to []');
   assert.deepEqual(filterSource(undefined), [], 'undefined source is filtered to []');
   assert.deepEqual(filterSource(''), [], 'empty string source is filtered to []');
+  assert.deepEqual(filterSource(' '), [], 'bad string source is filtered to []');
   assert.deepEqual(filterSource(1), [], 'number source is filtered to []');
   assert.deepEqual(filterSource([]), [], 'empty array source is filtered to []');
   assert.deepEqual(filterSource([[]]), [], 'empty array source is filtered to []');

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -1,0 +1,41 @@
+/* eslint-env qunit */
+import {filterSource} from '../../../src/js/utils/filter-source';
+
+QUnit.module('utils/filter-source');
+
+QUnit.test('invalid sources', function(assert) {
+  assert.equal(filterSource(null), null, 'null source is filtered to null');
+  assert.equal(filterSource(undefined), null, 'undefined source is filtered to null');
+  assert.equal(filterSource(''), null, 'empty string source is filtered to null');
+  assert.equal(filterSource(1), null, 'number source is filtered to null');
+  assert.equal(filterSource([]), null, 'empty array source is filtered to null');
+  assert.equal(filterSource(new Date()), null, 'Date source is filtered to null');
+  assert.equal(filterSource(new RegExp()), null, 'RegExp source is filtered to null');
+  assert.equal(filterSource(true), null, 'true boolean source is filtered to null');
+  assert.equal(filterSource(false), null, 'false boolean source is filtered to null');
+  assert.equal(filterSource([null]), null, 'invalid array source is filtered to null');
+  assert.equal(filterSource([undefined]), null, 'invalid array source is filtered to null');
+  assert.equal(filterSource([{src: 1}]), null, 'invalid array source is filtered to null');
+  assert.equal(filterSource({}), null, 'empty object source is filtered to null');
+  assert.equal(filterSource({src: 1}), null, 'invalid object source is filtered to null');
+  assert.equal(filterSource({src: ''}), null, 'invalid object source is filtered to null');
+  assert.equal(filterSource({src: null}), null, 'invalid object source is filtered to null');
+  assert.equal(filterSource({url: 1}), null, 'invalid object source is filtered to null');
+});
+
+QUnit.test('valid sources', function(assert) {
+  assert.deepEqual(filterSource('some-url'), {src: 'some-url'}, 'string source filters to object');
+  assert.deepEqual(filterSource({src: 'some-url'}), {src: 'some-url'}, 'valid source filters to itself');
+  assert.deepEqual(filterSource([{src: 'some-url'}]), [{src: 'some-url'}], 'valid source filters to itself');
+  assert.deepEqual(filterSource([{src: 'some-url'}, {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'valid source filters to itself');
+  assert.deepEqual(filterSource(['some-url', {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'mixed array filters to object array');
+  assert.deepEqual(filterSource(['some-url', undefined, {src: 'some-url2'}]), [{src: 'some-url'}, {src: 'some-url2'}], 'mostly-valid array filters to valid object array');
+});
+
+QUnit.test('Dont filter extra object properties', function(assert) {
+  assert.deepEqual(
+    filterSource({src: 'some-url', type: 'some-type'}),
+    {src: 'some-url', type: 'some-type'},
+    'string source filters to object'
+  );
+});


### PR DESCRIPTION
## Description
* Add a util that filters all possible `Tech~SourceObjects` into a valid `Tech~SourceObject` (see tests) 
* Remove `Player#sourceList_` as it is no longer in use

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
