### PR TITLE
Only report errors during linting in the build process, not warnings

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -450,7 +450,7 @@ module.exports = function(grunt) {
         }
       },
       lint: {
-        command: 'npm run lint',
+        command: 'npm run lint -- --errors',
         options: {
           preferLocal: true
         }


### PR DESCRIPTION
## Description
If `lint`ing fails during the `grunt` build process, the console messages only show any warnings that were reported, not the error that caused the failure. That's *really* unhelpful for people who don't know this feature!

## Specific Changes proposed
Change the lint parameters in build/grunt.js so that only errors are reported. (In the future we can bring back warnings, or provide a different way to build and display warnings.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix - **_N/A_**
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
