### PR TITLE
Add lang attribute to player el

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -566,6 +566,10 @@ class Player extends Component {
     Dom.prependTo(tag, el);
     this.children_.unshift(tag);
 
+    // Set lang attr on player to ensure CSS :lang() in consistent with player
+    // if it's been set to something different to the doc
+    this.el_.setAttribute('lang', this.language_);
+
     this.el_ = el;
 
     return el;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1160,6 +1160,23 @@ QUnit.test('inherits language from parent element', function(assert) {
   }
 });
 
+QUnit.test('sets lang attribute on player el', function(assert) {
+  const fixture = document.getElementById('qunit-fixture');
+  const oldLang = fixture.getAttribute('lang');
+
+  fixture.setAttribute('lang', 'x-attr-test');
+  const player = TestHelpers.makePlayer();
+
+  assert.equal(player.el().getAttribute('lang'), 'x-attr-test', 'player sets lang attribute on self');
+
+  player.dispose();
+  if (oldLang) {
+    fixture.setAttribute('lang', oldLang);
+  } else {
+    fixture.removeAttribute('lang');
+  }
+});
+
 QUnit.test('should return correct values for canPlayType', function(assert) {
   const player = TestHelpers.makePlayer();
 


### PR DESCRIPTION
## Description
If the player language had been set via player options to something other than the document language, the css `:lang()` pseudo-class would match a different language code than `player.language()`. This would be matter for #4028.

## Specific Changes proposed
Set the `lang` attribute on the player element during initialisation. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
