### PR TITLE
Fix `MuteToggle.controlText` when volume set to 0

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -88,7 +88,8 @@ class MuteToggle extends Button {
     // Don't rewrite the button text if the actual text doesn't change.
     // This causes unnecessary and confusing information for screen reader users.
     // This check is needed because this function gets called every time the volume level is changed.
-    const toMute = this.player_.muted() ? 'Unmute' : 'Mute';
+    const soundOff = this.player_.muted() || this.player_.volume() === 0;
+    const toMute = soundOff ? 'Unmute' : 'Mute';
 
     if (this.controlText() !== toMute) {
       this.controlText(toMute);


### PR DESCRIPTION
Because `MuteToggle.controlText` is coordinated only with `muted` and not with `volume`, it doesn't change when `volume` is set to zero:

![feb-10-2017 13-42-02](https://cloud.githubusercontent.com/assets/11491159/22839270/b7816750-ef96-11e6-9151-37c0f2bb9a59.gif)

This fixes by adding a check for `this.player_.volume() === 0` to the predicate of the conditional that sets `toMute`.