### PR TITLE
fix(sass): import path has cwd once again

### DIFF
--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -2,7 +2,7 @@
 @import "private-variables";
 @import "utilities";
 
-@import "../../node_modules/videojs-font/scss/icons";
+@import "node_modules/videojs-font/scss/icons";
 
 @import "components/layout";
 @import "components/big-play";


### PR DESCRIPTION
## Description
As described in https://github.com/videojs/video.js/issues/4055, node-sass v4.5.0 has reverted back to allowing `@import "node_modules/videojs-font/scss/icons";`

## Specific Changes proposed
Reverting back to this format allows for referencing video.js as a dependency in other projects without build failures when importing the sass files from this package. It would be ideal to bring this back into v5.x as well as v6.x of video.js

## Requirements Checklist
- [X] Bug fixed
- [ ] Reviewed by Two Core Contributors
