### PR TITLE
Solve a typo in translation files

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -33,7 +33,7 @@
   ", opens subtitles settings dialog": ", öffnet Einstellungen für Untertitel",
   ", selected": ", ausgewählt",
   "captions settings": "Untertiteleinstellungen",
-  "subititles settings": "Untertiteleinstellungen",
+  "subtitles settings": "Untertiteleinstellungen",
   "descriptions settings": "Einstellungen für Beschreibungen",
   "Close Modal Dialog": "Modales Fenster schließen",
   "Descriptions": "Beschreibungen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -43,7 +43,7 @@
   ", opens descriptions settings dialog": ", opens descriptions settings dialog",
   ", selected": ", selected",
   "captions settings": "captions settings",
-  "subititles settings": "subititles settings",
+  "subtitles settings": "subititles settings",
   "descriptions settings": "descriptions settings",
   "Text": "Text",
   "White": "White",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -39,7 +39,7 @@
   ", opens descriptions settings dialog": ", açıklama ayarları menüsünü açar",
   ", selected": ", seçildi",
   "captions settings": "altyazı ayarları",
-  "subititles settings": "altyazı ayarları",
+  "subtitles settings": "altyazı ayarları",
   "descriptions settings": "açıklama ayarları",
   "Text": "Yazı",
   "White": "Beyaz",


### PR DESCRIPTION
## Description
Solve a typo in translation files

## Specific Changes proposed
Change "subititles" with "subtitles"

This modification is not included in the PR #4062

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
