### PR TITLE
docs(guides): fix typos in faq guide

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -237,7 +237,7 @@ project which adds support.
 
 ## Q: Does video.js support MPEG Dash video?
 
-video.js itself does not support MPEG DASH, however an offical project called [videojs-contrib-dash][dash]
+video.js itself does not support MPEG DASH, however an official project called [videojs-contrib-dash][dash]
 adds support for MPEG DASH video.
 
 ## Q: Does video.js support live video?


### PR DESCRIPTION
Found a minor spelling mistake in the FAQ guide - 
`offical` > `official`
