### PR TITLE
Prevent error on IE8 - Cet objet ne gère pas cette action

### DIFF
--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -80,7 +80,7 @@ export const logByType = (type, args, stringify = !!IE_VERSION && IE_VERSION < 1
 
   // Old IE versions do not allow .apply() for console methods (they are
   // reported as objects rather than functions).
-  if (!fn.apply) {
+  if (typeof(fn.apply) == "unknow" || !fn.apply) {
     fn(args);
   } else {
     fn[Array.isArray(args) ? 'apply' : 'call'](window.console, args);

--- a/src/js/utils/log.js
+++ b/src/js/utils/log.js
@@ -80,7 +80,7 @@ export const logByType = (type, args, stringify = !!IE_VERSION && IE_VERSION < 1
 
   // Old IE versions do not allow .apply() for console methods (they are
   // reported as objects rather than functions).
-  if (typeof(fn.apply) == "unknow" || !fn.apply) {
+  if (typeof(fn.apply) == "unknown" || !fn.apply) {
     fn(args);
   } else {
     fn[Array.isArray(args) ? 'apply' : 'call'](window.console, args);


### PR DESCRIPTION
Prevent error on IE8 - Cet objet ne gère pas cette action
Testing before with typeof allow to pevent this error

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
