### PR TITLE
docs: Add MediaLoader to components list

### DIFF
--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -285,6 +285,7 @@ The default component structure of the Video.js player looks something like this
 
 ```tree
 Player
+├── MediaLoader (has no UI)
 ├── PosterImage
 ├── TextTrackDisplay
 ├── LoadingSpinner


### PR DESCRIPTION
Updated list.

As an aside, should the loader's `div` have a class so it's obvious what it is when looking at the DOM?
