### PR TITLE
chore: switch from ghooks to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "docs:lint": "remark -- './**/*.md'",
     "docs:fix": "remark --output -- './**/*.md'",
     "babel": "babel src/js -d es5",
-    "prepublish": "not-in-install && npm run docs:api || in-install"
+    "prepublish": "not-in-install && npm run docs:api || in-install",
+    "prepush": "npm run lint -- --errors"
   },
   "repository": {
     "type": "git",
@@ -65,7 +66,6 @@
     "conventional-changelog-videojs": "^3.0.0",
     "es5-shim": "^4.1.3",
     "es6-shim": "^0.35.1",
-    "ghooks": "^1.3.2",
     "grunt": "^0.4.5",
     "grunt-accessibility": "^5.0.0",
     "grunt-babel": "^6.0.0",
@@ -89,6 +89,7 @@
     "grunt-version": "~1.1.1",
     "grunt-videojs-languages": "0.0.4",
     "grunt-zip": "0.17.1",
+    "husky": "^0.13.1",
     "in-publish": "^2.0.0",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.2",
@@ -137,10 +138,5 @@
       "**/test/coverage/**",
       "**/test/karma.conf.js"
     ]
-  },
-  "config": {
-    "ghooks": {
-      "pre-push": "npm run lint -- --errors"
-    }
   }
 }


### PR DESCRIPTION
## Description

Fix [#3930](https://github.com/videojs/video.js/issues/3930)

`husky` will automatically migrate hooks installed by `ghooks` so there's no additional action.

## Specific Changes proposed

* Removes `ghooks` devDependency and configuration.
* Adds `husky` devDependency and adds `prepush` script.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
