### PR TITLE
fix: trap tab focus in modal when hitting s-tab

### DIFF
--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -467,6 +467,10 @@ class ModalDialog extends Component {
       }
     }
 
+    if (document.activeElement === this.el_) {
+      focusIndex = 0;
+    }
+
     if (event.shiftKey && focusIndex === 0) {
       focusableEls[focusableEls.length - 1].focus();
       event.preventDefault();


### PR DESCRIPTION
Pretend that the modal dialog is equivalent to the first
focusable/tabbable element when hitting shift-tab.

Fix #4049