### PR TITLE
Replace 'autoPlay' by 'autoplay'.

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -41,7 +41,7 @@ You can then use it like this:
 ```jsx
 // see https://github.com/videojs/video.js/blob/master/docs/guides/options.md
 const videoJsOptions = {
-  autoPlay: true,
+  autoplay: true,
   controls: true,
   sources: [{
     src: '/path/to/video.mp4',


### PR DESCRIPTION
## Description
I just replace an obsolete typo.
Issue: https://github.com/videojs/video.js/issues/3995

## Specific Changes proposed
I change in _docs/guides/react.md_, ```autoPlay``` by ```autoplay```
## Requirements Checklist
Nothing
