### PR TITLE
fix: make mergeOptions behave the same across browsers

### DIFF
--- a/src/js/utils/obj.js
+++ b/src/js/utils/obj.js
@@ -30,6 +30,18 @@
  */
 const toString = Object.prototype.toString;
 
+/**
+ * Get the keys of an Object
+ *
+ * @param {Object}
+ *        The Object to get the keys from
+ *
+ * @return {string[]}
+ *         An array of the keys from the object. Returns an empty array if the
+ *         object passed in was invalid or had no keys.
+ *
+ * @private
+ */
 const keys = function(object) {
   return isObject(object) ? Object.keys(object) : [];
 };

--- a/src/js/utils/obj.js
+++ b/src/js/utils/obj.js
@@ -30,6 +30,10 @@
  */
 const toString = Object.prototype.toString;
 
+const keys = function(object) {
+  return isObject(object) ? Object.keys(object) : [];
+};
+
 /**
  * Array-like iteration for objects.
  *
@@ -40,7 +44,7 @@ const toString = Object.prototype.toString;
  *        The callback function which is called for each key in the object.
  */
 export function each(object, fn) {
-  Object.keys(object).forEach(key => fn(object[key], key));
+  keys(object).forEach(key => fn(object[key], key));
 }
 
 /**
@@ -61,7 +65,7 @@ export function each(object, fn) {
  *         The final accumulated value.
  */
 export function reduce(object, fn, initial = 0) {
-  return Object.keys(object).reduce(
+  return keys(object).reduce(
     (accum, key) => fn(accum, object[key], key), initial);
 }
 

--- a/test/unit/utils/merge-options.test.js
+++ b/test/unit/utils/merge-options.test.js
@@ -2,6 +2,7 @@
 import mergeOptions from '../../../src/js/utils/merge-options.js';
 
 QUnit.module('merge-options');
+
 QUnit.test('should merge options objects', function(assert) {
   const ob1 = {
     a: true,
@@ -26,4 +27,10 @@ QUnit.test('should merge options objects', function(assert) {
     c: true,
     d: true
   }, 'options objects merged correctly');
+});
+
+QUnit.test('should ignore non-objects', function(assert) {
+  const obj = { a: 1 };
+
+  assert.deepEqual(mergeOptions(obj, true), obj, 'ignored non-object input');
 });


### PR DESCRIPTION
## Description
`Object.keys()` will error on IE11 instead of default to an empty array, this will make sure that `videojs.mergeOptions()` has the same behavior across browsers.

## Specific Changes proposed
Made a `keys()` function that defaults to `[]` when given an non-object.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
