### PR TITLE
fix: videojs.hooks and videojs.hook should have consistent return values.

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -163,9 +163,12 @@ videojs.hooks = function(type, fn) {
  *
  * @param {Function|Function[]}
  *        The function or array of functions to attach.
+ *
+ * @return {Array}
+ *         an array of hooks, or an empty array if there are none.
  */
 videojs.hook = function(type, fn) {
-  videojs.hooks(type, fn);
+  return videojs.hooks(type, fn);
 };
 
 /**


### PR DESCRIPTION
I noticed that while `videojs.hook` simply calls `videojs.hooks`, it does not return the same value.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
