### PR TITLE
fix: videojs.hooks and videojs.hook should have consistent return values.

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -162,9 +162,12 @@ videojs.hooks = function(type, fn) {
  *
  * @param {Function|Function[]}
  *        The function or array of functions to attach.
+ *
+ * @return {Array}
+ *         an array of hooks, or an empty array if there are none.
  */
 videojs.hook = function(type, fn) {
-  videojs.hooks(type, fn);
+  return videojs.hooks(type, fn);
 };
 
 /**


### PR DESCRIPTION
This is #4089 but for Video.js 6.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
