### PR TITLE
Only add vtt.js exports to window if they do not already exist

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -514,7 +514,9 @@ class Tech extends Component {
       // which will cause this if check to always fail.
       if (!this.options_['vtt.js'] && isPlain(vtt) && Object.keys(vtt).length > 0) {
         Object.keys(vtt).forEach(function(k) {
-          window[k] = vtt[k];
+          if (!window[k]) {
+            window[k] = vtt[k];
+          }
         });
         this.trigger('vttjsloaded');
         return;


### PR DESCRIPTION
## Description
Fixes #4093

Relates to:
https://github.com/videojs/videojs-contrib-dash/pull/135
https://github.com/videojs/videojs-contrib-dash/issues/103

## Specific Changes proposed
Please see #4093 for a detailed description, reduced test cases, and proposed solution.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
