### PR TITLE
fix: Do not create element for MediaLoader

### DIFF
--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -23,7 +23,7 @@ The architecture of the Video.js player is centered around components. The `Play
 
 A component is a JavaScript object that has the following features:
 
-* An associated DOM element.
+* An associated DOM element, in almost all cases.
 * An association to a `Player` object.
 * The ability to manage any number of child components.
 * The ability to listen for and trigger events.
@@ -285,7 +285,7 @@ The default component structure of the Video.js player looks something like this
 
 ```tree
 Player
-├── MediaLoader (has no UI)
+├── MediaLoader (has no DOM element)
 ├── PosterImage
 ├── TextTrackDisplay
 ├── LoadingSpinner

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -139,13 +139,15 @@ class Component {
     this.childIndex_ = null;
     this.childNameIndex_ = null;
 
-    // Remove element from DOM
-    if (this.el_.parentNode) {
-      this.el_.parentNode.removeChild(this.el_);
-    }
+    if (this.el_) {
+      // Remove element from DOM
+      if (this.el_.parentNode) {
+        this.el_.parentNode.removeChild(this.el_);
+      }
 
-    DomData.removeData(this.el_);
-    this.el_ = null;
+      DomData.removeData(this.el_);
+      this.el_ = null;
+    }
   }
 
   /**

--- a/src/js/tech/loader.js
+++ b/src/js/tech/loader.js
@@ -4,6 +4,7 @@
 import Component from '../component.js';
 import Tech from './tech.js';
 import toTitleCase from '../utils/to-title-case.js';
+import mergeOptions from '../utils/merge-options.js';
 
 /**
  * The `MediaLoader` is the `Component` that decides which playback technology to load
@@ -26,7 +27,10 @@ class MediaLoader extends Component {
    *        The function that is run when this component is ready.
    */
   constructor(player, options, ready) {
-    super(player, options, ready);
+    // MediaLoader has no element
+    const options_ = mergeOptions({createEl: false}, options);
+
+    super(player, options_, ready);
 
     // If there are no sources when the player is initialized,
     // load the first supported playback technology.


### PR DESCRIPTION
## Description
`MediaLoader` has a div that's unnecessary. See #4070

## Specific Changes proposed
- Do not create an element for `MediaLoader`
- Update `Component#dispose()` to check if it has an el before trying to remove it

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
