### PR TITLE
fix: remove redundant Html5#play()

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -342,19 +342,6 @@ class Html5 extends Tech {
   }
 
   /**
-   * Called by {@link Player#play} to play using the `Html5` `Tech`.
-   */
-  play() {
-    const playPromise = this.el_.play();
-
-    // Catch/silence error when a pause interrupts a play request
-    // on browsers which return a promise
-    if (playPromise !== undefined && typeof playPromise.then === 'function') {
-      playPromise.then(null, (e) => {});
-    }
-  }
-
-  /**
    * Set current time for the `HTML5` tech.
    *
    * @param {number} seconds

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -647,23 +647,6 @@ QUnit.test('Html5#reset calls Html5.resetMediaElement when called', function(ass
   Html5.resetMediaElement = oldResetMedia;
 });
 
-QUnit.test('Exception in play promise should be caught', function() {
-  const oldEl = tech.el_;
-
-  tech.el_ = {
-    play: () => {
-      return new Promise(function(resolve, reject) {
-        reject(new DOMException());
-      });
-    }
-  };
-
-  tech.play();
-  QUnit.ok(true, 'error was caught');
-
-  tech.el_ = oldEl;
-});
-
 test('When Android Chrome reports Infinity duration with currentTime 0, return NaN', function() {
   const oldIsAndroid = browser.IS_ANDROID;
   const oldIsChrome = browser.IS_CHROME;


### PR DESCRIPTION
## Description
`play()` is defined twice in `Html5`, [here](https://github.com/videojs/video.js/blob/e176b56843b2084c8b0c985d9ea491b5de1da113/src/js/tech/html5.js#L347) and then [here](https://github.com/videojs/video.js/blob/e176b56843b2084c8b0c985d9ea491b5de1da113/src/js/tech/html5.js#L1557).
The promise handling in the earlier one was moved into `Player#play()`

## Specific Changes proposed
Deleted redundant play() and associated test.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
