### PR TITLE
Muting with `MuteToggle` sets ARIA value of `VolumeBar` to 0

### DIFF
--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -107,9 +107,15 @@ class VolumeBar extends Slider {
   updateARIAAttributes(event) {
     // Current value of volume bar as a percentage
     const volume = Math.round((this.player_.volume() * 100)).toString();
+    const muted = this.player_.muted();
 
-    this.el_.setAttribute('aria-valuenow', volume);
-    this.el_.setAttribute('aria-valuetext', volume + '%');
+    if (muted) {
+      this.el_.setAttribute('aria-valuenow', 0);
+      this.el_.setAttribute('aria-valuetext', 0 + '%');
+    } else {
+      this.el_.setAttribute('aria-valuenow', volume);
+      this.el_.setAttribute('aria-valuetext', volume + '%');
+    }
   }
 
   /**

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -105,17 +105,19 @@ class VolumeBar extends Slider {
    * @listens Player#volumechange
    */
   updateARIAAttributes(event) {
-    // Current value of volume bar as a percentage
-    const volume = Math.round((this.player_.volume() * 100)).toString();
-    const muted = this.player_.muted();
+    const ariaValue = this.player_.muted() ? 0 : this.volumeAsPercentage_();
 
-    if (muted) {
-      this.el_.setAttribute('aria-valuenow', 0);
-      this.el_.setAttribute('aria-valuetext', 0 + '%');
-    } else {
-      this.el_.setAttribute('aria-valuenow', volume);
-      this.el_.setAttribute('aria-valuetext', volume + '%');
-    }
+    this.el_.setAttribute('aria-valuenow', ariaValue);
+    this.el_.setAttribute('aria-valuetext', ariaValue + '%');
+  }
+
+  /**
+   * Returns the current value of the player volume as a percentage
+   *
+   * @private
+   */
+  volumeAsPercentage_() {
+    return Math.round((this.player_.volume() * 100)).toString();
   }
 
   /**

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -117,7 +117,7 @@ class VolumeBar extends Slider {
    * @private
    */
   volumeAsPercentage_() {
-    return Math.round((this.player_.volume() * 100)).toString();
+    return Math.round(this.player_.volume() * 100);
   }
 
   /**

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -8,8 +8,16 @@ import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 import Html5 from '../../src/js/tech/html5.js';
+import sinon from 'sinon';
 
-QUnit.module('Controls');
+QUnit.module('Controls', {
+  beforeEach(assert) {
+    this.clock = sinon.useFakeTimers();
+  },
+  afterEach(assert) {
+    this.clock.restore();
+  }
+});
 
 QUnit.test('should hide volume control if it\'s not supported', function(assert) {
   assert.expect(2);
@@ -144,7 +152,7 @@ if (Html5.isSupported()) {
     const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
     const volumeBar = new VolumeBar(player);
 
-    volumeBar.updateARIAAttributes();
+    this.clock.tick(1);
 
     assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 100, 'ARIA value of VolumeBar is 100');
   });
@@ -153,8 +161,7 @@ if (Html5.isSupported()) {
     const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
     const volumeBar = new VolumeBar(player);
     const muteToggle = new MuteToggle(player);
-
-    volumeBar.updateARIAAttributes();
+    this.clock.tick(1);
 
     assert.equal(player.volume(), 1, 'Volume is 1');
     assert.equal(player.muted(), false, 'Muted is false');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -170,6 +170,9 @@ if (Html5.isSupported()) {
 
     muteToggle.handleClick();
 
+    // Because `MuteToggle#handleClick` is async, the `volumechange` event
+    // doesn't end up getting fired on `player` in the test environment, so we
+    // run it manually.
     player.trigger('volumechange');
 
     assert.equal(player.volume(), 1, 'Volume remains 1');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -1,6 +1,7 @@
 /* eslint-env qunit */
 import VolumeControl from '../../src/js/control-bar/volume-control/volume-control.js';
 import MuteToggle from '../../src/js/control-bar/mute-toggle.js';
+import VolumeBar from '../../src/js/control-bar/volume-control/volume-bar.js';
 import PlaybackRateMenuButton from '../../src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js';
 import Slider from '../../src/js/slider/slider.js';
 import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
@@ -138,4 +139,31 @@ if (Html5.isSupported()) {
     assert.equal(player.volume(), 0.5, 'volume is set to lastVolume');
     assert.equal(player.muted(), false, 'muted is set to false');
   });
+
+  QUnit.test('ARIA value of VolumeBar should start at 100', function(assert) {
+    const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+    const volumeBar = new VolumeBar(player);
+    volumeBar.updateARIAAttributes();
+
+    assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 100, 'ARIA value of VolumeBar is 100');
+  });
+
+  QUnit.test('Muting with MuteToggle should set ARIA value of VolumeBar to 0', function(assert) {
+    const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+    const volumeBar = new VolumeBar(player);
+    const muteToggle = new MuteToggle(player);
+    volumeBar.updateARIAAttributes();
+
+    assert.equal(player.volume(), 1, 'Volume is 1');
+    assert.equal(player.muted(), false, 'Muted is false');
+    assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 100, 'ARIA value of VolumeBar is 100');
+
+    muteToggle.handleClick();
+    volumeBar.updateARIAAttributes();
+
+    assert.equal(player.volume(), 1, 'Volume remains 1');
+    assert.equal(player.muted(), true, 'Muted is true');
+    assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 0, 'ARIA value of VolumeBar is 0');
+  });
+
 }

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -161,6 +161,7 @@ if (Html5.isSupported()) {
     const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
     const volumeBar = new VolumeBar(player);
     const muteToggle = new MuteToggle(player);
+
     this.clock.tick(1);
 
     assert.equal(player.volume(), 1, 'Volume is 1');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -170,9 +170,9 @@ if (Html5.isSupported()) {
 
     muteToggle.handleClick();
 
-    // Because `MuteToggle#handleClick` is async, the `volumechange` event
-    // doesn't end up getting fired on `player` in the test environment, so we
-    // run it manually.
+    // Because `volumechange` is triggered asynchronously, it doesn't end up
+    // getting fired on `player` in the test environment, so we run it
+    // manually.
     player.trigger('volumechange');
 
     assert.equal(player.volume(), 1, 'Volume remains 1');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -170,7 +170,7 @@ if (Html5.isSupported()) {
 
     muteToggle.handleClick();
 
-    volumeBar.updateARIAAttributes();
+    player.trigger('volumechange');
 
     assert.equal(player.volume(), 1, 'Volume remains 1');
     assert.equal(player.muted(), true, 'Muted is true');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -143,6 +143,7 @@ if (Html5.isSupported()) {
   QUnit.test('ARIA value of VolumeBar should start at 100', function(assert) {
     const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
     const volumeBar = new VolumeBar(player);
+
     volumeBar.updateARIAAttributes();
 
     assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 100, 'ARIA value of VolumeBar is 100');
@@ -152,6 +153,7 @@ if (Html5.isSupported()) {
     const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
     const volumeBar = new VolumeBar(player);
     const muteToggle = new MuteToggle(player);
+
     volumeBar.updateARIAAttributes();
 
     assert.equal(player.volume(), 1, 'Volume is 1');
@@ -159,6 +161,7 @@ if (Html5.isSupported()) {
     assert.equal(volumeBar.el_.getAttribute('aria-valuenow'), 100, 'ARIA value of VolumeBar is 100');
 
     muteToggle.handleClick();
+
     volumeBar.updateARIAAttributes();
 
     assert.equal(player.volume(), 1, 'Volume remains 1');


### PR DESCRIPTION
Currently, the ARIA value of `VolumeBar` tracks the value of `volume`. It should instead track the position of the slider on `VolumeBar`, which tracks `volume` except when the player is muted, in which case it's 0.

Addresses https://github.com/videojs/video.js/issues/4064.

### Question about testing

Clicking `MuteToggle` fires the `volumechange` event on the player, which in turn runs `VolumeBar#updateARIAAttributes`.

However, in the testing environment—at least as I have the tests set up!—clicking `MuteToggle` doesn't fire `volumechange` on the player, so I've had to manually call `VolumeBar#updateARIAAttributes` where it should have been run automatically in order to get the tests to pass. Of course, this needs to be fixed before merging.

Do any problems with my test configuration stick out, or is this likely a bug?