### PR TITLE
fix: copy basic plugin properties onto the wrapper

### DIFF
--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -312,6 +312,9 @@ class Plugin {
     if (name !== BASE_PLUGIN_NAME) {
       if (Plugin.isBasic(plugin)) {
         Player.prototype[name] = createBasicPlugin(name, plugin);
+        Object.keys(plugin).forEach(function(prop) {
+          Player.prototype[name][prop] = plugin[prop];
+        });
       } else {
         Player.prototype[name] = createPluginFactory(name, plugin);
       }

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -88,17 +88,25 @@ const markPluginAsActive = (player, name) => {
  * @returns {Function}
  *          A wrapper function for the given plugin.
  */
-const createBasicPlugin = (name, plugin) => function() {
-  const instance = plugin.apply(this, arguments);
+const createBasicPlugin = function(name, plugin) {
+  const basicPluginWrapper = function() {
+    const instance = plugin.apply(this, arguments);
 
-  markPluginAsActive(this, name);
+    markPluginAsActive(this, name);
 
-  // We trigger the "pluginsetup" event on the player regardless, but we want
-  // the hash to be consistent with the hash provided for advanced plugins.
-  // The only potentially counter-intuitive thing here is the `instance` is the
-  // value returned by the `plugin` function.
-  this.trigger('pluginsetup', {name, plugin, instance});
-  return instance;
+    // We trigger the "pluginsetup" event on the player regardless, but we want
+    // the hash to be consistent with the hash provided for advanced plugins.
+    // The only potentially counter-intuitive thing here is the `instance` is the
+    // value returned by the `plugin` function.
+    this.trigger('pluginsetup', {name, plugin, instance});
+    return instance;
+  };
+
+  Object.keys(plugin).forEach(function(prop) {
+    basicPluginWrapper[prop] = plugin[prop];
+  });
+
+  return basicPluginWrapper;
 };
 
 /**
@@ -312,9 +320,6 @@ class Plugin {
     if (name !== BASE_PLUGIN_NAME) {
       if (Plugin.isBasic(plugin)) {
         Player.prototype[name] = createBasicPlugin(name, plugin);
-        Object.keys(plugin).forEach(function(prop) {
-          Player.prototype[name][prop] = plugin[prop];
-        });
       } else {
         Player.prototype[name] = createPluginFactory(name, plugin);
       }

--- a/test/unit/plugin-basic.test.js
+++ b/test/unit/plugin-basic.test.js
@@ -76,4 +76,9 @@ QUnit.test('properties are copied', function(assert) {
 
   assert.strictEqual(this.player.foo.VERSION, foo.VERSION, 'properties are copied');
   assert.strictEqual(this.player.foo.someProp, foo.someProp, 'properties are copied');
+
+  this.player.foo();
+
+  assert.strictEqual(this.player.foo.VERSION, foo.VERSION, 'properties still exist after init');
+  assert.strictEqual(this.player.foo.someProp, foo.someProp, 'properties still exist after init');
 });

--- a/test/unit/plugin-basic.test.js
+++ b/test/unit/plugin-basic.test.js
@@ -38,6 +38,13 @@ QUnit.test('setup', function(assert) {
   assert.deepEqual(this.basic.firstCall.args, [{foo: 'bar'}, 123], 'the plugin had the correct arguments');
   assert.ok(this.player.usingPlugin('basic'), 'the player now recognizes that the plugin was set up');
   assert.ok(this.player.hasPlugin('basic'), 'player has the plugin available');
+
+  this.player.basic({foo: 'bar'}, 123);
+  assert.strictEqual(this.basic.callCount, 2, 'the plugin was called twice');
+  assert.strictEqual(this.basic.firstCall.thisValue, this.player, 'the plugin `this` value was the player');
+  assert.deepEqual(this.basic.firstCall.args, [{foo: 'bar'}, 123], 'the plugin had the correct arguments');
+  assert.ok(this.player.usingPlugin('basic'), 'the player now recognizes that the plugin was set up');
+  assert.ok(this.player.hasPlugin('basic'), 'player has the plugin available');
 });
 
 QUnit.test('"pluginsetup" event', function(assert) {
@@ -57,4 +64,16 @@ QUnit.test('"pluginsetup" event', function(assert) {
     instance,
     plugin: this.basic
   }, 'the event hash object is correct');
+});
+
+QUnit.test('properties are copied', function(assert) {
+  const foo = () => {};
+
+  foo.someProp = () => {};
+  foo.VERSION = '9.9.9';
+
+  Plugin.registerPlugin('foo', foo);
+
+  assert.strictEqual(this.player.foo.VERSION, foo.VERSION, 'properties are copied');
+  assert.strictEqual(this.player.foo.someProp, foo.someProp, 'properties are copied');
 });


### PR DESCRIPTION
## Description
Copy basic plugin properties to prevent breaking older basic plugins

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
