### PR TITLE
feat: focus play toggle from Big Play Btn on play

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -34,7 +34,23 @@ class BigPlayButton extends Button {
    * @listens click
    */
   handleClick(event) {
-    this.player_.play();
+    const playPromise = this.player_.play();
+
+    const cb = this.player_.getChild('controlBar');
+    const playToggle = cb && cb.getChild('playToggle');
+
+    if (!playToggle) {
+      this.player_.focus();
+      return;
+    }
+
+    if (playPromise) {
+      playPromise.then(() => playToggle.focus());
+    } else {
+      this.setTimeout(function() {
+        playToggle.focus();
+      }, 1);
+    }
   }
 }
 

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -34,7 +34,7 @@ class BigPlayButton extends Button {
    * @listens click
    */
   handleClick(event) {
-    const playPromise = this.player_.play();
+    this.player_.play();
 
     const cb = this.player_.getChild('controlBar');
     const playToggle = cb && cb.getChild('playToggle');
@@ -44,13 +44,9 @@ class BigPlayButton extends Button {
       return;
     }
 
-    if (playPromise) {
-      playPromise.then(() => playToggle.focus());
-    } else {
-      this.setTimeout(function() {
-        playToggle.focus();
-      }, 1);
-    }
+    this.setTimeout(function() {
+      playToggle.focus();
+    }, 1);
   }
 }
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1233,6 +1233,20 @@ class Component {
   }
 
   /**
+   * Set the focus to this component
+   */
+  focus() {
+    this.el_.focus();
+  }
+
+  /**
+   * Remove the focus from this component
+   */
+  blur() {
+    this.el_.blur();
+  }
+
+  /**
    * Emit a 'tap' events when touch event support gets detected. This gets used to
    * support toggling the controls through a tap on the video. They get enabled
    * because every sub-component would have extra overhead otherwise.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -481,6 +481,9 @@ class Player extends Component {
       el = this.el_ = super.createEl('div');
     }
 
+    // set tabindex to -1 so we could focus on the player element
+    tag.setAttribute('tabindex', '-1');
+
     // Remove width/height attrs from tag so CSS can make it 100% width/height
     tag.removeAttribute('width');
     tag.removeAttribute('height');


### PR DESCRIPTION
This is a port of https://github.com/videojs/video.js/pull/4018 onto 5.x.
The reason it's a `feat` rather than `fix` is because it adds the `focus()` and `blur()` methods on components.