### PR TITLE
fix: dom.getBoundingClientRect check that el is defined

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -484,7 +484,7 @@ export function unblockTextSelection() {
  *         Always returns a plain
  */
 export function getBoundingClientRect(el) {
-  if (el.getBoundingClientRect && el.parentNode) {
+  if (el && el.getBoundingClientRect && el.parentNode) {
     const rect = el.getBoundingClientRect();
     const result = {};
 


### PR DESCRIPTION
## Description
Verify that `el` is defined so that we don't throw if we get to this function with an undefined `el`
 
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
