### PR TITLE
Don't throw when re-registering a plugin

### DIFF
--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -5,6 +5,7 @@ import evented from './mixins/evented';
 import stateful from './mixins/stateful';
 import * as Events from './utils/events';
 import * as Fn from './utils/fn';
+import log from './utils/log';
 import Player from './player';
 
 /**
@@ -305,12 +306,12 @@ class Plugin {
       throw new Error(`Illegal plugin name, "${name}", must be a string, was ${typeof name}.`);
     }
 
-    if (pluginExists(name) || Player.prototype.hasOwnProperty(name)) {
-      throw new Error(`Illegal plugin name, "${name}", already exists.`);
-    }
-
     if (typeof plugin !== 'function') {
       throw new Error(`Illegal plugin for "${name}", must be a function, was ${typeof plugin}.`);
+    }
+
+    if (pluginExists(name) || Player.prototype.hasOwnProperty(name)) {
+      log.warn(`A plugin named "${name}" already exists. You may want to avoid re-registering plugins!`);
     }
 
     pluginStorage[name] = plugin;

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -306,12 +306,14 @@ class Plugin {
       throw new Error(`Illegal plugin name, "${name}", must be a string, was ${typeof name}.`);
     }
 
-    if (typeof plugin !== 'function') {
-      throw new Error(`Illegal plugin for "${name}", must be a function, was ${typeof plugin}.`);
+    if (pluginExists(name)) {
+      log.warn(`A plugin named "${name}" already exists. You may want to avoid re-registering plugins!`);
+    } else if (Player.prototype.hasOwnProperty(name)) {
+      throw new Error(`Illegal plugin name, "${name}", cannot share a name with an existing player method!`);
     }
 
-    if (pluginExists(name) || Player.prototype.hasOwnProperty(name)) {
-      log.warn(`A plugin named "${name}" already exists. You may want to avoid re-registering plugins!`);
+    if (typeof plugin !== 'function') {
+      throw new Error(`Illegal plugin for "${name}", must be a function, was ${typeof plugin}.`);
     }
 
     pluginStorage[name] = plugin;

--- a/test/unit/plugin-static.test.js
+++ b/test/unit/plugin-static.test.js
@@ -67,12 +67,16 @@ QUnit.test('registerPlugin() illegal arguments', function(assert) {
     'plugins must be functions'
   );
 
+  assert.throws(
+    () => Plugin.registerPlugin('play', function() {}),
+    new Error('Illegal plugin name, "play", cannot share a name with an existing player method!'),
+    'plugins must be functions'
+  );
+
   sinon.spy(log, 'warn');
   Plugin.registerPlugin('foo', function() {});
   Plugin.registerPlugin('foo', function() {});
-  Plugin.registerPlugin('play', function() {});
-
-  assert.strictEqual(log.warn.callCount, 2, 'warn on re-registering a plugin or registering a plugin that shares the name of a player method');
+  assert.strictEqual(log.warn.callCount, 1, 'warn on re-registering a plugin');
   log.warn.restore();
 });
 

--- a/test/unit/plugin-static.test.js
+++ b/test/unit/plugin-static.test.js
@@ -1,4 +1,6 @@
 /* eslint-env qunit */
+import sinon from 'sinon';
+import log from '../../src/js/utils/log';
 import Player from '../../src/js/player';
 import Plugin from '../../src/js/plugin';
 
@@ -54,12 +56,6 @@ QUnit.test('registerPlugin() illegal arguments', function(assert) {
   );
 
   assert.throws(
-    () => Plugin.registerPlugin('play'),
-    new Error('Illegal plugin name, "play", already exists.'),
-    'plugins cannot share a name with an existing player method'
-  );
-
-  assert.throws(
     () => Plugin.registerPlugin('foo'),
     new Error('Illegal plugin for "foo", must be a function, was undefined.'),
     'plugins require both arguments'
@@ -70,6 +66,14 @@ QUnit.test('registerPlugin() illegal arguments', function(assert) {
     new Error('Illegal plugin for "foo", must be a function, was object.'),
     'plugins must be functions'
   );
+
+  sinon.spy(log, 'warn');
+  Plugin.registerPlugin('foo', function() {});
+  Plugin.registerPlugin('foo', function() {});
+  Plugin.registerPlugin('play', function() {});
+
+  assert.strictEqual(log.warn.callCount, 2, 'warn on re-registering a plugin or registering a plugin that shares the name of a player method');
+  log.warn.restore();
 });
 
 QUnit.test('getPlugin()', function(assert) {


### PR DESCRIPTION
Currently, if a plugin is re-registered, it will throw an error. On the face, this makes sense, but it comes with two issues:

1. It will totally break in an unrecoverable way in a case where it might not actually be a break.
2. Nothing else has this behavior - components and techs do not throw.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
