### PR TITLE
5.x fix cue-points with a startTime of 0

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -198,7 +198,9 @@ class TextTrack extends Track {
     });
 
     if (mode !== 'disabled') {
-      tt.tech_.on('timeupdate', timeupdateHandler);
+      tt.tech_.ready(() => {
+        tt.tech_.on('timeupdate', timeupdateHandler);
+      }, true);
     }
 
     /**
@@ -232,7 +234,9 @@ class TextTrack extends Track {
         }
         mode = newMode;
         if (mode === 'showing') {
-          this.tech_.on('timeupdate', timeupdateHandler);
+          this.tech_.ready(() => {
+            this.tech_.on('timeupdate', timeupdateHandler);
+          }, true);
         }
         /**
          * An event that fires when mode changes on this track. This allows
@@ -331,7 +335,7 @@ class TextTrack extends Track {
   addCue(originalCue) {
     let cue = originalCue;
 
-    if (!(originalCue instanceof window.vttjs.VTTCue)) {
+    if (window.vttjs && !(originalCue instanceof window.vttjs.VTTCue)) {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -339,9 +339,7 @@ class TextTrack extends Track {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {
-        if (!(prop in cue)) {
-          cue[prop] = originalCue[prop];
-        }
+        cue[prop] = originalCue[prop];
       }
     }
 

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -9,7 +9,10 @@ class TechFaker extends Tech {
 
   constructor(options, handleReady) {
     super(options, handleReady);
-    this.triggerReady();
+
+    if (!options || options.autoReady !== false) {
+      this.triggerReady();
+    }
   }
 
   createEl() {

--- a/test/unit/tracks/html-track-element.test.js
+++ b/test/unit/tracks/html-track-element.test.js
@@ -1,14 +1,16 @@
 /* eslint-env qunit */
 import HTMLTrackElement from '../../../src/js/tracks/html-track-element.js';
+import TechFaker from '../tech/tech-faker';
 
-const defaultTech = {
-  textTracks() {},
-  on() {},
-  off() {},
-  currentTime() {}
-};
-
-QUnit.module('HTML Track Element');
+QUnit.module('HTML Track Element', {
+  beforeEach() {
+    this.tech = new TechFaker();
+  },
+  afterEach() {
+    this.tech.dispose();
+    this.tech = null;
+  }
+});
 
 QUnit.test('html track element requires a tech', function(assert) {
   assert.throws(
@@ -31,7 +33,7 @@ QUnit.test('can create a html track element with various properties', function(a
     label,
     language,
     src,
-    tech: defaultTech
+    tech: this.tech
   });
 
   assert.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');
@@ -45,7 +47,7 @@ QUnit.test('can create a html track element with various properties', function(a
 
 QUnit.test('defaults when items not provided', function(assert) {
   const htmlTrackElement = new HTMLTrackElement({
-    tech: defaultTech
+    tech: this.tech
   });
 
   assert.equal(typeof htmlTrackElement.default, 'undefined', 'we have a default');

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -2,6 +2,7 @@
 import TextTrackList from '../../../src/js/tracks/text-track-list.js';
 import TextTrack from '../../../src/js/tracks/text-track.js';
 import EventTarget from '../../../src/js/event-target.js';
+import TechFaker from '../tech/tech-faker.js';
 
 QUnit.module('Text Track List');
 QUnit.test('trigger "change" event when "modechange" is fired on a track', function(assert) {
@@ -23,11 +24,7 @@ QUnit.test('trigger "change" event when "modechange" is fired on a track', funct
 });
 
 QUnit.test('trigger "change" event when mode changes on a TextTrack', function(assert) {
-  const tt = new TextTrack({
-    tech: {
-      on() {}
-    }
-  });
+  const tt = new TextTrack({tech: new TechFaker()});
   const ttl = new TextTrackList([tt]);
   let changes = 0;
   const changeHandler = function() {

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -9,14 +9,16 @@ import proxyquireify from 'proxyquireify';
 import sinon from 'sinon';
 
 const proxyquire = proxyquireify(require);
-const defaultTech = {
-  textTracks() {},
-  on() {},
-  off() {},
-  currentTime() {}
-};
 
-QUnit.module('Text Track');
+QUnit.module('Text Track', {
+  beforeEach() {
+    this.tech = new TechFaker();
+  },
+  afterEach() {
+    this.tech.dispose();
+    this.tech = null;
+  }
+});
 
 // do baseline track testing
 TrackBaseline(TextTrack, {
@@ -25,7 +27,7 @@ TrackBaseline(TextTrack, {
   mode: 'disabled',
   label: 'English',
   language: 'en',
-  tech: defaultTech
+  tech: new TechFaker()
 });
 
 QUnit.test('requires a tech', function(assert) {
@@ -39,7 +41,7 @@ QUnit.test('can create a TextTrack with a mode property', function(assert) {
   const mode = 'disabled';
   const tt = new TextTrack({
     mode,
-    tech: defaultTech
+    tech: this.tech
   });
 
   assert.equal(tt.mode, mode, 'we have a mode');
@@ -47,7 +49,7 @@ QUnit.test('can create a TextTrack with a mode property', function(assert) {
 
 QUnit.test('defaults when items not provided', function(assert) {
   const tt = new TextTrack({
-    tech: TechFaker
+    tech: this.tech
   });
 
   assert.equal(tt.kind, 'subtitles', 'kind defaulted to subtitles');
@@ -58,7 +60,7 @@ QUnit.test('defaults when items not provided', function(assert) {
 
 QUnit.test('kind can only be one of several options, defaults to subtitles', function(assert) {
   let tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'foo'
   });
 
@@ -66,35 +68,35 @@ QUnit.test('kind can only be one of several options, defaults to subtitles', fun
   assert.notEqual(tt.kind, 'foo', 'the kind is set to subtitles, not foo');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'subtitles'
   });
 
   assert.equal(tt.kind, 'subtitles', 'the kind is set to subtitles');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'captions'
   });
 
   assert.equal(tt.kind, 'captions', 'the kind is set to captions');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'descriptions'
   });
 
   assert.equal(tt.kind, 'descriptions', 'the kind is set to descriptions');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'chapters'
   });
 
   assert.equal(tt.kind, 'chapters', 'the kind is set to chapters');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     kind: 'metadata'
   });
 
@@ -103,7 +105,7 @@ QUnit.test('kind can only be one of several options, defaults to subtitles', fun
 
 QUnit.test('mode can only be one of several options, defaults to disabled', function(assert) {
   let tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     mode: 'foo'
   });
 
@@ -111,21 +113,21 @@ QUnit.test('mode can only be one of several options, defaults to disabled', func
   assert.notEqual(tt.mode, 'foo', 'the mode is set to disabld, not foo');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     mode: 'disabled'
   });
 
   assert.equal(tt.mode, 'disabled', 'the mode is set to disabled');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     mode: 'hidden'
   });
 
   assert.equal(tt.mode, 'hidden', 'the mode is set to hidden');
 
   tt = new TextTrack({
-    tech: defaultTech,
+    tech: this.tech,
     mode: 'showing'
   });
 
@@ -136,7 +138,7 @@ QUnit.test('cue and activeCues are read only', function(assert) {
   const mode = 'disabled';
   const tt = new TextTrack({
     mode,
-    tech: defaultTech
+    tech: this.tech
   });
 
   tt.cues = 'foo';
@@ -148,7 +150,7 @@ QUnit.test('cue and activeCues are read only', function(assert) {
 
 QUnit.test('mode can only be set to a few options', function(assert) {
   const tt = new TextTrack({
-    tech: defaultTech
+    tech: this.tech
   });
 
   tt.mode = 'foo';
@@ -173,7 +175,7 @@ QUnit.test('mode can only be set to a few options', function(assert) {
 
 QUnit.test('cues and activeCues return a TextTrackCueList', function(assert) {
   const tt = new TextTrack({
-    tech: defaultTech
+    tech: this.tech
   });
 
   assert.ok(tt.cues.getCueById, 'cues are a TextTrackCueList');
@@ -182,7 +184,7 @@ QUnit.test('cues and activeCues return a TextTrackCueList', function(assert) {
 
 QUnit.test('cues can be added and removed from a TextTrack', function(assert) {
   const tt = new TextTrack({
-    tech: defaultTech
+    tech: this.tech
   });
   const cues = tt.cues;
 
@@ -242,6 +244,49 @@ QUnit.test('fires cuechange when cues become active and inactive', function(asse
   player.dispose();
 });
 
+QUnit.test('does not fire cuechange before Tech is ready', function(assert) {
+  const done = assert.async();
+  const player = TestHelpers.makePlayer({techfaker: {autoReady: false}});
+  let changes = 0;
+  const tt = new TextTrack({
+    tech: player.tech_,
+    mode: 'showing'
+  });
+  const cuechangeHandler = function() {
+    changes++;
+  };
+
+  tt.addCue({
+    id: '1',
+    startTime: 0,
+    endTime: 5
+  });
+
+  tt.oncuechange = cuechangeHandler;
+  tt.addEventListener('cuechange', cuechangeHandler);
+
+  player.tech_.currentTime = function() {
+    return 0;
+  };
+
+  player.tech_.trigger('timeupdate');
+  assert.equal(changes, 0, 'a cuechange event is not triggered');
+
+  player.tech_.on('ready', function() {
+    player.tech_.currentTime = function() {
+      return 0.2;
+    };
+
+    player.tech_.trigger('timeupdate');
+
+    assert.equal(changes, 2, 'a cuechange event trigger addEventListener and oncuechange');
+
+    player.dispose();
+    done();
+  });
+  player.tech_.triggerReady();
+});
+
 QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   const clock = sinon.useFakeTimers();
   const oldVTT = window.WebVTT;
@@ -270,7 +315,7 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
 
   /* eslint-disable no-unused-vars */
   const tt = new TextTrack_({
-    tech: defaultTech,
+    tech: this.tech,
     src: 'http://example.com'
   });
   /* eslint-enable no-unused-vars */


### PR DESCRIPTION
## Description
Wait for tech to be ready before worrying about timeupdate events

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
