### PR TITLE
fix(audio-tracks-button): add wrapper CSS builder to audio tracks menu button

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-button.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-button.js
@@ -37,6 +37,10 @@ class AudioTrackButton extends TrackButton {
     return `vjs-audio-button ${super.buildCSSClass()}`;
   }
 
+  buildWrapperCSSClass() {
+    return `vjs-audio-button ${super.buildWrapperCSSClass()}`;
+  }
+
   /**
    * Create a menu item for each audio track
    *


### PR DESCRIPTION
Similar to #4146, this update fixes the CSS on the audio tracks menu button wrapper after the changes in #4034.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
