### PR TITLE
Silence deprecation warning from test

### DIFF
--- a/test/unit/plugin-static.test.js
+++ b/test/unit/plugin-static.test.js
@@ -73,7 +73,7 @@ QUnit.test('registerPlugin() illegal arguments', function(assert) {
     'plugins must be functions'
   );
 
-  sinon.spy(log, 'warn');
+  sinon.stub(log, 'warn');
   Plugin.registerPlugin('foo', function() {});
   Plugin.registerPlugin('foo', function() {});
   assert.strictEqual(log.warn.callCount, 1, 'warn on re-registering a plugin');


### PR DESCRIPTION
This silences a deprecation warning for the plugin re-registration test.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
