### PR TITLE
fix(icon-placeholder): align icons on ie8 properly

### DIFF
--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -10,12 +10,12 @@
   width: 4em;
   @include flex(none);
 
-  & > .vjs-icon-placeholder:before {
-    font-size: 1.8em;
-    line-height: 1.67;
+}
+.vjs-button > .vjs-icon-placeholder:before {
+  font-size: 1.8em;
+  line-height: 1.67;
 
-    @extend %icon-default;
-  }
+  @extend %icon-default;
 }
 
 // Replacement for focus outline

--- a/src/js/control-bar/text-track-controls/subs-caps-button.js
+++ b/src/js/control-bar/text-track-controls/subs-caps-button.js
@@ -23,7 +23,6 @@ class SubsCapsButton extends TextTrackButton {
       this.label_ = 'captions';
     }
     this.menuButton_.controlText(toTitleCase(this.label_));
-
   }
 
   /**

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -38,6 +38,7 @@ class MenuButton extends Component {
     const buttonClass = Button.prototype.buildCSSClass();
 
     this.menuButton_.el_.className = this.buildCSSClass() + ' ' + buttonClass;
+    this.menuButton_.removeClass('vjs-control');
 
     this.addChild(this.menuButton_);
 


### PR DESCRIPTION
Make sure that the button inside the menu button element isn't a
vjs-control but make sure that the icon-placeholder is sized properly.