### PR TITLE
fix(ie8): various minor ie8 fixes

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -19,6 +19,10 @@
   overflow: auto;
 }
 
+.vjs-tracksettings legend {
+  color: $primary-foreground-color;
+}
+
 .vjs-caption-settings .vjs-tracksettings-colors,
 .vjs-caption-settings .vjs-tracksettings-font {
   float: left;

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -52,8 +52,11 @@ class PlayProgressBar extends Component {
         this.player_.currentTime();
 
       const content = formatTime(time, this.player_.duration());
+      const timeTooltip = this.getChild('timeTooltip');
 
-      this.getChild('timeTooltip').update(seekBarRect, seekBarPoint, content);
+      if (timeTooltip) {
+        timeTooltip.update(seekBarRect, seekBarPoint, content);
+      }
     });
   }
 }

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -33,6 +33,8 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
     // CaptionSettingsMenuItem has no concept of 'selected'
     options.selectable = false;
 
+    options.name = 'CaptionSettingsMenuItem';
+
     super(player, options);
     this.addClass('vjs-texttrack-settings');
     this.controlText(', opens ' + options.kind + ' settings dialog');
@@ -52,7 +54,6 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
   handleClick(event) {
     this.player().getChild('textTrackSettings').open();
   }
-
 }
 
 Component.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -49,7 +49,12 @@ class Menu extends Component {
       // Unpress the associated MenuButton, and move focus back to it
       if (this.menuButton_) {
         this.menuButton_.unpressButton();
-        this.menuButton_.focus();
+
+        // don't focus menu button if item is a caption settings item
+        // because focus will move elsewhere and it logs an error on IE8
+        if (component.name() !== 'CaptionSettingsMenuItem') {
+          this.menuButton_.focus();
+        }
       }
     }));
   }


### PR DESCRIPTION
This fixes a logging in the console regarding timetooltips which don't exist. Also, makes sure not to focus the menu button when the captions settings menu item is clicked since the caption settings is getting focused instead. In addition, it makes sure the legend text in the track settings is the foreground color.