### PR TITLE
fix(vttjs): wait till tech el in DOM before loading vttjs

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -515,7 +515,7 @@ class Tech extends Component {
     // Initially, Tech.el_ is a child of a dummy-div wait until the Component system
     // signals that the Tech is ready at which point Tech.el_ is part of the DOM
     // before inserting the WebVTT script
-    if (this.el().parentNode !== null && this.el().parentNode !== undefined) {
+    if (document.body.contains(this.el())) {
       const vtt = require('videojs-vtt.js');
 
       // load via require if available and vtt.js script location was not passed in


### PR DESCRIPTION
The issue is that in Flash, `Flash.embed` wraps the `object` element in a div but that `object` element is what is referenced by `this.el()`, so, `parentNode` isn't null but we aren't actually in the DOM. Instead, just check to see whether the tech element is in the DOM or not via `node.contains()`.