### PR TITLE
modified existing conditional so that time tooltips will not be added…

### DIFF
--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -2,7 +2,7 @@
  * @file play-progress-bar.js
  */
 import Component from '../../component.js';
-import {IE_VERSION} from '../../utils/browser.js';
+import {IE_VERSION, IS_IOS, IS_ANDROID} from '../../utils/browser.js';
 import formatTime from '../../utils/format-time.js';
 
 import './time-tooltip';
@@ -71,7 +71,8 @@ PlayProgressBar.prototype.options_ = {
   children: []
 };
 
-if (!IE_VERSION || IE_VERSION > 8) {
+// Time tooltips should not be added to a player on mobile devices or IE8
+if ((!IE_VERSION || IE_VERSION > 8) && !IS_IOS && !IS_ANDROID) {
   PlayProgressBar.prototype.options_.children.push('timeTooltip');
 }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -3,7 +3,7 @@
  */
 import Slider from '../../slider/slider.js';
 import Component from '../../component.js';
-import {IE_VERSION} from '../../utils/browser.js';
+import {IE_VERSION, IS_IOS, IS_ANDROID} from '../../utils/browser.js';
 import * as Dom from '../../utils/dom.js';
 import * as Fn from '../../utils/fn.js';
 import formatTime from '../../utils/format-time.js';
@@ -225,7 +225,8 @@ SeekBar.prototype.options_ = {
   barName: 'playProgressBar'
 };
 
-if (!IE_VERSION || IE_VERSION > 8) {
+// MouseTimeDisplay tooltips should not be added to a player on mobile devices or IE8
+if ((!IE_VERSION || IE_VERSION > 8) && !IS_IOS && !IS_ANDROID) {
   SeekBar.prototype.options_.children.splice(1, 0, 'mouseTimeDisplay');
 }
 


### PR DESCRIPTION
… to a player on mobile devices

## Description
Currently, the behavior of time tooltips is inconsistent across iOS and Android devices, so the decision was made by @gkatsev to hide tooltips on all mobile devices (for at least the time being).

## Specific Changes proposed
Modify existing conditionals in `seek-bar.js` and `play-progress-bar.js` so that the `TimeTooltip` and `MouseTimeDisplay` components will not be added to a player when it is initialized in iOS or Android.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
