### PR TITLE
fix: dont pause when the ErrorDisplay is opened

### DIFF
--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -58,6 +58,7 @@ class ErrorDisplay extends ModalDialog {
  * @private
  */
 ErrorDisplay.prototype.options_ = mergeOptions(ModalDialog.prototype.options_, {
+  pauseOnOpen: false,
   fillAlways: true,
   temporary: false,
   uncloseable: true

--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -180,7 +180,7 @@ class ModalDialog extends Component {
       // playing state.
       this.wasPlaying_ = !player.paused();
 
-      if (this.wasPlaying_) {
+      if (this.options_.pauseOnOpen && this.wasPlaying_) {
         player.pause();
       }
 
@@ -243,7 +243,7 @@ class ModalDialog extends Component {
       this.trigger('beforemodalclose');
       this.opened_ = false;
 
-      if (this.wasPlaying_) {
+      if (this.wasPlaying_ && this.options_.pauseOnOpen) {
         player.play();
       }
 
@@ -427,6 +427,7 @@ class ModalDialog extends Component {
  * @private
  */
 ModalDialog.prototype.options_ = {
+  pauseOnOpen: true,
   temporary: true
 };
 

--- a/test/unit/modal-dialog.test.js
+++ b/test/unit/modal-dialog.test.js
@@ -208,6 +208,35 @@ QUnit.test('open() pauses playback, close() resumes', function(assert) {
   assert.strictEqual(playSpy.callCount, 1, 'player is resumed when the modal closes');
 });
 
+QUnit.test('open() does not pause, close() does not play() with pauseOnOpen set to false', function(assert) {
+  const playSpy = sinon.spy();
+  const pauseSpy = sinon.spy();
+
+  // don't pause the video on modal open
+  this.modal.options_.pauseOnOpen = false;
+
+  // Quick and dirty; make it looks like the player is playing.
+  this.player.paused = function() {
+    return false;
+  };
+
+  this.player.play = function() {
+    playSpy();
+  };
+
+  this.player.pause = function() {
+    pauseSpy();
+  };
+
+  this.modal.open();
+
+  assert.expect(2);
+  assert.strictEqual(pauseSpy.callCount, 0, 'player remains playing when the modal opens');
+
+  this.modal.close();
+  assert.strictEqual(playSpy.callCount, 0, 'player is resumed when the modal closes');
+});
+
 QUnit.test('open() hides controls, close() shows controls', function(assert) {
   this.modal.open();
 


### PR DESCRIPTION
## Description
* Added a feature to make it optional for `ModalDialog` to `pauseOnOpen`
* Use `pauseOnOpen: false` in `ErrorDisplay` so that errors that can recover during playback will recover

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
