### PR TITLE
fix links in docs

### DIFF
--- a/build/fix-api-docs.js
+++ b/build/fix-api-docs.js
@@ -1,0 +1,20 @@
+var replace = require("replace");
+var path = require('path')
+var apiPath = path.join(__dirname, '..', 'docs', 'api');
+
+var replacements = [
+  {find: '\"/docs/guides/\"', replace: '"#"'},
+  {find: '\"/docs/guides/(.*)\.md\"', replace: '"tutorial-$1.html"'},
+  {find: '\"tutorial-tech.html\"', replace: '"tutorial-tech_.html"'}
+];
+
+
+replacements.forEach(function(obj) {
+  replace({
+    regex: obj.find,
+    replacement: obj.replace,
+    paths: [apiPath],
+    recursive: true,
+    silent: true
+  });
+});

--- a/build/fix-api-docs.js
+++ b/build/fix-api-docs.js
@@ -3,9 +3,9 @@ var path = require('path')
 var apiPath = path.join(__dirname, '..', 'docs', 'api');
 
 var replacements = [
-  {find: '\"/docs/guides/\"', replace: '"#"'},
-  {find: '\"/docs/guides/(.*)\.md\"', replace: '"tutorial-$1.html"'},
-  {find: '\"tutorial-tech.html\"', replace: '"tutorial-tech_.html"'}
+  {find: /\/docs\/guides\/(.+)\.md/, replace: 'tutorial-$1.html'},
+  {find: /tutorial-tech.html/, replace: 'tutorial-tech_.html'},
+  {find: /\/docs\/guides\//, replace: '#'}
 ];
 
 

--- a/build/fix-api-docs.js
+++ b/build/fix-api-docs.js
@@ -3,9 +3,9 @@ var path = require('path')
 var apiPath = path.join(__dirname, '..', 'docs', 'api');
 
 var replacements = [
-  {find: /\/docs\/guides\/(.+)\.md/, replace: 'tutorial-$1.html'},
-  {find: /tutorial-tech.html/, replace: 'tutorial-tech_.html'},
-  {find: /\/docs\/guides\//, replace: '#'}
+  {find: /\/docs\/guides\/(.+)\.md/g, replace: 'tutorial-$1.html'},
+  {find: /tutorial-tech.html/g, replace: 'tutorial-tech_.html'},
+  {find: /\/docs\/guides\//g, replace: '#'}
 ];
 
 

--- a/docs/guides/audio-tracks.md
+++ b/docs/guides/audio-tracks.md
@@ -25,7 +25,7 @@ cross-browser implementation of audio tracks.
   They must be added programmatically.
 * Video.js only stores track representations. Switching audio tracks for playback is
   _not handled by Video.js_ and must be handled elsewhere - for example,
-  [videojs-contrib-hls](http://github.com/videojs/videojs-contrib-hls) handles switching
+  [videojs-contrib-hls][hls] handles switching
   audio tracks to support track selection through the UI.
 
 ## Working with Audio Tracks
@@ -91,7 +91,7 @@ player.audioTracks().removeTrack(track);
 ## API
 
 For more complete information, refer to the
-[Video.js API docs](http://docs.videojs.com/docs/api/index.html), specifically:
+[Video.js API docs](http://docs.videojs.com/), specifically:
 
 * `Player#audioTracks`
 * `AudioTrackList`
@@ -140,7 +140,7 @@ The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of t
 track, e.g. `"en"` for English or `"es"` for Spanish.
 
 For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang)
-located in the Video.js root and refer to the [languages guide](languages.md) for more
+located in the Video.js root and refer to the [languages guide][languages-guide] for more
 information on languages in Video.js.
 
 #### `enabled`
@@ -154,4 +154,8 @@ than one, the last one to be enabled will end up being the only one. While the s
 allows for more than one track to be enabled, Safari and most implementations only allow
 one audio track to be enabled at a time.
 
+[languages-guide]: /docs/guides/languages.md
+
 [spec-audiotrack]: https://html.spec.whatwg.org/multipage/embedded-content.html#audiotrack
+
+[hls]: http://github.com/videojs/videojs-contrib-hls

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -29,7 +29,7 @@ A component is a JavaScript object that has the following features:
 * The ability to listen for and trigger events.
 * A lifecycle of initialization and disposal.
 
-For more specifics on the programmatic interface of a component, see [the component API docs](http://docs.videojs.com/docs/api/component.html).
+For more specifics on the programmatic interface of a component, see [the component API docs][api].
 
 ## Creating a Component
 
@@ -75,7 +75,7 @@ console.log(button.el());
 
 ## Component Children
 
-Again, refer to [the component API docs](http://docs.videojs.com/docs/api/component.html) for complete details on methods available for managing component structures.
+Again, refer to [the component API docs][api] for complete details on methods available for managing component structures.
 
 ### Basic Example
 
@@ -336,3 +336,5 @@ let player = videojs('myplayer', {
 ### Text Track Settings
 
 The text track settings component is only available when using emulated text tracks.
+
+[api]: http://docs.videojs.com/Component.html

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -107,6 +107,6 @@ Finally, the history (if enabled) can be cleared at any time via:
 videojs.log.history.clear();
 ```
 
-[api]: http://docs.videojs.com/docs/api/index.html
+[api]: http://docs.videojs.com/
 
 [console]: https://developer.mozilla.org/en-US/docs/Web/API/Console

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -112,7 +112,7 @@ with your issue.
 A reduced test case is an example of the problem that you are facing in isolation.
 Think of it as example page that reproduces the issue in the least amount of possible code.
 We have a [starter example][starter-example] for reduced test cases. To learn more
-about reduced test cases visit [css-tricks](https://css-tricks.com/reduced-test-cases/)
+about reduced test cases visit [css-tricks][reduced-test-case]
 
 ## Q: What media formats does video.js support?
 
@@ -270,19 +270,25 @@ Be sure to use `require('!style-loader!css-loader!video.js/dist/video-js.css')` 
 
 ## Q: Does video.js work with react?
 
-Yes! See [ReactJS integration example](./guides/react.md).
+Yes! See [ReactJS integration example][react-guide].
 
-[plugin-guide]: plugins.md
+[reduced-test-case]: https://css-tricks.com/reduced-test-cases/
+
+[react-guide]: /docs/guides/react.md
+
+[plugin-guide]: /docs/guides/plugins.md
 
 [install-guide]: http://videojs.com/getting-started/
 
-[troubleshooting]: troubleshooting.md
+[troubleshooting]: /docs/guides/troubleshooting.md
 
-[video-tracks]: video-tracks.md
+[video-tracks]: /docs/guides/video-tracks.md
 
-[audio-tracks]: audio-tracks.md
+[audio-tracks]: /docs/guides/audio-tracks.md
 
-[text-tracks]: text-tracks.md
+[text-tracks]: /docs/guides/text-tracks.md
+
+[debug-guide]: /docs/guides/debugging.md
 
 [pr-issue-question]: #q-i-think-i-found-a-bug-with-videojs-or-i-want-to-add-a-feature-what-should-i-do
 
@@ -324,4 +330,3 @@ Yes! See [ReactJS integration example](./guides/react.md).
 
 [starter-example]: http://jsbin.com/axedog/edit?html,output
 
-[debug-guide]: ./guides/debug.md

--- a/docs/guides/languages.md
+++ b/docs/guides/languages.md
@@ -58,12 +58,12 @@ Finally, each file's extension is always `.json`.
 
 ### Updating an Existing Translation
 
-If there is a [missing translation](../translations-needed.md), mistake, or room for improvement in an existing translation, don't hesitate to open a pull request!
+If there is a [missing translation](/docs/translations-needed.md), mistake, or room for improvement in an existing translation, don't hesitate to open a pull request!
 
 1. Edit the relevant JSON file and make the necessary changes.
 1. Verify the language compiles by running `grunt dist`.
 1. Verify the translation appears properly in the player UI.
-1. Run `grunt check-translations` to update the [missing translation document](../translations-needed.md).
+1. Run `grunt check-translations` to update the [missing translation document](/docs/translations-needed.md).
 1. Commit and open a pull request on GitHub.
 
 ### Writing a New Translation
@@ -103,7 +103,7 @@ videojs.addLanguage('es', {
 
 ### Per-Player Languages
 
-In addition to providing languages to Video.js itself, individual `Player` instances can be provided custom language support via [the `languages` option](options.md#languages):
+In addition to providing languages to Video.js itself, individual `Player` instances can be provided custom language support via [the `languages` option](/docs/guides/options.md#languages):
 
 ```js
 // Provide a custom definition of Spanish to this player.
@@ -116,7 +116,7 @@ videojs('my-player', {
 
 ### Setting Default Player Language
 
-Player instances can also have a default language via [the `language` option](options.md#language):
+Player instances can also have a default language via [the `language` option](/docs/guides/options.md#language):
 
 ```js
 // Set the default language to Spanish for this player.
@@ -143,14 +143,14 @@ The player language is set to one of the following in descending priority:
 
 ## References
 
-For information on translation/localization in plugins, see [the plugins guide](plugins.md).
+For information on translation/localization in plugins, see [the plugins guide](/docs/guides/plugins.md).
 
 Standard languages codes [are defined by the IANA][lang-codes].
 
 For all existing/supported languages, please see the [languages lolder (`lang/`)][lang-supported] folder located in the project root.
 
-[lang-en]: https://github.com/videojs/video.js/tree/master/lang/en.json
+[lang-en]: /lang/en.json
 
-[lang-supported]: https://github.com/videojs/video.js/tree/master/lang
+[lang-supported]: /lang
 
 [lang-codes]: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry

--- a/docs/guides/modal-dialog.md
+++ b/docs/guides/modal-dialog.md
@@ -4,7 +4,7 @@ The `ModalDialog` component is part of Video.js core and provides a baked-in UI 
 
 ## Table of Contents
 
-* [Creating the ModalDialog](#creating-the-modaldialog)
+* [Creating a ModalDialog](#creating-a-modaldialog)
   * [Example Using createModal()](#example-using-createmodal)
   * [Example Using the ModalDialog Constructor](#example-using-the-modaldialog-constructor)
 * [Styling Modals Independently](#styling-modals-independently)
@@ -73,6 +73,6 @@ A common need for modals is to style them independently from one another. The re
 modal.addClass('vjs-my-fancy-modal');
 ```
 
-[api-doc]: http://docs.videojs.com/docs/api/modal-dialog.html
+[api-doc]: http://docs.videojs.com/ModalDialog.html
 
-[creating-component]: ./components.md#creating-a-component
+[creating-component]: /docs/guides/components.md#creating-a-component

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -1,6 +1,6 @@
 # Video.js Options Reference
 
-> **Note:** This document is only a reference for available options. To learn about passing options to Video.js, see [the setup guide](setup.md#options).
+> **Note:** This document is only a reference for available options. To learn about passing options to Video.js, see [the setup guide](/docs/guides/setup.md#options).
 
 ## Table of Contents
 
@@ -41,7 +41,7 @@
 
 ## Standard `<video>` Element Options
 
-Each of these options is also available as a [standard `<video>` element attribute][video-attrs]; so, they can be defined in all three manners [outlined in the setup guide](setup.md#options). Typically, defaults are not listed as this is left to browser vendors.
+Each of these options is also available as a [standard `<video>` element attribute][video-attrs]; so, they can be defined in all three manners [outlined in the setup guide](/docs/guides/setup.md#options). Typically, defaults are not listed as this is left to browser vendors.
 
 ### `autoplay`
 
@@ -151,7 +151,7 @@ The `inactivityTimeout` determines how many milliseconds of inactivity is requir
 
 A [language code][lang-codes] matching one of the available languages in the player. This sets the initial language for a player, but it can always be changed.
 
-Learn more about [languages in Video.js](languages.md).
+Learn more about [languages in Video.js][languages].
 
 ### `languages`
 
@@ -159,7 +159,7 @@ Learn more about [languages in Video.js](languages.md).
 
 Customize which languages are available in a player. The keys of this object will be [language codes][lang-codes] and the values will be objects with English keys and translated values.
 
-Learn more about [languages in Video.js](languages.md).
+Learn more about [languages in Video.js][languages]
 
 > **Note**: Generally, this option is not needed and it would be better to pass your custom languages to `videojs.addLanguage()`, so they are available in all players!
 
@@ -201,7 +201,7 @@ player.boo({baz: false});
 
 Although, since the `plugins` option is an object, the order of initialization is not guaranteed!
 
-See [the plugins guide](plugins.md) for more information on Video.js plugins.
+See [the plugins guide][plugins] for more information on Video.js plugins.
 
 ### `sourceOrder`
 
@@ -291,7 +291,7 @@ This option will be used in the "novtt" build of video.js (i.e. `video.novtt.js`
 
 The Video.js player is a component. Like all components, you can define what children it includes, what order they appear in, and what options are passed to them.
 
-This is meant to be a quick reference; so, for more detailed information on components in Video.js, check out the [components guide](components.md).
+This is meant to be a quick reference; so, for more detailed information on components in Video.js, check out the [components guide](/docs/guides/components.md).
 
 ### `children`
 
@@ -373,6 +373,10 @@ Only supported by the `Html5` tech, this option can be set to `true` to force na
 > Type: `boolean`
 
 Can be set to `false` to force emulation of text tracks instead of native support. The `nativeCaptions` option also exists, but is simply an alias to `nativeTextTracks`.
+
+[plugins]: /docs/guides/plugins.md
+
+[languages]: /docs/guides/languages.md
 
 [ios-10-updates]: https://webkit.org/blog/6784/new-video-policies-for-ios/
 

--- a/docs/guides/player-workflows.md
+++ b/docs/guides/player-workflows.md
@@ -1,6 +1,6 @@
 # Player Workflows
 
-This document outlines many considerations for using Video.js for advanced player workflows. Be sure to read [the setup guide](setup.md) first!
+This document outlines many considerations for using Video.js for advanced player workflows. Be sure to read [the setup guide](/docs/guides/setup.md) first!
 
 ## Table of Contents
 
@@ -31,9 +31,9 @@ After an instance has been created it can be accessed globally in two ways:
 
 No matter the term used for it, web applications are becoming common. Not everything is a static, load-once-and-done web page anymore! This means that developers need to be able to manage the full lifecycle of a video player - from creation to destruction. Video.js supports player removal through the `dispose()` method.
 
-### [`dispose()`](http://docs.videojs.com/docs/api/player.html#Methodsdispose)
+### [`dispose()`](http://docs.videojs.com/Player.html#dispose)
 
-This method is available on all Video.js players and [components](http://docs.videojs.com/docs/api/component.html#Methodsdispose). It is _the only_ supported method of removing a Video.js player from both the DOM and memory. For example, the following code sets up a player and then disposes it when media playback is complete:
+This method is available on all Video.js players and [components](http://docs.videojs.com/Component.html#dispose). It is _the only_ supported method of removing a Video.js player from both the DOM and memory. For example, the following code sets up a player and then disposes it when media playback is complete:
 
 ```js
 var player = videojs('my-player');
@@ -367,7 +367,7 @@ Coming soon...
 
 ### React
 
-See [ReactJS integration example](./react.md)
+See [ReactJS integration example](/docs/guides/react.md)
 
 ### Ember
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,6 +1,6 @@
 # Video.js Plugins
 
-One of the great strengths of Video.js is its ecosystem of plugins that allow authors from all over the world to share their video player customizations. This includes everything from the simplest UI tweaks to new [playback technologies and source handlers](tech.md)!
+One of the great strengths of Video.js is its ecosystem of plugins that allow authors from all over the world to share their video player customizations. This includes everything from the simplest UI tweaks to new [playback technologies and source handlers][tech]!
 
 Because we view plugins as such an important part of Video.js, the organization is committed to maintaining a robust set of tools for plugin authorship:
 
@@ -63,7 +63,7 @@ While reading the following sections, you may want to refer to the [Plugin API d
 
 ### Write a JavaScript Class/Constructor
 
-If you're familiar with creating [components](components.md), this process is similar. An advanced plugin starts with a JavaScript class (a.k.a. a constructor function).
+If you're familiar with creating [components][components], this process is similar. An advanced plugin starts with a JavaScript class (a.k.a. a constructor function).
 
 If you're using ES6 already, you can use that syntax with your transpiler/language of choice (Babel, TypeScript, etc):
 
@@ -314,9 +314,13 @@ These two methods are functionally identical - use whichever you prefer!
 * [Plugin Generator][generator]
 * [Plugin Conventions][standards]
 
-[api-player]: http://docs.videojs.com/docs/api/player.html
+[components]: /docs/guides/components.md
 
-[api-plugin]: http://docs.videojs.com/docs/api/plugin.html
+[tech]: /docs/guides/tech.md
+
+[api-player]: http://docs.videojs.com/Player.html
+
+[api-plugin]: http://docs.videojs.com/Plugin.html
 
 [generator]: https://github.com/videojs/generator-videojs-plugin
 

--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -36,10 +36,9 @@ export default class VideoPlayer extends React.Component {
 }
 ```
 
-You can then use it like this:
+You can then use it like this: (see [options guide][options] for option information)
 
 ```jsx
-// see https://github.com/videojs/video.js/blob/master/docs/guides/options.md
 const videoJsOptions = {
   autoplay: true,
   controls: true,
@@ -53,3 +52,5 @@ return <VideoPlayer { ...videoJsOptions } />
 ```
 
 Dont forget to include the video.js CSS, located at `video.js/dist/video-js.css`.
+
+[options]: /docs/guides/options.md

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -82,7 +82,7 @@ videojs(document.querySelector('.video-js'));
 
 ## Options
 
-> **Note:** This guide only covers how to pass options during player setup. For a complete reference on _all_ available options, see the [options guide](options.md).
+> **Note:** This guide only covers how to pass options during player setup. For a complete reference on _all_ available options, see the [options guide](/docs/guides/options.md).
 
 There are three ways to pass options to Video.js. Because Video.js decorates an HTML5 `<video>` element, many of the options available are also available as [standard `<video>` tag attributes][video-attrs]:
 
@@ -175,7 +175,9 @@ In each case, the callback is called asynchronously - _even if the player is alr
 
 ## Advanced Player Workflows
 
-For a discussion of more advanced player workflows, see the [player workflows guide](player-workflows.md).
+For a discussion of more advanced player workflows, see the [player workflows guide][player-workflows].
+
+[player-workflows]: /docs/guides/player-workflows.md
 
 [boolean-attrs]: https://www.w3.org/TR/2011/WD-html5-20110525/common-microsyntaxes.html#boolean-attributes
 
@@ -185,7 +187,7 @@ For a discussion of more advanced player workflows, see the [player workflows gu
 
 [video-attrs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#Attributes
 
-[videojs]: http://docs.videojs.com/docs/api/video.html
+[videojs]: http://docs.videojs.com/module-videojs.html
 
 [w3c-media-events]: https://www.w3.org/2010/05/video/mediaevents.html
 

--- a/docs/guides/text-tracks.md
+++ b/docs/guides/text-tracks.md
@@ -91,7 +91,7 @@ The boolean `default` attribute can be used to indicate that a track's mode shou
 
 The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of the text track, e.g. `"en"` for English or `"es"` for Spanish.
 
-For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](./languages.md) for more information on languages in Video.js.
+For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
 
 ### Text Tracks from Another Domain
 
@@ -214,7 +214,7 @@ In general, `"descriptions"` tracks are of lower precedence than `"captions"` an
 
 ## API
 
-For more complete information, refer to the [Video.js API docs](http://docs.videojs.com/docs/api/index.html).
+For more complete information, refer to the [Video.js API docs](http://docs.videojs.com/).
 
 ### Remote Text Tracks
 

--- a/docs/guides/tracks.md
+++ b/docs/guides/tracks.md
@@ -8,14 +8,14 @@ There are currently three types of tracks:
 * [Video Tracks](#video-tracks)
 * [Text Tracks](#text-tracks)
 
-## [Audio Tracks](./audio-tracks.md)
+## [Audio Tracks](/docs/guides/audio-tracks.md)
 
 Audio tracks allow the selection of alternate audio for a video.
 
-## [Video Tracks](./video-tracks.md)
+## [Video Tracks](/docs/guides/video-tracks.md)
 
 Video tracks allow the selection of alternate video content.
 
-## [Text Tracks](./text-tracks.md)
+## [Text Tracks](/docs/guides/text-tracks.md)
 
 Text tracks are used to display subtitles and captions and add a menu for navigating between chapters in a video.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -91,7 +91,7 @@ To fix this issue please make sure that all event listeners are cleaned up on di
 
 [hosting-media]: #problems-when-hosting-media
 
-[text-tracks]: text-tracks.md
+[text-tracks]: /docs/guides/text-tracks.md
 
 [hls]: https://github.com/videojs/videojs-contrib-hls
 

--- a/docs/guides/video-tracks.md
+++ b/docs/guides/video-tracks.md
@@ -83,7 +83,7 @@ player.videoTracks().removeTrack(track);
 
 ## API
 
-For more complete information, refer to the [Video.js API docs](http://docs.videojs.com/docs/api/index.html), specifically:
+For more complete information, refer to the [Video.js API docs](http://docs.videojs.com/), specifically:
 
 * `Player#videoTracks`
 * `VideoTrackList`
@@ -127,7 +127,7 @@ The label for the track that will be shown to the user. For example, in a menu t
 
 The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of the video track, e.g. `"en"` for English or `"es"` for Spanish.
 
-For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](./languages.md) for more information on languages in Video.js.
+For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
 
 #### `selected`
 

--- a/docs/guides/videojs.md
+++ b/docs/guides/videojs.md
@@ -128,7 +128,7 @@ videojs.bind(someObj, function() {
 
 ## `plugin()`
 
-**See the [plugin guide](plugins.md) in the docs for a more detailed example**
+**See the [plugin guide](/docs/guides/plugins.md) in the docs for a more detailed example**
 
 ```js
 // Make a plugin that alerts when the player plays

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # [Video.js][vjs-website] Documentation
 
-There are two categories of docs: [Guides](guides) and [API docs][api].
+There are two categories of docs: [Guides](/docs/guides/) and [API docs][api].
 
 Guides explain general topics and use cases (e.g. setup). API docs are automatically generated from the codebase and give specific details about functions, properties, and events.
 
@@ -26,57 +26,57 @@ Guides explain general topics and use cases (e.g. setup). API docs are automatic
 
 ## Resolving Issues
 
-### [FAQ](guides/faq.md)
+### [FAQ](/docs/guides/faq.md)
 
 The frequently asked questions for video.js.
 
-### [Troubleshooting](guides/troubleshooting.md)
+### [Troubleshooting](/docs/guides/troubleshooting.md)
 
 Troubleshooting help for video.js.
 
-## [Guides](guides)
+## [Guides](/docs/guides/)
 
 ### Getting Started
 
-#### [Setup](guides/setup.md)
+#### [Setup](/docs/guides/setup.md)
 
 The setup guide covers all methods of setting up Video.js players.
 
-#### [Player Workflows](guides/player-workflows.md)
+#### [Player Workflows](/docs/guides/player-workflows.md)
 
 After mastering the basics of setup move over to this guide for some more advanced player workflows.
 
-#### [Options](guides/options.md)
+#### [Options](/docs/guides/options.md)
 
 There are a number of options that can be used to change how the player behaves, starting with the HTML5 media options like autoplay and preload, and expanding to Video.js specific options.
 
-#### [Tracks](guides/tracks.md)
+#### [Tracks](/docs/guides/tracks.md)
 
 Tracks are used for displaying text information over a video, selecting different audio tracks for a video, or selecting different video tracks.
 
 ### Customizing
 
-#### [Skins](guides/skins.md)
+#### [Skins](/docs/guides/skins.md)
 
 You can change the look of the player across playback technologies just by editing a CSS file. The skins documentation gives you a intro to how the HTML and CSS of the default skin is put together. For a list of skins you can check the [video.js wiki][skins-list].
 
-#### [Plugins](guides/plugins.md)
+#### [Plugins](/docs/guides/plugins.md)
 
 You can package up interesting Video.js customizations and reuse them elsewhere. Find out how to build your own plugin or [use one created by someone else][plugins-list].
 
-#### [Components](guides/components.md)
+#### [Components](/docs/guides/components.md)
 
 Video.js is built around a collection of components. These are the building blocks of the player UI.
 
-#### [Tech](guides/tech.md)
+#### [Tech](/docs/guides/tech.md)
 
 A "tech" is the shorthand we're using to describe any video playback technology - be it HTML5 video, Flash, . Basically anything that has a unique API to audio or video. Additional playback technologies can be added relatively easily.
 
-#### [Languages](guides/languages.md)
+#### [Languages](/docs/guides/languages.md)
 
 Video.js has multi-language support! Follow this guide to see how you can contribute to and use languages.
 
-#### [Hooks](guides/hooks.md)
+#### [Hooks](/docs/guides/hooks.md)
 
 A "hook" is functionality that wants to do when videojs creates a player. Right now only `beforesetup` and `setup` are supported. See the guide for more information on that.
 
@@ -88,8 +88,8 @@ You can refer to the [full list of API docs][api], but the most relevant API doc
 
 [skins-list]: https://github.com/videojs/video.js/wiki/Skins
 
-[api]: http://docs.videojs.com/docs/api/index.html
+[api]: http://docs.videojs.com/
 
-[api-player]: http://docs.videojs.com/docs/api/player.html
+[api-player]: http://docs.videojs.com/Player.html
 
 [vjs-website]: http://videojs.com

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -5,6 +5,7 @@ The currently available translations are in the lang dir. This table shows the c
 If you add or update a translation run `grunt check-translations` to update the list and include this modified doc in the pull request.
 
 ## Progress Bar Translations
+
 The progress bar as a translation with a few token replacements.
 They key is `progress bar timing: currentTime={1} duration={2}` and the default English value is `{1} of {2}`.
 This default value is hardcoded as a default to the localize method in the SeekBar component.
@@ -12,6 +13,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 ## Status of translations
 
 <!-- START langtable -->
+
 | Language file           | Missing translations                                                                |
 | ----------------------- | ----------------------------------------------------------------------------------- |
 | ar.json (missing 50)    | Audio Player                                                                        |
@@ -1541,4 +1543,5 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
 |                         | End of dialog window.                                                               |
+
 <!-- END langtable -->

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "grunt test",
     "docs": "npm run docs:lint && npm run docs:api",
     "jsdoc": "jsdoc",
+    "predocs:api": "node -e \"var s=require('shelljs'),d=['docs/api'];s.rm('-rf',d);\"",
     "docs:api": "jsdoc -c .jsdoc.json",
     "postdocs:api": "node ./build/fix-api-docs.js",
     "docs:lint": "remark -- './**/*.md'",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "docs": "npm run docs:lint && npm run docs:api",
     "jsdoc": "jsdoc",
     "docs:api": "jsdoc -c .jsdoc.json",
+    "postdocs:api": "node ./build/fix-api-docs.js",
     "docs:lint": "remark -- './**/*.md'",
     "docs:fix": "remark --output -- './**/*.md'",
     "babel": "babel src/js -d es5",
@@ -115,15 +116,16 @@
     "remark-lint": "^6.0.0",
     "remark-toc": "^4.0.0",
     "remark-validate-links": "^6.0.0",
+    "replace": "^0.3.0",
     "shelljs": "^0.7.5",
     "sinon": "^1.16.1",
     "time-grunt": "^1.1.1",
     "tui-jsdoc-template": "^1.1.0",
     "uglify-js": "~2.8.8",
     "videojs-doc-generator": "0.0.1",
+    "videojs-flash": "^1.0.0-RC.0",
     "videojs-standard": "^6.0.1",
-    "webpack": "^1.13.2",
-    "videojs-flash": "^1.0.0-RC.0"
+    "webpack": "^1.13.2"
   },
   "vjsstandard": {
     "ignore": [

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2957,9 +2957,9 @@ class Player extends Component {
    *
    * @param {boolean} [manualCleanup=true] if set to false, the TextTrack will be
    *
-   * @return {HTMLTrackElement}
+   * @return {HtmlTrackElement}
    *         the HTMLTrackElement that was created and added
-   *         to the HTMLTrackElementList and the remote
+   *         to the HtmlTrackElementList and the remote
    *         TextTrackList
    *
    * @deprecated The default value of the "manualCleanup" parameter will default
@@ -2973,7 +2973,7 @@ class Player extends Component {
 
   /**
    * Remove a remote {@link TextTrack} from the respective
-   * {@link TextTrackList} and {@link HTMLTrackElementList}.
+   * {@link TextTrackList} and {@link HtmlTrackElementList}.
    *
    * @param {Object} track
    *        Remote {@link TextTrack} to remove
@@ -3217,9 +3217,9 @@ class Player extends Component {
  */
 
 /**
- * Get the remote {@link HTMLTrackElementList} tracks.
+ * Get the remote {@link HtmlTrackElementList} tracks.
  *
- * @return {HTMLTrackElementList}
+ * @return {HtmlTrackElementList}
  *         The current remote text track element list
  *
  * @method Player.prototype.remoteTextTrackEls

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -88,7 +88,7 @@ const autoSetup = function() {
  * @param {number} wait
  *        How long to wait in ms
  *
- * @param {videojs} [vjs]
+ * @param {module:videojs} [vjs]
  *        The videojs library function
  */
 function autoSetupTimeout(wait, vjs) {

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -879,9 +879,9 @@ class Tech extends Component {
  */
 
 /**
- * Get the remote element {@link HTMLTrackElementList}
+ * Get the remote element {@link HtmlTrackElementList}
  *
- * @returns {HTMLTrackElementList}
+ * @returns {HtmlTrackElementList}
  * @method Tech.prototype.remoteTextTrackEls
  */
 

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -32,7 +32,7 @@ class HtmlTrackElementList {
     list.trackElements_ = [];
 
     /**
-     * @memberof HTMLTrackElementList
+     * @memberof HtmlTrackElementList
      * @member {number} length
      *         The current number of `Track`s in the this Trackist.
      * @instance

--- a/src/js/tracks/track-types.js
+++ b/src/js/tracks/track-types.js
@@ -1,7 +1,7 @@
 import AudioTrackList from './audio-track-list';
 import VideoTrackList from './video-track-list';
 import TextTrackList from './text-track-list';
-import HTMLTrackElementList from './html-track-element-list';
+import HtmlTrackElementList from './html-track-element-list';
 
 import TextTrack from './text-track';
 import AudioTrack from './audio-track';
@@ -47,7 +47,7 @@ const REMOTE = {
     privateName: 'remoteTextTracks_'
   },
   remoteTextEl: {
-    ListClass: HTMLTrackElementList,
+    ListClass: HtmlTrackElementList,
     TrackClass: HTMLTrackElement,
     capitalName: 'RemoteTextTrackEls',
     getterName: 'remoteTextTrackEls',

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -509,7 +509,7 @@ export function getBoundingClientRect(el) {
 /**
  * The postion of a DOM element on the page.
  *
- * @typedef {Object} Dom~Position
+ * @typedef {Object} module:dom~Position
  *
  * @property {number} left
  *           Pixels to the left
@@ -528,7 +528,7 @@ export function getBoundingClientRect(el) {
  * @param {Element} el
  *        Element from which to get offset
  *
- * @return {Dom~Position}
+ * @return {module:dom~Position}
  *         The position of the element that was passed in.
  */
 export function findPosition(el) {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -55,8 +55,6 @@ if (typeof HTMLVideoElement === 'undefined' && Dom.isReal()) {
  *
  * @return {Player}
  *         A player instance
- *
- * @mixes videojs
  */
 function videojs(id, options, ready) {
   let tag;
@@ -136,6 +134,7 @@ videojs.hooks_ = {};
 
 /**
  * Get a list of hooks for a specific lifecycle
+ * @function videojs.hooks
  *
  * @param {string} type
  *        the lifecyle to get hooks from
@@ -351,7 +350,6 @@ videojs.bind = Fn.bind;
  * Register a Video.js plugin.
  *
  * @borrows plugin:registerPlugin as videojs.registerPlugin
- * @mixes videojs
  * @method registerPlugin
  *
  * @param  {string} name


### PR DESCRIPTION
## Description
* Update the API doc build to fix links after generation
* Fix any currently broken API docs
* Used `linkdown` to make sure links are working

## Outstanding Issues (probably for another PR)
* The tech source handler mixin is currently not showing/broken in the docs
* videojs itself does not show most of its functions in the API docs
* Some things are using `Dom` when they should be using `module:dom`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Docs/guides updated
  - [ ] Reviewed by Two Core Contributors
