### PR TITLE
fix: default text tracks

### DIFF
--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -34,7 +34,6 @@ class TextTrackMenuItem extends MenuItem {
     super(player, options);
 
     this.track = track;
-
     const changeHandler = Fn.bind(this, this.handleTracksChange);
 
     player.on(['loadstart', 'texttrackchange'], changeHandler);

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -40,7 +40,6 @@ class TextTrackMenuItem extends MenuItem {
     tracks.addEventListener('change', changeHandler);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
-      player.off(['loadstart', 'texttrackchange'], changeHandler);
     });
 
     // iOS7 doesn't dispatch change events to TextTrackLists when an

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -34,11 +34,14 @@ class TextTrackMenuItem extends MenuItem {
     super(player, options);
 
     this.track = track;
+
     const changeHandler = Fn.bind(this, this.handleTracksChange);
 
+    player.on(['loadstart', 'texttrackchange'], changeHandler);
     tracks.addEventListener('change', changeHandler);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
+      player.off(['loadstart', 'texttrackchange'], changeHandler);
     });
 
     // iOS7 doesn't dispatch change events to TextTrackLists when an

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -595,11 +595,15 @@ class Tech extends Component {
 
     textTracksChanges();
     tracks.addEventListener('change', textTracksChanges);
+    tracks.addEventListener('addtrack', textTracksChanges);
+    tracks.addEventListener('removetrack', textTracksChanges);
 
     this.on('dispose', function() {
       remoteTracks.off('addtrack', handleAddTrack);
       remoteTracks.off('removetrack', handleRemoveTrack);
       tracks.removeEventListener('change', textTracksChanges);
+      tracks.removeEventListener('addtrack', textTracksChanges);
+      tracks.removeEventListener('removetrack', textTracksChanges);
 
       for (let i = 0; i < tracks.length; i++) {
         const track = tracks[i];

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -163,6 +163,12 @@ class TextTrack extends Track {
     if (settings.kind === 'metadata' || settings.kind === 'chapters') {
       mode = 'hidden';
     }
+
+    if (settings.default) {
+      mode = 'showing';
+    }
+
+
     // on IE8 this will be a document element
     // for every other browser this will be a normal object
     const tt = super(settings);

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -163,12 +163,6 @@ class TextTrack extends Track {
     if (settings.kind === 'metadata' || settings.kind === 'chapters') {
       mode = 'hidden';
     }
-
-    if (settings.default) {
-      mode = 'showing';
-    }
-
-
     // on IE8 this will be a document element
     // for every other browser this will be a normal object
     const tt = super(settings);


### PR DESCRIPTION
## Description
There are currently two issues with `TextTrack`s that have `default` set to `true` when added. 
1. The TextTrackMenu has the `captions off` and the new `default` caption button both selected
2. The captions do not show up until after a re-selection

## Specific Changes proposed
1. is addressed by listening for player `loadstart`, rather than just `texttrackchange` as in most cases text tracks will be added before we start to listen for `texttrackchange`
2. Treat `addtrack` and `removetrack` similar to how we treat `change` now (watch for `cuechange` on any showing tracks and update the display) 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
