### PR TITLE
Minimum volume after unmuting

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -57,7 +57,9 @@ class MuteToggle extends Button {
     const lastVolume = this.player_.lastVolume_();
 
     if (vol === 0) {
-      this.player_.volume(lastVolume);
+      const volumeToSet = lastVolume < 0.1 ? 0.1 : lastVolume;
+
+      this.player_.volume(volumeToSet);
       this.player_.muted(false);
     } else {
       this.player_.muted(this.player_.muted() ? false : true);

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -138,4 +138,18 @@ if (Html5.isSupported()) {
     assert.equal(player.volume(), 0.5, 'volume is set to lastVolume');
     assert.equal(player.muted(), false, 'muted is set to false');
   });
+
+  QUnit.test('Clicking MuteToggle when volume is 0, lastVolume is less than 0.1, and muted is true sets volume to 0.1 and muted to false', function(assert) {
+    const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+    const muteToggle = new MuteToggle(player);
+
+    player.volume(0);
+    player.muted(true);
+    player.lastVolume_(0.05);
+
+    muteToggle.handleClick();
+
+    assert.equal(player.volume(), 0.1, 'since lastVolume is less than 0.1, volume is set to 0.1');
+    assert.equal(player.muted(), false, 'muted is set to false');
+  });
 }


### PR DESCRIPTION
When unmuting and `lastVolume` is less than 0.1, set volume to 0.1 instead of to `lastVolume`.

Fixes #4054.

## Before

![less than 0 1](https://cloud.githubusercontent.com/assets/11491159/24305735/6c9e1eda-1094-11e7-8fa6-074408b7a05a.gif)

Volume set to **0.024390243902439025**.

## After

![0 1](https://cloud.githubusercontent.com/assets/11491159/24305705/48a9602a-1094-11e7-9937-d47f85b6ef72.gif)

Volume set to **0.1**.