### PR TITLE
Tracks settings updates

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -71,7 +71,6 @@
 .vjs-caption-settings .vjs-tracksetting label,
 .vjs-caption-settings .vjs-tracksetting legend {
   display: block;
-  width: 100px;
   margin-bottom: 5px;
 }
 

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -1,111 +1,50 @@
 .vjs-modal-dialog.vjs-text-track-settings {
-  position: relative;
-  top: 1em;
   background-color: $primary-background-color;
   background-color: rgba($primary-background-color, 0.75);
   color: $primary-foreground-color;
-  margin: 0 auto;
-  padding: 0.5em;
-  height: 22em;
-  width: 48em;
+  height: 70%;
 }
 
-.vjs-caption-settings .vjs-tracksettings {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  position: absolute;
-  overflow: auto;
+// Layout divs
+.vjs-text-track-settings .vjs-modal-dialog-content {
+  display: table;
 }
 
-.vjs-tracksettings legend {
-  color: $primary-foreground-color;
+.vjs-text-track-settings .vjs-track-settings-colors,
+.vjs-text-track-settings .vjs-track-settings-font,
+.vjs-text-track-settings .vjs-track-settings-controls {
+  display: table-cell;
 }
 
-.vjs-caption-settings .vjs-tracksettings-colors,
-.vjs-caption-settings .vjs-tracksettings-font {
-  float: left;
-}
-.vjs-caption-settings .vjs-tracksettings-colors:after,
-.vjs-caption-settings .vjs-tracksettings-font:after,
-.vjs-caption-settings .vjs-tracksettings-controls:after {
-  clear: both;
+.vjs-text-track-settings .vjs-track-settings-controls {
+  text-align: right;
+  vertical-align: bottom;
 }
 
-.vjs-caption-settings .vjs-tracksettings-controls {
-  position: absolute;
-  bottom: 1em;
-  right: 1em;
-}
-
-.vjs-tracksettings-controls button:focus,
-.vjs-tracksettings-controls button:active {
-  outline-style: solid;
-  outline-width: medium;
-  background-image: linear-gradient(0deg, $primary-foreground-color 88%, $secondary-background-color 100%);
-}
-
-.vjs-tracksettings-controls button:hover {
-  color: rgba(#2B333F, 0.75);
-}
-
-.vjs-tracksettings-controls button {
-  background-color: $primary-foreground-color;
-  background-image: linear-gradient(-180deg, $primary-foreground-color 88%, $secondary-background-color 100%);
-  color: #2B333F;
-  cursor: pointer;
-  border-radius: 2px;
-}
-
-.vjs-tracksettings-controls .vjs-default-button {
-  margin-right: 1em;
-}
-
-.vjs-caption-settings .vjs-tracksetting {
+// Form elements
+.vjs-text-track-settings fieldset {
   margin: 5px;
   padding: 3px;
-  min-height: 40px;
   border: none;
 }
-.vjs-caption-settings .vjs-tracksetting label,
-.vjs-caption-settings .vjs-tracksetting legend {
-  display: block;
-  margin-bottom: 5px;
-}
 
-.vjs-caption-settings .vjs-tracksetting span {
-  display: inline;
+.vjs-text-track-settings fieldset span {
+  display: inline-block;
   margin-left: 5px;
-  vertical-align: top;
-  float: right;
 }
 
-.vjs-caption-settings .vjs-tracksetting > div {
-  margin-bottom: 5px;
-  min-height: 20px;
+.vjs-text-track-settings legend {
+  color: $primary-foreground-color;
+  margin: 0 0 5px 0;
 }
 
-.vjs-caption-settings .vjs-tracksetting > div:last-child {
-  margin-bottom: 0;
-  padding-bottom: 0;
-  min-height: 0;
-}
-
-.vjs-caption-settings label > input {
-  margin-right: 10px;
-}
-
-.vjs-caption-settings fieldset {
-  margin-top: 1em;
-  margin-left: .5em;
-}
-
-// Hide labels within fieldsets, so they are only for screen reader users
-.vjs-caption-settings fieldset .vjs-label {
+// Hide labels, so they are only for screen reader users
+.vjs-text-track-settings .vjs-label {
   position: absolute;
-  clip: rect(1px 1px 1px 1px); /* for Internet Explorer */
+  clip: rect(1px 1px 1px 1px); // for Internet Explorer
   clip: rect(1px, 1px, 1px, 1px);
+  display: block;
+  margin: 0 0 5px 0;
   padding: 0;
   border: 0;
   height: 1px;
@@ -113,7 +52,25 @@
   overflow: hidden;
 }
 
-.vjs-caption-settings input[type="button"] {
-  width: 40px;
-  height: 40px;
+.vjs-track-settings-controls button:focus,
+.vjs-track-settings-controls button:active {
+  outline-style: solid;
+  outline-width: medium;
+  background-image: linear-gradient(0deg, $primary-foreground-color 88%, $secondary-background-color 100%);
+}
+
+.vjs-track-settings-controls button:hover {
+  color: rgba(#2B333F, 0.75);
+}
+
+.vjs-track-settings-controls button {
+  background-color: $primary-foreground-color;
+  background-image: linear-gradient(-180deg, $primary-foreground-color 88%, $secondary-background-color 100%);
+  color: #2B333F;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.vjs-track-settings-controls .vjs-default-button {
+  margin-right: 1em;
 }

--- a/src/css/components/_modal-dialog.scss
+++ b/src/css/components/_modal-dialog.scss
@@ -1,6 +1,18 @@
 .video-js .vjs-modal-dialog {
   @extend %fill-parent;
   @include linear-gradient(180deg, rgba(0, 0, 0, 0.8), rgba(255, 255, 255, 0));
+
+  // This allows scrolling of content if need be.
+  overflow: auto;
+
+  // When combined with `overflow: auto;`, this fixes gaps left by
+  // scrollbars in older IE versions.
+  box-sizing: content-box;
+}
+
+// Reset box-sizing inside the modal dialog.
+.video-js .vjs-modal-dialog > * {
+  box-sizing: border-box;
 }
 
 .vjs-modal-dialog .vjs-modal-dialog-content {

--- a/src/css/components/menu/_menu.scss
+++ b/src/css/components/menu/_menu.scss
@@ -16,8 +16,19 @@
   display: block;
   padding: 0;
   margin: 0;
-  overflow: auto;
   font-family: $text-font-family;
+
+  // This allows scrolling of content if need be.
+  overflow: auto;
+
+  // When combined with `overflow: auto;`, this fixes gaps left by
+  // scrollbars in older IE versions.
+  box-sizing: content-box;
+}
+
+// Reset box-sizing inside the menu.
+.vjs-menu .vjs-menu-content > * {
+  box-sizing: border-box;
 }
 
 // prevent menus from opening while scrubbing (FF, IE)

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -255,9 +255,6 @@ class TextTrackSettings extends ModalDialog {
     options.temporary = false;
 
     super(player, options);
-
-    this.contentEl().className += '  vjs-caption-settings';
-
     this.updateDisplay = Fn.bind(this, this.updateDisplay);
 
     // fill the modal and pretend we have opened it
@@ -354,7 +351,7 @@ class TextTrackSettings extends ModalDialog {
     }, undefined, this.createElSelect_('textOpacity', legend.id));
 
     return createEl('fieldset', {
-      className: 'vjs-fg-color vjs-tracksetting'
+      className: 'vjs-fg-color vjs-track-setting'
     }, undefined, [legend].concat(select, opacity));
   }
 
@@ -379,7 +376,7 @@ class TextTrackSettings extends ModalDialog {
     }, undefined, this.createElSelect_('backgroundOpacity', legend.id));
 
     return createEl('fieldset', {
-      className: 'vjs-bg-color vjs-tracksetting'
+      className: 'vjs-bg-color vjs-track-setting'
     }, undefined, [legend].concat(select, opacity));
   }
 
@@ -404,7 +401,7 @@ class TextTrackSettings extends ModalDialog {
     }, undefined, this.createElSelect_('windowOpacity', legend.id));
 
     return createEl('fieldset', {
-      className: 'vjs-window-color vjs-tracksetting'
+      className: 'vjs-window-color vjs-track-setting'
     }, undefined, [legend].concat(select, opacity));
   }
 
@@ -418,7 +415,7 @@ class TextTrackSettings extends ModalDialog {
    */
   createElColors_() {
     return createEl('div', {
-      className: 'vjs-tracksettings-colors'
+      className: 'vjs-track-settings-colors'
     }, undefined, [
       this.createElFgColor_(),
       this.createElBgColor_(),
@@ -436,19 +433,19 @@ class TextTrackSettings extends ModalDialog {
    */
   createElFont_() {
     const fontPercent = createEl('fieldset', {
-      className: 'vjs-font-percent vjs-tracksetting'
+      className: 'vjs-font-percent vjs-track-setting'
     }, undefined, this.createElSelect_('fontPercent', '', 'legend'));
 
     const edgeStyle = createEl('fieldset', {
-      className: 'vjs-edge-style vjs-tracksetting'
+      className: 'vjs-edge-style vjs-track-setting'
     }, undefined, this.createElSelect_('edgeStyle', '', 'legend'));
 
     const fontFamily = createEl('fieldset', {
-      className: 'vjs-font-family vjs-tracksetting'
+      className: 'vjs-font-family vjs-track-setting'
     }, undefined, this.createElSelect_('fontFamily', '', 'legend'));
 
     return createEl('div', {
-      className: 'vjs-tracksettings-font'
+      className: 'vjs-track-settings-font'
     }, undefined, [fontPercent, edgeStyle, fontFamily]);
   }
 
@@ -474,7 +471,7 @@ class TextTrackSettings extends ModalDialog {
     });
 
     return createEl('div', {
-      className: 'vjs-tracksettings-controls'
+      className: 'vjs-track-settings-controls'
     }, undefined, [defaultsButton, doneButton]);
   }
 
@@ -489,15 +486,11 @@ class TextTrackSettings extends ModalDialog {
   }
 
   content() {
-    const settings = createEl('div', {
-      className: 'vjs-tracksettings'
-    }, undefined, [
+    return [
       this.createElColors_(),
       this.createElFont_(),
       this.createElControls_()
-    ]);
-
-    return settings;
+    ];
   }
 
   label() {

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -306,7 +306,7 @@ class TextTrackSettings extends ModalDialog {
    *         The DOM element that gets created.
    * @private
    */
-  createElSelect_(key, legendId = '', type='label') {
+  createElSelect_(key, legendId = '', type = 'label') {
     const config = selectConfigs[key];
     const id = config.id.replace('%s', this.id_);
 

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -306,14 +306,14 @@ class TextTrackSettings extends ModalDialog {
    *         The DOM element that gets created.
    * @private
    */
-  createElSelect_(key, legendId = '') {
+  createElSelect_(key, legendId = '', type='label') {
     const config = selectConfigs[key];
     const id = config.id.replace('%s', this.id_);
 
     return [
-      createEl('label', {
+      createEl(type, {
         id,
-        className: 'vjs-label',
+        className: type === 'label' ? 'vjs-label' : '',
         textContent: this.localize(config.label)
       }, {
       }),
@@ -435,17 +435,17 @@ class TextTrackSettings extends ModalDialog {
    * @private
    */
   createElFont_() {
-    const fontPercent = createEl('div', {
+    const fontPercent = createEl('fieldset', {
       className: 'vjs-font-percent vjs-tracksetting'
-    }, undefined, this.createElSelect_('fontPercent'));
+    }, undefined, this.createElSelect_('fontPercent', '', 'legend'));
 
-    const edgeStyle = createEl('div', {
+    const edgeStyle = createEl('fieldset', {
       className: 'vjs-edge-style vjs-tracksetting'
-    }, undefined, this.createElSelect_('edgeStyle'));
+    }, undefined, this.createElSelect_('edgeStyle', '', 'legend'));
 
-    const fontFamily = createEl('div', {
+    const fontFamily = createEl('fieldset', {
       className: 'vjs-font-family vjs-tracksetting'
-    }, undefined, this.createElSelect_('fontFamily'));
+    }, undefined, this.createElSelect_('fontFamily', '', 'legend'));
 
     return createEl('div', {
       className: 'vjs-tracksettings-font'


### PR DESCRIPTION
Make the font column of the text track settings dialog also use fieldset and legends like the colors column. Also, don't set a width on the label and legend elements.
This makes it so that the two columns line themselves up similarly.