### PR TITLE
fix: remove focus ring from player itself

### DIFF
--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -33,6 +33,10 @@
   }
 }
 
+.video-js[tabindex="-1"] {
+  outline: none;
+}
+
 // All elements inherit border-box sizing
 .video-js *,
 .video-js *:before,


### PR DESCRIPTION
The focus ring on the player itself isn't necessary and can be confusing and distracting to sighted users. This PR removes the focus ring from the player element itself but not from other elements.