### PR TITLE
chore: ignore qunit and sinon from greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,11 @@
       "**/test/coverage/**",
       "**/test/karma.conf.js"
     ]
+  },
+  "greenkeeper": {
+    "ignore": [
+      "qunitjs",
+      "sinon"
+    ]
   }
 }


### PR DESCRIPTION
We can't update qunitjs yet because of our IE8 support.
We don't want to upgrade sinon until we're ready.
So, we are [telling greenkeeper to ignore](https://github.com/greenkeeperio/greenkeeper#repository-options) those two dependencies.