### PR TITLE
fix: silence play promise error

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1612,7 +1612,12 @@ class Player extends Component {
   play() {
     if (this.changingSrc_) {
       this.ready(function() {
-        this.techCall_('play');
+        const retval = this.techGet_('play');
+
+        // silence errors (unhandled promise from play)
+        if (retval !== undefined && typeof retval.then === 'function') {
+          retval.then(null, (e) => {});
+        }
       });
 
     // Only calls the tech's play if we already have a src loaded


### PR DESCRIPTION
This silences the play promise when `play` is called while source is changing.

There are a few other calls to `play` in video.js that we potentially should silence, like in the PosterImage. Those can be fixed later on if we see that they get rejected often.