### PR TITLE
npm-debug.log.* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ test/*.map
 .s3config.json
 
 node_modules
-npm-debug.log
+npm-debug.log*
 
 sandbox/*
 !sandbox/*.example


### PR DESCRIPTION
## Description
Just adding * at the end of npm-debug.log gitignore rule so that files like npm-debug.log.2170340511 are also ignored.

## Specific Changes proposed
Just adding * at the end of npm-debug.log gitignore rule so that files like npm-debug.log.2170340511 are also ignored.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
