### PR TITLE
feat: Add 'beforepluginsetup' event and named plugin setup events (e.g. 'pluginsetup:foo')

### DIFF
--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -176,6 +176,14 @@ Like components, advanced plugins offer an implementation of events. This includ
 
 By offering a built-in events system, advanced plugins offer a wider range of options for code structure with a pattern familiar to most web developers.
 
+##### Extra Event Data
+
+All events triggered by plugins include an additional data object as a second argument. This object has three properties:
+
+- `name`: The name of the plugin (e.g. `"examplePlugin"`) as a string.
+- `plugin`: The plugin constructor (e.g. `ExamplePlugin`).
+- `instance`: The plugin constructor instance.
+
 #### Statefulness
 
 A new concept introduced for advanced plugins is _statefulness_. This is similar to React components' `state` property and `setState` method.
@@ -306,6 +314,19 @@ player.examplePlugin({customClass: 'example-class'});
 ```
 
 These two methods are functionally identical - use whichever you prefer!
+
+### Plugin Setup Events
+
+Occasionally, a use-case arises where some code needs to wait for a plugin to be initialized. As of Video.js 6, this can be achieved by listening for `pluginsetup` events on the player.
+
+For any given plugin initialization, there are four events to be aware of:
+
+- `beforepluginsetup`: Triggered immediately before any plugin is initialized.
+- `beforepluginsetup:examplePlugin` Triggered immediately before the `examplePlugin` is initialized.
+- `pluginsetup`: Triggered after any plugin is initialized.
+- `pluginsetup:examplePlugin`: Triggered after he `examplePlugin` is initialized.
+
+These events work for both basic and advanced plugins. They are triggered on the player and each includes an object of [extra event data](#extra-event-data) as a second argument to its listeners.
 
 ## References
 

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -86,7 +86,8 @@ const markPluginAsActive = (player, name) => {
  *         A plugin event hash.
  *
  * @param  {Boolean} [before]
- *         If true, modifies the events to be "before" events.
+ *         If true, prefixes the event name with "before". In other words,
+ *         use this to trigger "beforepluginsetup" instead of "pluginsetup".
  */
 const triggerSetupEvent = (player, hash, before) => {
   const eventName = (before ? 'before' : '') + 'pluginsetup';

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -166,6 +166,8 @@ const createPluginFactory = (name, PluginSubClass) => {
     // The plugin is replaced by a function that returns the current instance.
     this[name] = () => instance;
 
+    triggerSetupEvent(this, instance.getEventHash());
+
     return instance;
   };
 };
@@ -215,7 +217,6 @@ class Plugin {
 
     // If the player is disposed, dispose the plugin.
     player.on('dispose', this.dispose);
-    triggerSetupEvent(player, this.getEventHash());
   }
 
   /**

--- a/test/unit/plugin-advanced.test.js
+++ b/test/unit/plugin-advanced.test.js
@@ -67,24 +67,35 @@ QUnit.test('setup', function(assert) {
   );
 });
 
-QUnit.test('"pluginsetup" event', function(assert) {
+QUnit.test('all "pluginsetup" events', function(assert) {
   const setupSpy = sinon.spy();
+  const events = [
+    'beforepluginsetup',
+    'beforepluginsetup:mock',
+    'pluginsetup',
+    'pluginsetup:mock'
+  ];
 
-  this.player.on('pluginsetup', setupSpy);
+  this.player.on(events, setupSpy);
 
   const instance = this.player.mock();
-  const event = setupSpy.firstCall.args[0];
-  const hash = setupSpy.firstCall.args[1];
 
-  assert.strictEqual(setupSpy.callCount, 1, 'the "pluginsetup" event was triggered');
-  assert.strictEqual(event.type, 'pluginsetup', 'the event has the correct type');
-  assert.strictEqual(event.target, this.player.el_, 'the event has the correct target');
+  events.forEach((type, i) => {
+    const event = setupSpy.getCall(i).args[0];
+    const hash = setupSpy.getCall(i).args[1];
 
-  assert.deepEqual(hash, {
-    name: 'mock',
-    instance,
-    plugin: this.MockPlugin
-  }, 'the event hash object is correct');
+    assert.strictEqual(event.type, type, `the "${type}" event was triggered`);
+    assert.strictEqual(event.target, this.player.el_, 'the event has the correct target');
+
+    assert.deepEqual(hash, {
+      name: 'mock',
+
+      // The "before" events have a `null` instance and the others have the
+      // return value of the plugin factory.
+      instance: i < 2 ? null : instance,
+      plugin: this.MockPlugin
+    }, 'the event hash object is correct');
+  });
 });
 
 QUnit.test('defaultState static property is used to populate state', function(assert) {

--- a/test/unit/plugin-basic.test.js
+++ b/test/unit/plugin-basic.test.js
@@ -47,23 +47,35 @@ QUnit.test('setup', function(assert) {
   assert.ok(this.player.hasPlugin('basic'), 'player has the plugin available');
 });
 
-QUnit.test('"pluginsetup" event', function(assert) {
+QUnit.test('all "pluginsetup" events', function(assert) {
   const setupSpy = sinon.spy();
+  const events = [
+    'beforepluginsetup',
+    'beforepluginsetup:basic',
+    'pluginsetup',
+    'pluginsetup:basic'
+  ];
 
-  this.player.on('pluginsetup', setupSpy);
+  this.player.on(events, setupSpy);
 
   const instance = this.player.basic();
-  const event = setupSpy.firstCall.args[0];
-  const hash = setupSpy.firstCall.args[1];
 
-  assert.strictEqual(setupSpy.callCount, 1, 'the "pluginsetup" event was triggered');
-  assert.strictEqual(event.type, 'pluginsetup', 'the event has the correct type');
+  events.forEach((type, i) => {
+    const event = setupSpy.getCall(i).args[0];
+    const hash = setupSpy.getCall(i).args[1];
 
-  assert.deepEqual(hash, {
-    name: 'basic',
-    instance,
-    plugin: this.basic
-  }, 'the event hash object is correct');
+    assert.strictEqual(event.type, type, `the "${type}" event was triggered`);
+    assert.strictEqual(event.target, this.player.el_, 'the event has the correct target');
+
+    assert.deepEqual(hash, {
+      name: 'basic',
+
+      // The "before" events have a `null` instance and the others have the
+      // return value of the plugin factory.
+      instance: i < 2 ? null : instance,
+      plugin: this.basic
+    }, 'the event hash object is correct');
+  });
 });
 
 QUnit.test('properties are copied', function(assert) {


### PR DESCRIPTION
This adds a `beforepluginsetup` event as well as `beforepluginsetup:$name` and `pluginsetup:$name` events.

The drive behind this is improving the ability for people to make cross-plugin dependencies in a more robust manner.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
