### PR TITLE
feat(VttLoader): a better way of loading vtt.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tsml": "1.0.1",
     "videojs-font": "2.0.0",
     "videojs-ie8": "1.1.2",
-    "videojs-vtt.js": "0.12.3",
+    "videojs-vtt.js": "videojs/vtt.js#use-browser-index",
     "xhr": "2.4.0"
   },
   "devDependencies": {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -34,6 +34,7 @@ import filterSource from './utils/filter-source';
 // are always included in the video.js package. Importing the modules will
 // execute them and they will register themselves with video.js.
 import './tech/loader.js';
+import './tracks/vtt.js';
 import './poster-image.js';
 import './tracks/text-track-display.js';
 import './loading-spinner.js';
@@ -3280,6 +3281,7 @@ Player.prototype.options_ = {
   // Included control sets
   children: [
     'mediaLoader',
+    'vttLoader',
     'posterImage',
     'textTrackDisplay',
     'loadingSpinner',

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -10,8 +10,6 @@ import { createTimeRange } from '../utils/time-ranges.js';
 import { bufferedPercent } from '../utils/buffer.js';
 import MediaError from '../media-error.js';
 import window from 'global/window';
-import document from 'global/document';
-import {isPlain} from '../utils/obj';
 import * as TRACK_TYPES from '../tracks/track-types';
 import toTitleCase from '../utils/to-title-case';
 
@@ -502,68 +500,6 @@ class Tech extends Component {
   }
 
   /**
-   * Emulate TextTracks using vtt.js if necessary
-   *
-   * @fires Tech#vttjsloaded
-   * @fires Tech#vttjserror
-   */
-  addWebVttScript_() {
-    if (window.WebVTT) {
-      return;
-    }
-
-    // Initially, Tech.el_ is a child of a dummy-div wait until the Component system
-    // signals that the Tech is ready at which point Tech.el_ is part of the DOM
-    // before inserting the WebVTT script
-    if (document.body.contains(this.el())) {
-      const vtt = require('videojs-vtt.js');
-
-      // load via require if available and vtt.js script location was not passed in
-      // as an option. novtt builds will turn the above require call into an empty object
-      // which will cause this if check to always fail.
-      if (!this.options_['vtt.js'] && isPlain(vtt) && Object.keys(vtt).length > 0) {
-        this.trigger('vttjsloaded');
-        return;
-      }
-
-      // load vtt.js via the script location option or the cdn of no location was
-      // passed in
-      const script = document.createElement('script');
-
-      script.src = this.options_['vtt.js'] || 'https://vjs.zencdn.net/vttjs/0.12.3/vtt.min.js';
-      script.onload = () => {
-        /**
-         * Fired when vtt.js is loaded.
-         *
-         * @event Tech#vttjsloaded
-         * @type {EventTarget~Event}
-         */
-        this.trigger('vttjsloaded');
-      };
-      script.onerror = () => {
-        /**
-         * Fired when vtt.js was not loaded due to an error
-         *
-         * @event Tech#vttjsloaded
-         * @type {EventTarget~Event}
-         */
-        this.trigger('vttjserror');
-      };
-      this.on('dispose', () => {
-        script.onload = null;
-        script.onerror = null;
-      });
-      // but have not loaded yet and we set it to true before the inject so that
-      // we don't overwrite the injected window.WebVTT if it loads right away
-      window.WebVTT = true;
-      this.el().parentNode.appendChild(script);
-    } else {
-      this.ready(this.addWebVttScript_);
-    }
-
-  }
-
-  /**
    * Emulate texttracks
    *
    */
@@ -575,8 +511,6 @@ class Tech extends Component {
 
     remoteTracks.on('addtrack', handleAddTrack);
     remoteTracks.on('removetrack', handleRemoveTrack);
-
-    this.addWebVttScript_();
 
     const updateDisplay = () => this.trigger('texttrackchange');
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -11,7 +11,7 @@ import { isCrossOrigin } from '../utils/url.js';
 import XHR from 'xhr';
 import merge from '../utils/merge-options';
 import * as browser from '../utils/browser.js';
-import {vttjsLoaded, getVttjs} from './vtt.js';
+import {vttjsLoaded} from './vtt.js';
 
 /**
  * Takes a webvtt file contents and parses it into cues
@@ -91,18 +91,18 @@ const loadTrack = function(src, track) {
     // NOTE: this is only used for the alt/video.novtt.js build
     if (vttjsLoaded) {
       parseCues(responseBody, track);
-    } else {
-      if (track.tech_) {
-        const loadHandler = () => parseCues(responseBody, track);
-
-        track.tech_.on('vttjsloaded', loadHandler);
-        track.tech_.on('vttjserror', () => {
-          log.error(`vttjs failed to load, stopping trying to process ${track.src}`);
-          track.tech_.off('vttjsloaded', loadHandler);
-        });
-      }
+      return;
     }
 
+    if (track.tech_) {
+      const loadHandler = () => parseCues(responseBody, track);
+
+      track.tech_.on('vttjsloaded', loadHandler);
+      track.tech_.on('vttjserror', () => {
+        log.error(`vttjs failed to load, stopping trying to process ${track.src}`);
+        track.tech_.off('vttjsloaded', loadHandler);
+      });
+    }
   }));
 };
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -11,6 +11,7 @@ import { isCrossOrigin } from '../utils/url.js';
 import XHR from 'xhr';
 import merge from '../utils/merge-options';
 import * as browser from '../utils/browser.js';
+import {vttjsLoaded, getVttjs} from './vtt.js';
 
 /**
  * Takes a webvtt file contents and parses it into cues
@@ -88,7 +89,9 @@ const loadTrack = function(src, track) {
 
     // Make sure that vttjs has loaded, otherwise, wait till it finished loading
     // NOTE: this is only used for the alt/video.novtt.js build
-    if (typeof window.WebVTT !== 'function') {
+    if (vttjsLoaded) {
+      parseCues(responseBody, track);
+    } else {
       if (track.tech_) {
         const loadHandler = () => parseCues(responseBody, track);
 
@@ -97,10 +100,7 @@ const loadTrack = function(src, track) {
           log.error(`vttjs failed to load, stopping trying to process ${track.src}`);
           track.tech_.off('vttjsloaded', loadHandler);
         });
-
       }
-    } else {
-      parseCues(responseBody, track);
     }
 
   }));

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -11,7 +11,7 @@ import { isCrossOrigin } from '../utils/url.js';
 import XHR from 'xhr';
 import merge from '../utils/merge-options';
 import * as browser from '../utils/browser.js';
-import {vttjsLoaded} from './vtt.js';
+import {vttjsLoaded, getVttjs} from './vtt.js';
 
 /**
  * Takes a webvtt file contents and parses it into cues
@@ -25,9 +25,8 @@ import {vttjsLoaded} from './vtt.js';
  * @private
  */
 const parseCues = function(srcContent, track) {
-  const parser = new window.WebVTT.Parser(window,
-                                          window.vttjs,
-                                          window.WebVTT.StringDecoder());
+  const vttjs = getVttjs();
+  const parser = new vttjs.WebVTT.Parser(window, vttjs, vttjs.WebVTT.StringDecoder());
   const errors = [];
 
   parser.oncue = function(cue) {
@@ -93,7 +92,6 @@ const loadTrack = function(src, track) {
       parseCues(responseBody, track);
       return;
     }
-
     if (track.tech_) {
       const loadHandler = () => parseCues(responseBody, track);
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -97,7 +97,7 @@ const loadTrack = function(src, track) {
 
       track.tech_.on('vttjsloaded', loadHandler);
       track.tech_.on('vttjserror', () => {
-        log.error(`vttjs failed to load, stopping trying to process ${track.src}`);
+        log.error(`vttjs failed to load, unable to process ${track.src}`);
         track.tech_.off('vttjsloaded', loadHandler);
       });
     }

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -43,6 +43,8 @@ class VttLoader extends Component {
   }
 
   triggerLoaded() {
+    vttjsLoaded = true;
+
     /**
      * Fired when vtt.js is loaded.
      *
@@ -57,7 +59,6 @@ class VttLoader extends Component {
      * @type {EventTarget~Event}
      */
     this.player_.tech_.trigger('vttjsloaded');
-    vttjsLoaded = true;
   }
 
   triggerError() {

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -1,0 +1,111 @@
+/**
+ * @file vtt.js
+ */
+import vttjs from 'videojs-vtt.js';
+import Component from '../component.js';
+import mergeOptions from '../utils/merge-options.js';
+import window from 'global/window';
+import document from 'global/document';
+import {isPlainEmpty} from '../utils/obj.js';
+
+/**
+ * The `VttLoader` is the `Component` that decides how to load in vttjs
+ *
+ * @extends Component
+ * @fires VttLoader#vttjsloaded
+ * @fires VttLoader#vttjserror
+ */
+class VttLoader extends Component {
+  constructor(player, options, ready) {
+    const options_ = mergeOptions({createEl: false}, options);
+
+    super(player, options_, ready);
+
+    if (isPlainEmpty(vttjs)) {
+      this.setVttjs(null);
+
+      player.on('ready', () => {
+        if (!player.tech_.featuresNativeTextTracks) {
+          this.loadRemoteVtt();
+        }
+      });
+    } else {
+      this.setVttjs(vttjs);
+      this.trigger('vttjsloaded');
+    }
+  }
+
+  setVttjs(newVttjs) {
+    this.vttjs = newVttjs;
+    VttLoader.vttjs = newVttjs;
+  }
+
+  triggerLoaded() {
+    /**
+     * Fired when vtt.js is loaded.
+     *
+     * @event VttLoader#vttjsloaded
+     * @type {EventTarget~Event}
+     */
+    this.trigger('vttjsloaded');
+    /**
+     * Fired when vtt.js is loaded.
+     *
+     * @event Tech#vttjsloaded
+     * @type {EventTarget~Event}
+     */
+    this.player_.tech_.trigger('vttjsloaded');
+    vttjsLoaded = true;
+  }
+
+  triggerError() {
+    /**
+     * Fired when vtt.js was not loaded due to an error
+     *
+     * @event VttLoader#vttjserror
+     * @type {EventTarget~Event}
+     */
+    this.trigger('vttjserror');
+    /**
+     * Fired when vtt.js was not loaded due to an error
+     *
+     * @event Tech#vttjserror
+     * @type {EventTarget~Event}
+     */
+    this.player_.tech_.trigger('vttjserror');
+    vttjsLoaded = false;
+  }
+
+  loadRemoteVtt() {
+    // load vtt.js via the script location option or the cdn of no location was passed in
+    const script = document.createElement('script');
+
+    script.src = this.options_.playerOptions['vtt.js'] || 'https://vjs.zencdn.net/vttjs/0.12.3/vtt.min.js';
+
+    script.onload = () => {
+      this.setVttjs(window.vttjs);
+      this.triggerLoaded();
+    };
+
+    script.onerror = () => {
+      this.triggerError();
+    };
+
+    this.on('dispose', () => {
+      script.onload = null;
+      script.onerror = null;
+    });
+
+    // but have not loaded yet and we set it to true before the inject so that
+    // we don't overwrite the injected window.WebVTT if it loads right away
+    window.WebVTT = true;
+
+    this.player().el().appendChild(script);
+  }
+}
+
+export const getVttjs = () => VttLoader.vttjs;
+export let vttjsLoaded = !isPlainEmpty(vttjs);
+
+Component.registerComponent('VttLoader', VttLoader);
+export default VttLoader;

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -8,6 +8,8 @@ import window from 'global/window';
 import document from 'global/document';
 import {isPlainEmpty} from '../utils/obj.js';
 
+export let vttjsLoaded = !isPlainEmpty(vttjs);
+
 /**
  * The `VttLoader` is the `Component` that decides how to load in vttjs
  *
@@ -105,7 +107,6 @@ class VttLoader extends Component {
 }
 
 export const getVttjs = () => VttLoader.vttjs;
-export let vttjsLoaded = !isPlainEmpty(vttjs);
 
 Component.registerComponent('VttLoader', VttLoader);
 export default VttLoader;

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -8,7 +8,8 @@ import window from 'global/window';
 import document from 'global/document';
 import {isPlainEmpty} from '../utils/obj.js';
 
-export let vttjsLoaded = !isPlainEmpty(vttjs);
+export let vttjsLoaded = !isPlainEmpty(vttjs) ||
+                         typeof window.WebVTT === 'function';
 
 /**
  * The `VttLoader` is the `Component` that decides how to load in vttjs
@@ -23,7 +24,10 @@ class VttLoader extends Component {
 
     super(player, options_, ready);
 
-    if (isPlainEmpty(vttjs)) {
+    if (vttjsLoaded) {
+      this.setVttjs(vttjs);
+      this.triggerLoaded();
+    } else {
       this.setVttjs(null);
 
       player.on('ready', () => {
@@ -31,14 +35,10 @@ class VttLoader extends Component {
           this.loadRemoteVtt();
         }
       });
-    } else {
-      this.setVttjs(vttjs);
-      this.trigger('vttjsloaded');
     }
   }
 
   setVttjs(newVttjs) {
-    this.vttjs = newVttjs;
     VttLoader.vttjs = newVttjs;
   }
 
@@ -105,6 +105,8 @@ class VttLoader extends Component {
     this.player().el().appendChild(script);
   }
 }
+
+VttLoader.vttjs = vttjsLoaded ? window.vttjs : null;
 
 export const getVttjs = () => VttLoader.vttjs;
 

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -9,6 +9,7 @@ import document from 'global/document';
 import {isPlainEmpty} from '../utils/obj.js';
 
 let loadedCallback;
+
 export let vttjsLoaded = !isPlainEmpty(vttjs) ||
                          typeof window.WebVTT === 'function';
 
@@ -65,6 +66,7 @@ class VttLoader extends Component {
     }, true);
 
     if (loadedCallback) {
+      // eslint-disable-next-line no-use-before-define
       loadedCallback(getVttjs());
     }
   }

--- a/src/js/tracks/vtt.js
+++ b/src/js/tracks/vtt.js
@@ -22,9 +22,9 @@ export let vttjsLoaded = !isPlainEmpty(vttjs) ||
  */
 class VttLoader extends Component {
   constructor(player, options, ready) {
-    const options_ = mergeOptions({createEl: false}, options);
+    const settings = mergeOptions({createEl: false}, options);
 
-    super(player, options_, ready);
+    super(player, settings, ready);
 
     if (vttjsLoaded) {
       this.setVttjs(vttjs);
@@ -47,14 +47,6 @@ class VttLoader extends Component {
   triggerLoaded() {
     vttjsLoaded = true;
 
-    /**
-     * Fired when vtt.js is loaded.
-     *
-     * @event VttLoader#vttjsloaded
-     * @type {EventTarget~Event}
-     */
-    this.trigger('vttjsloaded');
-
     this.player_.ready(() => {
       /**
        * Fired when vtt.js is loaded.
@@ -73,14 +65,6 @@ class VttLoader extends Component {
 
   triggerError() {
     vttjsLoaded = false;
-
-    /**
-     * Fired when vtt.js was not loaded due to an error
-     *
-     * @event VttLoader#vttjserror
-     * @type {EventTarget~Event}
-     */
-    this.trigger('vttjserror');
 
     this.player_.ready(() => {
       /**

--- a/src/js/utils/obj.js
+++ b/src/js/utils/obj.js
@@ -132,3 +132,13 @@ export function isPlain(value) {
     toString.call(value) === '[object Object]' &&
     value.constructor === Object;
 }
+
+/**
+ * Returns whether an object appears to be a "plain" object without any keys.
+ *
+ * @param {Object} value
+ * @return {Boolean}
+ */
+export function isPlainEmpty(value) {
+  return isPlain(value) && keys(value).length === 0;
+}

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -31,6 +31,7 @@ import xhr from 'xhr';
 // Include the built-in techs
 import Tech from './tech/tech.js';
 import { use as middlewareUse } from './tech/middleware.js';
+import {getVttjs, vttjsLoaded} from './tracks/vtt.js';
 
 // HTML5 Element Shim for IE8
 if (typeof HTMLVideoElement === 'undefined' && Dom.isReal()) {
@@ -721,6 +722,15 @@ videojs.dom = Dom;
  * and Tech's
  */
 videojs.url = Url;
+
+/**
+ * Export the ability to get vttjs
+ * as well as a boolean that tells you whether it is loaded
+ */
+videojs.vttjs = {
+  get: getVttjs,
+  loaded() { return vttjsLoaded; }
+};
 
 // We use Node-style module.exports here instead of ES6 because it is more
 // compatible with different module systems.

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -151,6 +151,7 @@ videojs.hooks = function(type, fn) {
   if (fn && type === 'vttjsloaded') {
     vttjsOnLoad((vttjs) => {
       const vttjsLoadedHooks = videojs.hooks('vttjsloaded');
+
       vttjsLoadedHooks.forEach((hookFn) => hookFn(vttjs));
       // we notified the listeners, now clear them out
       vttjsLoadedHooks.length = 0;
@@ -737,7 +738,9 @@ videojs.url = Url;
  */
 videojs.vttjs = {
   get: getVttjs,
-  loaded() { return vttjsLoaded; }
+  loaded() {
+    return vttjsLoaded;
+  }
 };
 
 // We use Node-style module.exports here instead of ES6 because it is more

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -31,7 +31,7 @@ import xhr from 'xhr';
 // Include the built-in techs
 import Tech from './tech/tech.js';
 import { use as middlewareUse } from './tech/middleware.js';
-import {getVttjs, vttjsLoaded} from './tracks/vtt.js';
+import {getVttjs, vttjsLoaded, onLoad as vttjsOnLoad} from './tracks/vtt.js';
 
 // HTML5 Element Shim for IE8
 if (typeof HTMLVideoElement === 'undefined' && Dom.isReal()) {
@@ -148,6 +148,14 @@ videojs.hooks_ = {};
  */
 videojs.hooks = function(type, fn) {
   videojs.hooks_[type] = videojs.hooks_[type] || [];
+  if (fn && type === 'vttjsloaded') {
+    vttjsOnLoad((vttjs) => {
+      const vttjsLoadedHooks = videojs.hooks('vttjsloaded');
+      vttjsLoadedHooks.forEach((hookFn) => hookFn(vttjs));
+      // we notified the listeners, now clear them out
+      vttjsLoadedHooks.length = 0;
+    });
+  }
   if (fn) {
     videojs.hooks_[type] = videojs.hooks_[type].concat(fn);
   }

--- a/test/unit/test-helpers.js
+++ b/test/unit/test-helpers.js
@@ -21,6 +21,11 @@ const TestHelpers = {
     playerOptions = playerOptions || {};
     playerOptions.techOrder = playerOptions.techOrder || ['techFaker'];
 
+    // disable the vttjsLoaded if not set explicitly
+    if (!('vttLoader' in playerOptions)) {
+      playerOptions.vttLoader = false;
+    }
+
     const player = new Player(videoTag, playerOptions);
 
     player.middleware_ = [player.tech_];

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -381,9 +381,28 @@ QUnit.test('tracks are parsed once vttjs is loaded', function(assert) {
   const oldVTT = window.WebVTT;
   let parserCreated = false;
 
+  const WebVTT = () => {};
+  WebVTT.StringDecoder = () => {};
+  WebVTT.Parser = () => {
+    parserCreated = true;
+    return {
+      oncue() {},
+      onparsingerror() {},
+      onflush() {},
+      parse() {},
+      flush() {}
+    };
+  };
+
+
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
+  let vttjs = {
+    vttjsLoaded: false,
+    getVttjs() { return { WebVTT } }
+  };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
+    './vtt.js': vttjs,
     xhr(options, fn) {
       xhrHandler = fn;
     }
@@ -409,19 +428,6 @@ QUnit.test('tracks are parsed once vttjs is loaded', function(assert) {
 
   clock.tick(100);
   assert.ok(!parserCreated, 'WebVTT still not loaded, do not try to parse yet');
-
-  window.WebVTT = () => {};
-  window.WebVTT.StringDecoder = () => {};
-  window.WebVTT.Parser = () => {
-    parserCreated = true;
-    return {
-      oncue() {},
-      onparsingerror() {},
-      onflush() {},
-      parse() {},
-      flush() {}
-    };
-  };
 
   testTech.trigger('vttjsloaded');
   assert.ok(parserCreated, 'WebVTT is loaded, so we can parse now');

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -446,7 +446,12 @@ QUnit.test('stops processing if vttjs loading errored out', function(assert) {
 
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
+  let vttjs = {
+    vttjsLoaded: false,
+    getVttjs() { return null; }
+  };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
+    './vtt.js': vttjs,
     xhr(options, fn) {
       xhrHandler = fn;
     },

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -332,9 +332,9 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   const oldVTT = window.WebVTT;
   let parserCreated = false;
 
-  window.WebVTT = () => {};
-  window.WebVTT.StringDecoder = () => {};
-  window.WebVTT.Parser = () => {
+  const WebVTT = () => {};
+  WebVTT.StringDecoder = () => {};
+  WebVTT.Parser = () => {
     parserCreated = true;
     return {
       oncue() {},
@@ -347,7 +347,14 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
 
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
+  let vttjs = {
+    vttjsLoaded: false,
+    getVttjs() {
+      return { WebVTT }
+    }
+  };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
+    './vtt.js': vttjs,
     xhr(options, fn) {
       xhrHandler = fn;
     }
@@ -361,6 +368,7 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   /* eslint-enable no-unused-vars */
 
   xhrHandler(null, {}, 'WEBVTT\n');
+  this.tech.trigger('vttjsloaded');
 
   assert.ok(parserCreated, 'WebVTT is loaded, so we can just parse');
 

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -491,7 +491,7 @@ QUnit.test('stops processing if vttjs loading errored out', function(assert) {
 
   assert.ok(errorSpy.called, 'vttjs failed to load, so log.error was called');
   if (errorSpy.called) {
-    assert.ok(/^vttjs failed to load, stopping trying to process/.test(errorSpy.getCall(0).args[0]),
+    assert.ok(/^vttjs failed to load, unable to process/.test(errorSpy.getCall(0).args[0]),
        'log.error was called with the expected message');
   }
   assert.ok(!parserCreated, 'WebVTT is not loaded, do not try to parse yet');

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -333,6 +333,7 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   let parserCreated = false;
 
   const WebVTT = () => {};
+
   WebVTT.StringDecoder = () => {};
   WebVTT.Parser = () => {
     parserCreated = true;
@@ -347,10 +348,10 @@ QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
 
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
-  let vttjs = {
+  const vttjs = {
     vttjsLoaded: false,
     getVttjs() {
-      return { WebVTT }
+      return { WebVTT };
     }
   };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
@@ -382,6 +383,7 @@ QUnit.test('tracks are parsed once vttjs is loaded', function(assert) {
   let parserCreated = false;
 
   const WebVTT = () => {};
+
   WebVTT.StringDecoder = () => {};
   WebVTT.Parser = () => {
     parserCreated = true;
@@ -394,12 +396,13 @@ QUnit.test('tracks are parsed once vttjs is loaded', function(assert) {
     };
   };
 
-
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
-  let vttjs = {
+  const vttjs = {
     vttjsLoaded: false,
-    getVttjs() { return { WebVTT } }
+    getVttjs() {
+      return { WebVTT };
+    }
   };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
     './vtt.js': vttjs,
@@ -446,9 +449,11 @@ QUnit.test('stops processing if vttjs loading errored out', function(assert) {
 
   // use proxyquire to stub xhr module because IE8s XDomainRequest usage
   let xhrHandler;
-  let vttjs = {
+  const vttjs = {
     vttjsLoaded: false,
-    getVttjs() { return null; }
+    getVttjs() {
+      return null;
+    }
   };
   const TextTrack_ = proxyquire('../../../src/js/tracks/text-track.js', {
     './vtt.js': vttjs,


### PR DESCRIPTION
This is the first commit in that feature. Still needs to be exposed
properly on video.js. Also, vtt.js needs to be updated so that the
WebVTT object is properly available on the vttjs object in the CDN
version of the file.
Afterwards, parseCues in TextTrack should be updated to use the new way
of getting vttjs.

This also means that if vttjs is being loaded via script, it won't load until a player is initialized and it is using a tech that requires emulated text tracks. So, if a player loads and only requests native text tracks, it won't ever try to load vttjs.
It also means that a user can disable loading of vttjs if using the novtt script by requesting that the component be unavailable.
```js
const player = videojs('vid', {
  vttLoader: false
});
```

It is now exported on `videojs` as an object with two properties, which are functions: `get` and `loaded`.
```js
if (videojs.vttjs.loaded()) {
  const vttjs = videojs.vttjs.get();
  /* use vttjs */
}
```

## Todos
* [x] expose vttjs on videojs object as `videojs.vttjs`
* [x] add videojs hooks for `vttjsloaded`
    this is so because vttjs isn't really a per-player thing. The only events aren't going away but should be considered deprecated.
* [x] if loaded vttjs via script, check to see if it has loaded previously.
* [ ] Tests!!!
* [ ] port to 5.x branch

@imbcmdth @gesinger @mjneil this is the start of exporting vttjs properly.