### PR TITLE
docs: Replaced VolumeMenuButton with VolumePanel in component tree doc

### DIFF
--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -292,7 +292,7 @@ Player
 ├── BigPlayButton
 ├─┬ ControlBar
 │ ├── PlayToggle
-│ ├── VolumeMenuButton
+│ ├── VolumePanel
 │ ├── CurrentTimeDisplay (hidden by default)
 │ ├── TimeDivider (hidden by default)
 │ ├── DurationDisplay (hidden by default)


### PR DESCRIPTION
## Description
Closes [#4266](https://github.com/videojs/video.js/issues/4266)

Video.js 6 replaces the `VolumeMenuButton` component with the `VolumePanel` component. This PR updates the default component tree in the video.js 6 docs (https://github.com/videojs/video.js/blob/master/docs/guides/components.md#default-component-tree) to reflect this. 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
