### PR TITLE
docs: remove mentions of bower support

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -261,7 +261,8 @@ git reset --hard upstream/master
 
 Releasing video.js is partially automated through [`conrib.json`](/contrib.json) scripts. To do a release, you need a couple of things: npm access, GitHub personal access token.
 
-Releases in video.js are done on npm and bower and GitHub and eventually posted on the CDN. This is the instruction for the npm/bower/GitHub releases.
+Releases in video.js are done on npm and GitHub and eventually posted on the CDN. These
+are the instructions for the npm/GitHub releases.
 
 When we do a release, we release it as a `next` tag on npm first and then at least a week later, we promote this release to `latest` on npm.
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -59,13 +59,15 @@ video.js is an extendable framework/library around the native video element. It 
 
 ## Q: How do I install video.js?
 
-Currently video.js can be installed using bower, npm, serving a release file from
+Currently video.js can be installed using npm, serving a release file from
 a github tag, or even using a CDN hosted version. For information on doing any of those
 see the [install guide][install-guide].
 
 ## Q: Is video.js on bower?
 
-Yes! See the [install guide][install-guide] for more information.
+Versions prior to video.js 6 do support bower, however, as of video.js 6, bower is no
+longer officially supported. Please see https://github.com/videojs/video.js/issues/4012
+for more information.
 
 ## Q: What do video.js version numbers mean?
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -14,7 +14,7 @@
 
 ## Getting Video.js
 
-Video.js is officially available via CDN, npm, and Bower.
+Video.js is officially available via CDN and npm.
 
 Video.js works out of the box with not only HTML `<script>` and `<link>` tags, but also all major bundlers/packagers/builders, such as Browserify, Node, WebPack, etc.
 


### PR DESCRIPTION
## Description
Since video.js 6 no longer officially supports bower (https://github.com/videojs/video.js/issues/4012), remove some old mentions in the docs of bower.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
