### PR TITLE
set IE_VERSION correctly for IE11

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -63,9 +63,17 @@ export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_EDGE = (/Edge/i).test(USER_AGENT);
 export const IS_CHROME = !IS_EDGE && (/Chrome/i).test(USER_AGENT);
 export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
-export const IE_VERSION = (function(result) {
-  return result && parseFloat(result[1]);
-}((/MSIE\s(\d+)\.\d/).exec(USER_AGENT)));
+export const IE_VERSION = (function() {
+  const result = (/MSIE\s(\d+)\.\d/).exec(USER_AGENT);
+  let version = result && parseFloat(result[1]);
+
+  if (!version && (/Trident\/7.0/i).test(USER_AGENT) && (/rv:11.0/).test(USER_AGENT)) {
+    // IE 11 has a different user agent string than other IE versions
+    version = 11.0;
+  }
+
+  return version;
+}());
 
 export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
 export const IS_ANY_SAFARI = IS_SAFARI || IS_IOS;


### PR DESCRIPTION
## Description
`videojs.browser.IE_VERSION` is `null` in IE11 because IE11 uses a different user agent string than other IE versions

#4278 