### PR TITLE
Persist caption/description choice over source changes

### DIFF
--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -70,6 +70,24 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     this.selected(selected);
   }
 
+  handleSelectedLanguageChange(event) {
+    const tracks = this.player().textTracks();
+    let allHidden = true;
+
+    for (let i = 0, l = tracks.length; i < l; i++) {
+      const track = tracks[i];
+
+      if ((['captions', 'descriptions', 'subtitles'].indexOf(track.kind) > -1) && track.mode === 'showing') {
+        allHidden = false;
+        break;
+      }
+    }
+
+    if (allHidden) {
+      this.player_.cache_.selectedLanguage = null;
+    }
+  }
+
 }
 
 Component.registerComponent('OffTextTrackMenuItem', OffTextTrackMenuItem);

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -84,7 +84,9 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     }
 
     if (allHidden) {
-      this.player_.cache_.selectedLanguage = null;
+      this.player_.cache_.selectedLanguage = {
+        enabled: false
+      };
     }
   }
 

--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -60,21 +60,41 @@ class TextTrackButton extends TrackButton {
     this.hideThreshold_ += 1;
 
     const tracks = this.player_.textTracks();
+    let preferredItem;
 
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
+      const selectedLanguage = this.player_.cache_.selectedLanguage;
 
       // only add tracks that are of an appropriate kind and have a label
       if (this.kinds_.indexOf(track.kind) > -1) {
+
         const item = new TrackMenuItem(this.player_, {
           track,
           // MenuItem is selectable
           selectable: true
         });
 
+        // Find a track that matches at least the selectedLanguage's language
+        if (selectedLanguage) {
+          // Matches both language and kind
+          if (track.language === selectedLanguage.language &&
+            track.kind === selectedLanguage.kind) {
+            preferredItem = item;
+          // Matches just language
+          } else if (!preferredItem &&
+            track.language === selectedLanguage.language) {
+            preferredItem = item;
+          }
+        }
+
         item.addClass(`vjs-${track.kind}-menu-item`);
         items.push(item);
       }
+    }
+
+    if (preferredItem) {
+      preferredItem.track.mode = 'showing';
     }
 
     return items;

--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -60,11 +60,9 @@ class TextTrackButton extends TrackButton {
     this.hideThreshold_ += 1;
 
     const tracks = this.player_.textTracks();
-    let preferredItem;
 
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
-      const selectedLanguage = this.player_.cache_.selectedLanguage;
 
       // only add tracks that are of an appropriate kind and have a label
       if (this.kinds_.indexOf(track.kind) > -1) {
@@ -75,26 +73,9 @@ class TextTrackButton extends TrackButton {
           selectable: true
         });
 
-        // Find a track that matches at least the selectedLanguage's language
-        if (selectedLanguage) {
-          // Matches both language and kind
-          if (track.language === selectedLanguage.language &&
-            track.kind === selectedLanguage.kind) {
-            preferredItem = item;
-          // Matches just language
-          } else if (!preferredItem &&
-            track.language === selectedLanguage.language) {
-            preferredItem = item;
-          }
-        }
-
         item.addClass(`vjs-${track.kind}-menu-item`);
         items.push(item);
       }
-    }
-
-    if (preferredItem) {
-      preferredItem.track.mode = 'showing';
     }
 
     return items;

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -38,10 +38,11 @@ class TextTrackMenuItem extends MenuItem {
     const handleSelectedLanguageChange = Fn.bind(this, this.handleSelectedLanguageChange);
 
     player.on(['loadstart', 'texttrackchange'], changeHandler);
-    player.tech_.on('selectedlanguagechange', handleSelectedLanguageChange);
     tracks.addEventListener('change', changeHandler);
+    tracks.addEventListener('selectedlanguagechange', handleSelectedLanguageChange);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
+      tracks.removeEventListener('selectedlanguagechange', handleSelectedLanguageChange);
     });
 
     // iOS7 doesn't dispatch change events to TextTrackLists when an

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -38,9 +38,7 @@ class TextTrackMenuItem extends MenuItem {
     const handleSelectedLanguageChange = Fn.bind(this, this.handleSelectedLanguageChange);
 
     player.on(['loadstart', 'texttrackchange'], changeHandler);
-    player.ready(function() {
-      player.tech_.on('selectedlanguagechange', handleSelectedLanguageChange);
-    });
+    player.tech_.on('selectedlanguagechange', handleSelectedLanguageChange);
     tracks.addEventListener('change', changeHandler);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
@@ -126,6 +124,15 @@ class TextTrackMenuItem extends MenuItem {
 
   handleSelectedLanguageChange(event) {
     if (this.track.mode === 'showing') {
+      const selectedLanguage = this.player_.cache_.selectedLanguage;
+
+      // Don't replace the kind of track across the same language
+      if (selectedLanguage &&
+        selectedLanguage.language === this.track.language &&
+        selectedLanguage.kind !== this.track.kind) {
+        return;
+      }
+
       this.player_.cache_.selectedLanguage = {
         language: this.track.language,
         kind: this.track.kind

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -29,7 +29,8 @@ class TextTrackMenuItem extends MenuItem {
 
     // Modify options for parent MenuItem class's init.
     options.label = track.label || track.language || 'Unknown';
-    options.selected = track.default || track.mode === 'showing';
+    options.selected = (track.language === player.cache_.selectedLanguage) ||
+      track.default || track.mode === 'showing';
 
     super(player, options);
 
@@ -102,6 +103,7 @@ class TextTrackMenuItem extends MenuItem {
 
       if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
         track.mode = 'showing';
+        this.player_.cache_.selectedLanguage = track.language;
       } else {
         track.mode = 'disabled';
       }

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -29,20 +29,20 @@ class TextTrackMenuItem extends MenuItem {
 
     // Modify options for parent MenuItem class's init.
     options.label = track.label || track.language || 'Unknown';
-    options.selected = track.default || track.mode === 'showing';
+    options.selected = track.mode === 'showing';
 
     super(player, options);
 
     this.track = track;
     const changeHandler = Fn.bind(this, this.handleTracksChange);
-    const handleSelectedLanguageChange = Fn.bind(this, this.handleSelectedLanguageChange);
+    const selectedLanguageChangeHandler = Fn.bind(this, this.handleSelectedLanguageChange);
 
     player.on(['loadstart', 'texttrackchange'], changeHandler);
     tracks.addEventListener('change', changeHandler);
-    tracks.addEventListener('selectedlanguagechange', handleSelectedLanguageChange);
+    tracks.addEventListener('selectedlanguagechange', selectedLanguageChangeHandler);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
-      tracks.removeEventListener('selectedlanguagechange', handleSelectedLanguageChange);
+      tracks.removeEventListener('selectedlanguagechange', selectedLanguageChangeHandler);
     });
 
     // iOS7 doesn't dispatch change events to TextTrackLists when an
@@ -128,13 +128,14 @@ class TextTrackMenuItem extends MenuItem {
       const selectedLanguage = this.player_.cache_.selectedLanguage;
 
       // Don't replace the kind of track across the same language
-      if (selectedLanguage &&
+      if (selectedLanguage && selectedLanguage.enabled &&
         selectedLanguage.language === this.track.language &&
         selectedLanguage.kind !== this.track.kind) {
         return;
       }
 
       this.player_.cache_.selectedLanguage = {
+        enabled: true,
         language: this.track.language,
         kind: this.track.kind
       };

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -29,15 +29,18 @@ class TextTrackMenuItem extends MenuItem {
 
     // Modify options for parent MenuItem class's init.
     options.label = track.label || track.language || 'Unknown';
-    options.selected = (track.language === player.cache_.selectedLanguage) ||
-      track.default || track.mode === 'showing';
+    options.selected = track.default || track.mode === 'showing';
 
     super(player, options);
 
     this.track = track;
     const changeHandler = Fn.bind(this, this.handleTracksChange);
+    const handleSelectedLanguageChange = Fn.bind(this, this.handleSelectedLanguageChange);
 
     player.on(['loadstart', 'texttrackchange'], changeHandler);
+    player.ready(function() {
+      player.tech_.on('selectedlanguagechange', handleSelectedLanguageChange);
+    });
     tracks.addEventListener('change', changeHandler);
     this.on('dispose', function() {
       tracks.removeEventListener('change', changeHandler);
@@ -103,7 +106,6 @@ class TextTrackMenuItem extends MenuItem {
 
       if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
         track.mode = 'showing';
-        this.player_.cache_.selectedLanguage = track.language;
       } else {
         track.mode = 'disabled';
       }
@@ -120,6 +122,15 @@ class TextTrackMenuItem extends MenuItem {
    */
   handleTracksChange(event) {
     this.selected(this.track.mode === 'showing');
+  }
+
+  handleSelectedLanguageChange(event) {
+    if (this.track.mode === 'showing') {
+      this.player_.cache_.selectedLanguage = {
+        language: this.track.language,
+        kind: this.track.kind
+      };
+    }
   }
 
 }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -115,22 +115,24 @@ class TextTrackDisplay extends Component {
       const trackList = this.player_.textTracks();
       let firstDesc;
       let firstCaptions;
+      let preferredTrack;
       let preferredDesc;
       let preferredCaptions;
 
       for (let i = 0; i < trackList.length; i++) {
         const track = trackList[i];
 
-        // If we find a track matching the preferred language
-        // there is no need to find the first default track
-        if (player.cache_.selectedLanguage &&
-          player.cache_.selectedLanguage === track.language) {
-          if (track.kind === 'descriptions' && !preferredDesc) {
+        if (this.player_.cache_.selectedLanguage &&
+          this.player_.cache_.selectedLanguage.language === track.language) {
+          if (track.kind === this.player_.cache_.selectedLanguage.kind ||
+            (track.kind in modes &&
+            this.player_.cache_.selectedLanguage.kind in modes)) {
+            preferredTrack = track;
+          } else if (track.kind === 'descriptions' && !preferredDesc) {
             preferredDesc = track;
           } else if (track.kind in modes && !preferredCaptions) {
             preferredCaptions = track;
           }
-          break;
 
         } else if (track.default) {
           if (track.kind === 'descriptions' && !firstDesc) {
@@ -141,11 +143,16 @@ class TextTrackDisplay extends Component {
         }
       }
 
+      // The preferredTrack matches the user preference exactly and takes
+      // precendence over all the other tracks.
       // The preferred tracks take precedence over the first default track,
       // captions and subtitles take precedence over descriptions.
-      // So, display the preferred track before the first default track
-      // and the subtitles or captions track before the descriptions track
-      if (preferredCaptions) {
+      // So, display the preferredTrack before the other preferred tracks,
+      // before the first default track and the subtitles or captions track
+      // before the descriptions track
+      if (preferredTrack) {
+        preferredTrack.mode = 'showing';
+      } else if (preferredCaptions) {
         preferredCaptions.mode = 'showing';
       } else if (preferredDesc) {
         preferredDesc.mode = 'showing';
@@ -154,6 +161,7 @@ class TextTrackDisplay extends Component {
       } else if (firstDesc) {
         firstDesc.mode = 'showing';
       }
+
     }));
   }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -147,7 +147,7 @@ class TextTrackDisplay extends Component {
         }
 
       // clear everything if offTextTrackMenuItem was clicked
-      } else if (track.default && userPref && !userPref.enabled) {
+      } else if (userPref && !userPref.enabled) {
         preferredTrack = null;
         firstDesc = null;
         firstCaptions = null;

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -124,9 +124,7 @@ class TextTrackDisplay extends Component {
 
         if (this.player_.cache_.selectedLanguage &&
           this.player_.cache_.selectedLanguage.language === track.language) {
-          if (track.kind === this.player_.cache_.selectedLanguage.kind ||
-            (track.kind in modes &&
-            this.player_.cache_.selectedLanguage.kind in modes)) {
+          if (track.kind === this.player_.cache_.selectedLanguage.kind) {
             preferredTrack = track;
           } else if (track.kind === 'descriptions' && !preferredDesc) {
             preferredDesc = track;

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -115,9 +115,23 @@ class TextTrackDisplay extends Component {
       const trackList = this.player_.textTracks();
       let firstDesc;
       let firstCaptions;
+      let preferredDesc;
+      let preferredCaptions;
 
       for (let i = 0; i < trackList.length; i++) {
         const track = trackList[i];
+
+        // If we find a track matching the preferred language
+        // there is no need to find the first default track
+        if (player.cache_.selectedLanguage &&
+          player.cache_.selectedLanguage === track.language) {
+          if (track.kind === 'descriptions' && !preferredDesc) {
+            preferredDesc = track;
+          } else if (track.kind in modes && !preferredCaptions) {
+            preferredCaptions = track;
+          }
+          break;
+        }
 
         if (track.default) {
           if (track.kind === 'descriptions' && !firstDesc) {
@@ -128,11 +142,15 @@ class TextTrackDisplay extends Component {
         }
       }
 
-      // We want to show the first default track but captions and subtitles
-      // take precedence over descriptions.
-      // So, display the first default captions or subtitles track
-      // and otherwise the first default descriptions track.
-      if (firstCaptions) {
+      // The preferred tracks take precedence over the first default track,
+      // captions and subtitles take precedence over descriptions.
+      // So, display the preferred track before the first default track
+      // and the subtitles or captions track before the descriptions track
+      if (preferredCaptions) {
+        preferredCaptions.mode = 'showing';
+      } else if (preferredDesc) {
+        preferredDesc.mode = 'showing';
+      } else if (firstCaptions) {
         firstCaptions.mode = 'showing';
       } else if (firstDesc) {
         firstDesc.mode = 'showing';

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -131,9 +131,8 @@ class TextTrackDisplay extends Component {
             preferredCaptions = track;
           }
           break;
-        }
 
-        if (track.default) {
+        } else if (track.default) {
           if (track.kind === 'descriptions' && !firstDesc) {
             firstDesc = track;
           } else if (track.kind in modes && !firstCaptions) {

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -61,6 +61,14 @@ class TextTrackList extends TrackList {
     track.addEventListener('modechange', Fn.bind(this, function() {
       this.trigger('change');
     }));
+
+    const nonLanguageTextTrackKind = ['metadata', 'chapters'];
+
+    if (nonLanguageTextTrackKind.indexOf(track.kind) === -1) {
+      track.addEventListener('modechange', Fn.bind(this, function() {
+        this.trigger('selectedlanguagechange');
+      }));
+    }
   }
 }
 export default TextTrackList;

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -254,14 +254,6 @@ class TextTrack extends Track {
          */
         this.trigger('modechange');
 
-        /**
-        *
-        */
-        const nonLanguageTextTrackKind = ['metadata', 'chapters'];
-
-        if (nonLanguageTextTrackKind.indexOf(tt.kind) === -1) {
-          this.tech_.trigger('selectedlanguagechange');
-        }
       }
     });
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -253,6 +253,15 @@ class TextTrack extends Track {
          * @type {EventTarget~Event}
          */
         this.trigger('modechange');
+
+        /**
+        *
+        */
+        const nonLanguageTextTrackKind = ['metadata', 'chapters'];
+
+        if (nonLanguageTextTrackKind.indexOf(tt.kind) === -1) {
+          this.tech_.trigger('selectedlanguagechange');
+        }
       }
     });
 

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -1,0 +1,265 @@
+/* eslint-env qunit */
+import Html5 from '../../../src/js/tech/html5.js';
+import Component from '../../../src/js/component.js';
+
+import * as browser from '../../../src/js/utils/browser.js';
+import TestHelpers from '../test-helpers.js';
+import document from 'global/document';
+import sinon from 'sinon';
+
+QUnit.module('Text Track Display', {
+  beforeEach(assert) {
+    this.clock = sinon.useFakeTimers();
+  },
+  afterEach(assert) {
+    this.clock.restore();
+  }
+});
+
+const getTrackByLanguage = function(player, language) {
+  const tracks = player.tech_.remoteTextTracks();
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
+
+    if (track.language === language) {
+      return track;
+    }
+  }
+};
+
+const getMenuItemByLanguage = function(items, language) {
+  for (let i = items.length - 1; i > 0; i--) {
+    const captionMenuItem = items[i];
+    const trackLanguage = captionMenuItem.track.language;
+
+    if (trackLanguage && trackLanguage === language) {
+      return captionMenuItem;
+    }
+  }
+};
+
+QUnit.test('if native text tracks are not supported, create a texttrackdisplay', function(assert) {
+  const oldTestVid = Html5.TEST_VID;
+  const oldIsFirefox = browser.IS_FIREFOX;
+  const oldTextTrackDisplay = Component.getComponent('TextTrackDisplay');
+  const tag = document.createElement('video');
+  const track1 = document.createElement('track');
+  const track2 = document.createElement('track');
+
+  track1.kind = 'captions';
+  track1.label = 'en';
+  track1.language = 'English';
+  track1.src = 'en.vtt';
+  tag.appendChild(track1);
+
+  track2.kind = 'captions';
+  track2.label = 'es';
+  track2.language = 'Spanish';
+  track2.src = 'es.vtt';
+  tag.appendChild(track2);
+
+  Html5.TEST_VID = {
+    textTracks: []
+  };
+
+  browser.IS_FIREFOX = true;
+
+  const fakeTTDSpy = sinon.spy();
+
+  class FakeTTD extends Component {
+    constructor() {
+      super();
+      fakeTTDSpy();
+    }
+  }
+
+  Component.registerComponent('TextTrackDisplay', FakeTTD);
+
+  const player = TestHelpers.makePlayer({}, tag);
+
+  assert.strictEqual(fakeTTDSpy.callCount, 1, 'text track display was created');
+
+  Html5.TEST_VID = oldTestVid;
+  browser.IS_FIREFOX = oldIsFirefox;
+  Component.registerComponent('TextTrackDisplay', oldTextTrackDisplay);
+
+  player.dispose();
+});
+
+QUnit.test('no captions tracks, no captions are displayed', function(assert) {
+  // The video has no captions
+  const player = TestHelpers.makePlayer();
+  const tracks = player.tech_.remoteTextTracks();
+  const captionsButton = player.controlBar.getChild('SubsCapsButton');
+
+  player.src({type: 'video/mp4', src: 'http://google.com'});
+  this.clock.tick(1);
+
+  // the captions track and button are not shown
+  assert.ok(tracks.length === 0, 'No captions tracks');
+  assert.ok(captionsButton.hasClass('vjs-hidden'), 'The captions button should not be shown');
+  player.dispose();
+});
+
+QUnit.test('shows the default caption track first', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const track1 = {
+    kind: 'captions',
+    label: 'English',
+    language: 'en',
+    src: 'en.vtt',
+    default: true
+  };
+  const track2 = {
+    kind: 'captions',
+    label: 'Spanish',
+    language: 'es',
+    src: 'es.vtt'
+  };
+
+  // Add the text tracks
+  player.addRemoteTextTrack(track1);
+  player.addRemoteTextTrack(track2);
+
+  // Make sure the ready handler runs
+  this.clock.tick(1);
+
+  const englishTrack = getTrackByLanguage(player, 'en');
+  const spanishTrack = getTrackByLanguage(player, 'es');
+
+  assert.ok(englishTrack.mode === 'showing', 'English track should be showing');
+  assert.ok(spanishTrack.mode === 'disabled', 'Spanish track should not be showing');
+  player.dispose();
+});
+
+QUnit.test('if user-selected language is unavailable, don\'t pick a track to show', function(assert) {
+  // The video has no default language but has ‘English’ captions only
+  const player = TestHelpers.makePlayer();
+  const track1 = {
+    kind: 'captions',
+    label: 'English',
+    language: 'en',
+    src: 'en.vtt'
+  };
+  const captionsButton = player.controlBar.getChild('SubsCapsButton');
+
+  player.src({type: 'video/mp4', src: 'http://google.com'});
+  // manualCleanUp = true by default
+  player.addRemoteTextTrack(track1);
+  // Force 'es' as user-selected track
+  player.cache_.selectedLanguage = 'es';
+
+  this.clock.tick(1);
+  player.play();
+
+  const englishTrack = getTrackByLanguage(player, 'en');
+
+  assert.ok(!captionsButton.hasClass('vjs-hidden'), 'The captions button is shown');
+  assert.ok(englishTrack.mode === 'disabled', 'English track should be disabled');
+  player.dispose();
+});
+
+QUnit.test('the user-selected language takes priority over default language', function(assert) {
+  // The video has ‘English’ captions as default, but has ‘Spanish’ captions also
+  const player = TestHelpers.makePlayer({techOrder: ['html5']});
+  const track1 = {
+    kind: 'captions',
+    label: 'English',
+    language: 'en',
+    src: 'en.vtt',
+    default: true
+  };
+  const track2 = {
+    kind: 'captions',
+    label: 'Spanish',
+    language: 'es',
+    src: 'es.vtt'
+  };
+
+  player.src({type: 'video/mp4', src: 'http://google.com'});
+  // manualCleanUp = true by default
+  player.addRemoteTextTrack(track1);
+  player.addRemoteTextTrack(track2);
+  // Force 'es' as user-selected track
+  player.cache_.selectedLanguage = 'es';
+  this.clock.tick(1);
+
+  // the spanish captions track should be shown
+  const englishTrack = getTrackByLanguage(player, 'en');
+  const spanishTrack = getTrackByLanguage(player, 'es');
+
+  assert.ok(spanishTrack.mode === 'showing', 'Spanish captions should be shown');
+  assert.ok(englishTrack.mode === 'disabled', 'English captions should be hidden');
+  player.dispose();
+});
+
+QUnit.test('the user-selected language is used for subsequent source changes', function(assert) {
+  // Start with two captions tracks: English and Spanish
+  const player = TestHelpers.makePlayer({techOrder: ['html5']});
+  const track1 = {
+    kind: 'captions',
+    label: 'English',
+    language: 'en',
+    src: 'en.vtt'
+  };
+  const track2 = {
+    kind: 'captions',
+    label: 'Spanish',
+    language: 'es',
+    src: 'es.vtt'
+  };
+  const tracks = player.tech_.remoteTextTracks();
+  const captionsButton = player.controlBar.getChild('SubsCapsButton');
+  let esCaptionMenuItem;
+  let enCaptionMenuItem;
+
+  player.src({type: 'video/mp4', src: 'http://google.com'});
+  // manualCleanUp = true by default
+  player.addRemoteTextTrack(track1);
+  player.addRemoteTextTrack(track2);
+
+  // Keep track of menu items
+  esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
+  enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
+
+  // The user chooses Spanish
+  player.play();
+  captionsButton.pressButton();
+  esCaptionMenuItem.trigger('click');
+
+  // Track mode changes on user-selection
+  assert.ok(esCaptionMenuItem.track.mode === 'showing',
+    'Spanish should be showing after selection');
+  assert.ok(enCaptionMenuItem.track.mode === 'disabled',
+    'English should be disabled after selecting Spanish');
+
+  // Switch source and remove old tracks
+  player.tech_.setSource({type: 'video/mp4', src: 'http://example.com'});
+  while (tracks.length > 0) {
+    player.removeRemoteTextTrack(tracks[0]);
+  }
+  // Add tracks for the new source
+  player.addRemoteTextTrack(track1);
+  player.addRemoteTextTrack(track2);
+
+  // Make sure player ready handler runs
+  this.clock.tick(1);
+
+  // Keep track of menu items
+  esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
+  enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
+
+  // The user-selection should have persisted
+  assert.ok(esCaptionMenuItem.track.mode === 'showing',
+    'Spanish should remain showing');
+  assert.ok(enCaptionMenuItem.track.mode === 'disabled',
+    'English should remain disabled');
+
+  const englishTrack = getTrackByLanguage(player, 'en');
+  const spanishTrack = getTrackByLanguage(player, 'es');
+
+  assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
+  assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');
+  player.dispose();
+});

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -133,133 +133,147 @@ QUnit.test('shows the default caption track first', function(assert) {
   player.dispose();
 });
 
-QUnit.test('if user-selected language is unavailable, don\'t pick a track to show', function(assert) {
-  // The video has no default language but has ‘English’ captions only
-  const player = TestHelpers.makePlayer();
-  const track1 = {
-    kind: 'captions',
-    label: 'English',
-    language: 'en',
-    src: 'en.vtt'
-  };
-  const captionsButton = player.controlBar.getChild('SubsCapsButton');
+if (!Html5.supportsNativeTextTracks()) {
+  QUnit.test('if user-selected language is unavailable, don\'t pick a track to show', function(assert) {
+    // The video has no default language but has ‘English’ captions only
+    const oldIsFirefox = browser.IS_FIREFOX;
+    const player = TestHelpers.makePlayer();
+    const track1 = {
+      kind: 'captions',
+      label: 'English',
+      language: 'en',
+      src: 'en.vtt'
+    };
+    const captionsButton = player.controlBar.getChild('SubsCapsButton');
 
-  player.src({type: 'video/mp4', src: 'http://google.com'});
-  // manualCleanUp = true by default
-  player.addRemoteTextTrack(track1);
-  // Force 'es' as user-selected track
-  player.cache_.selectedLanguage = 'es';
+    browser.IS_FIREFOX = true;
+    player.src({type: 'video/mp4', src: 'http://google.com'});
+    // manualCleanUp = true by default
+    player.addRemoteTextTrack(track1);
+    // Force 'es' as user-selected track
+    player.cache_.selectedLanguage = 'es';
 
-  this.clock.tick(1);
-  player.play();
+    this.clock.tick(1);
+    player.play();
 
-  const englishTrack = getTrackByLanguage(player, 'en');
+    const englishTrack = getTrackByLanguage(player, 'en');
 
-  assert.ok(!captionsButton.hasClass('vjs-hidden'), 'The captions button is shown');
-  assert.ok(englishTrack.mode === 'disabled', 'English track should be disabled');
-  player.dispose();
-});
+    assert.ok(!captionsButton.hasClass('vjs-hidden'), 'The captions button is shown');
+    assert.ok(englishTrack.mode === 'disabled', 'English track should be disabled');
 
-QUnit.test('the user-selected language takes priority over default language', function(assert) {
-  // The video has ‘English’ captions as default, but has ‘Spanish’ captions also
-  const player = TestHelpers.makePlayer({techOrder: ['html5']});
-  const track1 = {
-    kind: 'captions',
-    label: 'English',
-    language: 'en',
-    src: 'en.vtt',
-    default: true
-  };
-  const track2 = {
-    kind: 'captions',
-    label: 'Spanish',
-    language: 'es',
-    src: 'es.vtt'
-  };
+    browser.IS_FIREFOX = oldIsFirefox;
+    player.dispose();
+  });
 
-  player.src({type: 'video/mp4', src: 'http://google.com'});
-  // manualCleanUp = true by default
-  player.addRemoteTextTrack(track1);
-  player.addRemoteTextTrack(track2);
-  // Force 'es' as user-selected track
-  player.cache_.selectedLanguage = 'es';
-  this.clock.tick(1);
+  QUnit.test('the user-selected language takes priority over default language', function(assert) {
+    // The video has ‘English’ captions as default, but has ‘Spanish’ captions also
+    const oldIsFirefox = browser.IS_FIREFOX;
+    const player = TestHelpers.makePlayer({techOrder: ['html5']});
+    const track1 = {
+      kind: 'captions',
+      label: 'English',
+      language: 'en',
+      src: 'en.vtt',
+      default: true
+    };
+    const track2 = {
+      kind: 'captions',
+      label: 'Spanish',
+      language: 'es',
+      src: 'es.vtt'
+    };
 
-  // the spanish captions track should be shown
-  const englishTrack = getTrackByLanguage(player, 'en');
-  const spanishTrack = getTrackByLanguage(player, 'es');
+    browser.IS_FIREFOX = true;
+    player.src({type: 'video/mp4', src: 'http://google.com'});
+    // manualCleanUp = true by default
+    player.addRemoteTextTrack(track1);
+    player.addRemoteTextTrack(track2);
+    // Force 'es' as user-selected track
+    player.cache_.selectedLanguage = 'es';
+    this.clock.tick(1);
 
-  assert.ok(spanishTrack.mode === 'showing', 'Spanish captions should be shown');
-  assert.ok(englishTrack.mode === 'disabled', 'English captions should be hidden');
-  player.dispose();
-});
+    // the spanish captions track should be shown
+    const englishTrack = getTrackByLanguage(player, 'en');
+    const spanishTrack = getTrackByLanguage(player, 'es');
 
-QUnit.test('the user-selected language is used for subsequent source changes', function(assert) {
-  // Start with two captions tracks: English and Spanish
-  const player = TestHelpers.makePlayer({techOrder: ['html5']});
-  const track1 = {
-    kind: 'captions',
-    label: 'English',
-    language: 'en',
-    src: 'en.vtt'
-  };
-  const track2 = {
-    kind: 'captions',
-    label: 'Spanish',
-    language: 'es',
-    src: 'es.vtt'
-  };
-  const tracks = player.tech_.remoteTextTracks();
-  const captionsButton = player.controlBar.getChild('SubsCapsButton');
-  let esCaptionMenuItem;
-  let enCaptionMenuItem;
+    assert.ok(spanishTrack.mode === 'showing', 'Spanish captions should be shown');
+    assert.ok(englishTrack.mode === 'disabled', 'English captions should be hidden');
 
-  player.src({type: 'video/mp4', src: 'http://google.com'});
-  // manualCleanUp = true by default
-  player.addRemoteTextTrack(track1);
-  player.addRemoteTextTrack(track2);
+    browser.IS_FIREFOX = oldIsFirefox;
+    player.dispose();
+  });
 
-  // Keep track of menu items
-  esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
-  enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
+  QUnit.test('the user-selected language is used for subsequent source changes', function(assert) {
+    // Start with two captions tracks: English and Spanish
+    const oldIsFirefox = browser.IS_FIREFOX;
+    const player = TestHelpers.makePlayer();
+    const track1 = {
+      kind: 'captions',
+      label: 'English',
+      language: 'en',
+      src: 'en.vtt'
+    };
+    const track2 = {
+      kind: 'captions',
+      label: 'Spanish',
+      language: 'es',
+      src: 'es.vtt'
+    };
+    const tracks = player.tech_.remoteTextTracks();
+    const captionsButton = player.controlBar.getChild('SubsCapsButton');
+    let esCaptionMenuItem;
+    let enCaptionMenuItem;
 
-  // The user chooses Spanish
-  player.play();
-  captionsButton.pressButton();
-  esCaptionMenuItem.trigger('click');
+    browser.IS_FIREFOX = true;
+    player.src({type: 'video/mp4', src: 'http://google.com'});
+    // manualCleanUp = true by default
+    player.addRemoteTextTrack(track1);
+    player.addRemoteTextTrack(track2);
 
-  // Track mode changes on user-selection
-  assert.ok(esCaptionMenuItem.track.mode === 'showing',
-    'Spanish should be showing after selection');
-  assert.ok(enCaptionMenuItem.track.mode === 'disabled',
-    'English should be disabled after selecting Spanish');
+    // Keep track of menu items
+    esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
+    enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
 
-  // Switch source and remove old tracks
-  player.tech_.setSource({type: 'video/mp4', src: 'http://example.com'});
-  while (tracks.length > 0) {
-    player.removeRemoteTextTrack(tracks[0]);
-  }
-  // Add tracks for the new source
-  player.addRemoteTextTrack(track1);
-  player.addRemoteTextTrack(track2);
+    // The user chooses Spanish
+    player.play();
+    captionsButton.pressButton();
+    esCaptionMenuItem.trigger('click');
 
-  // Make sure player ready handler runs
-  this.clock.tick(1);
+    // Track mode changes on user-selection
+    assert.ok(esCaptionMenuItem.track.mode === 'showing',
+      'Spanish should be showing after selection');
+    assert.ok(enCaptionMenuItem.track.mode === 'disabled',
+      'English should be disabled after selecting Spanish');
 
-  // Keep track of menu items
-  esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
-  enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
+    // Switch source and remove old tracks
+    player.tech_.src({type: 'video/mp4', src: 'http://example.com'});
+    while (tracks.length > 0) {
+      player.removeRemoteTextTrack(tracks[0]);
+    }
+    // Add tracks for the new source
+    player.addRemoteTextTrack(track1);
+    player.addRemoteTextTrack(track2);
 
-  // The user-selection should have persisted
-  assert.ok(esCaptionMenuItem.track.mode === 'showing',
-    'Spanish should remain showing');
-  assert.ok(enCaptionMenuItem.track.mode === 'disabled',
-    'English should remain disabled');
+    // Make sure player ready handler runs
+    this.clock.tick(1);
 
-  const englishTrack = getTrackByLanguage(player, 'en');
-  const spanishTrack = getTrackByLanguage(player, 'es');
+    // Keep track of menu items
+    esCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'es');
+    enCaptionMenuItem = getMenuItemByLanguage(captionsButton.items, 'en');
 
-  assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
-  assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');
-  player.dispose();
-});
+    // The user-selection should have persisted
+    assert.ok(esCaptionMenuItem.track.mode === 'showing',
+      'Spanish should remain showing');
+    assert.ok(enCaptionMenuItem.track.mode === 'disabled',
+      'English should remain disabled');
+
+    const englishTrack = getTrackByLanguage(player, 'en');
+    const spanishTrack = getTrackByLanguage(player, 'es');
+
+    assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
+    assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');
+
+    browser.IS_FIREFOX = oldIsFirefox;
+    player.dispose();
+  });
+}

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -115,10 +115,10 @@ if (!Html5.supportsNativeTextTracks()) {
     const spy = sinon.spy();
     const selectedLanguageHandler = function(event) {
       spy();
-    }
+    };
     const englishTrack = player.addRemoteTextTrack(track1).track;
 
-    player.tech_.on('selectedlanguagechange', selectedLanguageHandler);
+    player.textTracks().addEventListener('selectedlanguagechange', selectedLanguageHandler);
     englishTrack.mode = 'showing';
 
     assert.strictEqual(spy.callCount, 1, 'selectedlanguagechange event was fired');
@@ -194,7 +194,7 @@ if (!Html5.supportsNativeTextTracks()) {
       kind: 'subtitles',
       label: 'English',
       language: 'en',
-      src: 'en.vtt',
+      src: 'en.vtt'
     };
 
     player.src({type: 'video/mp4', src: 'http://google.com'});
@@ -250,7 +250,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should be disabled after selecting Spanish');
     assert.deepEqual(player.cache_.selectedLanguage,
-      { language : 'es', kind : 'captions' });
+      { language: 'es', kind: 'captions' });
 
     // Switch source and remove old tracks
     player.tech_.src({type: 'video/mp4', src: 'http://example.com'});
@@ -277,7 +277,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should remain disabled');
     assert.deepEqual(player.cache_.selectedLanguage,
-      { language : 'es', kind : 'captions' });
+      { language: 'es', kind: 'captions' });
 
     assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
     assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -174,7 +174,7 @@ if (!Html5.supportsNativeTextTracks()) {
     const spanishTrack = player.addRemoteTextTrack(track2).track;
 
     // Force 'es' as user-selected track
-    player.cache_.selectedLanguage = { language: 'es', kind: 'captions' };
+    player.cache_.selectedLanguage = { enabled: true, language: 'es', kind: 'captions' };
     this.clock.tick(1);
 
     assert.ok(spanishTrack.mode === 'showing', 'Spanish captions should be shown');
@@ -203,7 +203,7 @@ if (!Html5.supportsNativeTextTracks()) {
     const subsTrack = player.addRemoteTextTrack(track2).track;
 
     // Force English captions as user-selected track
-    player.cache_.selectedLanguage = { language: 'en', kind: 'captions' };
+    player.cache_.selectedLanguage = { enabled: true, language: 'en', kind: 'captions' };
     this.clock.tick(1);
 
     assert.ok(captionTrack.mode === 'showing', 'Captions track should be preselected');
@@ -250,7 +250,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should be disabled after selecting Spanish');
     assert.deepEqual(player.cache_.selectedLanguage,
-      { language: 'es', kind: 'captions' });
+      { enabled: true, language: 'es', kind: 'captions' });
 
     // Switch source and remove old tracks
     player.tech_.src({type: 'video/mp4', src: 'http://example.com'});
@@ -277,7 +277,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should remain disabled');
     assert.deepEqual(player.cache_.selectedLanguage,
-      { language: 'es', kind: 'captions' });
+      { enabled: true, language: 'es', kind: 'captions' });
 
     assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
     assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');
@@ -307,13 +307,14 @@ if (!Html5.supportsNativeTextTracks()) {
     enCaptionMenuItem.trigger('click');
 
     assert.deepEqual(player.cache_.selectedLanguage,
-      { language: 'en', kind: 'captions' }, 'English track is selected');
+      { enabled: true, language: 'en', kind: 'captions' }, 'English track is selected');
     assert.ok(englishTrack.mode === 'showing', 'English track should be showing');
 
     // Select the off button
     offMenuItem.trigger('click');
 
-    assert.ok(!player.cache_.selectedLanguage, 'selectedLanguage is cleared');
+    assert.deepEqual(player.cache_.selectedLanguage,
+      { enabled: false }, 'selectedLanguage is cleared');
     assert.ok(englishTrack.mode === 'disabled', 'English track is disabled');
     player.dispose();
   });

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -153,7 +153,7 @@ if (!Html5.supportsNativeTextTracks()) {
     const spanishTrack = player.addRemoteTextTrack(track2).track;
 
     // Force 'es' as user-selected track
-    player.cache_.selectedLanguage = 'es';
+    player.cache_.selectedLanguage = { language: 'es', kind: 'captions' };
     this.clock.tick(1);
 
     assert.ok(spanishTrack.mode === 'showing', 'Spanish captions should be shown');
@@ -199,6 +199,8 @@ if (!Html5.supportsNativeTextTracks()) {
       'Spanish should be showing after selection');
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should be disabled after selecting Spanish');
+    assert.deepEqual(player.cache_.selectedLanguage,
+      { language : 'es', kind : 'captions' });
 
     // Switch source and remove old tracks
     player.tech_.src({type: 'video/mp4', src: 'http://example.com'});
@@ -206,6 +208,9 @@ if (!Html5.supportsNativeTextTracks()) {
       player.removeRemoteTextTrack(tracks[0]);
     }
     // Add tracks for the new source
+    // change the kind of track to subtitles
+    track1.kind = 'subtitles';
+    track2.kind = 'subtitles';
     const englishTrack = player.addRemoteTextTrack(track1).track;
     const spanishTrack = player.addRemoteTextTrack(track2).track;
 
@@ -221,6 +226,8 @@ if (!Html5.supportsNativeTextTracks()) {
       'Spanish should remain showing');
     assert.ok(enCaptionMenuItem.track.mode === 'disabled',
       'English should remain disabled');
+    assert.deepEqual(player.cache_.selectedLanguage,
+      { language : 'es', kind : 'captions' });
 
     assert.ok(spanishTrack.mode === 'showing', 'Spanish track remains showing');
     assert.ok(englishTrack.mode === 'disabled', 'English track remains disabled');

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -9,7 +9,6 @@ import TextTrack from '../../../src/js/tracks/text-track.js';
 import TextTrackDisplay from '../../../src/js/tracks/text-track-display.js';
 import Html5 from '../../../src/js/tech/html5.js';
 import Tech from '../../../src/js/tech/tech.js';
-import Component from '../../../src/js/component.js';
 
 import * as browser from '../../../src/js/utils/browser.js';
 import TestHelpers from '../test-helpers.js';
@@ -217,54 +216,6 @@ QUnit.test('update texttrack buttons on removetrack or addtrack', function(asser
   SubtitlesButton.prototype.update = oldSubsUpdate;
   ChaptersButton.prototype.update = oldChaptersUpdate;
   SubsCapsButton.prototype.update = oldSubsCapsUpdate;
-
-  player.dispose();
-});
-
-QUnit.test('if native text tracks are not supported, create a texttrackdisplay', function(assert) {
-  const oldTestVid = Html5.TEST_VID;
-  const oldIsFirefox = browser.IS_FIREFOX;
-  const oldTextTrackDisplay = Component.getComponent('TextTrackDisplay');
-  const tag = document.createElement('video');
-  const track1 = document.createElement('track');
-  const track2 = document.createElement('track');
-
-  track1.kind = 'captions';
-  track1.label = 'en';
-  track1.language = 'English';
-  track1.src = 'en.vtt';
-  tag.appendChild(track1);
-
-  track2.kind = 'captions';
-  track2.label = 'es';
-  track2.language = 'Spanish';
-  track2.src = 'es.vtt';
-  tag.appendChild(track2);
-
-  Html5.TEST_VID = {
-    textTracks: []
-  };
-
-  browser.IS_FIREFOX = true;
-
-  const fakeTTDSpy = sinon.spy();
-
-  class FakeTTD extends Component {
-    constructor() {
-      super();
-      fakeTTDSpy();
-    }
-  }
-
-  Component.registerComponent('TextTrackDisplay', FakeTTD);
-
-  const player = TestHelpers.makePlayer({}, tag);
-
-  assert.strictEqual(fakeTTDSpy.callCount, 1, 'text track display was created');
-
-  Html5.TEST_VID = oldTestVid;
-  browser.IS_FIREFOX = oldIsFirefox;
-  Component.registerComponent('TextTrackDisplay', oldTextTrackDisplay);
 
   player.dispose();
 });


### PR DESCRIPTION
## Description
This should allow a user's choice of subtitle or description to be respected across an entire session(if available).

## Specific Changes proposed
- Remember the user selection
- User selected choice is preferred over the first default track

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated (n/a)
- [ ] Reviewed by Two Core Contributors
