### PR TITLE
Only update track mode if changed

### DIFF
--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -101,7 +101,7 @@ class TextTrackMenuItem extends MenuItem {
       const track = tracks[i];
 
       if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
-        if (track.mode !== 'showing) {
+        if (track.mode !== 'showing') {
           track.mode = 'showing';
         }
       } else if (track.mode !== 'disabled') {

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -100,14 +100,10 @@ class TextTrackMenuItem extends MenuItem {
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
 
-      if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
-        if (track.mode !== 'showing') {
-          track.mode = 'showing';
-        }
-      } else {
-        if (track.mode !== 'disabled') {
-          track.mode = 'disabled';
-        }
+      if (track === this.track && (kinds.indexOf(track.kind) > -1) && track.mode !== 'showing') {
+        track.mode = 'showing';
+      } else if (track.mode !== 'disabled') {
+        track.mode = 'disabled';
       }
     }
   }

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -100,8 +100,10 @@ class TextTrackMenuItem extends MenuItem {
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
 
-      if (track === this.track && (kinds.indexOf(track.kind) > -1) && track.mode !== 'showing') {
-        track.mode = 'showing';
+      if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
+        if (track.mode !== 'showing) {
+          track.mode = 'showing';
+        }
       } else if (track.mode !== 'disabled') {
         track.mode = 'disabled';
       }

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -101,9 +101,13 @@ class TextTrackMenuItem extends MenuItem {
       const track = tracks[i];
 
       if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
-        track.mode = 'showing';
+        if (track.mode !== 'showing') {
+          track.mode = 'showing';
+        }
       } else {
-        track.mode = 'disabled';
+        if (track.mode !== 'disabled') {
+          track.mode = 'disabled';
+        }
       }
     }
   }


### PR DESCRIPTION
Hi there,

Would you consider this fix for triggering less track.modechange and subsequently trackList.change events - at the moment too many of those are triggered even if nothing has actually changed.

cc https://github.com/videojs/video.js/issues/4294