### PR TITLE
Prevent dupe events on enabled ClickableComponents

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -141,28 +141,30 @@ class ClickableComponent extends Component {
    * Enable this `Component`s element.
    */
   enable() {
-    this.removeClass('vjs-disabled');
-    this.el_.setAttribute('aria-disabled', 'false');
-    if (typeof this.tabIndex_ !== 'undefined') {
-      this.el_.setAttribute('tabIndex', this.tabIndex_);
+    if (!this.enabled_) {
+      this.enabled_ = true;
+      this.removeClass('vjs-disabled');
+      this.el_.setAttribute('aria-disabled', 'false');
+      if (typeof this.tabIndex_ !== 'undefined') {
+        this.el_.setAttribute('tabIndex', this.tabIndex_);
+      }
+      this.on(['tap', 'click'], this.handleClick);
+      this.on('focus', this.handleFocus);
+      this.on('blur', this.handleBlur);
     }
-    this.on('tap', this.handleClick);
-    this.on('click', this.handleClick);
-    this.on('focus', this.handleFocus);
-    this.on('blur', this.handleBlur);
   }
 
   /**
    * Disable this `Component`s element.
    */
   disable() {
+    this.enabled_ = false;
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
     if (typeof this.tabIndex_ !== 'undefined') {
       this.el_.removeAttribute('tabIndex');
     }
-    this.off('tap', this.handleClick);
-    this.off('click', this.handleClick);
+    this.off(['tap', 'click'], this.handleClick);
     this.off('focus', this.handleFocus);
     this.off('blur', this.handleBlur);
   }

--- a/test/unit/clickable-component.test.js
+++ b/test/unit/clickable-component.test.js
@@ -71,3 +71,25 @@ QUnit.test('handleClick should not be triggered when disabled', function() {
   testClickableComponent.dispose();
   player.dispose();
 });
+
+QUnit.test('handleClick should not be triggered more than once when enabled', function() {
+  let clicks = 0;
+
+  class TestClickableComponent extends ClickableComponent {
+    handleClick() {
+      clicks++;
+    }
+  }
+
+  const player = TestHelpers.makePlayer({});
+  const testClickableComponent = new TestClickableComponent(player);
+  const el = testClickableComponent.el();
+
+  testClickableComponent.enable();
+  // Click should still be handled just once
+  Events.trigger(el, 'click');
+  QUnit.equal(clicks, 1, 'no additional click handler when already enabled ClickableComponent has been enabled again');
+
+  testClickableComponent.dispose();
+  player.dispose();
+});


### PR DESCRIPTION
## Description
Prevent ClickableComponents re-adding event listeners each time `enabled()` is called
Fixes #4312

## Specific Changes proposed
- Keeps track of enabled state (`this.enabled_`)
- `enable()` doesn't do anything if the component is enabled, so the event handlers are not re-added

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
