### PR TITLE
Ensure existing text tracks are cleared when switching to a new source

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1175,7 +1175,7 @@ Tech.withSourceHandlers = function(_Tech) {
     // then we are loading something new
     // than clear all of our current tracks
     if (this.currentSource_) {
-      this.clearTracks(['audio', 'video']);
+      this.clearTracks(TRACK_TYPES.NORMAL.names);
       this.currentSource_ = null;
     }
 


### PR DESCRIPTION
## Description

Previously only audio/video tracks were cleared. This is a simple bug/oversight.

## Specific Changes proposed

Using the same pattern to clear tracks as elsewhere.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
