### PR TITLE
Remove playbackRate blacklist for recent Android Chrome

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -761,7 +761,7 @@ Html5.canControlVolume = function() {
 Html5.canControlPlaybackRate = function() {
   // Playback rate API is implemented in Android Chrome, but doesn't do anything
   // https://github.com/videojs/video.js/issues/3180
-  if (browser.IS_ANDROID && browser.IS_CHROME) {
+  if (browser.IS_ANDROID && browser.IS_CHROME && browser.CHROME_VERSION < 58) {
     return false;
   }
   // IE will error if Windows Media Player not installed #3315

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -62,6 +62,14 @@ export const IS_NATIVE_ANDROID = IS_ANDROID && ANDROID_VERSION < 5 && appleWebki
 export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_EDGE = (/Edge/i).test(USER_AGENT);
 export const IS_CHROME = !IS_EDGE && (/Chrome/i).test(USER_AGENT);
+export const CHROME_VERSION = (function() {
+  const match = USER_AGENT.match(/Chrome\/(\d+)/);
+
+  if (match && match[1]) {
+    return match[1];
+  }
+  return null;
+}());
 export const IS_IE8 = (/MSIE\s8\.0/).test(USER_AGENT);
 export const IE_VERSION = (function() {
   const result = (/MSIE\s(\d+)\.\d/).exec(USER_AGENT);

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -66,7 +66,7 @@ export const CHROME_VERSION = (function() {
   const match = USER_AGENT.match(/Chrome\/(\d+)/);
 
   if (match && match[1]) {
-    return match[1];
+    return parseFloat(match[1]);
   }
   return null;
 }());

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -100,6 +100,29 @@ QUnit.test('test defaultPlaybackRate', function(assert) {
   assert.strictEqual(tech.defaultPlaybackRate(), 0.75, 'can be changed from the API');
 });
 
+QUnit.test('blacklist playbackRate support on older verisons of Chrome on Android', function(assert) {
+  if (!Html5.canControlPlaybackRate()) {
+    assert.ok(true, 'playbackRate is not supported');
+    return;
+  }
+
+  const oldIsAndroid = browser.IS_ANDROID;
+  const oldIsChrome = browser.IS_CHROME;
+  const oldChromeVersion = browser.CHROME_VERSION;
+
+  browser.IS_ANDROID = true;
+  browser.IS_CHROME = true;
+  browser.CHROME_VERSION = '50';
+  assert.strictEqual(Html5.canControlPlaybackRate(), false, 'canControlPlaybackRate should return false on older Chrome');
+
+  browser.CHROME_VERSION = '58';
+  assert.strictEqual(Html5.canControlPlaybackRate(), true, 'canControlPlaybackRate should return true on newer Chrome');
+
+  browser.IS_ANDROID = oldIsAndroid;
+  browser.IS_CHROME = oldIsChrome;
+  browser.CHROME_VERSION = oldChromeVersion;
+});
+
 QUnit.test('test volume', function(assert) {
   if (!Html5.canControlVolume()) {
     assert.ok(true, 'Volume is not supported');

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -106,6 +106,9 @@ QUnit.test('blacklist playbackRate support on older verisons of Chrome on Androi
     return;
   }
 
+  // Reset playbackrate - Firefox's rounding of playbackRate causes the rate not to change in canControlPlaybackRate() after a few instances
+  Html5.TEST_VID.playbackRate = 1;
+
   const oldIsAndroid = browser.IS_ANDROID;
   const oldIsChrome = browser.IS_CHROME;
   const oldChromeVersion = browser.CHROME_VERSION;

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -115,10 +115,10 @@ QUnit.test('blacklist playbackRate support on older verisons of Chrome on Androi
 
   browser.IS_ANDROID = true;
   browser.IS_CHROME = true;
-  browser.CHROME_VERSION = '50';
+  browser.CHROME_VERSION = 50;
   assert.strictEqual(Html5.canControlPlaybackRate(), false, 'canControlPlaybackRate should return false on older Chrome');
 
-  browser.CHROME_VERSION = '58';
+  browser.CHROME_VERSION = 58;
   assert.strictEqual(Html5.canControlPlaybackRate(), true, 'canControlPlaybackRate should return true on newer Chrome');
 
   browser.IS_ANDROID = oldIsAndroid;


### PR DESCRIPTION
## Description
Android Chrome now supports playbackRate properly, so removes the blacklist added in #3246 for newer Chrome versions.  

## Specific Changes proposed
Adds `browser.CHROME_VERSION` as a necessary evil.
No longer blacklists for Chrome 58+ -- this could possibly be fixed since 52, but 58 is all I've been able to test on and most users should keep Chrome up to date.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
