### PR TITLE
Allow 'playsinline' player option

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -822,6 +822,7 @@ class Player extends Component {
       'textTracks': this.textTracks_,
       'audioTracks': this.audioTracks_,
       'autoplay': this.options_.autoplay,
+      'playsinline': this.options_.playsinline,
       'preload': this.options_.preload,
       'loop': this.options_.loop,
       'muted': this.options_.muted,
@@ -2397,7 +2398,7 @@ class Player extends Component {
       this.options_.playsinline = value;
       return this;
     }
-    return this.techGet_('playsinline', value);
+    return this.techGet_('playsinline');
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2394,6 +2394,8 @@ class Player extends Component {
    * @return {string|Player}
    *         - the current value of playsinline
    *         - the player when setting
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
    */
   playsinline(value) {
     if (value !== undefined) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2381,6 +2381,26 @@ class Player extends Component {
   }
 
   /**
+   * Get or set the playsinline attribute.
+   *
+   * @param {boolean} [value]
+   *        - true means that we should play inline in iOS Safari
+   *        - false means that we should not play inline in iOS Safari
+   *
+   * @return {string|Player}
+   *         - the current value of playsinline
+   *         - the player when setting
+   */
+  playsinline(value) {
+    if (value !== undefined) {
+      this.techCall_('setPlaysinline', value);
+      this.options_.playsinline = value;
+      return this;
+    }
+    return this.techGet_('playsinline', value);
+  }
+
+  /**
    * Get or set the loop attribute on the video element.
    *
    * @param {boolean} [value]

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2382,11 +2382,14 @@ class Player extends Component {
   }
 
   /**
-   * Get or set the playsinline attribute.
+   * Set or unset the playsinline attribute.
+   * Playsinline tells the browser that non-fullscreen playback is preferred.
    *
    * @param {boolean} [value]
-   *        - true means that we should play inline in iOS Safari
-   *        - false means that we should not play inline in iOS Safari
+   *        - true means that we should try to play inline by default
+   *        - false means that we should use the browser's default playback mode,
+   *          which in most cases is inline. iOS Safari is a notable exception
+   *          and plays fullscreen by default.
    *
    * @return {string|Player}
    *         - the current value of playsinline

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1236,7 +1236,8 @@ Html5.resetMediaElement = function(el) {
 
   /**
    * Get the value of `playsinline` from the media element. `playsinline` indicates
-   * that the media should play inline in iOS Safari.
+   * to the browser that non-fullscreen playback is preferred when fullscreen
+   * playback is the native default, such as in iOS Safari.
    *
    * @method Html5#playsinline
    * @return {boolean}
@@ -1532,8 +1533,9 @@ Html5.resetMediaElement = function(el) {
   'autoplay',
 
   /**
-   * Set the value of `playsinline` on the media element. `playsinline` indicates
-   * that the media should play inline in iOS Safari.
+   * Set the value of `playsinline` from the media element. `playsinline` indicates
+   * to the browser that non-fullscreen playback is preferred when fullscreen
+   * playback is the native default, such as in iOS Safari.
    *
    * @method Html5#setPlaysinline
    * @param {boolean} playsinline

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -223,7 +223,7 @@ class Html5 extends Tech {
     }
 
     // Update specific tag settings, in case they were overridden
-    const settingsAttrs = ['autoplay', 'preload', 'loop', 'muted'];
+    const settingsAttrs = ['autoplay', 'preload', 'loop', 'muted', 'playsinline'];
 
     for (let i = settingsAttrs.length - 1; i >= 0; i--) {
       const attr = settingsAttrs[i];
@@ -1233,6 +1233,20 @@ Html5.resetMediaElement = function(el) {
    * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-autoplay}
    */
   'autoplay',
+
+  /**
+   * Get the value of `playsinline` from the media element. `playsinline` indicates
+   * that the media should play inline in iOS Safari.
+   *
+   * @method Html5#playsinline
+   * @return {boolean}
+   *         - The value of `playsinline` from the media element.
+   *         - True indicates that the media should play inline.
+   *         - False indicates that the media should not play inline.
+   *
+   * @see [Spec]{@link https://github.com/whatwg/html/pull/1444}
+   */
+  'playsinline',
 
   /**
    * Get the value of `controls` from the media element. `controls` indicates

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1235,21 +1235,6 @@ Html5.resetMediaElement = function(el) {
   'autoplay',
 
   /**
-   * Get the value of `playsinline` from the media element. `playsinline` indicates
-   * to the browser that non-fullscreen playback is preferred when fullscreen
-   * playback is the native default, such as in iOS Safari.
-   *
-   * @method Html5#playsinline
-   * @return {boolean}
-   *         - The value of `playsinline` from the media element.
-   *         - True indicates that the media should play inline.
-   *         - False indicates that the media should not play inline.
-   *
-   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
-   */
-  'playsinline',
-
-  /**
    * Get the value of `controls` from the media element. `controls` indicates
    * whether the native media controls should be shown or hidden.
    *
@@ -1446,6 +1431,27 @@ Html5.resetMediaElement = function(el) {
   };
 });
 
+// This getter is declared outside of the loop because there is no 'playsinline'
+// property for the <video> element, but we still want to be able to detect the presence
+// of the 'playsinline' attribute
+
+/**
+ * Get the value of `playsinline` from the media element. `playsinline` indicates
+ * to the browser that non-fullscreen playback is preferred when fullscreen
+ * playback is the native default, such as in iOS Safari.
+ *
+ * @method Html5#playsinline
+ * @return {boolean}
+ *         - The value of `playsinline` from the media element.
+ *         - True indicates that the media should play inline.
+ *         - False indicates that the media should not play inline.
+ *
+ * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
+ */
+Html5.prototype.playsinline = function() {
+  return this.el_.hasAttribute('playsinline');
+};
+
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 [
@@ -1533,20 +1539,6 @@ Html5.resetMediaElement = function(el) {
   'autoplay',
 
   /**
-   * Set the value of `playsinline` from the media element. `playsinline` indicates
-   * to the browser that non-fullscreen playback is preferred when fullscreen
-   * playback is the native default, such as in iOS Safari.
-   *
-   * @method Html5#setPlaysinline
-   * @param {boolean} playsinline
-   *         - True indicates that the media should play inline.
-   *         - False indicates that the media should not play inline.
-   *
-   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
-   */
-  'playsinline',
-
-  /**
    * Set the value of `loop` on the media element. `loop` indicates
    * that the media should return to the start of the media and continue playing once
    * it reaches the end.
@@ -1581,6 +1573,30 @@ Html5.resetMediaElement = function(el) {
     this.el_[prop] = v;
   };
 });
+
+// This setter is declared outside of the loop because there is no 'playsinline'
+// property for the <video> element, but we still want to be able to add and remove
+// the 'playsinline' attribute
+
+/**
+ * Set the value of `playsinline` from the media element. `playsinline` indicates
+ * to the browser that non-fullscreen playback is preferred when fullscreen
+ * playback is the native default, such as in iOS Safari.
+ *
+ * @method Html5#setPlaysinline
+ * @param {boolean} playsinline
+ *         - True indicates that the media should play inline.
+ *         - False indicates that the media should not play inline.
+ *
+ * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
+ */
+Html5.prototype.setPlaysinline = function(value) {
+  if (value) {
+    this.el_.setAttribute('playsinline', 'playsinline');
+  } else {
+    this.el_.removeAttribute('playsinline');
+  }
+};
 
 // wrap native functions with a function
 [

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -831,7 +831,7 @@ class Html5 extends Tech {
       this.el_.removeAttribute('playsinline');
     }
   }
-  
+
   /**
    * Gets available media playback quality metrics as specified by the W3C's Media
    * Playback Quality API.

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1518,6 +1518,19 @@ Html5.resetMediaElement = function(el) {
   'autoplay',
 
   /**
+   * Set the value of `playsinline` on the media element. `playsinline` indicates
+   * that the media should play inline in iOS Safari.
+   *
+   * @method Html5#setPlaysinline
+   * @param {boolean} playsinline
+   *         - True indicates that the media should play inline.
+   *         - False indicates that the media should not play inline.
+   *
+   * @see [Spec]{@link https://github.com/whatwg/html/pull/1444}
+   */
+  'playsinline',
+
+  /**
    * Set the value of `loop` on the media element. `loop` indicates
    * that the media should return to the start of the media and continue playing once
    * it reaches the end.

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1244,7 +1244,7 @@ Html5.resetMediaElement = function(el) {
    *         - True indicates that the media should play inline.
    *         - False indicates that the media should not play inline.
    *
-   * @see [Spec]{@link https://github.com/whatwg/html/pull/1444}
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
    */
   'playsinline',
 
@@ -1540,7 +1540,7 @@ Html5.resetMediaElement = function(el) {
    *         - True indicates that the media should play inline.
    *         - False indicates that the media should not play inline.
    *
-   * @see [Spec]{@link https://github.com/whatwg/html/pull/1444}
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
    */
   'playsinline',
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -794,6 +794,43 @@ class Html5 extends Tech {
       }
     }
   }
+
+  /**
+   * Get the value of `playsinline` from the media element. `playsinline` indicates
+   * to the browser that non-fullscreen playback is preferred when fullscreen
+   * playback is the native default, such as in iOS Safari.
+   *
+   * @method Html5#playsinline
+   * @return {boolean}
+   *         - The value of `playsinline` from the media element.
+   *         - True indicates that the media should play inline.
+   *         - False indicates that the media should not play inline.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
+   */
+  playsinline() {
+    return this.el_.hasAttribute('playsinline');
+  }
+
+  /**
+   * Set the value of `playsinline` from the media element. `playsinline` indicates
+   * to the browser that non-fullscreen playback is preferred when fullscreen
+   * playback is the native default, such as in iOS Safari.
+   *
+   * @method Html5#setPlaysinline
+   * @param {boolean} playsinline
+   *         - True indicates that the media should play inline.
+   *         - False indicates that the media should not play inline.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
+   */
+  setPlaysinline(value) {
+    if (value) {
+      this.el_.setAttribute('playsinline', 'playsinline');
+    } else {
+      this.el_.removeAttribute('playsinline');
+    }
+  }
 }
 
 /* HTML5 Support Testing ---------------------------------------------------- */
@@ -1431,27 +1468,6 @@ Html5.resetMediaElement = function(el) {
   };
 });
 
-// This getter is declared outside of the loop because there is no 'playsinline'
-// property for the <video> element, but we still want to be able to detect the presence
-// of the 'playsinline' attribute
-
-/**
- * Get the value of `playsinline` from the media element. `playsinline` indicates
- * to the browser that non-fullscreen playback is preferred when fullscreen
- * playback is the native default, such as in iOS Safari.
- *
- * @method Html5#playsinline
- * @return {boolean}
- *         - The value of `playsinline` from the media element.
- *         - True indicates that the media should play inline.
- *         - False indicates that the media should not play inline.
- *
- * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
- */
-Html5.prototype.playsinline = function() {
-  return this.el_.hasAttribute('playsinline');
-};
-
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 [
@@ -1573,30 +1589,6 @@ Html5.prototype.playsinline = function() {
     this.el_[prop] = v;
   };
 });
-
-// This setter is declared outside of the loop because there is no 'playsinline'
-// property for the <video> element, but we still want to be able to add and remove
-// the 'playsinline' attribute
-
-/**
- * Set the value of `playsinline` from the media element. `playsinline` indicates
- * to the browser that non-fullscreen playback is preferred when fullscreen
- * playback is the native default, such as in iOS Safari.
- *
- * @method Html5#setPlaysinline
- * @param {boolean} playsinline
- *         - True indicates that the media should play inline.
- *         - False indicates that the media should not play inline.
- *
- * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
- */
-Html5.prototype.setPlaysinline = function(value) {
-  if (value) {
-    this.el_.setAttribute('playsinline', 'playsinline');
-  } else {
-    this.el_.removeAttribute('playsinline');
-  }
-};
 
 // wrap native functions with a function
 [

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -808,6 +808,20 @@ class Tech extends Component {
    */
   setPoster() {}
 
+  /**
+   * A method to check for the presence of the 'playsinine' <video> attribute.
+   *
+   * @abstract
+   */
+  playsinline() {}
+
+  /**
+   * A method to set or unset the 'playsinine' <video> attribute.
+   *
+   * @abstract
+   */
+  setPlaysinline() {}
+
   /*
    * Check if the tech can support the given mime-type.
    *

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -830,6 +830,33 @@ QUnit.test('should restore attributes from the original video tag when creating 
   assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
 });
 
+QUnit.test('player.playsinline() should be able to get/set playsinline attribute', function(assert) {
+  assert.expect(5);
+
+  const video = document.createElement('video');
+  const player = TestHelpers.makePlayer({techOrder: ['html5']}, video);
+
+  // test setter
+  assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline has not yet been added');
+
+  player.playsinline(true);
+
+  assert.ok(player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute added');
+
+  player.playsinline(false);
+
+  assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute removed');
+
+  // test getter
+  player.tech_.el().setAttribute('playsinline', 'playsinline');
+
+  assert.ok(player.playsinline(), 'correctly detects playsinline attribute');
+
+  player.tech_.el().removeAttribute('playsinline');
+
+  assert.ok(!player.playsinline(), 'correctly detects absence of playsinline attribute');
+});
+
 QUnit.test('if tag exists and movingMediaElementInDOM, re-use the tag', function(assert) {
   // simulate attributes stored from the original tag
   const tag = Dom.createEl('video');

--- a/test/unit/setup.test.js
+++ b/test/unit/setup.test.js
@@ -7,12 +7,13 @@ QUnit.test('should set options from data-setup even if autoSetup is not called b
   const el = TestHelpers.makeTag();
 
   el.setAttribute('data-setup',
-                  '{"controls": true, "autoplay": false, "preload": "auto"}');
+                  '{"controls": true, "autoplay": false, "preload": "auto", "playsinline": true}');
 
   const player = TestHelpers.makePlayer({}, el);
 
   assert.ok(player.options_.controls === true);
   assert.ok(player.options_.autoplay === false);
   assert.ok(player.options_.preload === 'auto');
+  assert.ok(player.options_.playsinline === true);
   player.dispose();
 });

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -50,6 +50,19 @@ QUnit.module('HTML5', {
   }
 });
 
+QUnit.test('should be able to set playsinline attribute', function(assert) {
+  assert.expect(2);
+
+  tech.createEl();
+  tech.setPlaysinline(true);
+
+  assert.ok(tech.el().hasAttribute('playsinline'), 'playsinline attribute was added');
+
+  tech.setPlaysinline(false);
+
+  assert.ok(!tech.el().hasAttribute('playsinline'), 'playsinline attribute was removed');
+});
+
 QUnit.test('should detect whether the volume can be changed', function(assert) {
 
   if (!{}.__defineSetter__) {


### PR DESCRIPTION
### Description
Video.js players can accept a number of standard `<video>` element options (`autoplay`, `muted`, `loop`, etc), but not currently `playsinline`, which is now part of the [HTML spec](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-video-playsinline). We should add it to the list of `<video>` attributes that can be provided to the player as options.

### Specific Changes proposed
Update the `Html5` and `Player` classes with getter and setter methods for `playsinline` and make a few other additions to ensure that the `playsinline` option works the same way as the other `<video>` element options.

### Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
