### PR TITLE
Add a version class to the player (v5)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -413,6 +413,11 @@ class Player extends Component {
     // Make player easily findable by ID
     Player.players[this.id_] = this;
 
+    // Add a major version class to aid css in plugins
+    const majorVersion = require('../../package.json').version.split('.')[0];
+
+    this.addClass(`vjs-v${majorVersion}`);
+
     // When the player is first initialized, trigger activity so components
     // like the control bar show themselves if needed
     this.userActive(true);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1387,3 +1387,12 @@ QUnit.test('should not allow to register custom player when any player has been 
   // reset the Player to the original value;
   videojs.registerComponent('Player', Player);
 });
+
+QUnit.test('should add a class with major version', function(assert) {
+  const majorVersion = require('../../package.json').version.split('.')[0];
+  const player = TestHelpers.makePlayer();
+
+  assert.ok(player.hasClass('vjs-v' + majorVersion), 'the version class should be added to the player');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
#4320 for v5.

Adds a version class to the player to simplify CSS for plugins supporting multiple versions. For example to add an icon to a button in v5 you'd target `.my-button:before`, in v6 `.my-button .vjs-icon-placeholder:before`.

## Specific Changes proposed
Adds a class e.g. `vjs-v5` to the player element.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
