### PR TITLE
test: fix playsinline test for IE8

### DIFF
--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -830,32 +830,34 @@ QUnit.test('should restore attributes from the original video tag when creating 
   assert.equal(el.getAttribute('webkit-playsinline'), '', 'webkit-playsinline attribute was set properly');
 });
 
-QUnit.test('player.playsinline() should be able to get/set playsinline attribute', function(assert) {
-  assert.expect(5);
+if (Html5.isSupported()) {
+  QUnit.test('player.playsinline() should be able to get/set playsinline attribute', function(assert) {
+    assert.expect(5);
 
-  const video = document.createElement('video');
-  const player = TestHelpers.makePlayer({techOrder: ['html5']}, video);
+    const video = document.createElement('video');
+    const player = TestHelpers.makePlayer({techOrder: ['html5']}, video);
 
-  // test setter
-  assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline has not yet been added');
+    // test setter
+    assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline has not yet been added');
 
-  player.playsinline(true);
+    player.playsinline(true);
 
-  assert.ok(player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute added');
+    assert.ok(player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute added');
 
-  player.playsinline(false);
+    player.playsinline(false);
 
-  assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute removed');
+    assert.ok(!player.tech_.el().hasAttribute('playsinline'), 'playsinline attribute removed');
 
-  // test getter
-  player.tech_.el().setAttribute('playsinline', 'playsinline');
+    // test getter
+    player.tech_.el().setAttribute('playsinline', 'playsinline');
 
-  assert.ok(player.playsinline(), 'correctly detects playsinline attribute');
+    assert.ok(player.playsinline(), 'correctly detects playsinline attribute');
 
-  player.tech_.el().removeAttribute('playsinline');
+    player.tech_.el().removeAttribute('playsinline');
 
-  assert.ok(!player.playsinline(), 'correctly detects absence of playsinline attribute');
-});
+    assert.ok(!player.playsinline(), 'correctly detects absence of playsinline attribute');
+  });
+}
 
 QUnit.test('if tag exists and movingMediaElementInDOM, re-use the tag', function(assert) {
   // simulate attributes stored from the original tag


### PR DESCRIPTION
This test is more of an integration test and uses the html5 tech to make
sure the setter and getter work properly. This causes issues with IE8
which doesn't work well with the Html5 tech.

Instead, we wrap the test in an if that checks whether Html5 is
supported.