### PR TITLE
fix: TextTrackButton on Safari and iOS

### DIFF
--- a/src/js/control-bar/text-track-controls/text-track-button.js
+++ b/src/js/control-bar/text-track-controls/text-track-button.js
@@ -26,10 +26,6 @@ class TextTrackButton extends TrackButton {
     options.tracks = player.textTracks();
 
     super(player, options);
-
-    if (!Array.isArray(this.kinds_)) {
-      this.kinds_ = [this.kind_];
-    }
   }
 
   /**
@@ -60,6 +56,10 @@ class TextTrackButton extends TrackButton {
     this.hideThreshold_ += 1;
 
     const tracks = this.player_.textTracks();
+
+    if (!Array.isArray(this.kinds_)) {
+      this.kinds_ = [this.kind_];
+    }
 
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];


### PR DESCRIPTION
On Safari and iOS, we use native text tracks, so, during text track
button creation, textTracks() is populated. However, `this.kinds_` isn't
necessarily set and ends up throwing.

Instead, we want to move the fallback for `this.kinds_` from the
constructor and right above the usage of `this.kinds_`.