### PR TITLE
Prevent dupe events on enabled ClickableComponents (v5)

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -147,15 +147,17 @@ class ClickableComponent extends Component {
    *         Returns itself; method can be chained.
    */
   enable() {
-    this.removeClass('vjs-disabled');
-    this.el_.setAttribute('aria-disabled', 'false');
-    if (typeof this.tabIndex_ !== 'undefined') {
-      this.el_.setAttribute('tabIndex', this.tabIndex_);
+    if (!this.enabled_) {
+      this.enabled_ = true;
+      this.removeClass('vjs-disabled');
+      this.el_.setAttribute('aria-disabled', 'false');
+      if (typeof this.tabIndex_ !== 'undefined') {
+        this.el_.setAttribute('tabIndex', this.tabIndex_);
+      }
+      this.on(['tap', 'click'], this.handleClick);
+      this.on('focus', this.handleFocus);
+      this.on('blur', this.handleBlur);
     }
-    this.on('tap', this.handleClick);
-    this.on('click', this.handleClick);
-    this.on('focus', this.handleFocus);
-    this.on('blur', this.handleBlur);
     return this;
   }
 
@@ -166,13 +168,13 @@ class ClickableComponent extends Component {
    *         Returns itself; method can be chained.
    */
   disable() {
+    this.enabled_ = false;
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
     if (typeof this.tabIndex_ !== 'undefined') {
       this.el_.removeAttribute('tabIndex');
     }
-    this.off('tap', this.handleClick);
-    this.off('click', this.handleClick);
+    this.off(['tap', 'click'], this.handleClick);
     this.off('focus', this.handleFocus);
     this.off('blur', this.handleBlur);
     return this;

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -147,17 +147,17 @@ class ClickableComponent extends Component {
    *         Returns itself; method can be chained.
    */
   enable() {
-    if (!this.enabled_) {
-      this.enabled_ = true;
-      this.removeClass('vjs-disabled');
-      this.el_.setAttribute('aria-disabled', 'false');
-      if (typeof this.tabIndex_ !== 'undefined') {
-        this.el_.setAttribute('tabIndex', this.tabIndex_);
-      }
-      this.on(['tap', 'click'], this.handleClick);
-      this.on('focus', this.handleFocus);
-      this.on('blur', this.handleBlur);
+    this.removeClass('vjs-disabled');
+    this.el_.setAttribute('aria-disabled', 'false');
+    if (typeof this.tabIndex_ !== 'undefined') {
+      this.el_.setAttribute('tabIndex', this.tabIndex_);
     }
+    this.off(['tap', 'click'], this.handleClick);
+    this.off('focus', this.handleFocus);
+    this.off('blur', this.handleBlur);
+    this.on(['tap', 'click'], this.handleClick);
+    this.on('focus', this.handleFocus);
+    this.on('blur', this.handleBlur);
     return this;
   }
 
@@ -168,7 +168,6 @@ class ClickableComponent extends Component {
    *         Returns itself; method can be chained.
    */
   disable() {
-    this.enabled_ = false;
     this.addClass('vjs-disabled');
     this.el_.setAttribute('aria-disabled', 'true');
     if (typeof this.tabIndex_ !== 'undefined') {

--- a/test/unit/clickable-component.test.js
+++ b/test/unit/clickable-component.test.js
@@ -71,3 +71,25 @@ QUnit.test('handleClick should not be triggered when disabled', function() {
   testClickableComponent.dispose();
   player.dispose();
 });
+
+QUnit.test('handleClick should not be triggered more than once when enabled', function() {
+  let clicks = 0;
+
+  class TestClickableComponent extends ClickableComponent {
+    handleClick() {
+      clicks++;
+    }
+  }
+
+  const player = TestHelpers.makePlayer({});
+  const testClickableComponent = new TestClickableComponent(player);
+  const el = testClickableComponent.el();
+
+  testClickableComponent.enable();
+  // Click should still be handled just once
+  Events.trigger(el, 'click');
+  QUnit.equal(clicks, 1, 'no additional click handler when already enabled ClickableComponent has been enabled again');
+
+  testClickableComponent.dispose();
+  player.dispose();
+});


### PR DESCRIPTION
## Description
Like #4316 for v6, this prevents multiple click handlers being added if an already enabled component is enabled. In the PR for six, `ClickableComponent` was tracking `this.enabled_`  but this is incompatible with v5 on a `MenuButton` which also changes the state of `this.enabled_`. 

## Specific Changes proposed
Removes event handlers in `enable()` before adding them. 

Do we want the same fix implemented in a different way in 5 and 6 though? 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
