### PR TITLE
Add new v6 buttons to the adaptive stylesheet

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -7,9 +7,9 @@
 
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate, .vjs-progress-control,
-  .vjs-mute-control, .vjs-volume-control,
+  .vjs-mute-control, .vjs-volume-panel,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-audio-button { display: none; }
+  .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
 }
 
 // When the player is x-small, display nothing but:
@@ -19,9 +19,9 @@
 .video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control,
+  .vjs-mute-control, .vjs-volume-panel,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-audio-button { display: none; }
+  .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
 }
 
 
@@ -34,7 +34,7 @@
 .video-js.vjs-layout-small:not(.vjs-fullscreen) {
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control,
+  .vjs-mute-control, .vjs-volume-panel,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button .vjs-audio-button { display: none; }
+  .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
 }


### PR DESCRIPTION
The controlbar elements .vjs-subs-caps-button and .vjs-volume-panel
are new in v6, but had not been added to this CSS file.

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
