### PR TITLE
fix: Update a translation key to match correct string

### DIFF
--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -60,7 +60,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -118,7 +118,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -176,7 +176,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -234,7 +234,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -292,7 +292,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -350,19 +350,12 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
 |                         | End of dialog window.                                                               |
-| de.json (missing 8)     | Audio Player                                                                        |
-|                         | Video Player                                                                        |
-|                         | Progress Bar                                                                        |
-|                         | progress bar timing: currentTime={1} duration={2}                                   |
-|                         | Volume Level                                                                        |
-|                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
-|                         | End of dialog window.                                                               |
+| de.json (Complete)      |                                                                                     |
 | el.json (missing 44)    | Audio Player                                                                        |
 |                         | Video Player                                                                        |
 |                         | Replay                                                                              |
@@ -402,7 +395,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -459,7 +452,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -517,7 +510,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -575,7 +568,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -633,7 +626,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -691,7 +684,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -749,7 +742,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -807,7 +800,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -865,7 +858,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -923,7 +916,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -981,7 +974,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1028,7 +1021,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1086,7 +1079,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1137,7 +1130,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1195,7 +1188,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1238,7 +1231,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1282,7 +1275,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1341,7 +1334,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1399,7 +1392,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1410,7 +1403,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | progress bar timing: currentTime={1} duration={2}                                   |
 |                         | Volume Level                                                                        |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | End of dialog window.                                                               |
 | uk.json (missing 44)    | Audio Player                                                                        |
 |                         | Video Player                                                                        |
@@ -1451,7 +1444,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1494,7 +1487,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1538,7 +1531,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |
@@ -1582,7 +1575,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
 |                         | Reset                                                                               |
-|                         | all settings to the default values                                                  |
+|                         | restore all settings to the default values                                          |
 |                         | Done                                                                                |
 |                         | Caption Settings Dialog                                                             |
 |                         | Beginning of dialog window. Escape will cancel and close the window.                |

--- a/lang/de.json
+++ b/lang/de.json
@@ -70,7 +70,15 @@
   "Casual": "Zwanglos",
   "Script": "Schreibeschrift",
   "Small Caps": "Small-Caps",
+  "Reset": "Zurücksetzen",
+  "restore all settings to the default values": "Alle Einstellungen auf die Standardwerte zurücksetzen",
   "Done": "Fertig",
   "Caption Settings Dialog": "Einstellungsdialog für Untertitel",
-  "Beginning of dialog window. Escape will cancel and close the window.": "Anfang des Dialogfensters. Esc bricht ab und schließt das Fenster."
+  "Beginning of dialog window. Escape will cancel and close the window.": "Anfang des Dialogfensters. Esc bricht ab und schließt das Fenster.",
+  "End of dialog window.": "Ende des Dialogfensters.",
+  "Audio Player": "Audio-Player",
+  "Video Player": "Video-Player",
+  "Progress Bar": "Forschrittsbalken",
+  "progress bar timing: currentTime={1} duration={2}": "{1} von {2}",
+  "Volume Level": "Lautstärkestufe"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -76,7 +76,7 @@
   "Script": "Script",
   "Small Caps": "Small Caps",
   "Reset": "Reset",
-  "all settings to the default values": "all settings to the default values",
+  "restore all settings to the default values": "restore all settings to the default values",
   "Done": "Done",
   "Caption Settings Dialog": "Caption Settings Dialog",
   "Beginning of dialog window. Escape will cancel and close the window.": "Beginning of dialog window. Escape will cancel and close the window.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -76,7 +76,7 @@
   "Script": "Scripte",
   "Small Caps": "Petites capitales",
   "Reset": "Réinitialiser",
-  "all settings to the default values": "tous les paramètres aux valeurs par défaut",
+  "restore all settings to the default values": "Restaurer tous les paramètres aux valeurs par défaut",
   "Done": "Terminé",
   "Caption Settings Dialog": "Boîte de dialogue des paramètres des sous-titres transcrits",
   "Beginning of dialog window. Escape will cancel and close the window.": "Début de la fenêtre de dialogue. La touche d'échappement annulera et fermera la fenêtre.",

--- a/lang/sk.json
+++ b/lang/sk.json
@@ -76,7 +76,7 @@
   "Script": "Písané",
   "Small Caps": "Malé kapitálky",
   "Reset": "Resetovať",
-  "all settings to the default values": "všetky nastavenia na základné hodnoty",
+  "restore all settings to the default values": "všetky nastavenia na základné hodnoty",
   "Done": "Hotovo",
   "Caption Settings Dialog": "Okno nastavení popiskov",
   "Beginning of dialog window. Escape will cancel and close the window.": "Začiatok okna. Klávesa Escape zruší a zavrie okno.",


### PR DESCRIPTION
## Description
The lang files were translating "all settings to the default values" instead of "[restore all settings to the default values](https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track-settings.js#L461)".

## Specific Changes proposed
- Updated the key in all lang files already using it
- Updated the French translation and added some further missing German translations

@h0lysl4y3r the Slovakian translation probably needs an update now.
 
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
