### PR TITLE
fix IE10 issue for disableOthers

### DIFF
--- a/src/js/tracks/audio-track-list.js
+++ b/src/js/tracks/audio-track-list.js
@@ -19,7 +19,7 @@ import document from 'global/document';
  */
 const disableOthers = function(list, track) {
   for (let i = 0; i < list.length; i++) {
-    if (track.id === list[i].id) {
+    if (!Object.keys(list[i]).length || track.id === list[i].id) {
       continue;
     }
     // another audio track is enabled, disable it

--- a/src/js/tracks/video-track-list.js
+++ b/src/js/tracks/video-track-list.js
@@ -18,7 +18,7 @@ import document from 'global/document';
  */
 const disableOthers = function(list, track) {
   for (let i = 0; i < list.length; i++) {
-    if (track.id === list[i].id) {
+    if (!Object.keys(list[i]).length || track.id === list[i].id) {
       continue;
     }
     // another video track is enabled, disable it


### PR DESCRIPTION
## Description
in IE10, the variable list for disableOthers returns "permission denied"
this causes an uncaught exception which breaks the rest of the javascript execution

issue described in #4378 

## Specific Changes proposed
directly invoking list[i].id triggers the permission denied error
however, if an object has all of its properties denied access to, Object.keys returns a length of 0

## Requirements Checklist
- [ x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
