### PR TITLE
Update name of FullscreenToggle in documentation

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -318,7 +318,7 @@ The `children` options can also be passed as an `Object`. In this case, it is us
 videojs('my-player', {
   children: {
     controlBar: {
-      fullscreenControl: false
+      fullscreenToggle: false
     }
   }
 });
@@ -333,7 +333,7 @@ Components can be given custom options via the _lower-camel-case variant of the 
 ```js
 videojs('my-player', {
   controlBar: {
-    fullscreenControl: false
+    fullscreenToggle: false
   }
 });
 ```


### PR DESCRIPTION
## Description
Update to the documentation to fix a broken example: fullscreenToggle is referred to as fullscreenControl. See #4407.