### PR TITLE
Fixing player.remoteTextTracks jsdoc

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3265,7 +3265,7 @@ class Player extends Component {
  * @return {TextTrackList}
  *         The current remote text track list
  *
- * @method Player.prototype.textTracks
+ * @method Player.prototype.remoteTextTracks
  */
 
 /**


### PR DESCRIPTION
## Description
A link was incorrect on the docs site. I believe this will fix it?