### PR TITLE
adjust volume ranges so muted(true) and vol=0 do not use the same icons

### DIFF
--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -83,9 +83,9 @@ class MuteToggle extends Button {
 
     if (this.player_.muted()) {
       level = 0;
-    } else if (vol === 0) {
+    } else if (vol < 0.33) {
       level = 1;
-    } else if (vol > 0 && vol <= 0.5) {
+    } else if (vol < 0.67) {
       level = 2;
     }
 

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -81,11 +81,11 @@ class MuteToggle extends Button {
     const vol = this.player_.volume();
     let level = 3;
 
-    if (vol === 0 || this.player_.muted()) {
+    if (this.player_.muted()) {
       level = 0;
-    } else if (vol < 0.33) {
+    } else if (vol === 0) {
       level = 1;
-    } else if (vol < 0.67) {
+    } else if (vol > 0 && vol <= 0.5) {
       level = 2;
     }
 


### PR DESCRIPTION
## Description
Potential fix for https://github.com/videojs/video.js/issues/4424

## Specific Changes proposed
Change the volume levels used to select the videojs-icon-volume-* classes so muted(true) and volume(0) do not use the same icon.  Fixes an issue where sliding the volume slider to 0 has the appearance of setting muted(true) but toggling the mute-toggle/volumeMenuButton does not restore the volume.  Only setting the volume using the slider removes the muted icon appearance.

## Requirements Checklist
- [ x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
