### PR TITLE
fix: Safari picture-in-picture triggers fullscreenchange

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -430,9 +430,12 @@ class Html5 extends Tech {
     };
 
     const beginFn = function() {
-      this.one('webkitendfullscreen', endFn);
+      if ('webkitPresentationMode' in this.el_ &&
+        this.el_.webkitPresentationMode !== 'picture-in-picture') {
+        this.one('webkitendfullscreen', endFn);
 
-      this.trigger('fullscreenchange', { isFullscreen: true });
+        this.trigger('fullscreenchange', { isFullscreen: true });
+      }
     };
 
     this.on('webkitbeginfullscreen', beginFn);


### PR DESCRIPTION
## Description
When picture-in-picture mode is entered on Safari, `webkitbeginfullscreen` is triggered which results in a proxied `fullscreenchange` event and adding the fullscreen class to the player. That causes the tech element to collapse to zero height so that the "this video is playing in picture in picture" placeholder is not visible. 

## Specific Changes proposed
On `webkitbeginfullscreen` check whether the presentation mode is `picture-in-picture` before proxying a `fullscreenchange` event.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
