### PR TITLE
fix: player.duration() should return NaN if duration is not known

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1747,7 +1747,6 @@ class Player extends Component {
    */
   duration(seconds) {
     if (seconds === undefined) {
-      
       // return NaN if the duration is not known
       return this.cache_.duration !== undefined ? this.cache_.duration : NaN;
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1747,10 +1747,12 @@ class Player extends Component {
    */
   duration(seconds) {
     if (seconds === undefined) {
-      return this.cache_.duration || 0;
+      
+      // return NaN if the duration is not known
+      return this.cache_.duration !== undefined ? this.cache_.duration : NaN;
     }
 
-    seconds = parseFloat(seconds) || 0;
+    seconds = parseFloat(seconds);
 
     // Standardize on Inifity for signaling video is live
     if (seconds < 0) {


### PR DESCRIPTION
## Description
`player.duration()` currently returns 0 if the duration is not known, when it should return `NaN`. The problem is that if `NaN` is passed to `player.duration()` as an argument, [we set the duration to 0](https://github.com/videojs/video.js/blob/5.x/src/js/player.js#L1700). If `player.cache_.duration` was set to `NaN` by other means, `player.duration()` [would still return 0](https://github.com/videojs/video.js/blob/5.x/src/js/player.js#L1697). If approved, this will require a sister PR in the 5.x branch as well.

## Specific Changes proposed
Modify the player `duration()` method so that it will 1.) set the cached duration to `NaN` if it is passed in as an argument, and 2.) return the proper value when called without an argument.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
