### PR TITLE
Use passive event listeners for touchstart/touchmove (5.x)

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -207,17 +207,19 @@ export function fixEvent(event) {
  */
 let _supportsPassive = false;
 
-try {
-  const opts = Object.defineProperty({}, 'passive', {
-    get() {
-      _supportsPassive = true;
-    }
-  });
+(function() {
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get() {
+        _supportsPassive = true;
+      }
+    });
 
-  window.addEventListener('test', null, opts);
-} catch (e) {
-  // disregard
-}
+    window.addEventListener('test', null, opts);
+  } catch (e) {
+    // disregard
+  }
+})();
 
 /**
  * Touch events Chrome expects to be passive

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -220,6 +220,14 @@ try {
 }
 
 /**
+ * Touch events Chrome expects to be passive
+ */
+const passiveEvents = [
+  'touchstart',
+  'touchmove'
+];
+
+/**
  * Add an event listener to element
  * It stores the handler function in a separate cache object
  * and adds a generic handler to the element's event,
@@ -293,7 +301,7 @@ export function on(elem, type, fn) {
       let options = false;
 
       if (_supportsPassive &&
-        ['touchstart', 'touchmove'].indexOf(type) > -1) {
+        passiveEvents.indexOf(type) > -1) {
         options = {passive: true};
       }
       elem.addEventListener(type, data.dispatcher, options);

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -203,6 +203,23 @@ export function fixEvent(event) {
 }
 
 /**
+ * Whether passive event listeners are supported
+ */
+let _supportsPassive = false;
+
+try {
+  const opts = Object.defineProperty({}, 'passive', {
+    get() {
+      _supportsPassive = true;
+    }
+  });
+
+  window.addEventListener('test', null, opts);
+} catch (e) {
+  // disregard
+}
+
+/**
  * Add an event listener to element
  * It stores the handler function in a separate cache object
  * and adds a generic handler to the element's event,
@@ -273,7 +290,13 @@ export function on(elem, type, fn) {
 
   if (data.handlers[type].length === 1) {
     if (elem.addEventListener) {
-      elem.addEventListener(type, data.dispatcher, false);
+      let options = false;
+
+      if (_supportsPassive &&
+        ['touchstart', 'touchmove'].indexOf(type) > -1) {
+        options = {passive: true};
+      }
+      elem.addEventListener(type, data.dispatcher, options);
     } else if (elem.attachEvent) {
       elem.attachEvent('on' + type, data.dispatcher);
     }


### PR DESCRIPTION
## Description
#4440 for 5.x
Not using passive event listeners now causes Chrome to log warnings to the console, and possibly has a performance impact

## Specific Changes proposed
Where supported, use passive event listeners for `touchmove` and `touchstart` 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
