### PR TITLE
refactor: Internal "evented" mixin can better handle changing `el_`s.

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -84,8 +84,8 @@ class Component {
       this.el_ = this.createEl();
     }
 
-    // Make this an evented object and use `el_`, if available, as its event bus
-    evented(this, {eventBusKey: this.el_ ? 'el_' : null});
+    // Make this an evented object and use `el_` as its event bus
+    evented(this, {eventBusKey: options.hasOwnProperty('eventBusKey') ? options.eventBusKey : 'el_'});
     stateful(this, this.constructor.defaultState);
 
     this.children_ = [];
@@ -124,6 +124,7 @@ class Component {
      *           bubble up
      */
     this.trigger({type: 'dispose', bubbles: false});
+    this.off();
 
     // Dispose all children.
     if (this.children_) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -8,7 +8,6 @@ import {version} from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import tsml from 'tsml';
-import evented from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
@@ -373,9 +372,6 @@ class Player extends Component {
     this.scrubbing_ = false;
 
     this.el_ = this.createEl();
-
-    // Make this an evented object and use `el_` as its event bus.
-    evented(this, {eventBusKey: 'el_'});
 
     // We also want to pass the original player options to each component and plugin
     // as well so they don't need to reach back into the player for options later.

--- a/src/js/tech/loader.js
+++ b/src/js/tech/loader.js
@@ -28,7 +28,11 @@ class MediaLoader extends Component {
    */
   constructor(player, options, ready) {
     // MediaLoader has no element
-    const options_ = mergeOptions({createEl: false}, options);
+    const options_ = mergeOptions({
+      createEl: false,
+      eventBusKey: null,
+      reportTouchActivity: false
+    }, options);
 
     super(player, options_, ready);
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -14,6 +14,18 @@ import window from 'global/window';
 import document from 'global/document';
 
 /**
+ * Determine if an object can have listeners attached.
+ *
+ * @param  {Mixed} obj
+ *         An object to inspect.
+ *
+ * @return {boolean}
+ */
+export function canHaveListeners(obj) {
+  return !!(obj && (obj.addEventListener || obj.attachEvent));
+}
+
+/**
  * Clean up the listener cache and dispatchers
  *
  * @param {Element|Object} elem

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -694,10 +694,10 @@ test('When Android Chrome reports Infinity duration with currentTime 0, return N
   browser.IS_ANDROID = true;
   browser.IS_CHROME = true;
 
-  tech.el_ = {
-    duration: Infinity,
-    currentTime: 0
-  };
+  tech.el_ = document.createElement('div');
+  tech.el_.duration = Infinity;
+  tech.el_.currentTime = 0;
+
   ok(Number.isNaN(tech.duration()), 'returned NaN with currentTime 0');
 
   browser.IS_ANDROID = oldIsAndroid;
@@ -716,17 +716,17 @@ QUnit.test('supports getting available media playback quality metrics', function
     totalVideoFrames: 5
   };
 
-  tech.el_ = {
-    getVideoPlaybackQuality: () => videoPlaybackQuality
-  };
+  tech.el_ = document.createElement('div');
+  tech.el_.getVideoPlaybackQuality = () => videoPlaybackQuality;
+
   assert.deepEqual(tech.getVideoPlaybackQuality(),
                    videoPlaybackQuality,
                    'uses native implementation when supported');
 
-  tech.el_ = {
-    webkitDroppedFrameCount: 1,
-    webkitDecodedFrameCount: 2
-  };
+  tech.el_ = document.createElement('div');
+  tech.el_.webkitDroppedFrameCount = 1;
+  tech.el_.webkitDecodedFrameCount = 2;
+
   window.performance = {
     now: () => 4
   };
@@ -734,10 +734,10 @@ QUnit.test('supports getting available media playback quality metrics', function
                    { droppedVideoFrames: 1, totalVideoFrames: 2, creationTime: 4 },
                    'uses webkit prefixed metrics and performance.now when supported');
 
-  tech.el_ = {
-    webkitDroppedFrameCount: 1,
-    webkitDecodedFrameCount: 2
-  };
+  tech.el_ = document.createElement('div');
+  tech.el_.webkitDroppedFrameCount = 1;
+  tech.el_.webkitDecodedFrameCount = 2;
+
   window.Date = {
     now: () => 10
   };
@@ -751,7 +751,7 @@ QUnit.test('supports getting available media playback quality metrics', function
                    'uses webkit prefixed metrics and Date.now() - navigationStart when ' +
                    'supported');
 
-  tech.el_ = {};
+  tech.el_ = document.createElement('div');
   window.performance = void 0;
   assert.deepEqual(tech.getVideoPlaybackQuality(), {}, 'empty object when not supported');
 
@@ -771,11 +771,11 @@ QUnit.test('supports getting available media playback quality metrics', function
                    { creationTime: 7 },
                    'only creation time when it\'s the only piece available');
 
-  tech.el_ = {
-    getVideoPlaybackQuality: () => videoPlaybackQuality,
-    webkitDroppedFrameCount: 1,
-    webkitDecodedFrameCount: 2
-  };
+  tech.el_ = document.createElement('div');
+  tech.el_.getVideoPlaybackQuality = () => videoPlaybackQuality;
+  tech.el_.webkitDroppedFrameCount = 1;
+  tech.el_.webkitDecodedFrameCount = 2;
+
   assert.deepEqual(tech.getVideoPlaybackQuality(),
                    videoPlaybackQuality,
                    'prefers native implementation when supported');


### PR DESCRIPTION
In those rare cases where someone manually overwrites `el_` on a component, current 6.x versions of Video.js will stop emitting events properly for that component because it caches a reference to the `el_` at init time. This refactor causes the evented mixin to cache the _property key_ of the element instead of the element itself and finds that element each time it's needed.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
