### PR TITLE
chore(gh-release): add prerelease flag and find right zip 

### DIFF
--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -18,7 +18,7 @@ var options = {
   owner: 'videojs',
   repo: 'video.js',
   body: currentChangelog(),
-  assets: ['./dist/videojs-'+pkg.version+'.zip'],
+  assets: ['./dist/video-js-'+pkg.version+'.zip'],
   endpoint: 'https://api.github.com',
   auth: {
     username: process.env.VJS_GITHUB_USER,

--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -2,6 +2,17 @@ var ghrelease = require('gh-release');
 var currentChangelog = require('./current-changelog.js');
 var safeParse = require('safe-json-parse/tuple');
 var pkg = require('../package.json')
+var minimist = require('minimist');
+
+var args = minimist(process.argv.slice(2), {
+  boolean: ['prelease'],
+  default: {
+    prelease: false
+  },
+  alias: {
+    p: 'prelease'
+  }
+}
 
 var options = {
   owner: 'videojs',
@@ -18,7 +29,7 @@ var options = {
 var tuple = safeParse(process.env.npm_config_argv);
 var npmargs = tuple[0] ? [] : tuple[1].cooked;
 
-if (npmargs.some(function(arg) { return /next/.test(arg); })) {
+if (args.prerelease || npmargs.some(function(arg) { return /next/.test(arg); })) {
   options.prerelease = true;
 }
 

--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -5,12 +5,12 @@ var pkg = require('../package.json')
 var minimist = require('minimist');
 
 var args = minimist(process.argv.slice(2), {
-  boolean: ['prelease'],
+  boolean: ['prerelease'],
   default: {
-    prelease: false
+    prerelease: false
   },
   alias: {
-    p: 'prelease'
+    p: 'prerelease'
   }
 }
 


### PR DESCRIPTION
Add a `--prerelease` flag so we can run `gh-release.js` manually and mark releases as prerelease.
Also, find the correct zip file.