### PR TITLE
Fix: issue where tracks are disabled and cuepoints are cleared in iOS native player

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -131,7 +131,7 @@ class Html5 extends Tech {
 
         // listen for first 'change' event only while in fullscreen
         if (data.isFullscreen) {
-          const textTracks = myPlayer.textTracks();
+          const textTracks = this.textTracks();
 
           textTracks.one('change', () => {
             for (let i = 0; i < textTracks.length; i++) {
@@ -141,9 +141,9 @@ class Html5 extends Tech {
                 track.mode = 'hidden';
               }
             }
-          })
+          });
         }
-      })
+      });
     }
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -145,7 +145,7 @@ class Html5 extends Tech {
           });
         }
       }
-    }
+    };
 
     // snapshot each metadata track's initial state, and update the snapshot
     // each time there is a track 'change' event

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -162,7 +162,9 @@ class Html5 extends Tech {
           for (let i = 0; i < metadataTracksPreFullscreenState.length; i++) {
             const storedTrack = metadataTracksPreFullscreenState[i];
 
-            storedTrack.track.mode = storedTrack.storedMode;
+            if (storedTrack.track.mode === 'disabled' && storedTrack.track.mode !== storedTrack.storedMode) {
+              storedTrack.track.mode = storedTrack.storedMode;
+            }
           }
         });
       } else {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -166,12 +166,20 @@ class Html5 extends Tech {
     // restore all track modes to their pre-fullscreen state
     this.on('webkitbeginfullscreen', () => {
       textTracks.removeEventListener('change', takeMetadataTrackSnapshot);
+
+      // remove the listener before adding it just in case it wasn't previously removed
+      textTracks.removeEventListener('change', restoreTrackMode);
       textTracks.addEventListener('change', restoreTrackMode);
     });
 
     // start updating the snapshot again after leaving fullscreen
     this.on('webkitendfullscreen', () => {
+      // remove the listener before adding it just in case it wasn't previously removed
+      textTracks.removeEventListener('change', takeMetadataTrackSnapshot);
       textTracks.addEventListener('change', takeMetadataTrackSnapshot);
+
+      // remove the restoreTrackMode handler in case it wasn't triggered during fullscreen playback
+      textTracks.removeEventListener('change', restoreTrackMode);
     });
   }
 


### PR DESCRIPTION
## Description
This PR addresses a behavior in the iOS Safari native player: if a captions text track has its mode set to `showing`, Safari will set the mode of any other present tracks to `disabled`, including metadata tracks. In iOS Safari, specifically, this also unfortunately means that the `cues` and `activeCues` arrays for those disabled tracks are set to `null`. This is a problem for developers who wish to have functional cue points in iOS fullscreen video playback.

## Specific Changes proposed
Add a private `Html5` tech method that snapshots the state of all metadata tracks leading up to a `'fullscreenchange'` event, then retroactively restores the metadata tracks to their pre-fullscreen state after the first track `'change'` event that occurs during native playback. Although it isn't ideal, we are presuming that the first change event will be the one initiated by Safari. The inevitable (but perhaps necessary) downside to this is that it removes the guarantee that all metadata tracks can be programmatically disabled at any point in the video. However, functional cue points in the iOS native player is almost certainly a more important feature to developers/publishers than the guaranteed ability to disable metadata tracks during iOS native playback.