### PR TITLE
fix: only change focus from BPB if not a mouse click

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -19,7 +19,6 @@ class BigPlayButton extends Button {
     this.on('mousedown', this.handleMouseDown);
   }
 
-
   /**
    * Builds the default DOM `className`.
    *

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -11,6 +11,14 @@ import Component from './component.js';
  * @extends Button
  */
 class BigPlayButton extends Button {
+  constructor(player, options) {
+    super(player, options);
+
+    this.mouseused_ = false;
+
+    this.on('mousedown', this.handleMouseDown);
+  }
+
 
   /**
    * Builds the default DOM `className`.
@@ -37,7 +45,7 @@ class BigPlayButton extends Button {
     const playPromise = this.player_.play();
 
     // exit early if clicked via the mouse
-    if (this._mouseused && event.clientX && event.clientY) {
+    if (this.mouseused_ && event.clientX && event.clientY) {
       return;
     }
 
@@ -56,6 +64,16 @@ class BigPlayButton extends Button {
         playToggle.focus();
       }, 1);
     }
+  }
+
+  handleKeyPress(event) {
+    this.mouseused_ = false;
+
+    super.handleKeyPress(event);
+  }
+
+  handleMouseDown(event) {
+    this.mouseused_ = true;
   }
 }
 

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -56,12 +56,13 @@ class BigPlayButton extends Button {
       return;
     }
 
-    if (playPromise) {
-      playPromise.then(() => playToggle.focus());
+    const playFocus = () => playToggle.focus();
+
+    if (playPromise && playPromise.then) {
+      const ignoreRejectedPlayPromise = () => {};
+      playPromise.then(playFocus, ignoreRejectedPlayPromise);
     } else {
-      this.setTimeout(function() {
-        playToggle.focus();
-      }, 1);
+      this.setTimeout(playFocus, 1);
     }
   }
 

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -36,6 +36,11 @@ class BigPlayButton extends Button {
   handleClick(event) {
     const playPromise = this.player_.play();
 
+    // exit early if clicked via the mouse
+    if (!this._keypressed) {
+      return;
+    }
+
     const cb = this.player_.getChild('controlBar');
     const playToggle = cb && cb.getChild('playToggle');
 

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -60,6 +60,7 @@ class BigPlayButton extends Button {
 
     if (playPromise && playPromise.then) {
       const ignoreRejectedPlayPromise = () => {};
+
       playPromise.then(playFocus, ignoreRejectedPlayPromise);
     } else {
       this.setTimeout(playFocus, 1);

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -37,7 +37,7 @@ class BigPlayButton extends Button {
     const playPromise = this.player_.play();
 
     // exit early if clicked via the mouse
-    if (!this._keypressed) {
+    if (this._mouseused && event.clientX && event.clientY) {
       return;
     }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -12,14 +12,6 @@ import {assign} from './utils/obj';
  * @extends ClickableComponent
  */
 class Button extends ClickableComponent {
-  constructor(player, options) {
-    super(player, options);
-
-    this._mouseused = false;
-
-    this.on('mousedown', this.handleMouseDown);
-  }
-
   /**
    * Create the `Button`s DOM element.
    *
@@ -114,8 +106,6 @@ class Button extends ClickableComponent {
    * @listens keydown
    */
   handleKeyPress(event) {
-    this._mouseused = false;
-
     // Ignore Space (32) or Enter (13) key operation, which is handled by the browser for a button.
     if (event.which === 32 || event.which === 13) {
       return;
@@ -123,10 +113,6 @@ class Button extends ClickableComponent {
 
     // Pass keypress handling up for unsupported keys
     super.handleKeyPress(event);
-  }
-
-  handleMouseDown(event) {
-    this._mouseused = true;
   }
 }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -12,6 +12,13 @@ import {assign} from './utils/obj';
  * @extends ClickableComponent
  */
 class Button extends ClickableComponent {
+  constructor(player, options) {
+    super(player, options);
+
+    this._keypressed = false;
+
+    this.on('mousedown', this.handleMouseDown);
+  }
 
   /**
    * Create the `Button`s DOM element.
@@ -107,6 +114,7 @@ class Button extends ClickableComponent {
    * @listens keydown
    */
   handleKeyPress(event) {
+    this._keypressed = true;
 
     // Ignore Space (32) or Enter (13) key operation, which is handled by the browser for a button.
     if (event.which === 32 || event.which === 13) {
@@ -115,6 +123,10 @@ class Button extends ClickableComponent {
 
     // Pass keypress handling up for unsupported keys
     super.handleKeyPress(event);
+  }
+
+  handleMouseDown(event) {
+    this._keypressed = false;
   }
 }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -15,7 +15,7 @@ class Button extends ClickableComponent {
   constructor(player, options) {
     super(player, options);
 
-    this._keypressed = false;
+    this._mouseused = false;
 
     this.on('mousedown', this.handleMouseDown);
   }
@@ -114,7 +114,7 @@ class Button extends ClickableComponent {
    * @listens keydown
    */
   handleKeyPress(event) {
-    this._keypressed = true;
+    this._mouseused = false;
 
     // Ignore Space (32) or Enter (13) key operation, which is handled by the browser for a button.
     if (event.which === 32 || event.which === 13) {
@@ -126,7 +126,7 @@ class Button extends ClickableComponent {
   }
 
   handleMouseDown(event) {
-    this._keypressed = false;
+    this._mouseused = true;
   }
 }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -12,6 +12,7 @@ import {assign} from './utils/obj';
  * @extends ClickableComponent
  */
 class Button extends ClickableComponent {
+
   /**
    * Create the `Button`s DOM element.
    *
@@ -106,6 +107,7 @@ class Button extends ClickableComponent {
    * @listens keydown
    */
   handleKeyPress(event) {
+
     // Ignore Space (32) or Enter (13) key operation, which is handled by the browser for a button.
     if (event.which === 32 || event.which === 13) {
       return;


### PR DESCRIPTION
This is a simple change to not change the focus to the play toggle from the Big Play Button when clicking on it with the mouse.
There's still work to be done with regards to the focus ring and mouse vs key events but that's for another time and would probably be more involved.

We cancel out focus changing if the mouse was used to click the button, or, as far as we could tell via the `mousedown` handler. Unfortunately, using VoiceOver's functionality (via control-option space), we also get a `mousedown` event. However, those events do not add `clientX` and `clientY` to the `click` event like a true mouse event does.