### PR TITLE
fix: remove 'use strict' from rollup because vttjs isn't strict

### DIFF
--- a/build/rollup.js
+++ b/build/rollup.js
@@ -71,6 +71,7 @@ const es = {
     legacy: true
   },
   banner: compiledLicense(Object.assign({includesVtt: true}, bannerData)),
+  useStrict: false,
   format: 'es',
   dest: 'dist/video.es.js'
 };
@@ -94,6 +95,7 @@ const umd = {
     legacy: true
   },
   banner: compiledLicense(Object.assign({includesVtt: true}, bannerData)),
+  useStrict: false,
   format: 'umd',
   dest: 'dist/video.js'
 };
@@ -134,10 +136,11 @@ const minifiedNovttUmd = Object.assign({}, _.cloneDeep(minifiedUmd), {
 
 minifiedNovttUmd.options.plugins.unshift(ignore(['videojs-vtt.js']));
 
-function runRollup({options, format, dest, banner}) {
+function runRollup({options, useStrict, format, dest, banner}) {
   rollup(options)
   .then(function(bundle) {
     bundle.write({
+      useStrict,
       format,
       dest,
       banner,
@@ -161,7 +164,7 @@ if (!args.watch) {
     runRollup(novttUmd);
   }
 } else {
-  const props = ['format', 'dest', 'banner'];
+  const props = ['format', 'dest', 'banner', 'useStrict'];
   const watchers = [
     ['es', watch({rollup},
                  Object.assign({},


### PR DESCRIPTION
When https://github.com/videojs/vtt.js/issues/15 is fixed, this should be reverted.