### PR TITLE
chore: improve dev and beginner experience

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -466,7 +466,7 @@ module.exports = function(grunt) {
         }
       },
       babel: {
-        command: 'npm run babel -- --watch',
+        command: 'npm run babel -- --watch --quiet',
         options: {
           preferLocal: true
         }

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -575,7 +575,7 @@ module.exports = function(grunt) {
   });
 
   // Run while developing
-  grunt.registerTask('dev', ['connect:dev', 'concurrent:dev']);
+  grunt.registerTask('dev', ['sandbox', 'connect:dev', 'concurrent:dev']);
   grunt.registerTask('watchAll', ['build', 'connect:dev', 'concurrent:watchAll']);
   grunt.registerTask('test-a11y', ['copy:a11y', 'accessibility']);
 

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -26,6 +26,10 @@ const args = minimist(process.argv.slice(2), {
   }
 });
 
+if (args.watch) {
+  args.progress = false;
+}
+
 const compiledLicense = _.template(fs.readFileSync('./build/license-header.txt', 'utf8'));
 const bannerData = _.pick(pkg, ['version', 'copyright']);
 

--- a/build/tasks/sandbox.js
+++ b/build/tasks/sandbox.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const klawSync = require('klaw-sync');
+
+module.exports = function(grunt) {
+  grunt.registerTask('sandbox', 'copy over sandbox example files if necessary', function() {
+    const files = klawSync('sandbox/').filter((file) => path.extname(file.path) === '.example');
+
+    const changes = files.map(function(file) {
+      const p = path.parse(file.path);
+      const nonExample = path.join(p.dir, p.name);
+      return {
+        file: file.path,
+        copy: nonExample
+      };
+    })
+    .filter(function(change) {
+      return !fs.existsSync(change.copy);
+    });
+
+    changes.forEach(function(change) {
+      grunt.file.copy(change.file, change.copy);
+    });
+
+    if (changes.length) {
+      grunt.log.writeln("Updated Sandbox files for:");
+      grunt.log.writeln('\t' + changes.map((chg) => chg.copy).join('\n\t'));
+    } else {
+      grunt.log.writeln("No sandbox updates necessary");
+    }
+
+  });
+};


### PR DESCRIPTION
Makes the output of dev rollup and babel watch more quiet.
Add a task to copy .example files over to non .example files if the non .example files are *not* present.