### PR TITLE
Fix playback rate default text

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -44,7 +44,7 @@ class PlaybackRateMenuButton extends MenuButton {
 
     this.labelEl_ = Dom.createEl('div', {
       className: 'vjs-playback-rate-value',
-      innerHTML: 1.0
+      innerHTML: '1x'
     });
 
     el.appendChild(this.labelEl_);


### PR DESCRIPTION
## Description
Bug: the playback rate default value was missing the "x".

## Specific Changes proposed
Changed the default value from "1", to "1x", to behave the same as when it is after you chose a rate.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors