### PR TITLE
Update playback rate menu for the new player layout

### DIFF
--- a/src/css/components/_playback-rate.scss
+++ b/src/css/components/_playback-rate.scss
@@ -10,12 +10,14 @@
 
 .vjs-playback-rate .vjs-playback-rate-value {
   pointer-events: none;
-  font-size: 1.5em;
-  line-height: 2;
+  font-size: 1em;
+  line-height: 3em;
   text-align: center;
 }
 
 .vjs-playback-rate .vjs-menu {
   width: 4em;
   left: 0em;
+
+  li { font-size: 1em; }
 }


### PR DESCRIPTION
## Description
Bug: the font-size and line-height were not following the new player layout.

## Specific Changes proposed
Change both the rate value and the menu to use the new player layout with font-size of 1.0em and line-height of 3.0em.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
