### PR TITLE
fix width and height of cc button

### DIFF
--- a/src/css/components/_button.scss
+++ b/src/css/components/_button.scss
@@ -1,10 +1,12 @@
 .video-js button {
-  background: none;
-  border: none;
-  color: inherit;
   display: inline-block;
-
   overflow: visible; // IE8
+  border: none;
+  width: 100%;
+  height: 100%;
+  background: none;
+  color: inherit;
+
   font-size: inherit; // IE in general. WTF.
   line-height: inherit;
   text-transform: none;


### PR DESCRIPTION
add as proposed 100% width and height and reorder css properties according to https://css-tricks.com/poll-results-how-do-you-order-your-css-properties/ fixies issue #4547

## Description
Bug fix of issue #4547
Add width 100% and height 100%
also change styles order in button.scss as in https://css-tricks.com/poll-results-how-do-you-order-your-css-properties/

Issue:
https://github.com/videojs/video.js/issues/4547

## Requirements Checklist
- [ 1] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ 1] Change has been verified in an actual browser (Chome, Firefox, IE) 
  Tested in Chrome and Firefox
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
