### PR TITLE
fix: rely on browser or tech to handle autoplay

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1076,7 +1076,6 @@ class Player extends Component {
       } catch (e) {
         log('deleting tag.poster throws in some browsers', e);
       }
-      this.play();
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2363,10 +2363,6 @@ class Player extends Component {
         this.load();
       }
 
-      if (this.options_.autoplay) {
-        this.play();
-      }
-
     // Set the source synchronously if possible (#2326)
     }, true);
 


### PR DESCRIPTION
## Description
When setting the source, we were calling `play` if `autoplay` was set. We shouldn't do that and instead we should rely on the browser or tech (like Flash) to handle it properly.
I'm unsure whether this should be a `fix` or a `feat`, thoughts?

There are two more places that we should consider removing but they are probably OK because they're specific/bug fixes rather than general "if autoplay, call play" kind of deals.
There's one in `enterFullscreen` on the html5 tech, which should only be called on iOS devices.
https://github.com/videojs/video.js/blob/fe63992bd1e0d6e4eb7783584bce17c2796c4a2c/src/js/tech/html5.js#L548-L557

In the player, in `handleTechReady_`, there's another call to `play`, which is a fix for older chrome and older safari. This one seems more of a candidate for removal than the html5 one above.
https://github.com/videojs/video.js/blob/fe63992bd1e0d6e4eb7783584bce17c2796c4a2c/src/js/player.js#L1068-L1079

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
