### PR TITLE
improvement: PlayProgressBar Smooth Transition

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -57,7 +57,7 @@ class SeekBar extends Slider {
       }, UPDATE_REFRESH_INTERVAL);
     });
 
-    this.on(player, ['ended', 'pause', 'waiting', 'stalled'], () => {
+    this.on(player, ['ended', 'pause', 'waiting'], () => {
       this.clearInterval(this.updateInterval);
     });
 


### PR DESCRIPTION
Instead of tying the play progress update lifecycle to the timeupdate
event, the update happens every 15ms. This makes it so the play progress
transitions smoothly.

Fixes #4526

## Description

Here's a video!

https://www.useloom.com/share/d578023adf3545e8b97a065d22d2ea92

## Specific Changes proposed

Instead of relying on the `timeupdate` event exclusively to update the play progress bar, we set an interval on `play` and clear this interval on `pause` and `ended`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
