### PR TITLE
fix: issue where changing focus is causing unwanted scrolling behavior on iOS

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -343,7 +343,7 @@ class MenuButton extends Component {
 
       // set the focus into the submenu, except on iOS where it is resulting in
       // undesired scrolling behavior when the player is in an iframe
-      if (!IS_IOS) {
+      if (!IS_IOS && !Dom.isPlayerInFrame()) {
         this.menu.focus();
       }
     }

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -343,7 +343,7 @@ class MenuButton extends Component {
 
       // set the focus into the submenu, except on iOS where it is resulting in
       // undesired scrolling behavior when the player is in an iframe
-      if (!IS_IOS && !Dom.isPlayerInFrame()) {
+      if (!IS_IOS && !Dom.isInFrame()) {
         this.menu.focus();
       }
     }

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -8,6 +8,7 @@ import * as Dom from '../utils/dom.js';
 import * as Fn from '../utils/fn.js';
 import * as Events from '../utils/events.js';
 import toTitleCase from '../utils/to-title-case.js';
+import IS_IOS from '../utils/browser.js';
 import document from 'global/document';
 
 /**
@@ -339,8 +340,12 @@ class MenuButton extends Component {
       this.buttonPressed_ = true;
       this.menu.lockShowing();
       this.menuButton_.el_.setAttribute('aria-expanded', 'true');
-      // set the focus into the submenu
-      this.menu.focus();
+
+      // set the focus into the submenu, except on iOS where it is resulting in
+      // undesired scrolling behavior when the player is in an iframe
+      if (!IS_IOS) {
+        this.menu.focus();
+      }
     }
   }
 

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -8,7 +8,7 @@ import * as Dom from '../utils/dom.js';
 import * as Fn from '../utils/fn.js';
 import * as Events from '../utils/events.js';
 import toTitleCase from '../utils/to-title-case.js';
-import IS_IOS from '../utils/browser.js';
+import { IS_IOS } from '../utils/browser.js';
 import document from 'global/document';
 
 /**

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -86,6 +86,23 @@ export function isEl(value) {
 }
 
 /**
+ * Determines if the player is embedded in an iframe.
+ *
+ * @return {boolean}
+ *
+ */
+export function isPlayerInFrame() {
+
+  // We need a try/catch here because Safari will throw errors when attempting
+  // to get either `parent` or `self`
+  try {
+    return window.parent !== window.self;
+  } catch (x) {
+    return true;
+  }
+}
+
+/**
  * Creates functions to query the DOM using a given method.
  *
  * @param {string} method

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -86,12 +86,12 @@ export function isEl(value) {
 }
 
 /**
- * Determines if the player is embedded in an iframe.
+ * Determines if the current DOM is embedded in an iframe.
  *
  * @return {boolean}
  *
  */
-export function isPlayerInFrame() {
+export function isInFrame() {
 
   // We need a try/catch here because Safari will throw errors when attempting
   // to get either `parent` or `self`


### PR DESCRIPTION
## Description
Changing focus to a sub-menu (ex. by tapping the captions menu button) when a player is embedded in an iframe is resulting in unwanted scrolling behavior on iOS. @gkatsev is planning to refactor all focus handling soon, but this will serve as a temporary fix in the meantime. 

## Specific Additions
Modify the MenuButton `pressButton()` method to only change focus to a sub-menu on platforms other than iOS