### PR TITLE
fix: reset to a play/pause button when seeking after ended

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -74,21 +74,11 @@ class PlayToggle extends Button {
       return;
     }
 
-    // if it has set us back to a play/pause button
-    // depending on the current state
+    // remove the ended class
     this.removeClass('vjs-ended');
 
-    if (this.player_.paused()) {
-      if (!this.hasClass('vjs-paused')) {
-        this.addClass('vjs-paused');
-      }
-      this.controlText('Pause');
-    } else {
-      if (!this.hasClass('vjs-playing')) {
-        this.addClass('vjs-playing');
-      }
-      this.controlText('Play');
-    }
+    // and set us back to showing the play button
+    this.handlePause(event);
   }
 
   /**
@@ -102,7 +92,10 @@ class PlayToggle extends Button {
   handlePlay(event) {
     this.removeClass('vjs-ended');
     this.removeClass('vjs-paused');
-    this.addClass('vjs-playing');
+
+    if (!this.hasClass('vjs-playing')) {
+      this.addClass('vjs-playing');
+    }
     // change the button text to "Pause"
     this.controlText('Pause');
   }
@@ -117,7 +110,10 @@ class PlayToggle extends Button {
    */
   handlePause(event) {
     this.removeClass('vjs-playing');
-    this.addClass('vjs-paused');
+
+    if (!this.hasClass('vjs-paused')) {
+      this.addClass('vjs-paused');
+    }
     // change the button text to "Play"
     this.controlText('Play');
   }
@@ -128,7 +124,10 @@ class PlayToggle extends Button {
    */
   handleEnded(event) {
     this.removeClass('vjs-playing');
-    this.addClass('vjs-ended');
+
+    if (!this.hasClass('vjs-ended')) {
+      this.addClass('vjs-ended');
+    }
     // change the button text to "Replay"
     this.controlText('Replay');
   }

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -26,7 +26,6 @@ class PlayToggle extends Button {
     this.on(player, 'play', this.handlePlay);
     this.on(player, 'pause', this.handlePause);
     this.on(player, 'ended', this.handleEnded);
-    this.on(player, 'seeked', this.handleSeeked);
   }
 
   /**
@@ -59,9 +58,8 @@ class PlayToggle extends Button {
   }
 
   /**
-   * This gets called whenever the player seeks. We want to change the replay button
-   * back to a play/pause button on any seek because you cannot seek to the very end
-   * of a video
+   * This gets called once after the video has ended and the user seeks so that
+   * we can change the replay button back to a play button.
    *
    * @param {EventTarget~Event} [event]
    *        The event that caused this function to run.
@@ -69,11 +67,6 @@ class PlayToggle extends Button {
    * @listens Player#seeked
    */
   handleSeeked(event) {
-    // check to see if the video has ended yet
-    if (!this.hasClass('vjs-ended')) {
-      return;
-    }
-
     // remove the ended class
     this.removeClass('vjs-ended');
 
@@ -121,6 +114,10 @@ class PlayToggle extends Button {
   /**
    * Add the vjs-ended class to the element so it can change appearance
    *
+   * @param {EventTarget~Event} [event]
+   *        The event that caused this function to run.
+   *
+   * @listens Player#ended
    */
   handleEnded(event) {
     this.removeClass('vjs-playing');
@@ -130,6 +127,8 @@ class PlayToggle extends Button {
     }
     // change the button text to "Replay"
     this.controlText('Replay');
+
+    this.one(this.player_, 'seeked', this.handleSeeked);
   }
 }
 

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -26,6 +26,7 @@ class PlayToggle extends Button {
     this.on(player, 'play', this.handlePlay);
     this.on(player, 'pause', this.handlePause);
     this.on(player, 'ended', this.handleEnded);
+    this.on(player, 'seeked', this.handleSeeked);
   }
 
   /**
@@ -54,6 +55,39 @@ class PlayToggle extends Button {
       this.player_.play();
     } else {
       this.player_.pause();
+    }
+  }
+
+  /**
+   * This gets called whenever the player seeks. We want to change the replay button
+   * back to a play/pause button on any seek because you cannot seek to the very end
+   * of a video
+   *
+   * @param {EventTarget~Event} [event]
+   *        The event that caused this function to run.
+   *
+   * @listens Player#seeked
+   */
+  handleSeeked(event) {
+    // check to see if the video has ended yet
+    if (!this.hasClass('vjs-ended')) {
+      return;
+    }
+
+    // if it has set us back to a play/pause button
+    // depending on the current state
+    this.removeClass('vjs-ended');
+
+    if (this.player_.paused()) {
+      if (!this.hasClass('vjs-paused')) {
+        this.addClass('vjs-paused');
+      }
+      this.controlText('Pause');
+    } else {
+      if (!this.hasClass('vjs-playing')) {
+        this.addClass('vjs-playing');
+      }
+      this.controlText('Play');
     }
   }
 

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -70,8 +70,11 @@ class PlayToggle extends Button {
     // remove the ended class
     this.removeClass('vjs-ended');
 
-    // and set us back to showing the play button
-    this.handlePause(event);
+    if (this.player_.paused()) {
+      this.handlePause(event);
+    } else {
+      this.handlePlay(event);
+    }
   }
 
   /**
@@ -83,12 +86,8 @@ class PlayToggle extends Button {
    * @listens Player#play
    */
   handlePlay(event) {
-    this.removeClass('vjs-ended');
     this.removeClass('vjs-paused');
-
-    if (!this.hasClass('vjs-playing')) {
-      this.addClass('vjs-playing');
-    }
+    this.addClass('vjs-playing');
     // change the button text to "Pause"
     this.controlText('Pause');
   }
@@ -103,10 +102,7 @@ class PlayToggle extends Button {
    */
   handlePause(event) {
     this.removeClass('vjs-playing');
-
-    if (!this.hasClass('vjs-paused')) {
-      this.addClass('vjs-paused');
-    }
+    this.addClass('vjs-paused');
     // change the button text to "Play"
     this.controlText('Play');
   }
@@ -121,13 +117,11 @@ class PlayToggle extends Button {
    */
   handleEnded(event) {
     this.removeClass('vjs-playing');
-
-    if (!this.hasClass('vjs-ended')) {
-      this.addClass('vjs-ended');
-    }
+    this.addClass('vjs-ended');
     // change the button text to "Replay"
     this.controlText('Replay');
 
+    // on the next seek remove the replay button
     this.one(this.player_, 'seeked', this.handleSeeked);
   }
 }


### PR DESCRIPTION
## Description
When seeking backwards after the video has ended, the `vjs-ended` class will remain on the video until play is pushed. This means the the play button will still show as a replay button, which seems incorrect to me.

## Specific Changes proposed
This PR removes `vjs-ended` on any `seeked` event on the player and resets the button into a play/pause state depending upon the player state.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
