### PR TITLE
ignore: alias rollup-dev to watch for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "rollup": "babel-node build/rollup.js",
     "rollup-minify": "babel-node build/rollup.js --minify",
     "rollup-dev": "babel-node build/rollup.js --watch",
+    "watch": "npm run rollup-dev",
     "assets": "node build/assets.js",
     "change": "grunt chg-add",
     "clean": "grunt clean",


### PR DESCRIPTION
## Description
Most of our other projects have a watch command (rebuild on change, but no dev server). This PR simply adds an alias for a command that already exists so that their is a common command.