### PR TITLE
feat: add remainingTimeDisplay method

### DIFF
--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -49,7 +49,7 @@ class RemainingTimeDisplay extends TimeDisplay {
       return;
     }
 
-    this.updateFormattedTime_(this.player_.remainingTime());
+    this.updateFormattedTime_(this.player_.remainingTimeDisplay());
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1787,6 +1787,17 @@ class Player extends Component {
     return this.duration() - this.currentTime();
   }
 
+  /**
+   * A remaining time function that is intented to be used when
+   * the time is to be displayed directly to the user.
+   *
+   * @return {number}
+   *         The rounded time remaining in seconds
+   */
+  remainingTimeDisplay() {
+    return Math.floor(this.duration()) - Math.floor(this.currentTime());
+  }
+
   //
   // Kind of like an array of portions of the video that have been downloaded.
 


### PR DESCRIPTION
## Description
Allow remainingTime to be given a rounding function during use. Add a function which should be used as the default when displaying remaining time.

Fixes #4608 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
