### PR TITLE
fix typo in plugins guide

### DIFF
--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -251,7 +251,7 @@ class Advanced extends Plugin {
   }
 
   updateState() {
-    this.setState({playing: !player.paused()});
+    this.setState({playing: !this.paused()});
   }
 
   logState(changed) {

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -251,7 +251,7 @@ class Advanced extends Plugin {
   }
 
   updateState() {
-    this.setState({playing: !this.paused()});
+    this.setState({playing: !this.player.paused()});
   }
 
   logState(changed) {


### PR DESCRIPTION
Based on the docs it should be `this` instead of `player`.

vjsstandard also found issue in my plugin:

```
/home/foo/projects/videojs-wavesurfer/src/videojs.wavesurfer.js:30:30: "player" is not defined.
```
