### PR TITLE
Feat/ended display time

### DIFF
--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -12,6 +12,20 @@ import Component from '../../component.js';
 class CurrentTimeDisplay extends TimeDisplay {
 
   /**
+   * Creates an instance of this class.
+   *
+   * @param {Player} player
+   *        The `Player` that this class should be attached to.
+   *
+   * @param {Object} [options]
+   *        The key/value store of player options.
+   */
+  constructor(player, options) {
+    super(player, options);
+    this.on(player, 'ended', this.handleEnded);
+  }
+
+  /**
    * Builds the default DOM `className`.
    *
    * @return {string}
@@ -34,6 +48,23 @@ class CurrentTimeDisplay extends TimeDisplay {
     const time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();
 
     this.updateFormattedTime_(time);
+  }
+
+  /**
+   * When the player fires ended there should be no time left. Sadly
+   * this is not always the case, lets make it seem like that is the case
+   * for users.
+   *
+   * @param {EventTarget~Event} [event]
+   *        The `ended` event that caused this to run.
+   *
+   * @listens Player#ended
+   */
+  handleEnded(event) {
+    if (!this.player_.duration()) {
+      return;
+    }
+    this.updateFormattedTime_(this.player.duration());
   }
 
 }

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -22,6 +22,7 @@ class RemainingTimeDisplay extends TimeDisplay {
   constructor(player, options) {
     super(player, options);
     this.on(player, 'durationchange', this.throttledUpdateContent);
+    this.on(player, 'ended', this.handleEnded);
   }
 
   /**
@@ -49,6 +50,23 @@ class RemainingTimeDisplay extends TimeDisplay {
     }
 
     this.updateFormattedTime_(this.player_.remainingTime());
+  }
+
+  /**
+   * When the player fires ended there should be no time left. Sadly
+   * this is not always the case, lets make it seem like that is the case
+   * for users.
+   *
+   * @param {EventTarget~Event} [event]
+   *        The `ended` event that caused this to run.
+   *
+   * @listens Player#ended
+   */
+  handleEnded(event) {
+    if (!this.player_.duration()) {
+      return;
+    }
+    this.updateFormattedTime_(0);
   }
 }
 


### PR DESCRIPTION
## Description
Sometimes ended fires before we hit the video duration. This can cause the remaining time display and the duration display to show that their is still a second of video left, when there isn't. Instead we should display 0 for remainingTime and the video duration for currentTime when ended fires. 

Based on #4633 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)