### PR TITLE
fix: don't throttle duration change updates

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1239,7 +1239,9 @@ class Component {
     fn = Fn.bind(this, fn);
 
     const timeoutId = window.setTimeout(fn, timeout);
-    const disposeFn = () => this.clearTimeout(timeoutId);
+    const disposeFn = function() {
+      this.clearTimeout(timeoutId);
+    };
 
     disposeFn.guid = `vjs-timeout-${timeoutId}`;
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1239,9 +1239,7 @@ class Component {
     fn = Fn.bind(this, fn);
 
     const timeoutId = window.setTimeout(fn, timeout);
-    const disposeFn = function() {
-      this.clearTimeout(timeoutId);
-    };
+    const disposeFn = () => this.clearTimeout(timeoutId);
 
     disposeFn.guid = `vjs-timeout-${timeoutId}`;
 
@@ -1302,9 +1300,7 @@ class Component {
 
     const intervalId = window.setInterval(fn, interval);
 
-    const disposeFn = function() {
-      this.clearInterval(intervalId);
-    };
+    const disposeFn = () => this.clearInterval(intervalId);
 
     disposeFn.guid = `vjs-interval-${intervalId}`;
 

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1239,9 +1239,7 @@ class Component {
     fn = Fn.bind(this, fn);
 
     const timeoutId = window.setTimeout(fn, timeout);
-    const disposeFn = function() {
-      this.clearTimeout(timeoutId);
-    };
+    const disposeFn = () => this.clearTimeout(timeoutId);
 
     disposeFn.guid = `vjs-timeout-${timeoutId}`;
 

--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -23,14 +23,15 @@ class DurationDisplay extends TimeDisplay {
   constructor(player, options) {
     super(player, options);
 
-    this.on(player, [
-      'durationchange',
+    // we do not want to/need to throttle duration changes,
+    // as they should always display the changed duration as
+    // it has changed
+    this.on(player, 'durationchange', this.updateContent);
 
-      // Also listen for timeupdate (in the parent) and loadedmetadata because removing those
-      // listeners could have broken dependent applications/libraries. These
-      // can likely be removed for 7.0.
-      'loadedmetadata'
-    ], this.throttledUpdateContent);
+    // Also listen for timeupdate (in the parent) and loadedmetadata because removing those
+    // listeners could have broken dependent applications/libraries. These
+    // can likely be removed for 7.0.
+    this.on(player, 'loadedmetadata', this.throttledUpdateContent);
   }
 
   /**

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -48,7 +48,7 @@ class TimeDisplay extends Component {
       'aria-live': 'off'
     }, Dom.createEl('span', {
       className: 'vjs-control-text',
-      textContent: this.localize(this.contentText_)
+      textContent: this.localize(this.controlText_)
     }));
 
     this.updateTextNode_();
@@ -63,7 +63,7 @@ class TimeDisplay extends Component {
    * @private
    */
   updateTextNode_() {
-    if (this.textNode_) {
+    if (this.textNode_ && this.contentEl_ && this.contentEl_.contains(this.textNode_)) {
       this.contentEl_.removeChild(this.textNode_);
     }
     this.textNode_ = document.createTextNode(this.formattedTime_ || '0:00');

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -67,10 +67,10 @@ class TimeDisplay extends Component {
       return;
     }
 
-    // ie8/9 don't support `el.contains` inside of setTimeout call.
-    if (this.textNode_ && this.textNode_.parentNode === this.contentEl_) {
-      this.contentEl_.removeChild(this.textNode_);
+    while (this.contentEl_.firstChild) {
+      this.contentEl_.removeChild(this.contentEl_.firstChild);
     }
+
     this.textNode_ = document.createTextNode(this.formattedTime_ || '0:00');
     this.contentEl_.appendChild(this.textNode_);
   }

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -67,7 +67,7 @@ class TimeDisplay extends Component {
       return;
     }
 
-    if (this.textNode_ && this.contentEl_.contains(this.textNode_)) {
+    if (this.textNode_ && this.textNode_.parentNode === this.contentEl_) {
       this.contentEl_.removeChild(this.textNode_);
     }
     this.textNode_ = document.createTextNode(this.formattedTime_ || '0:00');

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -106,7 +106,7 @@ class TimeDisplay extends Component {
     }
 
     this.formattedTime_ = formattedTime;
-    this.requestAnimationFrame(() => this.updateTextNode_());
+    this.requestAnimationFrame(this.updateTextNode_);
   }
 
   /**

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -67,6 +67,7 @@ class TimeDisplay extends Component {
       return;
     }
 
+    // ie8/9 don't support `el.contains` inside of setTimeout call.
     if (this.textNode_ && this.textNode_.parentNode === this.contentEl_) {
       this.contentEl_.removeChild(this.textNode_);
     }

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -63,7 +63,11 @@ class TimeDisplay extends Component {
    * @private
    */
   updateTextNode_() {
-    if (this.textNode_ && this.contentEl_ && this.contentEl_.contains(this.textNode_)) {
+    if (!this.contentEl_) {
+      return;
+    }
+
+    if (this.textNode_ && this.contentEl_.contains(this.textNode_)) {
       this.contentEl_.removeChild(this.textNode_);
     }
     this.textNode_ = document.createTextNode(this.formattedTime_ || '0:00');
@@ -102,7 +106,7 @@ class TimeDisplay extends Component {
     }
 
     this.formattedTime_ = formattedTime;
-    this.requestAnimationFrame(this.updateTextNode_);
+    this.requestAnimationFrame(() => this.updateTextNode_());
   }
 
   /**


### PR DESCRIPTION
## Description
Right now the `durationchange` event is throttled with the other two events, `timeupdate` and `loadedmetadata`. This means that only one of those events will trigger an update if they all occur within 25ms of each other. 

This functionality makes sense for `timeupdate` or `loadedmetadata` as those should not indicate a time update (even though they often do). 

For `durationchange` however it will always indicate a change in the duration, and we want to always update the display when it happens. Here is a scenario of how we could show duration incorrectly right now:

User is playing a video that has a postroll ad at the end. After the postroll ad their will be a `timeupdate`, and then a `durationchange` to signify that we are back in content. Then `ended` will fire, and no more events will happen.

The player will still show the duration of the ad, as the `durationchange` was eaten by the `timeupdate` that happened at nearly the same time.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
