### PR TITLE
Fix safari play() after source change

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1624,8 +1624,8 @@ class Player extends Component {
       this.ready(function() {
 
         // Safari struggles to play immediately following a source change
-        // without first calling load()
-        if (browser.IS_ANY_SAFARI) {
+        // without first calling load() if preload="none", except in desktop Safari 11
+        if (this.preload() === 'none' && (browser.IS_IOS || browser.DESKTOP_SAFARI_VERSION < 11)) {
           this.techCall_('load');
         }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1622,6 +1622,13 @@ class Player extends Component {
   play() {
     if (this.changingSrc_) {
       this.ready(function() {
+
+        // Safari struggles to play immediately following a source change
+        // without first calling load()
+        if (browser.IS_ANY_SAFARI) {
+          this.techCall_('load');
+        }
+
         const retval = this.techGet_('play');
 
         // silence errors (unhandled promise from play)

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1625,7 +1625,7 @@ class Player extends Component {
 
         // Safari struggles to play immediately following a source change
         // without first calling load() if preload="none", except in desktop Safari 11
-        if (this.preload() === 'none' && (browser.IS_IOS || browser.DESKTOP_SAFARI_VERSION < 11)) {
+        if (this.techGet_('preload') === 'none' && (browser.IS_IOS || browser.DESKTOP_SAFARI_VERSION < 11)) {
           this.techCall_('load');
         }
 

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -85,6 +85,14 @@ export const IE_VERSION = (function() {
 
 export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
 export const IS_ANY_SAFARI = IS_SAFARI || IS_IOS;
+export const DESKTOP_SAFARI_VERSION = (function() {
+  const match = USER_AGENT.match(/Version\/(\d+)/);
+
+  if (match && match[1] && IS_SAFARI && !IS_IOS) {
+    return parseFloat(match[1]);
+  }
+  return null;
+}());
 
 export const TOUCH_ENABLED = Dom.isReal() && (
   'ontouchstart' in window ||

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -81,6 +81,10 @@ class TechFaker extends Tech {
   controls() {
     return false;
   }
+  preload() {
+    return 'auto';
+  }
+  load() {}
 
   // Support everything except for "video/unsupported-format"
   static isSupported() {


### PR DESCRIPTION
## Description
Programmatically calling `player.play()` immediately following a source change will fail in Safari (desktop and iOS) if the video element's `preload` attribute is set to `none`.

Open the following links in Safari, start playback, then press the "Play new source" button. These samples demonstrate the problem using a vanilla `<video>` element.
- [play() FAILS following source change](http://jsbin.com/qiyoqiluhi/1/edit?html,output)
- [play() SUCCEEDS after calling load() following source change](http://jsbin.com/jokikadeke/1/edit?html,output)

**Expected behavior:** the source changes and starts to play.
**Actual behavior:**  playback stalls

One observed effect of this problem is with the implementation of playlists. With `preload: "none"`, playlists, whether configured to autoadvance or click-to-play, do not work in Safari because playback stalls when switching sources.

**Note:** This bug has apparently been fixed in Safari 11.

## Specific additions
Modify the `player.play()` method so that if it is called while the content source is still changing in Safari, `load()` will be called before `play()`.
