### PR TITLE
fix: Make sure time displays use correctly-formatted time.

### DIFF
--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -36,6 +36,21 @@ class RemainingTimeDisplay extends TimeDisplay {
   }
 
   /**
+   * The remaining time display prefixes numbers with a "minus" character.
+   *
+   * @param  {number} time
+   *         A numeric time, in seconds.
+   *
+   * @return {string}
+   *         A formatted time
+   *
+   * @private
+   */
+  formatTime_(time) {
+    return '-' + super.formatTime_(time);
+  }
+
+  /**
    * Update remaining time display.
    *
    * @param {EventTarget~Event} [event]

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -66,8 +66,23 @@ class TimeDisplay extends Component {
     if (this.textNode_) {
       this.contentEl_.removeChild(this.textNode_);
     }
-    this.textNode_ = document.createTextNode(` -${this.formattedTime_ || '0:00'}`);
+    this.textNode_ = document.createTextNode(this.formattedTime_ || '0:00');
     this.contentEl_.appendChild(this.textNode_);
+  }
+
+  /**
+   * Generates a formatted time for this component to use in display.
+   *
+   * @param  {number} time
+   *         A numeric time, in seconds.
+   *
+   * @return {string}
+   *         A formatted time
+   *
+   * @private
+   */
+  formatTime_(time) {
+    return formatTime(time);
   }
 
   /**
@@ -80,7 +95,7 @@ class TimeDisplay extends Component {
    * @private
    */
   updateFormattedTime_(time) {
-    const formattedTime = formatTime(time);
+    const formattedTime = this.formatTime_(time);
 
     if (formattedTime === this.formattedTime_) {
       return;


### PR DESCRIPTION
The recent refactoring of time displays is great, but it seems there was a bug where it would always prepend times with `-` even when we want a positive number (i.e. everywhere except remaining time display)!

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
