### PR TITLE
fix: Fix a typo in current time display component.

### DIFF
--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -64,7 +64,7 @@ class CurrentTimeDisplay extends TimeDisplay {
     if (!this.player_.duration()) {
       return;
     }
-    this.updateFormattedTime_(this.player.duration());
+    this.updateFormattedTime_(this.player_.duration());
   }
 
 }


### PR DESCRIPTION
Pretty self-explanatory. This can cause an error to be thrown.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
