### PR TITLE
feat: allow progress controls to be disabled

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -8,6 +8,10 @@
   min-width: 4em;
 }
 
+.video-js .vjs-progress-control.disabled {
+  cursor: default;
+}
+
 .vjs-live .vjs-progress-control {
   display: none;
 }
@@ -36,7 +40,7 @@
 
 // This increases the size of the progress holder so there is an increased
 // hit area for clicks/touches.
-.video-js .vjs-progress-control:hover .vjs-progress-holder {
+.video-js .vjs-progress-control:hover .vjs-progress-holder.enabled {
   font-size: 1.666666666666666666em;
 }
 

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -45,7 +45,7 @@
 }
 
 .video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
-  font-size: inherit;
+  font-size: 1em;
 }
 
 // .vjs-play-progress / PlayProgressBar and .vjs-load-progress / LoadProgressBar
@@ -139,6 +139,10 @@
   // Ensure that we maintain a font-size of ~10px.
   font-size: 0.6em;
   visibility: visible;
+}
+
+.video-js .vjs-progress-control.disabled:hover .vjs-time-tooltip {
+  font-size: 1em;
 }
 
 // .vjs-mouse-display / MouseTimeDisplay

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -40,9 +40,14 @@
 
 // This increases the size of the progress holder so there is an increased
 // hit area for clicks/touches.
-.video-js .vjs-progress-control:hover .vjs-progress-holder.enabled {
+.video-js .vjs-progress-control:hover .vjs-progress-holder {
   font-size: 1.666666666666666666em;
 }
+
+.video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
+  font-size: inherit;
+}
+
 
 // .vjs-play-progress / PlayProgressBar and .vjs-load-progress / LoadProgressBar
 //

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -48,7 +48,6 @@
   font-size: inherit;
 }
 
-
 // .vjs-play-progress / PlayProgressBar and .vjs-load-progress / LoadProgressBar
 //
 // These are bars that appear within the progress control to communicate the

--- a/src/css/components/_slider.scss
+++ b/src/css/components/_slider.scss
@@ -7,13 +7,11 @@
   @include user-select(none);
 
   @include background-color-with-alpha($secondary-background-color, $secondary-background-transparency);
-
  }
 
 .video-js .vjs-slider.disabled {
   cursor: default;
 }
-
 
 .video-js .vjs-slider:focus {
   text-shadow: 0em 0em 1em rgba($primary-foreground-color, 1);

--- a/src/css/components/_slider.scss
+++ b/src/css/components/_slider.scss
@@ -7,7 +7,13 @@
   @include user-select(none);
 
   @include background-color-with-alpha($secondary-background-color, $secondary-background-transparency);
+
+ }
+
+.video-js .vjs-slider.disabled {
+  cursor: default;
 }
+
 
 .video-js .vjs-slider:focus {
   text-shadow: 0em 0em 1em rgba($primary-foreground-color, 1);

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -27,10 +27,9 @@ class ProgressControl extends Component {
   constructor(player, options) {
     super(player, options);
     this.handleMouseMove = throttle(bind(this, this.handleMouseMove), 25);
-    this.on(this.el_, 'mousemove', this.handleMouseMove);
-
     this.throttledHandleMouseSeek = throttle(bind(this, this.handleMouseSeek), 25);
-    this.on(['mousedown', 'touchstart'], this.handleMouseDown);
+
+    this.enableControls();
   }
 
   /**
@@ -99,6 +98,47 @@ class ProgressControl extends Component {
     const seekBar = this.getChild('seekBar');
 
     seekBar.handleMouseMove(event);
+  }
+
+  /**
+   * Are controls are currently enabled for this progress control.
+   *
+   * @return {boolean}
+   *         true if controls are enabled, false otherwise
+   */
+  controlsEnabled() {
+    return this.controlsEnabled_;
+  }
+
+  /**
+   * Disable all controls on the progress control and its children
+   */
+  disableControls() {
+    this.children().forEach((child) => child.disableControls && child.disableControls());
+
+    if (!this.controlsEnabled()) {
+      return;
+    }
+
+    this.off(['mousedown', 'touchstart'], this.handleMouseDown);
+    this.off(this.el_, 'mousemove', this.handleMouseMove);
+    this.handleMouseUp();
+    this.controlsEnabled_ = false;
+  }
+
+  /**
+   * Enable all controls on the progress control and its children
+   */
+  enableControls() {
+    this.children().forEach((child) => child.enableControls && child.enableControls());
+
+    if (this.controlsEnabled()) {
+      return;
+    }
+
+    this.on(['mousedown', 'touchstart'], this.handleMouseDown);
+    this.on(this.el_, 'mousemove', this.handleMouseMove);
+    this.controlsEnabled_ = true;
   }
 
   /**

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -124,7 +124,6 @@ class ProgressControl extends Component {
     this.off(this.el_, 'mousemove', this.handleMouseMove);
     this.handleMouseUp();
 
-    this.removeClass('enabled');
     this.addClass('disabled');
 
     this.enabled_ = false;
@@ -143,7 +142,6 @@ class ProgressControl extends Component {
     this.on(['mousedown', 'touchstart'], this.handleMouseDown);
     this.on(this.el_, 'mousemove', this.handleMouseMove);
     this.removeClass('disabled');
-    this.addClass('enabled');
 
     this.enabled_ = true;
   }

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -29,7 +29,7 @@ class ProgressControl extends Component {
     this.handleMouseMove = throttle(bind(this, this.handleMouseMove), 25);
     this.throttledHandleMouseSeek = throttle(bind(this, this.handleMouseSeek), 25);
 
-    this.enableControls();
+    this.enable();
   }
 
   /**
@@ -106,39 +106,46 @@ class ProgressControl extends Component {
    * @return {boolean}
    *         true if controls are enabled, false otherwise
    */
-  controlsEnabled() {
-    return this.controlsEnabled_;
+  enabled() {
+    return this.enabled_;
   }
 
   /**
    * Disable all controls on the progress control and its children
    */
-  disableControls() {
-    this.children().forEach((child) => child.disableControls && child.disableControls());
+  disable() {
+    this.children().forEach((child) => child.disable && child.disable());
 
-    if (!this.controlsEnabled()) {
+    if (!this.enabled()) {
       return;
     }
 
     this.off(['mousedown', 'touchstart'], this.handleMouseDown);
     this.off(this.el_, 'mousemove', this.handleMouseMove);
     this.handleMouseUp();
-    this.controlsEnabled_ = false;
+
+    this.removeClass('enabled');
+    this.addClass('disabled');
+
+    this.enabled_ = false;
   }
 
   /**
    * Enable all controls on the progress control and its children
    */
-  enableControls() {
-    this.children().forEach((child) => child.enableControls && child.enableControls());
+  enable() {
+    this.children().forEach((child) => child.enable && child.enable());
 
-    if (this.controlsEnabled()) {
+    if (this.enabled()) {
       return;
     }
 
     this.on(['mousedown', 'touchstart'], this.handleMouseDown);
     this.on(this.el_, 'mousemove', this.handleMouseMove);
-    this.controlsEnabled_ = true;
+    this.removeClass('disabled');
+    this.addClass('enabled');
+
+    this.enabled_ = true;
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -141,6 +141,28 @@ class SeekBar extends Slider {
     this.player_.currentTime(newTime);
   }
 
+  enable() {
+    super.enable();
+    const mouseTimeDisplay = this.getChild('mouseTimeDisplay');
+
+    if (!mouseTimeDisplay) {
+      return;
+    }
+
+    mouseTimeDisplay.show();
+  }
+
+  disable() {
+    super.disable();
+    const mouseTimeDisplay = this.getChild('mouseTimeDisplay');
+
+    if (!mouseTimeDisplay) {
+      return;
+    }
+
+    mouseTimeDisplay.hide();
+  }
+
   /**
    * Handle mouse up on seek bar
    *

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -31,7 +31,7 @@ class Slider extends Component {
     // Set a horizontal or vertical class on the slider depending on the slider type
     this.vertical(!!this.options_.vertical);
 
-    this.enableControls();
+    this.enable();
   }
 
   /**
@@ -40,15 +40,15 @@ class Slider extends Component {
    * @return {boolean}
    *         true if controls are enabled, false otherwise
    */
-  controlsEnabled() {
-    return this.controlsEnabled_;
+  enabled() {
+    return this.enabled_;
   }
 
   /**
    * Enable controls for this slider if they are disabled
    */
-  enableControls() {
-    if (this.controlsEnabled()) {
+  enable() {
+    if (this.enabled()) {
       return;
     }
 
@@ -63,14 +63,19 @@ class Slider extends Component {
     if (this.playerEvent) {
       this.on(this.player_, this.playerEvent, this.update);
     }
-    this.controlsEnabled_ = true;
+
+    this.removeClass('disabled');
+    this.addClass('enabled');
+    this.setAttribute('tabindex', 0);
+
+    this.enabled_ = true;
   }
 
   /**
    * Disable controls for this slider if they are enabled
    */
-  disableControls() {
-    if (!this.controlsEnabled()) {
+  disable() {
+    if (!this.enabled()) {
       return;
     }
     const doc = this.bar.el_.ownerDocument;
@@ -85,11 +90,15 @@ class Slider extends Component {
     this.off(doc, 'mouseup', this.handleMouseUp);
     this.off(doc, 'touchmove', this.handleMouseMove);
     this.off(doc, 'touchend', this.handleMouseUp);
+    this.removeAttribute('tabindex');
+
+    this.removeClass('enabled');
+    this.addClass('disabled');
 
     if (this.playerEvent) {
       this.off(this.player_, this.playerEvent, this.update);
     }
-    this.controlsEnabled_ = false;
+    this.enabled_ = false;
   }
 
   /**

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -65,7 +65,6 @@ class Slider extends Component {
     }
 
     this.removeClass('disabled');
-    this.addClass('enabled');
     this.setAttribute('tabindex', 0);
 
     this.enabled_ = true;
@@ -92,7 +91,6 @@ class Slider extends Component {
     this.off(doc, 'touchend', this.handleMouseUp);
     this.removeAttribute('tabindex');
 
-    this.removeClass('enabled');
     this.addClass('disabled');
 
     if (this.playerEvent) {

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -31,17 +31,65 @@ class Slider extends Component {
     // Set a horizontal or vertical class on the slider depending on the slider type
     this.vertical(!!this.options_.vertical);
 
+    this.enableControls();
+  }
+
+  /**
+   * Are controls are currently enabled for this slider or not.
+   *
+   * @return {boolean}
+   *         true if controls are enabled, false otherwise
+   */
+  controlsEnabled() {
+    return this.controlsEnabled_;
+  }
+
+  /**
+   * Enable controls for this slider if they are disabled
+   */
+  enableControls() {
+    if (this.controlsEnabled()) {
+      return;
+    }
+
     this.on('mousedown', this.handleMouseDown);
     this.on('touchstart', this.handleMouseDown);
     this.on('focus', this.handleFocus);
     this.on('blur', this.handleBlur);
     this.on('click', this.handleClick);
 
-    this.on(player, 'controlsvisible', this.update);
+    this.on(this.player_, 'controlsvisible', this.update);
 
     if (this.playerEvent) {
-      this.on(player, this.playerEvent, this.update);
+      this.on(this.player_, this.playerEvent, this.update);
     }
+    this.controlsEnabled_ = true;
+  }
+
+  /**
+   * Disable controls for this slider if they are enabled
+   */
+  disableControls() {
+    if (!this.controlsEnabled()) {
+      return;
+    }
+    const doc = this.bar.el_.ownerDocument;
+
+    this.off('mousedown', this.handleMouseDown);
+    this.off('touchstart', this.handleMouseDown);
+    this.off('focus', this.handleFocus);
+    this.off('blur', this.handleBlur);
+    this.off('click', this.handleClick);
+    this.off(this.player_, 'controlsvisible', this.update);
+    this.off(doc, 'mousemove', this.handleMouseMove);
+    this.off(doc, 'mouseup', this.handleMouseUp);
+    this.off(doc, 'touchmove', this.handleMouseMove);
+    this.off(doc, 'touchend', this.handleMouseUp);
+
+    if (this.playerEvent) {
+      this.off(this.player_, this.playerEvent, this.update);
+    }
+    this.controlsEnabled_ = false;
   }
 
   /**


### PR DESCRIPTION
## Description
Sometimes you do not want the user to be able to use the progress controls, such as during an ad. It would be quite difficult to do this outside of video.js due to the complexity of it. I think that we should allow this within video.js.

## Specific Changes proposed
Add functions to disable/enable progress controls

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
