### PR TITLE
fix: a breaking change caused by the use of remainingTimeDisplay

### DIFF
--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -64,7 +64,13 @@ class RemainingTimeDisplay extends TimeDisplay {
       return;
     }
 
-    this.updateFormattedTime_(this.player_.remainingTimeDisplay());
+    // @deprecated We should only use remainingTimeDisplay
+    // as of video.js 7
+    if (this.player_.remainingTimeDisplay) {
+      this.updateFormattedTime_(this.player_.remainingTimeDisplay());
+    } else {
+      this.updateFormattedTime_(this.player_.remainingTime());
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
Anyone that mocked the player would have to also mock this new method. This would cause them to break until they have it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
