### PR TITLE
chore(gh-release): no console log on success

### DIFF
--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -36,9 +36,8 @@ if (args.prerelease || npmargs.some(function(arg) { return /next/.test(arg); }))
 ghrelease(options, function(err, result) {
   if (err) {
     console.log('Unable to publish release to github');
-    console.log(err);
+    console.log('err:', err, '\nresult:', result);
   } else {
     console.log('Publish release to github!');
-    console.log(result);
   }
 });

--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -37,7 +37,7 @@ ghrelease(options, function(err, result) {
   if (err) {
     console.error('Unable to publish release to github');
     console.error('err:', err);
-    console.error('\nresult:', result);
+    console.error('result:', result);
   } else {
     console.log('Publish release to github!');
   }

--- a/build/gh-release.js
+++ b/build/gh-release.js
@@ -35,8 +35,9 @@ if (args.prerelease || npmargs.some(function(arg) { return /next/.test(arg); }))
 
 ghrelease(options, function(err, result) {
   if (err) {
-    console.log('Unable to publish release to github');
-    console.log('err:', err, '\nresult:', result);
+    console.error('Unable to publish release to github');
+    console.error('err:', err);
+    console.error('\nresult:', result);
   } else {
     console.log('Publish release to github!');
   }


### PR DESCRIPTION
We've been printing the resulting value from a successful call to the ghrelease, this was useful for debugging but isn't necessary anymore.
Add the result to the error conditional with some headings.