### PR TITLE
fix: Fix cases where the player reports that it is ready during source selection, but before tech selection.

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -3,6 +3,7 @@
  */
 import Button from './button.js';
 import Component from './component.js';
+import {isPromise} from './utils/promise';
 
 /**
  * The initial play button that shows before the video has played. The hiding of the
@@ -58,10 +59,8 @@ class BigPlayButton extends Button {
 
     const playFocus = () => playToggle.focus();
 
-    if (playPromise && playPromise.then) {
-      const ignoreRejectedPlayPromise = () => {};
-
-      playPromise.then(playFocus, ignoreRejectedPlayPromise);
+    if (isPromise(playPromise)) {
+      playPromise.then(playFocus, () => {});
     } else {
       this.setTimeout(playFocus, 1);
     }

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -590,12 +590,20 @@ class Component {
   }
 
   /**
-   * Bind a listener to the component's ready state.
-   * Different from event listeners in that if the ready event has already happened
-   * it will trigger the function immediately.
+   * Queue a callback to the component's next ready state update.
    *
-   * @return {Component}
-   *         Returns itself; method can be chained.
+   * This is different from an event listener in two ways. First, if the
+   * component is already ready, it will call the callback asynchronously (or
+   * synchronously if the second argument is `true`). Second, it will only
+   * call the callback once; so, it's similar to binding an event listener via
+   * the `one` method.
+   *
+   * @param  {Function} fn
+   *         A callback to call.
+   *
+   * @param  {boolean} [sync=false]
+   *         Pass `true` to execute the callback synchronously if the component
+   *         is ready. Otherwise, calls it asynchronously.
    */
   ready(fn, sync = false) {
     if (!fn) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2358,36 +2358,34 @@ class Player extends Component {
   src_(source) {
     const sourceTech = this.selectSource([source]);
 
+    // There is no tech available that can play the chosen source.
     if (!sourceTech) {
       return true;
     }
 
+    // The tech that was found is not the tech that is currently loaded into
+    // the player; so, we need to unload the old tech, load a new one, and
+    // set the source on it.
     if (!titleCaseEquals(sourceTech.tech, this.techName_)) {
-
-      // load this technology with the chosen source
       this.loadTech_(sourceTech.tech, sourceTech.source);
       return false;
     }
 
-    // wait until the tech is ready to set the source
-    this.ready(function() {
+    // The existing tech will work with this source; so, we can set the
+    // source on the existing tech.
+    //
+    // The `setSource` method was added with source handlers; so, older techs
+    // won't support it. Also, we need to check the direct prototype for
+    // the case where subclasses of `Tech` do not support source handlers.
+    if (this.tech_.constructor.prototype.hasOwnProperty('setSource')) {
+      this.techCall_('setSource', source);
+    } else {
+      this.techCall_('src', source.src);
+    }
 
-      // The setSource tech method was added with source handlers
-      // so older techs won't support it
-      // We need to check the direct prototype for the case where subclasses
-      // of the tech do not support source handlers
-      if (this.tech_.constructor.prototype.hasOwnProperty('setSource')) {
-        this.techCall_('setSource', source);
-      } else {
-        this.techCall_('src', source.src);
-      }
-
-      if (this.options_.preload === 'auto') {
-        this.load();
-      }
-
-    // Set the source synchronously if possible (#2326)
-    }, true);
+    if (this.options_.preload === 'auto') {
+      this.load();
+    }
 
     return false;
   }

--- a/src/js/utils/promise.js
+++ b/src/js/utils/promise.js
@@ -1,0 +1,28 @@
+
+/**
+ * Returns whether an object is `Promise`-like (i.e. has a `then` method).
+ *
+ * @param  {Object}  value
+ *         An object that may or may not be `Promise`-like.
+ *
+ * @return {Boolean}
+ *         Whether or not the object is `Promise`-like.
+ */
+export function isPromise(value) {
+  return value !== undefined && typeof value.then === 'function';
+}
+
+/**
+ * Silence a Promise-like object.
+ *
+ * This is useful for avoiding non-harmful, but potentially confusing "uncaught
+ * play promise" rejection error messages.
+ *
+ * @param  {Object} value
+ *         An object that may or may not be `Promise`-like.
+ */
+export function silencePromise(value) {
+  if (isPromise(value)) {
+    value.then(null, (e) => {});
+  }
+}

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1602,14 +1602,22 @@ QUnit.test('src_ does not call loadTech is name is titleCaseEquals', function(as
         tech: 'html5'
       };
     },
+    options_: {},
+    tech_: {
+      constructor: {
+        prototype: {}
+      }
+    },
+    techCall_() {},
     techName_: 'Html5',
-    ready() {},
+    // ready() {},
+    load() {},
     loadTech_() {
       loadTechCalled++;
     }
   };
 
-  Player.prototype.src_.call(playerProxy);
+  Player.prototype.src_.call(playerProxy, {});
 
   assert.equal(loadTechCalled, 0, 'loadTech was not called');
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1073,7 +1073,7 @@ if (window.Promise) {
       type: 'video/mp4'
     });
 
-    this.clock.tick(1);
+    this.clock.tick(2);
 
     player.tech_.play = () => window.Promise.resolve('foo');
     const p = player.play();
@@ -1097,7 +1097,7 @@ QUnit.test('play promise should resolve to native value if returned', function(a
     type: 'video/mp4'
   });
 
-  this.clock.tick(1);
+  this.clock.tick(2);
 
   player.tech_.play = () => 'foo';
   const p = player.play();
@@ -1654,7 +1654,7 @@ QUnit.test('subsequent calls to src() will put the player in a non-ready state, 
   assert.equal(onReadySpy.callCount, 1, 'did not see a "ready" because middleware queues up another async operation');
   assert.equal(readySpy.callCount, 1, 'did not see a ready() callback because middleware queues up another async operation');
 
-  this.clock.tick(1);
+  this.clock.tick(2);
 
   assert.equal(onReadySpy.callCount, 2, 'saw second "ready" because source setting and tech selection are complete');
   assert.equal(readySpy.callCount, 2, 'saw second ready() callback because source setting and tech selection are complete');
@@ -1674,7 +1674,7 @@ QUnit.test('subsequent calls to src() will put the player in a non-ready state, 
   assert.equal(onReadySpy.callCount, 2, 'did not see a "ready" because middleware queues up another async operation');
   assert.equal(readySpy.callCount, 2, 'did not see a ready() callback because middleware queues up another async operation');
 
-  this.clock.tick(1);
+  this.clock.tick(2);
 
   assert.equal(onReadySpy.callCount, 3, 'saw third "ready" because source setting and tech selection are complete');
   assert.equal(readySpy.callCount, 3, 'saw third ready() callback because source setting and tech selection are complete');

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -574,7 +574,7 @@ if (Html5.isSupported()) {
     player.addRemoteTextTrack(track, false);
     player.src({src: 'example.mp4', type: 'video/mp4'});
 
-    this.clock.tick(1);
+    this.clock.tick(2);
     assert.equal(player.textTracks().length, 0, 'we do not have any tracks left');
 
     player.dispose();


### PR DESCRIPTION
In working on some issues with asynchronous middleware and playlists, I realized that there is a period of time during the source and tech setting process where a new source and tech have not been selected, but the player still considers itself "ready".

The effect of this is to cause any callbacks to `ready()` during source selection to be called immediately instead of waiting for the source/tech to be selected:

```js
player.src({src: 'foo.mp4', type: 'video/mp4'});
player.ready(() => {
  player.play();
});
```

I think most people would expect, in that case, `foo.mp4` to begin playback. However, if there is asynchronous middleware happening, what you may get is some playback of the current source and then a source change to `foo.mp4` (which will pause the player).

The essence of this change is to separate the player's readiness from the tech's readiness. The tech can be ready when the player is not because the player is still resolving middleware, etc.

This should be backward-compatible and make `ready()` more reliable and better match user expectations.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
