### PR TITLE
Fixing an issue where patching functions into Object.prototype makes the event removal crash.

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -351,11 +351,9 @@ export function off(elem, type, fn) {
 
   // Are we removing all bound events?
   if (!type) {
-    if (!!data && !!data.handlers) {
-      for (const t in data.handlers) {
-        if (!!data.handlers && !!data.handlers.hasOwnProperty && data.handlers.hasOwnProperty(t)) {
-          removeType(t);
-        }
+    for (const t in data.handlers) {
+      if (data.handlers) {
+        removeType(t);
       }
     }
     return;

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -351,8 +351,12 @@ export function off(elem, type, fn) {
 
   // Are we removing all bound events?
   if (!type) {
-    for (const t in data.handlers) {
-      removeType(t);
+    if(!!data && !!data.handlers) {
+      for (var t in data.handlers) {
+        if(!!data.handlers && !!data.handlers.hasOwnProperty && data.handlers.hasOwnProperty(t)) {
+          removeType(t);
+        }
+      } 
     }
     return;
   }

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -350,9 +350,9 @@ export function off(elem, type, fn) {
   };
 
   // Are we removing all bound events?
-  if (!type) {
+  if (type === undefined) {
     for (const t in data.handlers) {
-      if (data.handlers) {
+      if (Object.prototype.hasOwnProperty.call(data.handlers || {}, t)) {
         removeType(t);
       }
     }

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -351,12 +351,12 @@ export function off(elem, type, fn) {
 
   // Are we removing all bound events?
   if (!type) {
-    if(!!data && !!data.handlers) {
-      for (var t in data.handlers) {
-        if(!!data.handlers && !!data.handlers.hasOwnProperty && data.handlers.hasOwnProperty(t)) {
+    if (!!data && !!data.handlers) {
+      for (const t in data.handlers) {
+        if (!!data.handlers && !!data.handlers.hasOwnProperty && data.handlers.hasOwnProperty(t)) {
           removeType(t);
         }
-      } 
+      }
     }
     return;
   }

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -85,10 +85,6 @@ export const parseUrl = function(url) {
     document.body.removeChild(div);
   }
 
-  if (details.protocol === '') {
-    details.protocol = window.location.protocol;
-  }
-
   return details;
 };
 

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -85,6 +85,10 @@ export const parseUrl = function(url) {
     document.body.removeChild(div);
   }
 
+  if (details.protocol === '') {
+    details.protocol = window.location.protocol;
+  }
+
   return details;
 };
 


### PR DESCRIPTION
## Description
I found a problem, where adding custom functions to Object.prototype made the event-off function crash upon iterating over all properties of an object.
I fixed it by checking for ```hasOwnProperty```. ~~As the tests failed for me on Win10 IE11 I also fixed issue #3100 that addressed this.~~

## Specific Changes proposed
~~I added an if-clause to url.js‘s ```parseUrl``` to add the current window.location.protocol if the protocol of the given url is empty (or ```//```).~~

~~I also added 2 if statements to events.js‘s ```off``` in the "type is falsy" if to check that data and data.handler is present (occasionally was undefined with me) and within the loop check if data.handler has t as it‘s own property~~.
I added an if statement to events.js‘s off in the ```if (!type)``` to check that data.handler is still present and has ```t``` as its own property while running the for loop. This way it won‘t try to remove monkey-patched properties.

To make the loop only run in the case of an omitted type parameter the surrounding if was corrected from ```(!type)``` to ```(type === undefined)```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors