### PR TITLE
feat: Add a noConflict method.

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -132,6 +132,23 @@ function videojs(id, options, ready) {
   return player;
 }
 
+// Cache the previous videojs global in case it's overwritten.
+const previousVideojs = window.videojs;
+
+/**
+ * Removes this `videojs` global from the global namespace and returns it, so
+ * it can be re-used under a different name.
+ *
+ * @return {Function}
+ *         Returns `videojs`.
+ */
+videojs.noConflict = function() {
+  if (window.videojs === videojs) {
+    window.videojs = previousVideojs;
+  }
+  return videojs;
+};
+
 /**
  * An Object that contains lifecycle hooks as keys which point to an array
  * of functions that are run when a lifecycle is triggered

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -3,6 +3,7 @@ import videojs from '../../src/js/video.js';
 import * as Dom from '../../src/js/utils/dom.js';
 import log from '../../src/js/utils/log.js';
 import document from 'global/document';
+import window from 'global/window';
 import sinon from 'sinon';
 
 QUnit.module('video.js', {
@@ -330,4 +331,15 @@ QUnit.test('should create a new tag for movingMediaElementInDOM', function(asser
   Html5.prototype.movingMediaElementInDOM = oldMoving;
   Html5.isSupported = oldIS;
   Html5.nativeSourceHandler.canPlayType = oldCPT;
+});
+
+QUnit.test('noConflict', function(assert) {
+
+  // The test build does not expose a global videojs, so we need to fake it.
+  window.videojs = videojs;
+
+  const vjs = videojs.noConflict();
+
+  assert.strictEqual(window.videojs, undefined);
+  assert.strictEqual(vjs, videojs);
 });


### PR DESCRIPTION
## Description
Add a `noConflict` method, like jQuery offers. This can help in those rare cases where a user embeds multiple copies of Video.js of different versions on the same page.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
