### PR TITLE
Bugfix for issue #3100

### DIFF
--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -81,12 +81,12 @@ export const parseUrl = function(url) {
     details.host = details.host.replace(/:443$/, '');
   }
 
-  if (addToBody) {
-    document.body.removeChild(div);
+  if (!details.protocol) {
+    details.protocol = window.location.protocol;
   }
 
-  if (details.protocol === '') {
-    details.protocol = window.location.protocol;
+  if (addToBody) {
+    document.body.removeChild(div);
   }
 
   return details;

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -85,6 +85,10 @@ export const parseUrl = function(url) {
     document.body.removeChild(div);
   }
 
+  if (details.protocol === '') {
+    details.protocol = window.location.protocol;
+  }
+
   return details;
 };
 


### PR DESCRIPTION
## Description
url.js ```parseUrl``` drops the protocol from the return object on IE if the url starts with "//:". Chrome returns the current ```window.location.protocol``` value in that case. This causes the test mentioned in #3100 to fail on IE, but not on Chrome or FF.

## Specific Changes proposed
I added an if-clause to url.js‘s ```parseUrl``` to add the current window.location.protocol if the protocol of the given url is empty (or ```//```).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
