### PR TITLE
fix: Don't enable player controls if they where disabled when ModalDialog closes.

### DIFF
--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -187,7 +187,10 @@ class ModalDialog extends Component {
         this.on(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
       }
 
+      // Hide controls and note if they were enabled.
+      this.hadControls_ = player.controls();
       player.controls(false);
+
       this.show();
       this.conditionalFocus_();
       this.el().setAttribute('aria-hidden', 'false');
@@ -249,7 +252,10 @@ class ModalDialog extends Component {
       this.off(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
     }
 
-    player.controls(true);
+    if (this.hadControls_) {
+      player.controls(true);
+    }
+
     this.hide();
     this.el().setAttribute('aria-hidden', 'true');
 


### PR DESCRIPTION
## Description
Don't enable player controls if they where disabled when ModalDialog closes.

## Specific Changes proposed
Save the result of "player.controls()" when the ModalDialgo opens and set it again on close.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
