### PR TITLE
add warning, if the element given to Video.js is not in the DOM

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -99,6 +99,11 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
+  // Check if element is included in the DOM
+  if (Dom.isEl(tag) && !document.body.contains(tag)) {
+    log.warn('The element supplied is\'t included in the DOM');
+  }
+
   // Element may have a player attr referring to an already created player instance.
   // If so return that otherwise set up a new player below
   if (tag.player || Player.players[tag.playerId]) {

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -101,7 +101,7 @@ function videojs(id, options, ready) {
 
   // Check if element is included in the DOM
   if (Dom.isEl(tag) && !document.body.contains(tag)) {
-    log.warn('The element supplied is\'t included in the DOM');
+    log.warn('The element supplied is not included in the DOM');
   }
 
   // Element may have a player attr referring to an already created player instance.


### PR DESCRIPTION
## Description
Issue #4697 

## Specific Changes proposed
Add warning, if the element given to Video.js is not in the DOM

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
