### PR TITLE
refactor options.language (player.constructor)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -289,24 +289,21 @@ class Player extends Component {
     options.reportTouchActivity = false;
 
     // If language is not set, get the closest lang attribute
-    if (!options.language) {
-      if (typeof tag.closest === 'function') {
-        const closest = tag.closest('[lang]');
+    if (options.language) {
+      let element = tag;
 
-        if (closest) {
-          options.language = closest.getAttribute('lang');
+      while (element && element.nodeType === 1) {
+        if (Dom.getAttributes(element).hasOwnProperty('lang')) {
+          break; // current element have 'lang' property
         }
-      } else {
-        let element = tag;
-
-        while (element && element.nodeType === 1) {
-          if (Dom.getAttributes(element).hasOwnProperty('lang')) {
-            options.language = element.getAttribute('lang');
-            break;
-          }
-          element = element.parentNode;
-        }
+        element = element.parentNode;
       }
+
+      options.language = element.getAttribute('lang');
+    }
+
+    if (!options.language && tag.closest instanceof Function && tag.closest('[lang]')) {
+      options.language = tag.closest('[lang]').getAttribute('lang');
     }
 
     // Run base component initializing with new options

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -292,9 +292,10 @@ class Player extends Component {
     if (options.language) {
       let element = tag;
 
+      // find element have 'lang' property
       while (element && element.nodeType === 1) {
         if (Dom.getAttributes(element).hasOwnProperty('lang')) {
-          break; // current element have 'lang' property
+          break;
         }
         element = element.parentNode;
       }


### PR DESCRIPTION
move down this line, so we don't have to think too much while in the loop
```js
options.language = element.getAttribute('lang');
```

#### Requirements Checklist
- [x] refactor options.language (player.constructor)