### PR TITLE
fix: aria-labelledby attribute has an extra space

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -312,14 +312,14 @@ class TextTrackSettings extends ModalDialog {
       `<${type} id="${id}" class="${type === 'label' ? 'vjs-label' : ''}">`,
       this.localize(config.label),
       `</${type}>`,
-      `<select aria-labelledby="${legendId} ${id}">`
+      `<select aria-labelledby="${legendId !== '' ? legendId + ' ' : ''}${id}">`
     ].
       concat(config.options.map(o => {
         const optionId = id + '-' + o[1];
 
         return [
           `<option id="${optionId}" value="${o[0]}" `,
-          `aria-labelledby="${legendId} ${id} ${optionId}">`,
+          `aria-labelledby="${legendId !== '' ? legendId + ' ' : ''}${id} ${optionId}">`,
           this.localize(o[1]),
           '</option>'
         ].join('');


### PR DESCRIPTION
## Description
The `aria-labelledby` attribute on the `fontPercent`, `edgeStyle`, and
`fontFamily` select options includes an extra space since there is
no `ledgendId` variable being set on the `createElFont_()` method.

[Fixes #4688](https://github.com/videojs/video.js/issues/4688)

## Specific Changes proposed
This fix adds a check to see if the `legendId` value is set or not inside
the `createElSelect_()` method. This should keep the extra space
from appearing on the select tags created by the `createElFont_()`
method.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
