### PR TITLE
fix: default cached src to empty string

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2285,7 +2285,7 @@ class Player extends Component {
   src(source) {
     // getter usage
     if (typeof source === 'undefined') {
-      return this.cache_.src;
+      return this.cache_.src || '';
     }
     // filter out invalid sources and turn our source into
     // an array of source objects

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -193,6 +193,7 @@ QUnit.test('should get current source from src set', function(assert) {
 
   // check for matching undefined src
   assert.deepEqual(player.currentSource(), {});
+  assert.equal(player.src(), '');
 
   player.src('http://google.com');
 


### PR DESCRIPTION
## Description
`player.src()` returns `undefined` for a new player.

## Specific Changes proposed
Default to `''` if there is no source cached.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
