### PR TITLE
feat: add a version function to all advanced plugin instances

### DIFF
--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -220,6 +220,13 @@ class Plugin {
   }
 
   /**
+   * Get the version of the plugin that was set on <pluginName>.VERSION
+   */
+  version() {
+    return this.constructor.VERSION;
+  }
+
+  /**
    * Each event triggered by plugins includes a hash of additional data with
    * conventional properties.
    *

--- a/test/unit/plugin-advanced.test.js
+++ b/test/unit/plugin-advanced.test.js
@@ -17,6 +17,8 @@ QUnit.module('Plugin: advanced', {
       }
     }
 
+    MockPlugin.VERSION = '1.0.0';
+
     this.MockPlugin = MockPlugin;
     Plugin.registerPlugin('mock', MockPlugin);
   },
@@ -59,6 +61,8 @@ QUnit.test('setup', function(assert) {
   assert.strictEqual(typeof instance.one, 'function', 'instance is evented');
   assert.strictEqual(typeof instance.trigger, 'function', 'instance is evented');
   assert.strictEqual(typeof instance.dispose, 'function', 'instance has dispose method');
+  assert.strictEqual(typeof instance.version, 'function', 'instance has version method');
+  assert.strictEqual(instance.version(), '1.0.0', 'version function returns VERSION value');
 
   assert.throws(
     () => new Plugin(this.player),


### PR DESCRIPTION
## Description
Having to use videojs.getPluginVersion(<pluginInstance>.constructor.name) is a bit weird when you already have an instance. I would even say we should get rid of the getPluginVersion function or deprecate it.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
