### PR TITLE
test: warning, if the element is not in the DOM

### DIFF
--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -72,7 +72,6 @@ function(assert) {
   assert.equal(warnLogs.length, 0, 'no warn logs');
 
   const vid2 = document.createElement('video');
-
   const player2 = videojs(vid2);
 
   assert.ok(player2, 'created player from tag');
@@ -82,7 +81,6 @@ function(assert) {
                'logged the right message');
 
   log.warn = origWarnLog;
-
   player.dispose();
   player2.dispose();
 });

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -53,6 +53,40 @@ QUnit.test('should return a video player instance', function(assert) {
   player2.dispose();
 });
 
+QUnit.test('should log if the supplied element is not included in the DOM',
+function(assert) {
+  const origWarnLog = log.warn;
+  const fixture = document.getElementById('qunit-fixture');
+  const warnLogs = [];
+
+  log.warn = (args) => {
+    warnLogs.push(args);
+  };
+
+  const vid = document.createElement('video');
+
+  fixture.appendChild(vid);
+  const player = videojs(vid);
+
+  assert.ok(player, 'created player from tag');
+  assert.equal(warnLogs.length, 0, 'no warn logs');
+
+  const vid2 = document.createElement('video');
+
+  const player2 = videojs(vid2);
+
+  assert.ok(player2, 'created player from tag');
+  assert.equal(warnLogs.length, 1, 'logged a warning');
+  assert.equal(warnLogs[0],
+               'The element supplied is not included in the DOM',
+               'logged the right message');
+
+  log.warn = origWarnLog;
+
+  player.dispose();
+  player2.dispose();
+});
+
 QUnit.test('should log about already initalized players if options already passed',
 function(assert) {
   const origWarnLog = log.warn;


### PR DESCRIPTION
## Description
Add test to #4698 

## Specific Changes proposed
Test to make sure that warning is printed, when element given to Video.js is not in the DOM

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
