### PR TITLE
fix: Wait for loadstart when changing sources, instead of just ready.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "version": "6.2.8",
+  "version": "6.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1126,14 +1126,10 @@
       }
     },
     "babelify": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
-      "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "object-assign": "4.1.1"
-      }
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-8.0.0.tgz",
+      "integrity": "sha512-xVr63fKEvMWUrrIbqlHYsMcc5Zdw4FSVesAHgkgajyCE1W8gbm9rbMakqavhxKvikGYMhEcqxTwB/gQmQ6lBtw==",
+      "dev": true
     },
     "babylon": {
       "version": "6.18.0",

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -3,6 +3,7 @@
  */
 import Button from './button.js';
 import Component from './component.js';
+import {isPromise} from './utils/promise';
 
 /**
  * The initial play button that shows before the video has played. The hiding of the
@@ -58,10 +59,8 @@ class BigPlayButton extends Button {
 
     const playFocus = () => playToggle.focus();
 
-    if (playPromise && playPromise.then) {
-      const ignoreRejectedPlayPromise = () => {};
-
-      playPromise.then(playFocus, ignoreRejectedPlayPromise);
+    if (isPromise(playPromise)) {
+      playPromise.then(playFocus, () => {});
     } else {
       this.setTimeout(playFocus, 1);
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1638,7 +1638,7 @@ class Player extends Component {
     // If this is called while we have a play queued up on a loadstart, remove
     // that listener to avoid getting in a potentially bad state.
     if (this.playOnLoadstart_) {
-      this.tech_.off('loadstart', this.playOnLoadstart_);
+      this.off('loadstart', this.playOnLoadstart_);
     }
 
     // If the player/tech is not ready, queue up another call to `play()` for
@@ -1658,7 +1658,7 @@ class Player extends Component {
       });
 
     // If the player/tech is ready and we have a source, we can attempt playback.
-    } else if (!this.changingSrc && (this.src() || this.currentSrc())) {
+    } else if (!this.changingSrc_ && (this.src() || this.currentSrc())) {
       return this.techGet_('play');
 
     // If the tech is ready, but we do not have a source, we'll need to wait
@@ -1674,7 +1674,7 @@ class Player extends Component {
         silencePromise(this.play());
       };
 
-      this.tech_.one('loadstart', this.playOnLoadstart_);
+      this.one('loadstart', this.playOnLoadstart_);
     }
   }
 

--- a/src/js/utils/promise.js
+++ b/src/js/utils/promise.js
@@ -1,0 +1,28 @@
+
+/**
+ * Returns whether an object is `Promise`-like (i.e. has a `then` method).
+ *
+ * @param  {Object}  value
+ *         An object that may or may not be `Promise`-like.
+ *
+ * @return {Boolean}
+ *         Whether or not the object is `Promise`-like.
+ */
+export function isPromise(value) {
+  return value !== undefined && typeof value.then === 'function';
+}
+
+/**
+ * Silence a Promise-like object.
+ *
+ * This is useful for avoiding non-harmful, but potentially confusing "uncaught
+ * play promise" rejection error messages.
+ *
+ * @param  {Object} value
+ *         An object that may or may not be `Promise`-like.
+ */
+export function silencePromise(value) {
+  if (isPromise(value)) {
+    value.then(null, (e) => {});
+  }
+}

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -33,7 +33,8 @@ QUnit.test('tech not ready + no source = wait for ready, then loadstart', functi
   assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because there was no source');
 
   // Add a source and trigger loadstart.
-  this.player.src = () => 'xyz.mp4';
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
   this.player.trigger('loadstart');
   assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
 });
@@ -42,7 +43,8 @@ QUnit.test('tech not ready + has source = wait for ready', function(assert) {
 
   // Mock the player/tech not being ready, but having a source.
   this.player.isReady_ = false;
-  this.player.src = () => 'xyz.mp4';
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
 
   // Attempt to play.
   this.player.play();
@@ -63,7 +65,8 @@ QUnit.test('tech ready + no source = wait for loadstart', function(assert) {
   assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
 
   // Add a source and trigger loadstart.
-  this.player.src = () => 'xyz.mp4';
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
   this.player.trigger('loadstart');
   assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
 });
@@ -71,9 +74,24 @@ QUnit.test('tech ready + no source = wait for loadstart', function(assert) {
 QUnit.test('tech ready + has source = play immediately!', function(assert) {
 
   // Mock the player having a source.
-  this.player.src = () => 'xyz.mp4';
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
 
   // Attempt to play, but silence the promise that might be returned.
   silencePromise(this.player.play());
+  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+});
+
+QUnit.test('tech ready + has source + changing source = wait for loadstart', function(assert) {
+
+  // Mock the player having a source and in the process of changing its source.
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
+  this.player.src('abc.mp4');
+  this.player.play();
+  this.clock.tick(100);
+  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the source was changing');
+
+  this.player.trigger('loadstart');
   assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
 });

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -1,0 +1,79 @@
+/* eslint-env qunit */
+import sinon from 'sinon';
+import {silencePromise} from '../../src/js/utils/promise';
+import TestHelpers from './test-helpers';
+
+QUnit.module('Player#play', {
+
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer({techOrder: ['html5']});
+    this.techPlaySpy = sinon.spy(this.player.tech_, 'play');
+  },
+
+  afterEach() {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+QUnit.test('tech not ready + no source = wait for ready, then loadstart', function(assert) {
+
+  // Mock the player/tech not being ready.
+  this.player.isReady_ = false;
+
+  // Attempt to play.
+  this.player.play();
+  this.clock.tick(100);
+  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+
+  // Ready the player.
+  this.player.triggerReady();
+  this.clock.tick(100);
+  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because there was no source');
+
+  // Add a source and trigger loadstart.
+  this.player.src = () => 'xyz.mp4';
+  this.player.trigger('loadstart');
+  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+});
+
+QUnit.test('tech not ready + has source = wait for ready', function(assert) {
+
+  // Mock the player/tech not being ready, but having a source.
+  this.player.isReady_ = false;
+  this.player.src = () => 'xyz.mp4';
+
+  // Attempt to play.
+  this.player.play();
+  this.clock.tick(100);
+  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+
+  // Ready the player.
+  this.player.triggerReady();
+  this.clock.tick(100);
+  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+});
+
+QUnit.test('tech ready + no source = wait for loadstart', function(assert) {
+
+  // Attempt to play.
+  this.player.play();
+  this.clock.tick(100);
+  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+
+  // Add a source and trigger loadstart.
+  this.player.src = () => 'xyz.mp4';
+  this.player.trigger('loadstart');
+  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+});
+
+QUnit.test('tech ready + has source = play immediately!', function(assert) {
+
+  // Mock the player having a source.
+  this.player.src = () => 'xyz.mp4';
+
+  // Attempt to play, but silence the promise that might be returned.
+  silencePromise(this.player.play());
+  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+});

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -7,7 +7,7 @@ QUnit.module('Player#play', {
 
   beforeEach() {
     this.clock = sinon.useFakeTimers();
-    this.player = TestHelpers.makePlayer({techOrder: ['html5']});
+    this.player = TestHelpers.makePlayer({});
     this.techPlaySpy = sinon.spy(this.player.tech_, 'play');
   },
 

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -8,7 +8,10 @@ QUnit.module('Player#play', {
   beforeEach() {
     this.clock = sinon.useFakeTimers();
     this.player = TestHelpers.makePlayer({});
-    this.techPlaySpy = sinon.spy(this.player.tech_, 'play');
+    this.techPlayCallCount = 0;
+    this.player.tech_.play = () => {
+      this.techPlayCallCount++;
+    };
   },
 
   afterEach() {
@@ -25,18 +28,18 @@ QUnit.test('tech not ready + no source = wait for ready, then loadstart', functi
   // Attempt to play.
   this.player.play();
   this.clock.tick(100);
-  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+  assert.strictEqual(this.techPlayCallCount, 0, 'tech_.play was not called because the tech was not ready');
 
   // Ready the player.
   this.player.triggerReady();
   this.clock.tick(100);
-  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because there was no source');
+  assert.strictEqual(this.techPlayCallCount, 0, 'tech_.play was not called because there was no source');
 
   // Add a source and trigger loadstart.
   this.player.src('xyz.mp4');
   this.clock.tick(100);
   this.player.trigger('loadstart');
-  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
 
 QUnit.test('tech not ready + has source = wait for ready', function(assert) {
@@ -49,12 +52,12 @@ QUnit.test('tech not ready + has source = wait for ready', function(assert) {
   // Attempt to play.
   this.player.play();
   this.clock.tick(100);
-  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+  assert.strictEqual(this.techPlayCallCount, 0, 'tech_.play was not called because the tech was not ready');
 
   // Ready the player.
   this.player.triggerReady();
   this.clock.tick(100);
-  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
 
 QUnit.test('tech ready + no source = wait for loadstart', function(assert) {
@@ -62,13 +65,13 @@ QUnit.test('tech ready + no source = wait for loadstart', function(assert) {
   // Attempt to play.
   this.player.play();
   this.clock.tick(100);
-  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the tech was not ready');
+  assert.strictEqual(this.techPlayCallCount, 0, 'tech_.play was not called because the tech was not ready');
 
   // Add a source and trigger loadstart.
   this.player.src('xyz.mp4');
   this.clock.tick(100);
   this.player.trigger('loadstart');
-  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
 
 QUnit.test('tech ready + has source = play immediately!', function(assert) {
@@ -79,7 +82,7 @@ QUnit.test('tech ready + has source = play immediately!', function(assert) {
 
   // Attempt to play, but silence the promise that might be returned.
   silencePromise(this.player.play());
-  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
 
 QUnit.test('tech ready + has source + changing source = wait for loadstart', function(assert) {
@@ -90,8 +93,8 @@ QUnit.test('tech ready + has source + changing source = wait for loadstart', fun
   this.player.src('abc.mp4');
   this.player.play();
   this.clock.tick(100);
-  assert.notOk(this.techPlaySpy.called, 'tech_.play was not called because the source was changing');
+  assert.strictEqual(this.techPlayCallCount, 0, 'tech_.play was not called because the source was changing');
 
   this.player.trigger('loadstart');
-  assert.ok(this.techPlaySpy.calledOnce, 'tech_.play was called');
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });

--- a/test/unit/utils/promise.test.js
+++ b/test/unit/utils/promise.test.js
@@ -1,0 +1,19 @@
+/* eslint-env qunit */
+import window from 'global/window';
+import * as promise from '../../../src/js/utils/promise';
+
+QUnit.module('utils/promise');
+
+QUnit.test('can correctly identify a native Promise (if supported)', function(assert) {
+  if (!window.Promise) {
+    assert.expect(0);
+    return;
+  }
+
+  assert.ok(promise.isPromise(new window.Promise((resolve) => resolve())));
+});
+
+QUnit.test('can identify a Promise-like object', function(assert) {
+  assert.notOk(promise.isPromise({}));
+  assert.ok(promise.isPromise({then: () => {}}));
+});

--- a/test/unit/utils/promise.test.js
+++ b/test/unit/utils/promise.test.js
@@ -5,15 +5,16 @@ import * as promise from '../../../src/js/utils/promise';
 QUnit.module('utils/promise');
 
 QUnit.test('can correctly identify a native Promise (if supported)', function(assert) {
+
+  // If Promises aren't supported, skip this.
   if (!window.Promise) {
-    assert.expect(0);
-    return;
+    return assert.expect(0);
   }
 
-  assert.ok(promise.isPromise(new window.Promise((resolve) => resolve())));
+  assert.ok(promise.isPromise(new window.Promise((resolve) => resolve())), 'a native Promise was recognized');
 });
 
 QUnit.test('can identify a Promise-like object', function(assert) {
-  assert.notOk(promise.isPromise({}));
-  assert.ok(promise.isPromise({then: () => {}}));
+  assert.notOk(promise.isPromise({}), 'an object without a `then` method is not Promise-like');
+  assert.ok(promise.isPromise({then: () => {}}), 'an object with a `then` method is Promise-like');
 });


### PR DESCRIPTION
The core goal here is to make sure the following works in light of some middleware process that makes setting the source more async than next tick:

```js
player.src('...');
player.ready(() => player.play());
```

In fact, given this change, we should even be able to do:

```js
player.src('...');
player.play();
```

Unlike #4665, which would have clarified/changed the meaning of "ready", it remains a reflection of the tech's state and we make better use of the ability to queue things on that state and on the middleware `setSource` process.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
