### PR TITLE
Avoid weird menu item tooltip title

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -113,7 +113,7 @@ class ClickableComponent extends Component {
    *         - The control text when getting
    */
   controlText(text, el = this.el()) {
-    if (!text) {
+    if (text === undefined) {
       return this.controlText_ || 'Need Text';
     }
 

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -97,8 +97,7 @@ class MenuItem extends ClickableComponent {
         this.removeClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'false');
         // Indicate un-selected state to screen reader
-        // Note that a space clears out the selected state text
-        this.controlText(' ');
+        this.controlText('');
       }
     }
   }


### PR DESCRIPTION
@gkatsev @misteroneill cc @luarmr I'd like to make this change to avoid having weird titles for the menu items in the player. You can easily reproduce the bug by keeping your mouse over any submenu item (caption language, video quality) on your own homepage e.g.

Note: Firefox just hides an empty-space tooltip, but this issue does pop up in Chrome, IE, likely others

before:
<img width="171" alt="screen shot 2017-11-13 at 23 27 13" src="https://user-images.githubusercontent.com/904818/32755316-88138d44-c8cc-11e7-85e7-cf8c090dbc05.png">

after:
<img width="145" alt="screen shot 2017-11-13 at 23 26 57" src="https://user-images.githubusercontent.com/904818/32755312-8429928c-c8cc-11e7-885b-064ae6a47d3b.png">
