### PR TITLE
test: cleanup test warnings

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -100,15 +100,15 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
-  // Check if element is included in the DOM
-  if (Dom.isEl(tag) && !document.body.contains(tag)) {
-    log.warn('The element supplied is not included in the DOM');
-  }
-
   // Element may have a player attr referring to an already created player instance.
   // If so return that otherwise set up a new player below
   if (tag.player || Player.players[tag.playerId]) {
     return tag.player || Player.players[tag.playerId];
+  }
+
+  // Check if element is included in the DOM
+  if (Dom.isEl(tag) && !document.body.contains(tag)) {
+    log.warn('The element supplied is not included in the DOM');
   }
 
   options = options || {};

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -100,15 +100,15 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
+  // Check if element is included in the DOM
+  if (Dom.isEl(tag) && !document.body.contains(tag)) {
+    log.warn('The element supplied is not included in the DOM');
+  }
+
   // Element may have a player attr referring to an already created player instance.
   // If so return that otherwise set up a new player below
   if (tag.player || Player.players[tag.playerId]) {
     return tag.player || Player.players[tag.playerId];
-  }
-
-  // Check if element is included in the DOM
-  if (Dom.isEl(tag) && !document.body.contains(tag)) {
-    log.warn('The element supplied is not included in the DOM');
   }
 
   options = options || {};

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1119,10 +1119,6 @@ QUnit.test('should throw on startup no techs are specified', function(assert) {
   }, 'a falsey techOrder should throw');
 
   videojs.options.techOrder = techOrder;
-
-  while (fixture.firstChild) {
-    fixture.removeChild(fixture.firstChild);
-  }
 });
 
 QUnit.test('should have a sensible toJSON that is equivalent to player.options', function(assert) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1107,13 +1107,22 @@ QUnit.test('play promise should resolve to native value if returned', function(a
 
 QUnit.test('should throw on startup no techs are specified', function(assert) {
   const techOrder = videojs.options.techOrder;
+  const fixture = document.getElementById('qunit-fixture');
 
   videojs.options.techOrder = null;
   assert.throws(function() {
-    videojs(TestHelpers.makeTag());
+    const tag = TestHelpers.makeTag();
+
+    fixture.appendChild(tag);
+
+    videojs(tag);
   }, 'a falsey techOrder should throw');
 
   videojs.options.techOrder = techOrder;
+
+  while (fixture.firstChild) {
+    fixture.removeChild(fixture.firstChild);
+  }
 });
 
 QUnit.test('should have a sensible toJSON that is equivalent to player.options', function(assert) {
@@ -1428,6 +1437,10 @@ QUnit.test('should allow to register custom player when any player has not been 
   videojs.registerComponent('Player', CustomPlayer);
 
   const tag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+
   const player = videojs(tag);
 
   assert.equal(player instanceof CustomPlayer, true, 'player is custom');
@@ -1439,6 +1452,10 @@ QUnit.test('should allow to register custom player when any player has not been 
 
 QUnit.test('should not allow to register custom player when any player has been created', function(assert) {
   const tag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+
   const player = videojs(tag);
 
   class CustomPlayer extends Player {}
@@ -1471,6 +1488,10 @@ QUnit.test('techGet runs through middleware if allowedGetter', function(assert) 
   }));
 
   const tag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+
   const player = videojs(tag, {
     techOrder: ['techFaker']
   });
@@ -1504,6 +1525,10 @@ QUnit.test('techCall runs through middleware if allowedSetter', function(assert)
   }));
 
   const tag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+
   const player = videojs(tag, {
     techOrder: ['techFaker']
   });
@@ -1560,7 +1585,11 @@ QUnit.test('src selects tech based on middleware', function(assert) {
     }
   }));
 
+  const fixture = document.getElementById('qunit-fixture');
   const tag = TestHelpers.makeTag();
+
+  fixture.appendChild(tag);
+
   const player = videojs(tag, {
     techOrder: ['fooTech', 'barTech']
   });


### PR DESCRIPTION
## Description
Currently we get logs in the tests due to a recent change. This PR fixes that. It also fixes a case were we would log that the dom element isn't in the dom, when it really is:

Here is an example (taken from the test that showed me it)
```js
const fixture = document.getElementById('qunit-fixture');

fixture.innerHTML += '<video id="test_vid_id"></video>';

const tag = document.getElementById('test_vid_id');

const player = videojs(tag)

// this would log a warning about tag not being in the dom. Technically its not because
// of the changes we made to it. I would even say that this is a bad way to get the player again.
// but I think that warning that the players tag is not in the dom on the first creation is enough, and // warning that it isn't in the dom because the tag has been changed is a bit weird.

// returns the same player as above.
playerAgain(tag);

```
