### PR TITLE
fix: only print dom warning on player creation

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -100,15 +100,15 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
-  // Check if element is included in the DOM
-  if (Dom.isEl(tag) && !document.body.contains(tag)) {
-    log.warn('The element supplied is not included in the DOM');
-  }
-
   // Element may have a player attr referring to an already created player instance.
   // If so return that otherwise set up a new player below
   if (tag.player || Player.players[tag.playerId]) {
     return tag.player || Player.players[tag.playerId];
+  }
+
+  // Check if element is included in the DOM
+  if (Dom.isEl(tag) && !document.body.contains(tag)) {
+    log.warn('The element supplied is not included in the DOM');
   }
 
   options = options || {};

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -65,6 +65,7 @@ function(assert) {
 
   const vid = document.createElement('video');
 
+  vid.id = 'test_vid_id';
   fixture.appendChild(vid);
   const player = videojs(vid);
 
@@ -72,6 +73,8 @@ function(assert) {
   assert.equal(warnLogs.length, 0, 'no warn logs');
 
   const vid2 = document.createElement('video');
+
+  vid2.id = 'test_vid_id2';
   const player2 = videojs(vid2);
 
   assert.ok(player2, 'created player from tag');
@@ -79,6 +82,11 @@ function(assert) {
   assert.equal(warnLogs[0],
                'The element supplied is not included in the DOM',
                'logged the right message');
+
+  // should only log warnings on the first creation
+  videojs(vid2);
+  videojs('test_vid_id2');
+  assert.equal(warnLogs.length, 1, 'did not log another warning');
 
   log.warn = origWarnLog;
   player.dispose();


### PR DESCRIPTION
## Description
Previously 'element is not in the dom' warnings would go off every time that we get a player from videojs. This change fixes that as well as a bug that would occur if the tag was passed in twice to video.js. This would cause the tag to technically not be in the dom as the element has changed, but the correct player is still returned.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
