### PR TITLE
Edge 15 fix for closest.getAttribute

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -297,7 +297,7 @@ class Player extends Component {
       if (typeof tag.closest === 'function') {
         const closest = tag.closest('[lang]');
 
-        if (closest) {
+        if (closest && closest.getAttribute) {
           options.language = closest.getAttribute('lang');
         }
       } else {


### PR DESCRIPTION
## Description
If the HTML element doesn't have a lang attribute, Edge throws an exception when calling closest.getAttribute because tag.closest('[lang]') returns an empty object (which will be coerced to true) instead of null.

## Specific Changes proposed
Just test for getAttribute on closest.

## Requirements Checklist
- [x ] Bug fixed
