### PR TITLE
fix: off text tracks should be set based on current state

### DIFF
--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -45,7 +45,6 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     options.selectable = true;
 
     super(player, options);
-    this.selected(true);
   }
 
   /**

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -76,6 +76,9 @@ class TextTrackMenuItem extends MenuItem {
         tracks.dispatchEvent(event);
       });
     }
+
+    // set the default state based on current tracks
+    this.handleTracksChange();
   }
 
   /**


### PR DESCRIPTION
## Description
Prevents a race condition where `TextTrackList` triggers a change but it is ignored and the `OffTextTrackItem` is selected alongside the correct track.

## Specific Changes proposed
* Use the `handleTracksChange` function in the parent class to set the default state of menu items.
* Do not set `OffTextTrackItem` to true by default.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
