### PR TITLE
fix: can not drag on drag-bar IE9

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -8,6 +8,7 @@ import log from './log.js';
 import tsml from 'tsml';
 import {isObject} from './obj';
 import computedStyle from './computed-style';
+import * as browser from './browser';
 
 /**
  * Detect if a value is a string with any non-whitespace characters.
@@ -778,6 +779,12 @@ export function isSingleLeftClick(event) {
   if (event.button === 0 && event.buttons === undefined) {
     // Touch screen, sometimes on some specific device, `buttons`
     // doesn't have anything (safari on ios, blackberry...)
+
+    return true;
+  }
+
+  if (browser.IE_VERSION === 9) {
+    // Ignore IE9
 
     return true;
   }


### PR DESCRIPTION
#### Requirements Checklist
- [x] Bug fixed https://github.com/videojs/video.js/issues/4773

#### Note
On handleTechClick_, before the checking was
```js
button.event !== 0 // it work on IE9
```
Now it become
```js
!dom.isSingleLeftClick // ignore IE9 check, so doesn't work anymore
```

Could make it to be something like
```js
!dom.isSingleLeftClick && browser.IE_VERSION !== 9
// should we do this or sacrifice IE9 right click pause video to make code cleaner
```