### PR TITLE
Remove listener used to test if passive listeners are supported

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -216,6 +216,7 @@ let _supportsPassive = false;
     });
 
     window.addEventListener('test', null, opts);
+    window.removeEventListener('test', null, opts);
   } catch (e) {
     // disregard
   }


### PR DESCRIPTION
Once you have successfully tested that passive listeners are supported you should remove the test listeners :)