### PR TITLE
feat: add throttle on adding vjs-waiting class

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1233,7 +1233,7 @@ class Player extends Component {
    * @private
    */
   handleTechWaiting_() {
-    this.addClass('vjs-waiting');
+    this.throttle(() => this.addClass('vjs-waiting'), 500);
     /**
      * A readyState change on the DOM element has caused playback to stop.
      *


### PR DESCRIPTION
In some browsers (chrome on windows) when playing high fps video (.mp4 60 fps) there is blinking loader that keeps showing all the time while playing, despite buffer size. 

I suggest to add a short throttle to avoid this.