### PR TITLE
#4501 Seek to 0 if attempt is made to seek to negative value

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1789,6 +1789,9 @@ class Player extends Component {
    */
   currentTime(seconds) {
     if (typeof seconds !== 'undefined') {
+      if (seconds < 0) {
+        seconds = 0;
+      }
       this.techCall_('setCurrentTime', seconds);
       return;
     }


### PR DESCRIPTION
## Description
Fix for bug #4501 

## Specific Changes proposed
Added if statement to player.currentTime() that sets argument 'seconds' to 0 if negative value is passed to the function

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
