### PR TITLE
feat: player resize event

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -659,11 +659,14 @@ class Player extends Component {
    * @param {number} [value]
    *        The value to set the `Player`'s width to.
    *
+   * @param {boolean} [skipListeners]
+   *        Skip the playerresize event trigger
+   *
    * @return {number}
    *         The current width of the `Player` when getting.
    */
-  width(value) {
-    return this.dimension('width', value);
+  width(value, skipListeners) {
+    return this.dimension('width', value, skipListeners);
   }
 
   /**
@@ -673,11 +676,14 @@ class Player extends Component {
    * @param {number} [value]
    *        The value to set the `Player`'s heigth to.
    *
+   * @param {boolean} [skipListeners]
+   *        Skip the playerresize event trigger
+   *
    * @return {number}
    *         The current height of the `Player` when getting.
    */
-  height(value) {
-    return this.dimension('height', value);
+  height(value, skipListeners) {
+    return this.dimension('height', value, skipListeners);
   }
 
   /**
@@ -693,10 +699,13 @@ class Player extends Component {
    * @param {number} [value]
    *        Value for dimension specified in the first argument.
    *
+   * @param {boolean} [skipListeners]
+   *        Skip the playerresize event trigger
+   *
    * @return {number}
    *         The dimension arguments value when getting (width/height).
    */
-  dimension(dimension, value) {
+  dimension(dimension, value, skipListeners) {
     const privDimension = dimension + '_';
 
     if (value === undefined) {
@@ -720,7 +729,8 @@ class Player extends Component {
     this[privDimension] = parsedVal;
     this.updateStyleEl_();
 
-    if (this.isReady_) {
+    // skipListeners allows us to avoid triggering the resize event when setting both width and height
+    if (this.isReady_ && !skipListeners) {
       /**
        * Triggered when the player is resized.
        *

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -683,6 +683,8 @@ class Player extends Component {
   /**
    * A getter/setter for the `Player`'s width & height.
    *
+   * @fires Player#playerresize
+   *
    * @param {string} dimension
    *        This string can be:
    *        - 'width'
@@ -717,6 +719,16 @@ class Player extends Component {
 
     this[privDimension] = parsedVal;
     this.updateStyleEl_();
+
+    if (this.isReady_) {
+      /**
+       * Triggered when the player is resized.
+       *
+       * @event Player#playerresize
+       * @type {EventTarget~Event}
+       */
+      this.trigger('playerresize');
+    }
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1709,3 +1709,18 @@ QUnit.test('player.duration() sets the value of player.cache_.duration', functio
   player.duration(200);
   assert.equal(player.duration(), 200, 'duration() set and get integer duration value');
 });
+
+QUnit.test('should fire playerresize when player is resized', function(assert) {
+  assert.expect(2);
+
+  const player = TestHelpers.makePlayer();
+
+  player.on('playerresize', function() {
+    assert.ok(true, 'playerresize fired');
+  });
+
+  player.width(400);
+  player.height(300);
+
+  player.dispose();
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1724,3 +1724,17 @@ QUnit.test('should fire playerresize when player is resized', function(assert) {
 
   player.dispose();
 });
+
+QUnit.test('should fire playerresize exactly once for a two-dimensional resize', function(assert) {
+  assert.expect(1);
+
+  const player = TestHelpers.makePlayer();
+
+  player.on('playerresize', function() {
+    assert.ok(true, 'playerresize fired once');
+  });
+
+  player.dimensions(400, 300);
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
Fixes #4629, and also handles multi-dimensional resizing correctly. I.e. `playerresize` event is only triggered once when width and height is changed at once (using `Component#dimensions`).

## Specific Changes proposed
Trigger a `playerresize` event in `Player#dimension` if `Player.isReady_` and `skipListeners` is falsy.

`skipListeners`  is added as an optional parameter to the following methods: `Player#width`, `Player#height`, and `Player#dimension`. This parameter can be used to skip the `playerresize` event trigger.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors
