### PR TITLE
fix: force autoplay in Chrome

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -475,7 +475,10 @@ class Player extends Component {
     // chrome started pausing the video when moving in the DOM
     // causing autoplay to not continue due to how Video.js functions.
     // See #4720 for more info.
-    if (this.paused() && this.options_.autoplay && browser.IS_CHROME) {
+    if (this.paused() &&
+        this.options_.autoplay &&
+        browser.IS_CHROME &&
+        !browser.IS_ANDROID) {
       this.play();
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -472,15 +472,7 @@ class Player extends Component {
     this.playWaitingForReady_ = false;
     this.playOnLoadstart_ = null;
 
-    // chrome started pausing the video when moving in the DOM
-    // causing autoplay to not continue due to how Video.js functions.
-    // See #4720 for more info.
-    if (this.paused() &&
-        this.options_.autoplay &&
-        browser.IS_CHROME &&
-        !browser.IS_ANDROID) {
-      this.play();
-    }
+    this.forceAutoplayInChrome_();
   }
 
   /**
@@ -2567,9 +2559,26 @@ class Player extends Component {
     if (value !== undefined) {
       this.techCall_('setAutoplay', value);
       this.options_.autoplay = value;
+      this.ready(this.forceAutoplayInChrome_);
       return;
     }
     return this.techGet_('autoplay', value);
+  }
+
+  /**
+   * chrome started pausing the video when moving in the DOM
+   * causing autoplay to not continue due to how Video.js functions.
+   * See #4720 for more info.
+   *
+   * @private
+   */
+  forceAutoplayInChrome_() {
+    if (this.paused() &&
+        this.autoplay() &&
+        browser.IS_CHROME &&
+        !browser.IS_ANDROID) {
+      this.play();
+    }
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -471,6 +471,13 @@ class Player extends Component {
     this.changingSrc_ = false;
     this.playWaitingForReady_ = false;
     this.playOnLoadstart_ = null;
+
+    // chrome started pausing the video when moving in the DOM
+    // causing autoplay to not continue due to how Video.js functions.
+    // See #4720 for more info.
+    if (this.paused() && this.options().autoplay && browser.IS_CHROME) {
+      this.play();
+    }
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -475,7 +475,7 @@ class Player extends Component {
     // chrome started pausing the video when moving in the DOM
     // causing autoplay to not continue due to how Video.js functions.
     // See #4720 for more info.
-    if (this.paused() && this.options().autoplay && browser.IS_CHROME) {
+    if (this.paused() && this.options_.autoplay && browser.IS_CHROME) {
       this.play();
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2574,9 +2574,10 @@ class Player extends Component {
    */
   forceAutoplayInChrome_() {
     if (this.paused() &&
-        this.autoplay() &&
-        browser.IS_CHROME &&
-        !browser.IS_ANDROID) {
+        // read from the video element or options
+        (this.autoplay() || this.options_.autoplay) &&
+        // only target desktop chrome
+        (browser.IS_CHROME && !browser.IS_ANDROID)) {
       this.play();
     }
   }

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -36,6 +36,8 @@ class TechFaker extends Tech {
 
   setMuted() {}
 
+  setAutoplay() {}
+
   currentTime() {
     return 0;
   }
@@ -52,6 +54,9 @@ class TechFaker extends Tech {
     return 0;
   }
   muted() {
+    return false;
+  }
+  autoplay() {
     return false;
   }
   pause() {


### PR DESCRIPTION
Chrome has started pausing autoplaying video elements when they are
moved in the DOM. Here we need to make sure that if the video started
autoplaying, after we move the element in the DOM we call play again.

Fixes #4720.