### PR TITLE
fix(html5): loop video el attributes in order

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -315,7 +315,7 @@ class Html5 extends Tech {
     // when iOS/Safari or other browsers attempt to autoplay.
     const settingsAttrs = ['loop', 'muted', 'playsinline', 'autoplay'];
 
-    for (let i = settingsAttrs.length - 1; i >= 0; i--) {
+    for (let i = 0; i < settingsAttrs.length; i++) {
       const attr = settingsAttrs[i];
       const value = this.options_[attr];
 


### PR DESCRIPTION
Due to historical issues, we loops the settings attributes like muted
and autoplay in reverse order but we want to loop them in order.