### PR TITLE
feat(css): add a delay before showing loading spinner

### DIFF
--- a/src/css/components/_loading.scss
+++ b/src/css/components/_loading.scss
@@ -17,11 +17,14 @@
   width: 50px;
   height: 50px;
   border-radius: 25px;
+  visibility: hidden;
 }
 
 .vjs-seeking .vjs-loading-spinner,
 .vjs-waiting .vjs-loading-spinner {
   display: block;
+  // add a delay before actual show the spinner
+  animation: 0s linear 0.3s forwards vjs-spinner-show;
 }
 
 .vjs-loading-spinner:before,
@@ -59,6 +62,18 @@
   border-top-color: rgb(255,255,255);
   -webkit-animation-delay: 0.44s;
   animation-delay: 0.44s;
+}
+
+@keyframes vjs-spinner-show {
+  to {
+    visibility: visible;
+  }
+}
+
+@-webkit-keyframes vjs-spinner-show {
+  to {
+    visibility: visible;
+  }
 }
 
 @keyframes vjs-spinner-spin {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1233,7 +1233,7 @@ class Player extends Component {
    * @private
    */
   handleTechWaiting_() {
-    this.throttle(() => this.addClass('vjs-waiting'), 500);
+    this.addClass('vjs-waiting');
     /**
      * A readyState change on the DOM element has caused playback to stop.
      *


### PR DESCRIPTION
In some browsers (chrome on windows) when playing high fps video (.mp4 60 fps) there is blinking loader that keeps showing all the time while playing, despite buffer size.

I suggest add a delay (0.3s) before showing it. 