### PR TITLE
Add translation for "caption settings"

### DIFF
--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -36,5 +36,6 @@
   ", opens captions settings dialog": ", 開啟標題設定對話框",
   ", opens subtitles settings dialog": ", 開啟字幕設定對話框",
   ", opens descriptions settings dialog": ", 開啟描述設定對話框",
-  ", selected": ", 選擇"
+  ", selected": ", 選擇",
+  "captions settings": "字幕設定"
 }


### PR DESCRIPTION
## Description
Add translation for "caption settings"

## Specific Changes proposed
Added a single line, translating "caption settings" to "字幕設定"

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors