### PR TITLE
Fix: use correct logic for menu focus

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -345,7 +345,8 @@ class MenuButton extends Component {
       // set the focus into the submenu, except on iOS where it is resulting in
       // undesired scrolling behavior when the player is in an iframe
       if (IS_IOS && Dom.isInFrame()) {
-        return; //Return early so that the menu isn't focused
+         // Return early so that the menu isn't focused
+        return;
       }
 
       this.menu.focus();

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -344,9 +344,11 @@ class MenuButton extends Component {
 
       // set the focus into the submenu, except on iOS where it is resulting in
       // undesired scrolling behavior when the player is in an iframe
-      if (!IS_IOS && !Dom.isInFrame()) {
-        this.menu.focus();
+      if (IS_IOS && Dom.isInFrame()) {
+        return; //Return early so that the menu isn't focused
       }
+
+      this.menu.focus();
     }
   }
 

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -345,7 +345,7 @@ class MenuButton extends Component {
       // set the focus into the submenu, except on iOS where it is resulting in
       // undesired scrolling behavior when the player is in an iframe
       if (IS_IOS && Dom.isInFrame()) {
-         // Return early so that the menu isn't focused
+        // Return early so that the menu isn't focused
         return;
       }
 


### PR DESCRIPTION
This was resulting in the menu not being focused for all browsers/devices (if the player was in a frame), but it should target only IOS. This fixes #4821


