### PR TITLE
replace &nbsp; with \u00a0 fixes #4309

### DIFF
--- a/src/js/control-bar/spacer-controls/custom-control-spacer.js
+++ b/src/js/control-bar/spacer-controls/custom-control-spacer.js
@@ -34,7 +34,7 @@ class CustomControlSpacer extends Spacer {
 
     // No-flex/table-cell mode requires there be some content
     // in the cell to fill the remaining space of the table.
-    el.innerHTML = '&nbsp;';
+    el.innerHTML = '\u00a0';
     return el;
   }
 }


### PR DESCRIPTION
## Description

fixes #4309

## Specific Changes proposed

replace `&nbsp;` with `\u00a0` in `src/js/control-bar/spacer-controls/custom-control-spacer.js`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
