### PR TITLE
fix: Fix an issue where hookOnce failed for the 'beforesetup' hook.

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -186,7 +186,7 @@ videojs.hookOnce = function(type, fn) {
   videojs.hooks(type, [].concat(fn).map(original => {
     const wrapper = (...args) => {
       videojs.removeHook(type, wrapper);
-      original(...args);
+      return original(...args);
     };
 
     return wrapper;

--- a/test/unit/videojs-hooks.test.js
+++ b/test/unit/videojs-hooks.test.js
@@ -123,6 +123,17 @@ QUnit.test('should be able to add a hook that runs once', function(assert) {
   assert.equal(videojs.hooks_.foo.length, 0, 'should have 0 foo hooks');
 });
 
+QUnit.test('hooks registered using hookOnce should return the original callback return value', function(assert) {
+  let result;
+
+  videojs.hookOnce('foo', () => 'ok');
+  videojs.hooks('foo').forEach(fn => {
+    result = fn();
+  });
+
+  assert.equal(result, 'ok', 'the hookOnce callback returned "ok"');
+});
+
 QUnit.test('should trigger beforesetup and setup during videojs setup', function(assert) {
   const vjsOptions = {techOrder: ['techFaker']};
   let setupCalled = false;


### PR DESCRIPTION
I noticed that the `hookOnce` function failed when used for the `beforesetup` hook because it didn't return the value of its inner function.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
