### PR TITLE
fix: Don't bind and dispose audio track menu item prototype methods

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -3,7 +3,6 @@
  */
 import MenuItem from '../../menu/menu-item.js';
 import Component from '../../component.js';
-import * as Fn from '../../utils/fn.js';
 
 /**
  * An {@link AudioTrack} {@link MenuItem}
@@ -33,7 +32,9 @@ class AudioTrackMenuItem extends MenuItem {
 
     this.track = track;
 
-    const changeHandler = Fn.bind(this, this.handleTracksChange);
+    const changeHandler = (...args) => {
+      this.handleTracksChange.apply(this, args);
+    };
 
     tracks.addEventListener('change', changeHandler);
     this.on('dispose', () => {


### PR DESCRIPTION
## Description
Audio track menu items are not updating properly. This change is related to https://github.com/videojs/video.js/pull/4745

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors