### PR TITLE
docs: callback alternative to addRemoteTextTrack

### DIFF
--- a/docs/guides/text-tracks.md
+++ b/docs/guides/text-tracks.md
@@ -229,7 +229,7 @@ As mentioned [above](#a-note-on-remote-text-tracks), remote text tracks represen
   **Note**: If you need a callback, instead of a callback you could use the technique below:
   ```js
   const trackEl = player.addRemoteTextTrack({src: 'en.vtt'}, false);
-  trackEl.on('load', function() {
+  trackEl.addEventListener('load', function() {
     // your callback go here
   });
   ```

--- a/docs/guides/text-tracks.md
+++ b/docs/guides/text-tracks.md
@@ -225,6 +225,14 @@ As mentioned [above](#a-note-on-remote-text-tracks), remote text tracks represen
 * `Player#addRemoteTextTrack(Object options)`
 
   Available options are the same as the [available `track` attributes](#track-attributes). And `language` is a supported option as an alias for the `srclang` attribute - either works here.
+  
+  **Note**: If you need a callback, instead of a callback you could use the technique below:
+  ```js
+  const trackEl = player.addRemoteTextTrack({src: 'en.vtt'}, false);
+  trackEl.on('load', function() {
+    // your callback go here
+  });
+  ```
 
 * `Player#removeRemoteTextTrack(HTMLTrackElement|TextTrack)`
 


### PR DESCRIPTION
## Description
Add docs to guide new user to use callback alternative of function ```player.addRemoteTextTrack```

issue: https://github.com/videojs/video.js/issues/4849
