### PR TITLE
fix: let the tech preload auto on its own

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2504,11 +2504,7 @@ class Player extends Component {
         this.techCall_('src', source.src);
       }
 
-      if (this.options_.preload === 'auto') {
-        this.load();
-      }
-
-    // Set the source synchronously if possible (#2326)
+      // Set the source synchronously if possible (#2326)
     }, true);
 
     return false;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2492,6 +2492,7 @@ class Player extends Component {
     }
 
     // wait until the tech is ready to set the source
+    // and set it synchronously if possible (#2326)
     this.ready(function() {
 
       // The setSource tech method was added with source handlers
@@ -2504,7 +2505,6 @@ class Player extends Component {
         this.techCall_('src', source.src);
       }
 
-      // Set the source synchronously if possible (#2326)
     }, true);
 
     return false;

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -104,8 +104,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       });
     });
 
-    // TODO: unskip when https://github.com/videojs/video.js/pull/4861 is merged
-    QUnit.skip('data-setup preload auto', function(assert) {
+    QUnit.test('data-setup preload auto', function(assert) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('data-setup', JSON.stringify({sources: [this.testSrc]}));
@@ -176,8 +175,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       this.player.src(this.testSrc);
     });
 
-    // TODO: unskip when https://github.com/videojs/video.js/pull/4861 is merged
-    QUnit.skip('player.src({...}) preload auto', function(assert) {
+    QUnit.test('player.src({...}) preload auto', function(assert) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('preload', 'auto');


### PR DESCRIPTION
## Description
This was found due to the work done in #4660. Basically we reload the video element twice on every source with preload set to auto. This can potentially cause the same data to be downloaded twice.

## Specific Changes proposed
* remove players call to load, as tech should handle preload on its own, and this is harmful for the html5 tech.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
