### PR TITLE
chore(netlify): add some debug info in the netlify command

### DIFF
--- a/build/netlify-docs.js
+++ b/build/netlify-docs.js
@@ -1,6 +1,8 @@
 const sh = require('shelljs');
 
 const GIT_CONTAINS = `git tag --contains ${process.env.COMMIT_REF}`;
+console.log('CONTAINS command:', GIT_CONTAINS);
+console.log('BRANCH:', process.env.BRANCH);
 
 const output = sh.exec(GIT_CONTAINS, {async: false, silent:true}).stdout;
 

--- a/build/netlify-docs.js
+++ b/build/netlify-docs.js
@@ -1,10 +1,12 @@
 const sh = require('shelljs');
 
 const GIT_CONTAINS = `git tag --contains ${process.env.COMMIT_REF}`;
+const output = sh.exec(GIT_CONTAINS, {async: false, silent:true}).stdout;
+
 console.log('CONTAINS command:', GIT_CONTAINS);
 console.log('BRANCH:', process.env.BRANCH);
+console.log('OUTPUT', output);
 
-const output = sh.exec(GIT_CONTAINS, {async: false, silent:true}).stdout;
 
 // if we're on master branch and not on a tagged commit,
 // error the build so it doesn't redeploy the docs


### PR DESCRIPTION
The netlify script seemed like it should be working fine at the time and while it runs great for PRs it's failing against master. This allows us to debug the script better.