### PR TITLE
fix: Hide horizontal volume panel while the slider is not active and mute toggle button is on focus

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -53,10 +53,8 @@
   &:focus  .vjs-volume-control,
   & .vjs-volume-control:hover  ,
   & .vjs-volume-control:active ,
-  & .vjs-volume-control:focus  ,
   & .vjs-mute-control:hover  ~ .vjs-volume-control,
   & .vjs-mute-control:active ~ .vjs-volume-control,
-  & .vjs-mute-control:focus  ~ .vjs-volume-control,
   & .vjs-volume-control.vjs-slider-active {
     &.vjs-volume-horizontal {
       width: 5em;
@@ -81,7 +79,6 @@
 
   &.vjs-volume-panel-horizontal {
     &:hover,
-    &:focus,
     &:active,
     &.vjs-slider-active {
       width: 9em;

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -54,7 +54,6 @@
   & .vjs-volume-control:hover  ,
   & .vjs-volume-control:active ,
   & .vjs-mute-control:hover  ~ .vjs-volume-control,
-  & .vjs-mute-control:active ~ .vjs-volume-control,
   & .vjs-volume-control.vjs-slider-active {
     &.vjs-volume-horizontal {
       width: 5em;

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -46,12 +46,10 @@ class VolumePanel extends Component {
     checkVolumeSupport(this, player);
 
     // while the slider is active (the mouse has been pressed down and
-    // is dragging) or in focus we do not want to hide the VolumeBar
+    // is dragging) we do not want to hide the VolumeBar
     this.on(this.volumeControl, ['slideractive'], this.sliderActive_);
-    this.on(this.muteToggle, 'focus', this.sliderActive_);
 
     this.on(this.volumeControl, ['sliderinactive'], this.sliderInactive_);
-    this.on(this.muteToggle, 'blur', this.sliderInactive_);
   }
 
   /**


### PR DESCRIPTION
## Description
Show horizontal volume panel only when the volume slider is active or volume button is hovered but not when focused. This addresses [#4431](https://github.com/videojs/video.js/issues/4431)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
