### PR TITLE
fix: Do not patch canPlayType on Android Chrome

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1051,7 +1051,8 @@ const mp4RE = /^video\/mp4/i;
 Html5.patchCanPlayType = function() {
 
   // Android 4.0 and above can play HLS to some extent but it reports being unable to do so
-  if (browser.ANDROID_VERSION >= 4.0 && !browser.IS_FIREFOX) {
+  // Firefox and Chrome report correctly
+  if (browser.ANDROID_VERSION >= 4.0 && !browser.IS_FIREFOX && !browser.IS_CHROME) {
     Html5.TEST_VID.constructor.prototype.canPlayType = function(type) {
       if (type && mpegurlRE.test(type)) {
         return 'maybe';

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -191,11 +191,13 @@ QUnit.test('patchCanPlayType patches canplaytype with our function, conditionall
 
   const oldAV = browser.ANDROID_VERSION;
   const oldIsFirefox = browser.IS_FIREFOX;
+  const oldIsChrome = browser.IS_CHROME;
   const video = document.createElement('video');
   const canPlayType = Html5.TEST_VID.constructor.prototype.canPlayType;
 
   browser.ANDROID_VERSION = 4.0;
   browser.IS_FIREFOX = false;
+  browser.IS_CHROME = false;
   Html5.patchCanPlayType();
 
   assert.notStrictEqual(video.canPlayType,
@@ -214,6 +216,32 @@ QUnit.test('patchCanPlayType patches canplaytype with our function, conditionall
 
   browser.ANDROID_VERSION = oldAV;
   browser.IS_FIREFOX = oldIsFirefox;
+  browser.IS_CHROME = oldIsChrome;
+  Html5.unpatchCanPlayType();
+});
+
+QUnit.test('patchCanPlayType doesn\'t patch canplaytype with our function in Chrome for Android', function(assert) {
+  // the patch runs automatically so we need to first unpatch
+  Html5.unpatchCanPlayType();
+
+  const oldAV = browser.ANDROID_VERSION;
+  const oldIsChrome = browser.IS_CHROME;
+  const oldIsFirefox = browser.IS_FIREFOX;
+  const video = document.createElement('video');
+  const canPlayType = Html5.TEST_VID.constructor.prototype.canPlayType;
+
+  browser.ANDROID_VERSION = 4.0;
+  browser.IS_CHROME = true;
+  browser.IS_FIREFOX = false;
+  Html5.patchCanPlayType();
+
+  assert.strictEqual(video.canPlayType,
+                 canPlayType,
+                 'original canPlayType and patched canPlayType should be equal');
+
+  browser.ANDROID_VERSION = oldAV;
+  browser.IS_CHROME = oldIsChrome;
+  browser.IS_FIREFOX = oldIsFirefox;
   Html5.unpatchCanPlayType();
 });
 
@@ -223,11 +251,13 @@ QUnit.test('patchCanPlayType doesn\'t patch canplaytype with our function in Fir
 
   const oldAV = browser.ANDROID_VERSION;
   const oldIsFirefox = browser.IS_FIREFOX;
+  const oldIsChrome = browser.IS_CHROME;
   const video = document.createElement('video');
   const canPlayType = Html5.TEST_VID.constructor.prototype.canPlayType;
 
   browser.ANDROID_VERSION = 4.0;
   browser.IS_FIREFOX = true;
+  browser.IS_CHROME = false;
   Html5.patchCanPlayType();
 
   assert.strictEqual(video.canPlayType,
@@ -236,16 +266,19 @@ QUnit.test('patchCanPlayType doesn\'t patch canplaytype with our function in Fir
 
   browser.ANDROID_VERSION = oldAV;
   browser.IS_FIREFOX = oldIsFirefox;
+  browser.IS_CHROME = oldIsChrome;
   Html5.unpatchCanPlayType();
 });
 
-QUnit.test('should return maybe for HLS urls on Android 4.0 or above', function(assert) {
+QUnit.test('should return maybe for HLS urls on Android 4.0 or above when not Chrome or Firefox', function(assert) {
   const oldAV = browser.ANDROID_VERSION;
   const oldIsFirefox = browser.IS_FIREFOX;
+  const oldIsChrome = browser.IS_CHROME;
   const video = document.createElement('video');
 
   browser.ANDROID_VERSION = 4.0;
   browser.IS_FIREFOX = false;
+  browser.IS_CHROME = false;
   Html5.patchCanPlayType();
 
   assert.strictEqual(video.canPlayType('application/x-mpegurl'),
@@ -265,6 +298,7 @@ QUnit.test('should return maybe for HLS urls on Android 4.0 or above', function(
 
   browser.ANDROID_VERSION = oldAV;
   browser.IS_FIREFOX = oldIsFirefox;
+  browser.IS_CHROME = oldIsChrome;
   Html5.unpatchCanPlayType();
 });
 


### PR DESCRIPTION
## Description
Patching `canPlayType` on Android shouldn't be necessary on Android Chrome since it reports its ability to player HLS correctly.

## Specific Changes proposed
Skip patching if UA is Android Chrome.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
