### PR TITLE
chore: generate a test example on netlify on PRs

### DIFF
--- a/build/generate-example.js
+++ b/build/generate-example.js
@@ -17,7 +17,7 @@ export function cleanupExample() {
   sh.rm('-rf', path.join(dest, 'node_modules'));
 }
 
-export default function generateExample({skipBuild}) {
+export default function generateExample({skipBuild} = {}) {
   // run the build
   if (!skipBuild) {
     sh.exec('npm run build');

--- a/build/generate-example.js
+++ b/build/generate-example.js
@@ -1,0 +1,33 @@
+import path from 'path';
+import sh from 'shelljs';
+import klawSync from 'klaw-sync';
+
+const dest = 'docs/api/';
+const distDest = path.join(dest, 'dist');
+const exampleDest = path.join(dest, 'test-example');
+
+export function cleanupExample() {
+  sh.rm('-rf', distDest);
+  sh.rm('-rf', exampleDest);
+}
+
+export default function generateExample({skipBuild}) {
+  // run the build
+  if (!skipBuild) {
+    sh.exec('npm run build');
+  }
+
+  // make sure that the example dest is available
+  sh.mkdir('-p', exampleDest);
+
+  // copy the `dist` dir
+  sh.cp('-R', 'dist', path.join(dest, 'dist'));
+
+  const files = klawSync('sandbox/').filter((file) => path.extname(file.path) === '.example');
+
+  // copy the sandbox example files
+  files.forEach(function(file) {
+    const p = path.parse(file.path);
+    sh.cp(file.path, path.join(exampleDest, p.name));
+  });
+}

--- a/build/generate-example.js
+++ b/build/generate-example.js
@@ -1,14 +1,20 @@
 import path from 'path';
+import fs from 'fs';
 import sh from 'shelljs';
 import klawSync from 'klaw-sync';
 
 const dest = 'docs/api/';
+const vjsFlash = 'node_modules/videojs-flash';
+const vjsSwf = 'node_modules/videojs-swf/';
 const distDest = path.join(dest, 'dist');
 const exampleDest = path.join(dest, 'test-example');
+const vjsFlashDest = path.join(dest, vjsFlash, 'dist');
+const swfDest = path.join(dest, vjsFlash, vjsSwf, 'dist');
 
 export function cleanupExample() {
   sh.rm('-rf', distDest);
   sh.rm('-rf', exampleDest);
+  sh.rm('-rf', path.join(dest, 'node_modules'));
 }
 
 export default function generateExample({skipBuild}) {
@@ -17,11 +23,22 @@ export default function generateExample({skipBuild}) {
     sh.exec('npm run build');
   }
 
-  // make sure that the example dest is available
+  // make sure that the example, flash, and swf dests are available
   sh.mkdir('-p', exampleDest);
+  sh.mkdir('-p', vjsFlashDest);
+  sh.mkdir('-p', swfDest);
 
   // copy the `dist` dir
   sh.cp('-R', 'dist', path.join(dest, 'dist'));
+
+  // copy videojs-flash
+  sh.cp(path.join(vjsFlash, 'dist', 'videojs-flash.js'), vjsFlashDest);
+  // copy videojs-swf
+  if (fs.existsSync(path.join(vjsFlash, vjsSwf, 'dist', 'video-js.swf'))) {
+    sh.cp(path.join(vjsFlash, vjsSwf, 'dist', 'video-js.swf'), swfDest);
+  } else {
+    sh.cp(path.join(vjsSwf, 'dist', 'video-js.swf'), swfDest);
+  }
 
   const files = klawSync('sandbox/').filter((file) => path.extname(file.path) === '.example');
 

--- a/build/grunt.js
+++ b/build/grunt.js
@@ -151,7 +151,6 @@ module.exports = function(grunt) {
         ]
       },
       fonts: { cwd: 'node_modules/videojs-font/fonts/', src: ['*'], dest: 'build/temp/font/', expand: true, filter: 'isFile' },
-      swf:   { cwd: 'node_modules/videojs-swf/dist/', src: 'video-js.swf', dest: 'build/temp/', expand: true, filter: 'isFile' },
       ie8:   { cwd: 'node_modules/videojs-ie8/dist/', src: ['**/**'], dest: 'build/temp/ie8/', expand: true, filter: 'isFile' },
       dist:  { cwd: 'build/temp/', src: ['**/**', '!test*'], dest: 'dist/', expand: true, filter: 'isFile' },
       a11y:  { src: 'sandbox/descriptions.html.example', dest: 'sandbox/descriptions.test-a11y.html' }, // Can only test a file with a .html or .htm extension
@@ -449,7 +448,6 @@ module.exports = function(grunt) {
     'cssmin',
 
     'copy:fonts',
-    'copy:swf',
     'copy:ie8',
     'vjslanguages'
   ]);

--- a/build/netlify-docs.js
+++ b/build/netlify-docs.js
@@ -1,5 +1,6 @@
 const sh = require('shelljs');
 const semver = require('semver');
+const generateExample = require('./generate-example.js').default;
 
 const GIT_LOG = `git log --format=%B -n 1 ${process.env.COMMIT_REF}`;
 const output = sh.exec(GIT_LOG, {async: false, silent:true}).stdout;
@@ -16,4 +17,9 @@ if (process.env.BRANCH === 'master' && semver.valid(output.trim()) === null) {
 
   // copy the legacy docs over
   sh.cp('-R', 'docs/legacy-docs', 'docs/api/docs');
+
+  if (process.env.BRANCH !== 'master') {
+    // generate the example
+    generateExample();
+  }
 }

--- a/sandbox/combined-tracks.html.example
+++ b/sandbox/combined-tracks.html.example
@@ -8,7 +8,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
   <script src="../node_modules/videojs-flash/dist/videojs-flash.js"></script>
 

--- a/sandbox/descriptions.html.example
+++ b/sandbox/descriptions.html.example
@@ -8,7 +8,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
 
   <!-- Set the location of the flash SWF -->

--- a/sandbox/embeds.html.example
+++ b/sandbox/embeds.html.example
@@ -6,13 +6,13 @@
   <script src='../node_modules/es5-shim/es5-shim.js'></script>
   <script src='../node_modules/es6-shim/es6-shim.js'></script>
 
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
 
   <script src='../node_modules/videojs-flash/dist/videojs-flash.js'></script>
   <script src="https://unpkg.com/videojs-contrib-hls@latest/dist/videojs-contrib-hls.js"></script>
 
-  <script src="../build/temp/lang/es.js"></script>
+  <script src="../dist/lang/es.js"></script>
 
   <!-- Set the location of the flash SWF -->
   <script>

--- a/sandbox/flash.html.example
+++ b/sandbox/flash.html.example
@@ -8,7 +8,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
   <script src="../node_modules/videojs-flash/dist/videojs-flash.js"></script>
 

--- a/sandbox/icons.html.example
+++ b/sandbox/icons.html.example
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Video.js Icons Sandbox</title>
 
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../build/video-js.css" rel="stylesheet" type="text/css">
 
   <style>
   .icon-list li span { font-size: 150% }

--- a/sandbox/index.html.example
+++ b/sandbox/index.html.example
@@ -8,7 +8,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
   <script src="../node_modules/videojs-flash/dist/videojs-flash.js"></script>
 

--- a/sandbox/language.html.example
+++ b/sandbox/language.html.example
@@ -9,7 +9,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
 
   <!-- Set the location of the flash SWF -->

--- a/sandbox/plugin.html.example
+++ b/sandbox/plugin.html.example
@@ -8,7 +8,7 @@
   <script src="../dist/ie8/videojs-ie8.js"></script>
 
   <!-- Load the source files -->
-  <link href="../build/temp/video-js.css" rel="stylesheet" type="text/css">
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
   <script src="../dist/video.js"></script>
 
   <!-- Set the location of the flash SWF -->


### PR DESCRIPTION
Sometimes, we get a small PR that has code that's good but testing it means that we have to check out the code locally. This should generate a `test-example` folder on the docs site for the PR with a built version of Video.js from the PR.
Hopefully, this PR will be the the very first example of it too.