### PR TITLE
Only select TextTrackMenuItem if unselected

### DIFF
--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -55,6 +55,7 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
     this.player().getChild('textTrackSettings').open();
   }
 
+  // No operation is needed following text track list changes
   handleTracksChange(event) {
 
   }

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -54,12 +54,6 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
   handleClick(event) {
     this.player().getChild('textTrackSettings').open();
   }
-
-  // CaptionSettingsMenuItem does not need to handle track list change events because
-  // it has no concept of 'selected'
-  handleTracksChange(event) {
-
-  }
 }
 
 Component.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -55,7 +55,8 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
     this.player().getChild('textTrackSettings').open();
   }
 
-  // No operation is needed following text track list changes
+  // CaptionSettingsMenuItem does not need to handle track list change events because
+  // it has no concept of 'selected'
   handleTracksChange(event) {
 
   }

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -54,6 +54,10 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
   handleClick(event) {
     this.player().getChild('textTrackSettings').open();
   }
+
+  handleTracksChange(event) {
+
+  }
 }
 
 Component.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -54,19 +54,28 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
    *        The event that caused this function to run
    */
   handleTracksChange(event) {
+    // console.log('handleTracksChange() called', event); // eslint-disable-line
     const tracks = this.player().textTracks();
-    let selected = true;
+    let shouldBeSelected = true;
 
     for (let i = 0, l = tracks.length; i < l; i++) {
       const track = tracks[i];
 
       if ((this.options_.kinds.indexOf(track.kind) > -1) && track.mode === 'showing') {
-        selected = false;
+        shouldBeSelected = false;
         break;
       }
     }
 
-    this.selected(selected);
+    if (shouldBeSelected) {
+      if (!this.isSelected_) {
+        this.selected(true);
+        this.isSelected_ = true;
+      }
+    } else {
+      this.selected(false);
+      this.isSelected_ = false;
+    }
   }
 
   handleSelectedLanguageChange(event) {

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -66,14 +66,10 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
       }
     }
 
-    if (shouldBeSelected) {
-      // Prevent redundant selected(true) calls because they may cause
-      // screen readers to read the appended control text unnecessarily
-      if (!this.isSelected_) {
-        this.selected(true);
-      }
-    } else {
-      this.selected(false);
+    // Prevent redundant selected() calls because they may cause
+    // screen readers to read the appended control text unnecessarily
+    if (shouldBeSelected !== this.isSelected_) {
+      this.selected(shouldBeSelected);
     }
   }
 

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -71,11 +71,9 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
       // screen readers to read the appended control text unnecessarily
       if (!this.isSelected_) {
         this.selected(true);
-        this.isSelected_ = true;
       }
     } else {
       this.selected(false);
-      this.isSelected_ = false;
     }
   }
 

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -54,7 +54,6 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
    *        The event that caused this function to run
    */
   handleTracksChange(event) {
-    // console.log('handleTracksChange() called', event); // eslint-disable-line
     const tracks = this.player().textTracks();
     let shouldBeSelected = true;
 
@@ -68,6 +67,8 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     }
 
     if (shouldBeSelected) {
+      // Prevent redundant selected(true) calls because they may cause
+      // screen readers to read the appended control text unnecessarily
       if (!this.isSelected_) {
         this.selected(true);
         this.isSelected_ = true;

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -33,7 +33,7 @@ class TextTrackMenuItem extends MenuItem {
     super(player, options);
 
     this.track = track;
-    const changeHandler = (event, ...args) => {
+    const changeHandler = (...args) => {
       this.handleTracksChange.apply(this, args);
     };
     const selectedLanguageChangeHandler = (...args) => {

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -33,7 +33,8 @@ class TextTrackMenuItem extends MenuItem {
     super(player, options);
 
     this.track = track;
-    const changeHandler = (...args) => {
+    const changeHandler = (event, ...args) => {
+      // console.log('changeHandler called on:', event) // eslint-disable-line
       this.handleTracksChange.apply(this, args);
     };
     const selectedLanguageChangeHandler = (...args) => {
@@ -129,6 +130,7 @@ class TextTrackMenuItem extends MenuItem {
    * @listens TextTrackList#change
    */
   handleTracksChange(event) {
+    console.log('handleTracksChange() called with track:', this.track); // eslint-disable-line
     // determine if the menu item *should* be selected at this time
     const trackModeIsShowing = this.track.mode === 'showing';
 

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -34,7 +34,6 @@ class TextTrackMenuItem extends MenuItem {
 
     this.track = track;
     const changeHandler = (event, ...args) => {
-      // console.log('changeHandler called on:', event) // eslint-disable-line
       this.handleTracksChange.apply(this, args);
     };
     const selectedLanguageChangeHandler = (...args) => {
@@ -130,17 +129,15 @@ class TextTrackMenuItem extends MenuItem {
    * @listens TextTrackList#change
    */
   handleTracksChange(event) {
-    console.log('handleTracksChange() called with track:', this.track); // eslint-disable-line
-    // determine if the menu item *should* be selected at this time
     const trackModeIsShowing = this.track.mode === 'showing';
 
-    // menu item should either be selected, or remain selected if it already was
     if (trackModeIsShowing) {
+      // Prevent redundant selected(true) calls because they may cause
+      // screen readers to read the appended control text unnecessarily
       if (!this.isSelected_) {
         this.selected(true);
         this.isSelected_ = true;
       }
-    // menu item should not be selected
     } else {
       this.selected(false);
       this.isSelected_ = false;

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -129,16 +129,12 @@ class TextTrackMenuItem extends MenuItem {
    * @listens TextTrackList#change
    */
   handleTracksChange(event) {
-    const trackModeIsShowing = this.track.mode === 'showing';
+    const shouldBeSelected = this.track.mode === 'showing';
 
-    if (trackModeIsShowing) {
-      // Prevent redundant selected(true) calls because they may cause
-      // screen readers to read the appended control text unnecessarily
-      if (!this.isSelected_) {
-        this.selected(true);
-      }
-    } else {
-      this.selected(false);
+    // Prevent redundant selected() calls because they may cause
+    // screen readers to read the appended control text unnecessarily
+    if (shouldBeSelected !== this.isSelected_) {
+      this.selected(shouldBeSelected);
     }
   }
 

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -129,7 +129,20 @@ class TextTrackMenuItem extends MenuItem {
    * @listens TextTrackList#change
    */
   handleTracksChange(event) {
-    this.selected(this.track.mode === 'showing');
+    // determine if the menu item *should* be selected at this time
+    const trackModeIsShowing = this.track.mode === 'showing';
+
+    // menu item should either be selected, or remain selected if it already was
+    if (trackModeIsShowing) {
+      if (!this.isSelected_) {
+        this.selected(true);
+        this.isSelected_ = true;
+      }
+    // menu item should not be selected
+    } else {
+      this.selected(false);
+      this.isSelected_ = false;
+    }
   }
 
   handleSelectedLanguageChange(event) {

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -136,11 +136,9 @@ class TextTrackMenuItem extends MenuItem {
       // screen readers to read the appended control text unnecessarily
       if (!this.isSelected_) {
         this.selected(true);
-        this.isSelected_ = true;
       }
     } else {
       this.selected(false);
-      this.isSelected_ = false;
     }
   }
 

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -78,7 +78,6 @@ class MenuItem extends ClickableComponent {
    */
   handleClick(event) {
     this.selected(true);
-    this.isSelected_ = true;
   }
 
   /**
@@ -95,11 +94,13 @@ class MenuItem extends ClickableComponent {
         // aria-checked isn't fully supported by browsers/screen readers,
         // so indicate selected state to screen reader in the control text.
         this.controlText(', selected');
+        this.isSelected_ = true;
       } else {
         this.removeClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'false');
         // Indicate un-selected state to screen reader
         this.controlText('');
+        this.isSelected_ = false;
       }
     }
   }

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -26,11 +26,9 @@ class MenuItem extends ClickableComponent {
     super(player, options);
 
     this.selectable = options.selectable;
-
-    this.selected(options.selected);
-
-    // I ADDED THIS
     this.isSelected_ = options.selected;
+
+    this.selected(this.isSelected_);
 
     if (this.selectable) {
       // TODO: May need to be either menuitemcheckbox or menuitemradio,
@@ -90,14 +88,13 @@ class MenuItem extends ClickableComponent {
    *        if the menu item is selected or not
    */
   selected(selected) {
-    console.log(`selected(${selected}) called on`, this); // eslint-disable-line
     if (this.selectable) {
       if (selected) {
         this.addClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'true');
         // aria-checked isn't fully supported by browsers/screen readers,
         // so indicate selected state to screen reader in the control text.
-        this.controlText('alex');
+        this.controlText(', selected');
       } else {
         this.removeClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'false');

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -29,6 +29,9 @@ class MenuItem extends ClickableComponent {
 
     this.selected(options.selected);
 
+    // I ADDED THIS
+    this.isSelected_ = options.selected;
+
     if (this.selectable) {
       // TODO: May need to be either menuitemcheckbox or menuitemradio,
       //       and may need logical grouping of menu items.
@@ -77,6 +80,7 @@ class MenuItem extends ClickableComponent {
    */
   handleClick(event) {
     this.selected(true);
+    this.isSelected_ = true;
   }
 
   /**
@@ -86,13 +90,14 @@ class MenuItem extends ClickableComponent {
    *        if the menu item is selected or not
    */
   selected(selected) {
+    console.log(`selected(${selected}) called on`, this); // eslint-disable-line
     if (this.selectable) {
       if (selected) {
         this.addClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'true');
         // aria-checked isn't fully supported by browsers/screen readers,
         // so indicate selected state to screen reader in the control text.
-        this.controlText(', selected');
+        this.controlText('alex');
       } else {
         this.removeClass('vjs-selected');
         this.el_.setAttribute('aria-checked', 'false');

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -26,7 +26,7 @@ class MenuItem extends ClickableComponent {
     super(player, options);
 
     this.selectable = options.selectable;
-    this.isSelected_ = options.selected;
+    this.isSelected_ = options.selected || false;
 
     this.selected(this.isSelected_);
 


### PR DESCRIPTION
## Description
These changes address an issue where screen readers may repeatedly and redundantly read `TextTrackMenuItem`'s [control text](https://github.com/videojs/video.js/blob/master/src/js/menu/menu-item.js#L95) on every `texttrackchange` event in some browsers.

The source of the problem is in the `handleTracksChange()` method of [`TextTrackMenuItem`](https://github.com/videojs/video.js/blob/master/src/js/control-bar/text-track-controls/text-track-menu-item.js#L131-L133) and its subclass [`OffTextTrackMenuItem`](https://github.com/videojs/video.js/blob/master/src/js/control-bar/text-track-controls/off-text-track-menu-item.js#L56-L70), in which `this.selected(true/false)` gets called even if the selected state has not changed since its previous invocation.

## Specific Changes proposed
1. Create private `isSelected_` property for menu items
2. Only call `.selected(true)` in `handleTracksChange()` if `!isSelected_`