### PR TITLE
Allow techs to change poster if player option `techCanOverridePoster` is set

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -30,6 +30,7 @@
   * [plugins](#plugins)
   * [sourceOrder](#sourceorder)
   * [sources](#sources)
+  * [techCanOverridePoster](#techCanOverridePoster)
   * [techOrder](#techorder)
   * [vtt.js](#vttjs)
 * [Component Options](#component-options)
@@ -253,6 +254,15 @@ Using `<source>` elements will have the same effect:
   <source src="//path/to/video.webm" type="video/webm">
 </video>
 ```
+
+### `techCanOverridePoster`
+
+> Type: `boolean`
+
+Gives the possibility to techs to override the player's poster 
+and integrate into the player's poster life-cycle.
+This can be useful when multiple techs are used and each has to set their own poster
+ any time a new source is played.
 
 ### `techOrder`
 

--- a/docs/guides/tech.md
+++ b/docs/guides/tech.md
@@ -57,6 +57,21 @@ videojs("videoID", {
 });
 ```
 
+### Posters
+
+By default, techs will have to handle their own posters and are somewhat locked out of the player's poster lifecycle. 
+However, when the player is initialized with the `techCanOverridePoster` option 
+it will be possible for techs to integrate into that lifecycle  and the player's `PosterImage` component to be used.
+ 
+Techs can check if they have this capability by checking the `canOverridePoster` boolean in their options. 
+
+**`techCanOverridePoster` requirements**
+
+ - `poster()` which returns the tech's current poster url
+ - `setPoster()` which updates the tech's poster url and triggers a `posterchange` event
+   which the player will handle
+
+
 ## Technology Ordering
 
 When Video.js is given an array of sources, which to use is determined by finding the first supported source / tech combination. Each tech will be queried in the order specified in `techOrder` whether it can play the first source. The first match wins. If no tech can play the first source, then the next will be tested. It's important to set the `type` of each source correctly for this test to be accurate.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -927,7 +927,8 @@ class Player extends Component {
       'poster': this.poster(),
       'language': this.language(),
       'playerElIngest': this.playerElIngest_ || false,
-      'vtt.js': this.options_['vtt.js']
+      'vtt.js': this.options_['vtt.js'],
+      'canOverridePoster': !!this.options_.techCanOverridePoster
     };
 
     TRACK_TYPES.names.forEach((name) => {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -317,6 +317,9 @@ class Player extends Component {
     // Run base component initializing with new options
     super(null, options, ready);
 
+    // Tracks when a tech changes the poster
+    this.isPosterFromTech_ = false;
+
     // Turn off API access because we're loading a new tech that might load asynchronously
     this.isReady_ = false;
 
@@ -513,6 +516,8 @@ class Player extends Component {
 
     if (this.tech_) {
       this.tech_.dispose();
+      this.isPosterFromTech_ = false;
+      this.poster_ = '';
     }
 
     if (this.playerElIngest_) {
@@ -1017,6 +1022,13 @@ class Player extends Component {
     this.tech_.dispose();
 
     this.tech_ = false;
+
+    if (this.isPosterFromTech_) {
+      this.poster_ = '';
+      this.trigger('posterchange');
+    }
+
+    this.isPosterFromTech_ = false;
   }
 
   /**
@@ -2655,11 +2667,17 @@ class Player extends Component {
       src = '';
     }
 
+    if (src === this.poster_) {
+      return;
+    }
+
     // update the internal poster variable
     this.poster_ = src;
 
     // update the tech's poster
     this.techCall_('setPoster', src);
+
+    this.isPosterFromTech_ = false;
 
     // alert components that the poster has been set
     /**
@@ -2684,11 +2702,16 @@ class Player extends Component {
    * @private
    */
   handleTechPosterChange_() {
-    if (!this.poster_ && this.tech_ && this.tech_.poster) {
-      this.poster_ = this.tech_.poster() || '';
+    if ((!this.poster_ || this.options_.techCanOverridePoster) && this.tech_ && this.tech_.poster) {
+      const newPoster = this.tech_.poster() || '';
 
-      // Let components know the poster has changed
-      this.trigger('posterchange');
+      if (newPoster !== this.poster_) {
+        this.poster_ = newPoster;
+        this.isPosterFromTech_ = true;
+
+        // Let components know the poster has changed
+        this.trigger('posterchange');
+      }
     }
   }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1719,6 +1719,7 @@ QUnit.test('setPoster in tech with `techCanOverridePoster` in player should over
   const techPosterUrl = 'https://somewhere.text/my/image.png';
 
   assert.equal(player.options_.techCanOverridePoster, true);
+  assert.equal(player.tech_.options_.canOverridePoster, true);
 
   player.on('posterchange', posterchangeSpy);
 
@@ -1746,6 +1747,7 @@ QUnit.test('setPoster in tech WITHOUT `techCanOverridePoster` in player should N
   const techPosterUrl = 'https://somewhere.test/my/image.png';
 
   assert.equal(player.options_.techCanOverridePoster, undefined);
+  assert.equal(player.tech_.options_.canOverridePoster, false);
 
   player.on('posterchange', posterchangeSpy);
 
@@ -1769,6 +1771,7 @@ QUnit.test('disposing a tech that set a poster, should unset the poster', functi
   const techPosterUrl = 'https://somewhere.test/my/image.png';
 
   assert.equal(player.options_.techCanOverridePoster, true);
+  assert.equal(player.tech_.options_.canOverridePoster, true);
 
   player.tech_.setPoster(techPosterUrl);
   assert.equal(player.poster(), techPosterUrl);
@@ -1788,6 +1791,7 @@ QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster',
   const posterUrl = 'https://myposter.test/lol.jpg';
 
   assert.equal(player.options_.techCanOverridePoster, true);
+  assert.equal(player.tech_.options_.canOverridePoster, true);
 
   player.poster(posterUrl);
   assert.equal(player.poster(), posterUrl);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1709,3 +1709,31 @@ QUnit.test('player.duration() sets the value of player.cache_.duration', functio
   player.duration(200);
   assert.equal(player.duration(), 200, 'duration() set and get integer duration value');
 });
+
+QUnit.test('setPoster in tech with `techCanOverridePoster` in player should override poster', function(assert) {
+  const player = TestHelpers.makePlayer({
+    techCanOverridePoster: true
+  });
+  const posterchangeSpy = sinon.spy();
+  const firstPosterUrl = 'https://wherever.test/test.jpg';
+  const techPosterUrl = 'https://somewhere.text/my/image.png';
+
+  assert.equal(player.options_.techCanOverridePoster, true);
+
+  player.on('posterchange', posterchangeSpy);
+
+  player.poster('');
+  assert.ok(posterchangeSpy.notCalled, 'posterchangeSpy not called when no change of poster');
+  assert.equal(player.isPosterFromTech_, false);
+
+  player.poster(firstPosterUrl);
+  assert.ok(posterchangeSpy.calledOnce, 'posterchangeSpy only called once on update');
+  assert.equal(player.poster(), firstPosterUrl);
+  assert.equal(player.isPosterFromTech_, false);
+
+  posterchangeSpy.reset();
+
+  player.tech_.setPoster(techPosterUrl);
+  assert.ok(posterchangeSpy.calledOnce, "posterchangeSpy should've been called");
+});
+

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1737,3 +1737,36 @@ QUnit.test('setPoster in tech with `techCanOverridePoster` in player should over
   assert.ok(posterchangeSpy.calledOnce, "posterchangeSpy should've been called");
 });
 
+QUnit.test('disposing a tech that set a poster, should unset the poster', function(assert) {
+  const player = TestHelpers.makePlayer({
+    techCanOverridePoster: true
+  });
+  const techPosterUrl = 'https://somewhere.test/my/image.png';
+
+  assert.equal(player.options_.techCanOverridePoster, true);
+
+  player.tech_.setPoster(techPosterUrl);
+  assert.equal(player.poster(), techPosterUrl);
+  assert.equal(player.isPosterFromTech_, true);
+
+  player.unloadTech_();
+
+  assert.equal(player.poster(), '');
+});
+
+QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster', function(assert) {
+  const player = TestHelpers.makePlayer({
+    techCanOverridePoster: true
+  });
+  const posterUrl = 'https://myposter.test/lol.jpg';
+
+  assert.equal(player.options_.techCanOverridePoster, true);
+
+  player.poster(posterUrl);
+  assert.equal(player.poster(), posterUrl);
+  assert.equal(player.isPosterFromTech_, false);
+
+  player.unloadTech_();
+
+  assert.equal(player.poster(), posterUrl);
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1718,24 +1718,25 @@ QUnit.test('setPoster in tech with `techCanOverridePoster` in player should over
   const firstPosterUrl = 'https://wherever.test/test.jpg';
   const techPosterUrl = 'https://somewhere.text/my/image.png';
 
-  assert.equal(player.options_.techCanOverridePoster, true);
-  assert.equal(player.tech_.options_.canOverridePoster, true);
+  assert.equal(player.options_.techCanOverridePoster, true, 'make sure player option was passed correctly');
+  assert.equal(player.tech_.options_.canOverridePoster, true, 'make sure tech option was passed correctly');
 
   player.on('posterchange', posterchangeSpy);
 
   player.poster('');
   assert.ok(posterchangeSpy.notCalled, 'posterchangeSpy not called when no change of poster');
-  assert.equal(player.isPosterFromTech_, false);
+  assert.equal(player.isPosterFromTech_, false, "ensure tech didn't change poster after empty call from player");
 
   player.poster(firstPosterUrl);
   assert.ok(posterchangeSpy.calledOnce, 'posterchangeSpy only called once on update');
-  assert.equal(player.poster(), firstPosterUrl);
-  assert.equal(player.isPosterFromTech_, false);
+  assert.equal(player.poster(), firstPosterUrl, "ensure tech didn't change poster after setting from player");
+  assert.equal(player.isPosterFromTech_, false, "ensure player didn't mark poster as changed by the tech");
 
   posterchangeSpy.reset();
 
   player.tech_.setPoster(techPosterUrl);
   assert.ok(posterchangeSpy.calledOnce, "posterchangeSpy should've been called");
+  assert.equal(player.isPosterFromTech_, true, 'ensure player marked poster as set by tech after the fact');
 
   player.dispose();
 });
@@ -1746,20 +1747,21 @@ QUnit.test('setPoster in tech WITHOUT `techCanOverridePoster` in player should N
   const firstPosterUrl = 'https://wherever.test/test.jpg';
   const techPosterUrl = 'https://somewhere.test/my/image.png';
 
-  assert.equal(player.options_.techCanOverridePoster, undefined);
-  assert.equal(player.tech_.options_.canOverridePoster, false);
+  assert.equal(player.options_.techCanOverridePoster, undefined, "ensure player option wasn't unwittingly set");
+  assert.equal(player.tech_.options_.canOverridePoster, false, "ensure tech option wasn't unwittinyly set");
 
   player.on('posterchange', posterchangeSpy);
 
   player.poster(firstPosterUrl);
   assert.ok(posterchangeSpy.calledOnce, 'posterchangeSpy only called once on update');
-  assert.equal(player.poster(), firstPosterUrl);
-  assert.equal(player.isPosterFromTech_, false);
+  assert.equal(player.poster(), firstPosterUrl, "ensure tech didn't change poster after setting from player");
+  assert.equal(player.isPosterFromTech_, false, "ensure player didn't mark poster as changed by the tech");
 
   posterchangeSpy.reset();
 
   player.tech_.setPoster(techPosterUrl);
   assert.ok(posterchangeSpy.notCalled, "posterchangeSpy shouldn't have been called");
+  assert.equal(player.isPosterFromTech_, false, "ensure tech didn't change poster because player option was false");
 
   player.dispose();
 });
@@ -1770,16 +1772,16 @@ QUnit.test('disposing a tech that set a poster, should unset the poster', functi
   });
   const techPosterUrl = 'https://somewhere.test/my/image.png';
 
-  assert.equal(player.options_.techCanOverridePoster, true);
-  assert.equal(player.tech_.options_.canOverridePoster, true);
+  assert.equal(player.options_.techCanOverridePoster, true, 'make sure player option was passed correctly');
+  assert.equal(player.tech_.options_.canOverridePoster, true, 'make sure tech option was passed correctly');
 
   player.tech_.setPoster(techPosterUrl);
-  assert.equal(player.poster(), techPosterUrl);
-  assert.equal(player.isPosterFromTech_, true);
+  assert.equal(player.poster(), techPosterUrl, 'player poster should equal tech poster');
+  assert.equal(player.isPosterFromTech_, true, 'setting the poster with the tech should be remembered in the player');
 
   player.unloadTech_();
 
-  assert.equal(player.poster(), '');
+  assert.equal(player.poster(), '', 'ensure poster set by poster is unset after tech disposal');
 
   player.dispose();
 });
@@ -1790,16 +1792,16 @@ QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster',
   });
   const posterUrl = 'https://myposter.test/lol.jpg';
 
-  assert.equal(player.options_.techCanOverridePoster, true);
-  assert.equal(player.tech_.options_.canOverridePoster, true);
+  assert.equal(player.options_.techCanOverridePoster, true, 'make sure player option was passed correctly');
+  assert.equal(player.tech_.options_.canOverridePoster, true, 'make sure tech option was passed correctly');
 
   player.poster(posterUrl);
-  assert.equal(player.poster(), posterUrl);
-  assert.equal(player.isPosterFromTech_, false);
+  assert.equal(player.poster(), posterUrl, 'player poster should NOT have changed');
+  assert.equal(player.isPosterFromTech_, false, 'player should mark poster as set by itself');
 
   player.unloadTech_();
 
-  assert.equal(player.poster(), posterUrl);
+  assert.equal(player.poster(), posterUrl, 'player poster should stay the same after unloading / dispoing tech');
 
   player.dispose();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1737,6 +1737,29 @@ QUnit.test('setPoster in tech with `techCanOverridePoster` in player should over
   assert.ok(posterchangeSpy.calledOnce, "posterchangeSpy should've been called");
 });
 
+QUnit.test('setPoster in tech WITHOUT `techCanOverridePoster` in player should NOT override poster', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const posterchangeSpy = sinon.spy();
+  const firstPosterUrl = 'https://wherever.test/test.jpg';
+  const techPosterUrl = 'https://somewhere.test/my/image.png';
+
+  assert.equal(player.options_.techCanOverridePoster, undefined);
+
+  player.on('posterchange', posterchangeSpy);
+
+  player.poster(firstPosterUrl);
+  assert.ok(posterchangeSpy.calledOnce, 'posterchangeSpy only called once on update');
+  assert.equal(player.poster(), firstPosterUrl);
+  assert.equal(player.isPosterFromTech_, false);
+
+  posterchangeSpy.reset();
+
+  player.tech_.setPoster(techPosterUrl);
+  assert.ok(posterchangeSpy.notCalled, "posterchangeSpy shouldn't have been called");
+
+  player.dispose();
+});
+
 QUnit.test('disposing a tech that set a poster, should unset the poster', function(assert) {
   const player = TestHelpers.makePlayer({
     techCanOverridePoster: true

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1735,6 +1735,8 @@ QUnit.test('setPoster in tech with `techCanOverridePoster` in player should over
 
   player.tech_.setPoster(techPosterUrl);
   assert.ok(posterchangeSpy.calledOnce, "posterchangeSpy should've been called");
+
+  player.dispose();
 });
 
 QUnit.test('setPoster in tech WITHOUT `techCanOverridePoster` in player should NOT override poster', function(assert) {
@@ -1775,6 +1777,8 @@ QUnit.test('disposing a tech that set a poster, should unset the poster', functi
   player.unloadTech_();
 
   assert.equal(player.poster(), '');
+
+  player.dispose();
 });
 
 QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster', function(assert) {
@@ -1792,4 +1796,6 @@ QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster',
   player.unloadTech_();
 
   assert.equal(player.poster(), posterUrl);
+
+  player.dispose();
 });

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -28,6 +28,7 @@ class TechFaker extends Tech {
   }
   setPoster(val) {
     this.el().poster = val;
+    this.trigger('posterchange');
   }
 
   setControls(val) {}


### PR DESCRIPTION
## Description

The option for the player `techCanOverridePoster` is introduced in this commit. It allows techs to update the post whenever they like. `isPosterFromTech_` is introduced as a private player field in order to track when a poster was set by a tech. This allows us to clear the poster whenever the tech is disposed of by the player.

Additionally, attempting to set the same poster more than once will have no effect / no changes will be made, since the poster is the same. This was done in order to stop triggering multiple *posterchange* events when calling `player.poster(aPoster)` with `techCanOverridePoster` set to true.

Related to #4910 

## Specific Changes proposed

 - `techCanOverridePoster` option
 - `isPosterFromTech_` player field
 - `player.poster(aPoster)` triggers a single *posterchange* event
 - `poster.poster(aPoster) && poster.poster(aPoster)` triggers a single *posterchange* event

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
