### PR TITLE
Fix the advance plugin example in documentation

### DIFF
--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -260,7 +260,7 @@ class Advanced extends Plugin {
 
     // Whenever the player emits a playing or paused event, we update the
     // state if necessary.
-    this.on(player, ['playing', 'paused'], this.updateState);
+    this.on(player, ['playing', 'pause'], this.updateState);
     this.on('statechanged', this.logState);
   }
 


### PR DESCRIPTION
## Description
Fix the typo in advance plugin, the event hook should be 'pause' instead of 'paused'

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
