### PR TITLE
fix: cache middleware instances per player

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -523,6 +523,8 @@ class Player extends Component {
       this.tag = null;
     }
 
+    middleware.clearCacheForPlayer(this);
+
     // the actual .el_ is removed here
     super.dispose();
   }

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -105,40 +105,32 @@ function executeRight(mws, method, value, terminated) {
 
 /**
  * {
- *  [type]: [[player, [[mwFactory, mwInstance], ...]], ...]
+ *  [playerId]: [[mwFactory, mwInstance], ...]
  * }
  */
-function getOrCreateFactory(type, player, mwFactory) {
-  const mws = middlewareInstances[type];
+function getOrCreateFactory(player, mwFactory) {
+  const mws = middlewareInstances[player.id()];
   let mw = null;
 
   if (mws === undefined) {
     mw = mwFactory(player);
-    middlewareInstances[type] = [[player, [[mwFactory, mw]]]];
+    middlewareInstances[player.id()] = [[mwFactory, mw]];
     return mw;
   }
 
   for (let i = 0; i < mws.length; i++) {
-    const [mwplayer, mwpp] = mws[i];
+    const [mwf, mwi] = mws[i];
 
-    if (mwplayer !== player) {
+    if (mwf !== mwFactory) {
       continue;
     }
 
-    for (let j = 0; j < mwpp.length; j++) {
-      const [mwf, mwi] = mwpp[j];
+    mw = mwi;
+  }
 
-      if (mwf !== mwFactory) {
-        continue;
-      }
-
-      mw = mwi;
-    }
-
-    if (mw === null) {
-      mw = mwFactory(player);
-      mwpp.push([mwFactory, mw]);
-    }
+  if (mw === null) {
+    mw = mwFactory(player);
+    mws.push([mwFactory, mw]);
   }
 
   return mw;
@@ -154,7 +146,7 @@ function setSourceHelper(src = {}, middleware = [], next, player, acc = [], last
   // if we have an mwFactory, call it with the player to get the mw,
   // then call the mw's setSource method
   } else if (mwFactory) {
-    const mw = getOrCreateFactory(src.type, player, mwFactory);
+    const mw = getOrCreateFactory(player, mwFactory);
 
     mw.setSource(assign({}, src), function(err, _src) {
 

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -103,6 +103,10 @@ function executeRight(mws, method, value, terminated) {
   }
 }
 
+export function clearCacheForPlayer(player) {
+  middlewareInstances[player.id()] = null;
+}
+
 /**
  * {
  *  [playerId]: [[mwFactory, mwInstance], ...]

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -116,7 +116,7 @@ function getOrCreateFactory(player, mwFactory) {
   const mws = middlewareInstances[player.id()];
   let mw = null;
 
-  if (mws === undefined) {
+  if (mws === undefined || mws === null) {
     mw = mwFactory(player);
     middlewareInstances[player.id()] = [[mwFactory, mw]];
     return mw;

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -250,6 +250,7 @@ QUnit.test('setSource is run asynchronously', function(assert) {
   let acc;
 
   middleware.setSource({
+    id() { return 'vid1'; },
     setTimeout: window.setTimeout
   }, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
     src = _src;
@@ -281,6 +282,7 @@ QUnit.test('setSource selects a source based on the middleware given', function(
   middleware.use('video/foo', fooFactory);
 
   middleware.setSource({
+    id() { return 'vid1'; },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
@@ -323,6 +325,7 @@ QUnit.test('setSource can select multiple middleware from multiple types', funct
   middleware.use('video/bar', barFactory);
 
   middleware.setSource({
+    id() { return 'vid1'; },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
@@ -377,6 +380,7 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
   middleware.use('video/foo', fooFactory3);
 
   middleware.setSource({
+    id() { return 'vid1'; },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -423,8 +423,6 @@ QUnit.test('a middleware without a mediator method will not throw an error', fun
 });
 
 QUnit.test('a middleware factory is not called on source change', function(assert) {
-  let src;
-  let acc;
   let mwfactoryCalled = 0;
   const mw = {
     setSource(_src, next) {
@@ -447,10 +445,7 @@ QUnit.test('a middleware factory is not called on source change', function(asser
       return 'vid1';
     },
     setTimeout: window.setTimeout
-  }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
-    src = _src;
-    acc = _acc;
-  });
+  }, {src: 'foo', type: 'video/foo'}, function() {});
 
   this.clock.tick(1);
 
@@ -462,10 +457,7 @@ QUnit.test('a middleware factory is not called on source change', function(asser
       return 'vid1';
     },
     setTimeout: window.setTimeout
-  }, {src: 'bar', type: 'video/foo'}, function(_src, _acc) {
-    src = _src;
-    acc = _acc;
-  });
+  }, {src: 'bar', type: 'video/foo'}, function() {});
 
   this.clock.tick(1);
 
@@ -475,8 +467,6 @@ QUnit.test('a middleware factory is not called on source change', function(asser
 });
 
 QUnit.test('a middleware factory is called on a new source with a new player', function(assert) {
-  let src;
-  let acc;
   let mwfactoryCalled = 0;
   const mw = {
     setSource(_src, next) {
@@ -499,10 +489,7 @@ QUnit.test('a middleware factory is called on a new source with a new player', f
       return 'vid1';
     },
     setTimeout: window.setTimeout
-  }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
-    src = _src;
-    acc = _acc;
-  });
+  }, {src: 'foo', type: 'video/foo'}, function() {});
 
   this.clock.tick(1);
 
@@ -514,10 +501,7 @@ QUnit.test('a middleware factory is called on a new source with a new player', f
       return 'vid2';
     },
     setTimeout: window.setTimeout
-  }, {src: 'bar', type: 'video/foo'}, function(_src, _acc) {
-    src = _src;
-    acc = _acc;
-  });
+  }, {src: 'bar', type: 'video/foo'}, function() {});
 
   this.clock.tick(1);
 

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -250,7 +250,9 @@ QUnit.test('setSource is run asynchronously', function(assert) {
   let acc;
 
   middleware.setSource({
-    id() { return 'vid1'; },
+    id() {
+      return 'vid1';
+    },
     setTimeout: window.setTimeout
   }, { src: 'foo', type: 'video/foo' }, function(_src, _acc) {
     src = _src;
@@ -282,7 +284,9 @@ QUnit.test('setSource selects a source based on the middleware given', function(
   middleware.use('video/foo', fooFactory);
 
   middleware.setSource({
-    id() { return 'vid1'; },
+    id() {
+      return 'vid1';
+    },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
@@ -325,7 +329,9 @@ QUnit.test('setSource can select multiple middleware from multiple types', funct
   middleware.use('video/bar', barFactory);
 
   middleware.setSource({
-    id() { return 'vid1'; },
+    id() {
+      return 'vid1';
+    },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;
@@ -380,7 +386,9 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
   middleware.use('video/foo', fooFactory3);
 
   middleware.setSource({
-    id() { return 'vid1'; },
+    id() {
+      return 'vid1';
+    },
     setTimeout: window.setTimeout
   }, {src: 'foo', type: 'video/foo'}, function(_src, _acc) {
     src = _src;

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -435,7 +435,7 @@ QUnit.test('a middleware factory is not called on source change', function(asser
   const fooFactory = () => {
     mwfactoryCalled++;
     return mw;
-  }
+  };
 
   middleware.use('video/foo', fooFactory);
 
@@ -479,7 +479,7 @@ QUnit.test('a middleware factory is called on a new source with a new player', f
   const fooFactory = () => {
     mwfactoryCalled++;
     return mw;
-  }
+  };
 
   middleware.use('video/foo', fooFactory);
 


### PR DESCRIPTION
## Description
This is the work to fix #4677. Currently, it caches middleware instances per player in an object whose keys are player ids and the value is an array of arrays. The inner array associates middleware factories and the middleware instances.

Tests need to be added and updated as well.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
