### PR TITLE
feat: add mimetype type to source object when possible (#4469)

### DIFF
--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -57,27 +57,14 @@ const filterSource = function(src) {
  *        src Object with known type
  */
 function checkMimetype(src) {
-  const type = extractType(src.src);
+  const ext = Url.getFileExtension(src.src);
+  const mimetype = MimetypesKind[ext.toLowerCase()];
 
-  if (!src.type && type) {
-    src.type = type;
+  if (!src.type && mimetype) {
+    src.type = mimetype;
   }
 
   return src;
-}
-
-/**
- * Extracts video mimetype
- *
- * @param {string} src
- *        The src whose type will be extracted
- * @return {string}
- *        Extracted Mimetype for src
- */
-function extractType(src) {
-  const ext = Url.getFileExtension(src);
-
-  return MimetypesKind[ext.toLowerCase()];
 }
 
 export default filterSource;

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -2,6 +2,8 @@
  * @module filter-source
  */
 import {isObject} from './obj';
+import {MimetypesKind} from './mimetypes';
+import * as Url from '../utils/url.js';
 
 /**
  * Filter out single bad source objects or multiple source objects in an
@@ -34,10 +36,10 @@ const filterSource = function(src) {
     src = newsrc;
   } else if (typeof src === 'string' && src.trim()) {
     // convert string into object
-    src = [{src}];
+    src = [checkMimetype({src})];
   } else if (isObject(src) && typeof src.src === 'string' && src.src && src.src.trim()) {
     // src is already valid
-    src = [src];
+    src = [checkMimetype(src)];
   } else {
     // invalid source, turn it into an empty array
     src = [];
@@ -45,5 +47,37 @@ const filterSource = function(src) {
 
   return src;
 };
+
+/**
+ * Checks src mimetype, adding it when possible
+ *
+ * @param {Tech~SourceObject} src
+ *        The src object to check
+ * @return {Tech~SourceObject}
+ *        src Object with known type
+ */
+function checkMimetype(src) {
+  const type = extractType(src.src);
+
+  if (!src.type && type) {
+    src.type = type;
+  }
+
+  return src;
+}
+
+/**
+ * Extracts video mimetype
+ *
+ * @param {string} src
+ *        The src whose type will be extracted
+ * @return {string}
+ *        Extracted Mimetype for src
+ */
+function extractType(src) {
+  const ext = Url.getFileExtension(src);
+
+  return MimetypesKind[ext.toLowerCase()];
+}
 
 export default filterSource;

--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -12,11 +12,7 @@ export const MimetypesKind = {
   mov: 'video/mp4',
   m4v: 'video/mp4',
   mkv: 'video/x-matroska',
-  mp1: 'audio/mpeg',
-  mp2: 'audio/mpeg',
   mp3: 'audio/mpeg',
-  mpg: 'audio/mpeg',
-  mpeg: 'audio/mpeg',
   aac: 'audio/aac',
   oga: 'audio/ogg',
   m3u8: 'application/x-mpegURL'

--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -1,0 +1,23 @@
+/**
+ * Mimetypes
+ *
+ * @see http://hul.harvard.edu/ois/////systems/wax/wax-public-help/mimetypes.htm
+ * @typedef Mimetypes~Kind
+ * @enum
+ */
+export const MimetypesKind = {
+  opus: 'video/ogg',
+  ogv: 'video/ogg',
+  mp4: 'video/mp4',
+  mov: 'video/mp4',
+  m4v: 'video/mp4',
+  mkv: 'video/x-matroska',
+  mp1: 'audio/mpeg',
+  mp2: 'audio/mpeg',
+  mp3: 'audio/mpeg',
+  mpg: 'audio/mpeg',
+  mpeg: 'audio/mpeg',
+  aac: 'audio/aac',
+  oga: 'audio/ogg',
+  m3u8: 'application/x-mpegURL'
+};

--- a/test/unit/utils/filter-source.test.js
+++ b/test/unit/utils/filter-source.test.js
@@ -122,3 +122,69 @@ QUnit.test('Dont filter extra object properties', function(assert) {
   );
 
 });
+
+QUnit.test('SourceObject type is filled with default values when extension is known', function(assert) {
+  assert.deepEqual(
+    filterSource('some-url.mp4'),
+    [{src: 'some-url.mp4', type: 'video/mp4'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource('some-url.ogv'),
+    [{src: 'some-url.ogv', type: 'video/ogg'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource('some-url.aac'),
+    [{src: 'some-url.aac', type: 'audio/aac'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource({src: 'some-url.mp4'}),
+    [{src: 'some-url.mp4', type: 'video/mp4'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource({src: 'some-url.ogv'}),
+    [{src: 'some-url.ogv', type: 'video/ogg'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource([{src: 'some-url.MP4'}, {src: 'some-url.OgV'}, {src: 'some-url.AaC'}]),
+    [{src: 'some-url.MP4', type: 'video/mp4'}, {src: 'some-url.OgV', type: 'video/ogg'}, {src: 'some-url.AaC', type: 'audio/aac'}],
+    'string source filters to object'
+  );
+});
+
+QUnit.test('SourceObject type is not filled when extension is unknown', function(assert) {
+  assert.deepEqual(
+    filterSource('some-url.ppp'),
+    [{src: 'some-url.ppp'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource('some-url.a'),
+    [{src: 'some-url.a'}],
+    'string source filters to object'
+  );
+
+  assert.deepEqual(
+    filterSource('some-url.mp8'),
+    [{src: 'some-url.mp8'}],
+    'string source filters to object'
+  );
+});
+
+QUnit.test('SourceObject type is not changed when type exists', function(assert) {
+  assert.deepEqual(
+    filterSource({src: 'some-url.aac', type: 'video/zzz'}),
+    [{src: 'some-url.aac', type: 'video/zzz'}],
+    'string source filters to object'
+  );
+});


### PR DESCRIPTION
File mimetype is filled when the file extension is known and type is not provided.

## Description
Feature to support some bad behaviours like #4469 and #4851.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [x] Reviewed by Two Core Contributors
