### PR TITLE
feat: Add an option to override format-time (#2931)

### DIFF
--- a/src/js/utils/format-time.js
+++ b/src/js/utils/format-time.js
@@ -16,7 +16,7 @@
  * @return {string}
  *         Time formatted as H:MM:SS or M:SS
  */
-function formatTime(seconds, guide = seconds) {
+function implementation(seconds, guide) {
   seconds = seconds < 0 ? 0 : seconds;
   let s = Math.floor(seconds % 60);
   let m = Math.floor(seconds / 60 % 60);
@@ -44,4 +44,11 @@ function formatTime(seconds, guide = seconds) {
   return h + m + s;
 }
 
-export default formatTime;
+// override format-time with a custom implementation
+export function setFormatTime (customImplementation) {
+  implementation = customImplementation;
+}
+
+export default function (seconds, guide = seconds) {
+  return implementation(seconds, duration)
+};

--- a/src/js/utils/format-time.js
+++ b/src/js/utils/format-time.js
@@ -3,20 +3,7 @@
  * @module Format-time
  */
 
-/**
- * Format seconds as a time string, H:MM:SS or M:SS. Supplying a guide (in seconds)
- * will force a number of leading zeros to cover the length of the guide.
- *
- * @param {number} seconds
- *        Number of seconds to be turned into a string
- *
- * @param {number} guide
- *        Number (in seconds) to model the string after
- *
- * @return {string}
- *         Time formatted as H:MM:SS or M:SS
- */
-function implementation(seconds, guide) {
+let implementation = function(seconds, guide) {
   seconds = seconds < 0 ? 0 : seconds;
   let s = Math.floor(seconds % 60);
   let m = Math.floor(seconds / 60 % 60);
@@ -42,13 +29,32 @@ function implementation(seconds, guide) {
   s = (s < 10) ? '0' + s : s;
 
   return h + m + s;
-}
+};
 
-// override format-time with a custom implementation
-export function setFormatTime (customImplementation) {
+/**
+ * Replaces the default formatTime implementation with a custom implementation.
+ *
+ * @param {Function} customImplementation
+ *        A function which will be used in place of the default formatTime implementation.
+ *        Will receive the current time in seconds and the guide (in seconds) as arguments.
+ */
+export function setFormatTime(customImplementation) {
   implementation = customImplementation;
 }
 
-export default function (seconds, guide = seconds) {
-  return implementation(seconds, duration)
-};
+/**
+ * Format seconds as a time string, H:MM:SS or M:SS. Supplying a guide (in seconds)
+ * will force a number of leading zeros to cover the length of the guide.
+ *
+ * @param {number} seconds
+ *        Number of seconds to be turned into a string
+ *
+ * @param {number} guide
+ *        Number (in seconds) to model the string after
+ *
+ * @return {string}
+ *         Time formatted as H:MM:SS or M:SS
+ */
+export default function(seconds, guide = seconds) {
+  return implementation(seconds, guide);
+}

--- a/src/js/utils/format-time.js
+++ b/src/js/utils/format-time.js
@@ -1,9 +1,22 @@
 /**
  * @file format-time.js
- * @module Format-time
+ * @module format-time
  */
 
-let implementation = function(seconds, guide) {
+ /**
+ * Format seconds as a time string, H:MM:SS or M:SS. Supplying a guide (in seconds)
+ * will force a number of leading zeros to cover the length of the guide.
+ *
+ * @param {number} seconds
+ *        Number of seconds to be turned into a string
+ *
+ * @param {number} guide
+ *        Number (in seconds) to model the string after
+ *
+ * @return {string}
+ *         Time formatted as H:MM:SS or M:SS
+ */
+const defaultImplementation = function(seconds, guide) {
   seconds = seconds < 0 ? 0 : seconds;
   let s = Math.floor(seconds % 60);
   let m = Math.floor(seconds / 60 % 60);
@@ -31,6 +44,8 @@ let implementation = function(seconds, guide) {
   return h + m + s;
 };
 
+let implementation = defaultImplementation;
+
 /**
  * Replaces the default formatTime implementation with a custom implementation.
  *
@@ -43,18 +58,12 @@ export function setFormatTime(customImplementation) {
 }
 
 /**
- * Format seconds as a time string, H:MM:SS or M:SS. Supplying a guide (in seconds)
- * will force a number of leading zeros to cover the length of the guide.
- *
- * @param {number} seconds
- *        Number of seconds to be turned into a string
- *
- * @param {number} guide
- *        Number (in seconds) to model the string after
- *
- * @return {string}
- *         Time formatted as H:MM:SS or M:SS
+ * Resets formatTime to the default implementation.
  */
+export function resetFormatTime() {
+  implementation = defaultImplementation;
+}
+
 export default function(seconds, guide = seconds) {
   return implementation(seconds, guide);
 }

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -19,7 +19,7 @@ import AudioTrack from './tracks/audio-track.js';
 import VideoTrack from './tracks/video-track.js';
 
 import { createTimeRanges } from './utils/time-ranges.js';
-import formatTime, { setFormatTime } from './utils/format-time.js';
+import formatTime, { setFormatTime, resetFormatTime } from './utils/format-time.js';
 import log from './utils/log.js';
 import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
@@ -557,9 +557,32 @@ videojs.createTimeRange = videojs.createTimeRanges = createTimeRanges;
 videojs.formatTime = formatTime;
 
 /**
+ * Replaces format-time with a custom implementation, to be used in place of the default.
+ *
+ * @borrows format-time:setFormatTime as videojs.setFormatTime
+ *
+ * @method setFormatTime
+ *
+ * @param {Function} customFn
+ *        A custom format-time function which will be called with the current time and guide (in seconds) as arguments.
+ *        Passed fn should return a string.
+ */
+videojs.setFormatTime = setFormatTime;
+
+/**
+ * Resets format-time to the default implementation.
+ *
+ * @borrows format-time:resetFormatTime as videojs.resetFormatTime
+ *
+ * @method resetFormatTime
+ */
+videojs.resetFormatTime = resetFormatTime;
+
+/**
  * Resolve and parse the elements of a URL
  *
  * @borrows url:parseUrl as videojs.parseUrl
+ *
  */
 videojs.parseUrl = Url.parseUrl;
 
@@ -809,11 +832,6 @@ videojs.dom = Dom;
  * and Tech's
  */
 videojs.url = Url;
-
-/**
- * Replaces format-time with a custom implementation
- */
-videojs.setFormatTime = setFormatTime;
 
 export default videojs;
 

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -19,7 +19,7 @@ import AudioTrack from './tracks/audio-track.js';
 import VideoTrack from './tracks/video-track.js';
 
 import { createTimeRanges } from './utils/time-ranges.js';
-import formatTime from './utils/format-time.js';
+import formatTime, { setFormatTime } from './utils/format-time.js';
 import log from './utils/log.js';
 import * as Dom from './utils/dom.js';
 import * as browser from './utils/browser.js';
@@ -809,6 +809,11 @@ videojs.dom = Dom;
  * and Tech's
  */
 videojs.url = Url;
+
+/**
+ * Replaces format-time with a custom implementation
+ */
+videojs.setFormatTime = setFormatTime;
 
 export default videojs;
 

--- a/test/unit/utils/format-time.test.js
+++ b/test/unit/utils/format-time.test.js
@@ -1,7 +1,7 @@
 /* eslint-env qunit */
-import formatTime from '../../../src/js/utils/format-time.js';
+import formatTime, { setFormatTime } from '../../../src/js/utils/format-time.js';
 
-QUnit.module('format-time');
+QUnit.module('format-time standard implementation');
 
 QUnit.test('should format time as a string', function(assert) {
   assert.ok(formatTime(1) === '0:01');
@@ -32,4 +32,12 @@ QUnit.test('should format invalid times as dashes', function(assert) {
   assert.equal(formatTime(NaN), '-:-');
   assert.equal(formatTime(10, Infinity), '0:00:10');
   assert.equal(formatTime(90, NaN), '1:30');
+});
+
+QUnit.module('setFormatTime', {
+  before: setFormatTime((seconds, guide) => `custom:${seconds}:${guide}`)
+});
+
+QUnit.only('should replace the standard implementation of formatTime with the custom function', function(assert) {
+  assert.equal(formatTime(1, 2), 'custom:1:2');
 });

--- a/test/unit/utils/format-time.test.js
+++ b/test/unit/utils/format-time.test.js
@@ -1,7 +1,9 @@
 /* eslint-env qunit */
-import formatTime, { setFormatTime } from '../../../src/js/utils/format-time.js';
+import formatTime, { setFormatTime, resetFormatTime } from '../../../src/js/utils/format-time.js';
 
-QUnit.module('format-time standard implementation');
+QUnit.module('format-time standard implementation', {
+  afterEach: resetFormatTime()
+});
 
 QUnit.test('should format time as a string', function(assert) {
   assert.ok(formatTime(1) === '0:01');
@@ -34,10 +36,15 @@ QUnit.test('should format invalid times as dashes', function(assert) {
   assert.equal(formatTime(90, NaN), '1:30');
 });
 
-QUnit.module('setFormatTime', {
-  before: setFormatTime((seconds, guide) => `custom:${seconds}:${guide}`)
+QUnit.test('setFormatTime', function(assert) {
+  setFormatTime((seconds, guide) => `custom:${seconds}:${guide}`);
+  assert.equal(formatTime(1, 2), 'custom:1:2', 'it should replace the default formatTime implementation');
 });
 
-QUnit.only('should replace the standard implementation of formatTime with the custom function', function(assert) {
+QUnit.test('resetFormatTime ', function(assert) {
+  setFormatTime((seconds, guide) => `custom:${seconds}:${guide}`);
   assert.equal(formatTime(1, 2), 'custom:1:2');
+  resetFormatTime();
+  assert.equal(formatTime(1), '0:01', 'it should reset formatTime to the default implementation');
 });
+


### PR DESCRIPTION
## Description
Addresses #2931, approximately following the suggestions of @gkatsev in the discussion on #3433.  Adds named export `setFormatTime`  to **utils/format-time.js**. Allows overwriting the standard format-time implementation with a custom function, which will be called with seconds and guide as arguments. Also exposes setFormatTime on **videojs**.

Example:

```javascript
videojs.setFormatTime((seconds, guide) => `${seconds}, ${guide}`));
```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
