### PR TITLE
fix: regression for getting a player via the tech's id

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -269,13 +269,23 @@ videojs.getPlayers = () => Player.players;
  */
 videojs.getPlayer = (id) => {
   const players = Player.players;
+  let tag;
 
   if (typeof id === 'string') {
-    return players[normalizeId(id)];
+    const nId = normalizeId(id);
+    const player = players[nId];
+
+    if (player) {
+      return player;
+    }
+
+    tag = Dom.$('#' + nId);
+  } else {
+    tag = id;
   }
 
-  if (Dom.isEl(id)) {
-    const {player, playerId} = id;
+  if (Dom.isEl(tag)) {
+    const {player, playerId} = tag;
 
     // Element may have a `player` property referring to an already created
     // player instance. If so, return that.

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -379,7 +379,7 @@ QUnit.test('videojs() works with the tech id', function(assert) {
   fixture.innerHTML += '<video-js id="player"></video-js>';
 
   const tag = document.querySelector('#player');
-  const player = videojs('#player');
+  const player = videojs('#player', {techOrder: ['html5']});
 
   assert.strictEqual(videojs('player_html5_api'), player, 'the player was returned for the tech id');
   assert.strictEqual(videojs(tag), player, 'the player was returned when using the original tag/element');
@@ -393,7 +393,7 @@ QUnit.test('getPlayer works with the tech id', function(assert) {
   fixture.innerHTML += '<video-js id="player"></video-js>';
 
   const tag = document.querySelector('#player');
-  const player = videojs('#player');
+  const player = videojs('#player', {techOrder: ['html5']});
 
   assert.strictEqual(videojs.getPlayer('player_html5_api'), player, 'the player was returned for the tech id');
   assert.strictEqual(videojs.getPlayer(tag), player, 'the player was returned when using the original tag/element');

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -373,6 +373,34 @@ QUnit.test('getPlayer', function(assert) {
   player.dispose();
 });
 
+QUnit.test('videojs() works with the tech id', function(assert) {
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.innerHTML += '<video-js id="player"></video-js>';
+
+  const tag = document.querySelector('#player');
+  const player = videojs('#player');
+
+  assert.strictEqual(videojs('player_html5_api'), player, 'the player was returned for the tech id');
+  assert.strictEqual(videojs(tag), player, 'the player was returned when using the original tag/element');
+
+  player.dispose();
+});
+
+QUnit.test('getPlayer works with the tech id', function(assert) {
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.innerHTML += '<video-js id="player"></video-js>';
+
+  const tag = document.querySelector('#player');
+  const player = videojs('#player');
+
+  assert.strictEqual(videojs.getPlayer('player_html5_api'), player, 'the player was returned for the tech id');
+  assert.strictEqual(videojs.getPlayer(tag), player, 'the player was returned when using the original tag/element');
+
+  player.dispose();
+});
+
 QUnit.test('getAllPlayers', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 


### PR DESCRIPTION
As part of https://github.com/videojs/video.js/pull/4836, this piece of code was removed because it was thought it was not needed as everything else covers it. Turns out it's needed.

https://github.com/videojs/video.js/blob/f6eaa5e2ae417ffe27251133e1d1212cd9afa8e2/src/js/video.js#L103-L107