### PR TITLE
Small addition to an if check to fix an error

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -278,7 +278,7 @@ class TextTrackDisplay extends Component {
 
     window.WebVTT.processCues(window, cues, this.el_);
 
-    if (this.player_.textTrackSettings === false) {
+    if (!this.player_.textTrackSettings) {
       return;
     }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -266,7 +266,7 @@ class TextTrackDisplay extends Component {
    *        Text track object to be added to the list.
    */
   updateForTrack(track) {
-    if (typeof window.WebVTT !== 'function' || !track.activeCues) {
+    if (typeof window.WebVTT !== 'function' || !track.activeCues || this.player_.textTrackSettings === false) {
       return;
     }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -266,11 +266,10 @@ class TextTrackDisplay extends Component {
    *        Text track object to be added to the list.
    */
   updateForTrack(track) {
-    if (typeof window.WebVTT !== 'function' || !track.activeCues || this.player_.textTrackSettings === false) {
+    if (typeof window.WebVTT !== 'function' || !track.activeCues) {
       return;
     }
 
-    const overrides = this.player_.textTrackSettings.getValues();
     const cues = [];
 
     for (let i = 0; i < track.activeCues.length; i++) {
@@ -278,7 +277,12 @@ class TextTrackDisplay extends Component {
     }
 
     window.WebVTT.processCues(window, cues, this.el_);
-
+	
+	if(this.player_.textTrackSettings === false)
+		return;
+	
+    const overrides = this.player_.textTrackSettings.getValues();
+	
     let i = cues.length;
 
     while (i--) {

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -277,12 +277,14 @@ class TextTrackDisplay extends Component {
     }
 
     window.WebVTT.processCues(window, cues, this.el_);
-	
-	if(this.player_.textTrackSettings === false)
-		return;
-	
+
+    if (this.player_.textTrackSettings === false)
+    {
+        return;
+    }
+
     const overrides = this.player_.textTrackSettings.getValues();
-	
+
     let i = cues.length;
 
     while (i--) {

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -278,9 +278,8 @@ class TextTrackDisplay extends Component {
 
     window.WebVTT.processCues(window, cues, this.el_);
 
-    if (this.player_.textTrackSettings === false)
-    {
-        return;
+    if (this.player_.textTrackSettings === false) {
+      return;
     }
 
     const overrides = this.player_.textTrackSettings.getValues();


### PR DESCRIPTION
## Description
Bug fix for issue https://github.com/videojs/video.js/issues/4964

## Specific Changes proposed
added one condition to early out to check if this.player_.textTrackSettings is false if so return as the later code isn't needed.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
