### PR TITLE
fix(events): triggering with an object had incorrect target property on event object

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -413,7 +413,10 @@ export function trigger(elem, event, hash) {
   // If an event name was passed as a string, creates an event out of it
   if (typeof event === 'string') {
     event = {type: event, target: elem};
+  } else if (!event.target) {
+    event.target = elem;
   }
+
   // Normalizes the event properties.
   event = fixEvent(event);
 

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -284,3 +284,12 @@ QUnit.test('should execute remaining handlers after an exception in an event han
 
   log.error = oldLogError;
 });
+
+QUnit.test('trigger with an object should set the correct target property', function(assert) {
+  const el = document.createElement('div');
+
+  Events.on(el, 'click', function(e) {
+    assert.equal(e.target, el, 'the event object target should be our element');
+  });
+  Events.trigger(el, { type: 'click'});
+});

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -293,3 +293,31 @@ QUnit.test('trigger with an object should set the correct target property', func
   });
   Events.trigger(el, { type: 'click'});
 });
+
+QUnit.test('retrigger with a string should use the new element as target', function(assert) {
+  const el1 = document.createElement('div');
+  const el2 = document.createElement('div');
+
+  Events.on(el2, 'click', function(e) {
+    assert.equal(e.target, el2, 'the event object target should be the new element');
+  });
+  Events.on(el1, 'click', function(e) {
+    Events.trigger(el2, 'click');
+  });
+  Events.trigger(el1, 'click');
+  Events.trigger(el1, {type: 'click'});
+});
+
+QUnit.test('retrigger with an object should use the old element as target', function(assert) {
+  const el1 = document.createElement('div');
+  const el2 = document.createElement('div');
+
+  Events.on(el2, 'click', function(e) {
+    assert.equal(e.target, el1, 'the event object target should be the old element');
+  });
+  Events.on(el1, 'click', function(e) {
+    Events.trigger(el2, e);
+  });
+  Events.trigger(el1, 'click');
+  Events.trigger(el1, {type: 'click'});
+});


### PR DESCRIPTION
Currently, trigger an event with an object rather than a string will have `document` as a `target` on the event object rather than the element.