### PR TITLE
Use CSS grid for caption Setting overlay to avoid cutoff

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -43,11 +43,15 @@
   .vjs-text-track-settings .vjs-track-settings-controls {
     grid-column: 2;
     grid-row: 2;
-    text-align: unset;
-    vertical-align: unset;
+
   }
+
   .vjs-text-track-settings fieldset span.vjs-opacity {
     margin-left: unset;
+  }
+
+  .vjs-track-setting > select {
+    margin-right: 5px;
   }
 }
 

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -45,17 +45,13 @@
     grid-row: 2;
 
   }
-
-  .vjs-text-track-settings fieldset span.vjs-opacity {
-    margin-left: unset;
-  }
-
-  .vjs-track-setting > select {
-    margin-right: 5px;
-  }
 }
 
 // Form elements
+.vjs-track-setting > select {
+  margin-right: 5px;
+}
+
 .vjs-text-track-settings fieldset {
   margin: 5px;
   padding: 3px;
@@ -64,7 +60,7 @@
 
 .vjs-text-track-settings fieldset span {
   display: inline-block;
-  margin-left: 5px;
+  margin-left: 0px;
 }
 
 .vjs-text-track-settings legend {

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -60,7 +60,6 @@
 
 .vjs-text-track-settings fieldset span {
   display: inline-block;
-  margin-left: 0px;
 }
 
 .vjs-text-track-settings legend {

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -90,13 +90,13 @@
 }
 
 .vjs-track-settings-controls button:hover {
-  color: rgba(#2B333f, 0.75);
+  color: rgba(#2B333F, 0.75);
 }
 
 .vjs-track-settings-controls button {
   background-color: $primary-foreground-color;
   background-image: linear-gradient(-180deg, $primary-foreground-color 88%, $secondary-background-color 100%);
-  color: #2B333f;
+  color: #2B333F;
   cursor: pointer;
   border-radius: 2px;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -2,7 +2,7 @@
   background-color: $primary-background-color;
   background-color: rgba($primary-background-color, 0.75);
   color: $primary-foreground-color;
-  height: 100%;
+  height: 70%;
 }
 
 // Layout divs

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -2,7 +2,7 @@
   background-color: $primary-background-color;
   background-color: rgba($primary-background-color, 0.75);
   color: $primary-foreground-color;
-  height: 70%;
+  height: 100%;
 }
 
 // Layout divs
@@ -21,6 +21,48 @@
   vertical-align: bottom;
 }
 
+// code that will only run if CSS Grid is supported by the browser
+@supports (display: grid) {
+  .vjs-text-track-settings .vjs-modal-dialog-content {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: 1fr auto;
+  }
+
+  .vjs-text-track-settings .vjs-track-settings-colors {
+    display: block;
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .vjs-text-track-settings .vjs-track-settings-font {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .vjs-text-track-settings .vjs-track-settings-controls {
+    grid-column: 2;
+    grid-row: 2;
+    text-align: unset;
+    vertical-align: unset;
+  }
+  .vjs-text-track-settings fieldset span.vjs-opacity {
+    margin-left: unset;
+  }
+  .video-js {
+    @media (max-width: 365px) {
+      .vjs-modal-dialog .vjs-modal-dialog-content {
+        font-size: 1em;
+        line-height: 1em;
+        padding: 5px 5px;
+      }
+      .vjs-text-track-settings legend {
+        margin: unset;
+      }
+    }
+  }
+}
+
 // Form elements
 .vjs-text-track-settings fieldset {
   margin: 5px;
@@ -35,7 +77,7 @@
 
 .vjs-text-track-settings legend {
   color: $primary-foreground-color;
-  margin: 0 0 5px 0;
+  margin: 0 0 5px;
 }
 
 // Hide labels, so they are only for screen reader users
@@ -44,7 +86,7 @@
   clip: rect(1px 1px 1px 1px); // for Internet Explorer
   clip: rect(1px, 1px, 1px, 1px);
   display: block;
-  margin: 0 0 5px 0;
+  margin: 0 0 5px;
   padding: 0;
   border: 0;
   height: 1px;
@@ -52,21 +94,21 @@
   overflow: hidden;
 }
 
-.vjs-track-settings-controls button:focus,
-.vjs-track-settings-controls button:active {
+.vjs-track-settings-controls button:active,
+.vjs-track-settings-controls button:focus {
   outline-style: solid;
   outline-width: medium;
   background-image: linear-gradient(0deg, $primary-foreground-color 88%, $secondary-background-color 100%);
 }
 
 .vjs-track-settings-controls button:hover {
-  color: rgba(#2B333F, 0.75);
+  color: rgba(#2b333f, 0.75);
 }
 
 .vjs-track-settings-controls button {
   background-color: $primary-foreground-color;
   background-image: linear-gradient(-180deg, $primary-foreground-color 88%, $secondary-background-color 100%);
-  color: #2B333F;
+  color: #2b333f;
   cursor: pointer;
   border-radius: 2px;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -49,18 +49,6 @@
   .vjs-text-track-settings fieldset span.vjs-opacity {
     margin-left: unset;
   }
-  .video-js {
-    @media (max-width: 365px) {
-      .vjs-modal-dialog .vjs-modal-dialog-content {
-        font-size: 1em;
-        line-height: 1em;
-        padding: 5px 5px;
-      }
-      .vjs-text-track-settings legend {
-        margin: unset;
-      }
-    }
-  }
 }
 
 // Form elements
@@ -77,7 +65,7 @@
 
 .vjs-text-track-settings legend {
   color: $primary-foreground-color;
-  margin: 0 0 5px;
+  margin: 0 0 5px 0;
 }
 
 // Hide labels, so they are only for screen reader users
@@ -86,7 +74,7 @@
   clip: rect(1px 1px 1px 1px); // for Internet Explorer
   clip: rect(1px, 1px, 1px, 1px);
   display: block;
-  margin: 0 0 5px;
+  margin: 0 0 5px 0;
   padding: 0;
   border: 0;
   height: 1px;
@@ -94,21 +82,21 @@
   overflow: hidden;
 }
 
-.vjs-track-settings-controls button:active,
-.vjs-track-settings-controls button:focus {
+.vjs-track-settings-controls button:focus,
+.vjs-track-settings-controls button:active {
   outline-style: solid;
   outline-width: medium;
   background-image: linear-gradient(0deg, $primary-foreground-color 88%, $secondary-background-color 100%);
 }
 
 .vjs-track-settings-controls button:hover {
-  color: rgba(#2b333f, 0.75);
+  color: rgba(#2B333f, 0.75);
 }
 
 .vjs-track-settings-controls button {
   background-color: $primary-foreground-color;
   background-image: linear-gradient(-180deg, $primary-foreground-color 88%, $secondary-background-color 100%);
-  color: #2b333f;
+  color: #2B333f;
   cursor: pointer;
   border-radius: 2px;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -25,7 +25,7 @@
 @supports (display: grid) {
   .vjs-text-track-settings .vjs-modal-dialog-content {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr auto;
   }
 


### PR DESCRIPTION
## Description
Currently the Caption settings menu has two issues:
1. extra characters added to the classname here: https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track-settings.js#L437
2. When the player is smaller than ~450px the menu is squished together and some items are cut off. 

## Enhancements/ Changes
1. Removed the extra characters from the class name so the CSS will target correctly
2. Switch to CSS Grid with minmax column row size to make sure the menu is responsive and looks uniform at all sizes. 
**Before:**
Large Player:
![hiddenbuttons](https://user-images.githubusercontent.com/9756614/34268715-c55b4d5e-e64f-11e7-83ac-176c1d7023a9.png)

Small Player: 
![screenshot2](https://user-images.githubusercontent.com/9756614/34268717-c9797ef6-e64f-11e7-8a50-71c64f3026fe.png)

**After:**
Large Player:
![screen shot 2017-12-21 at 12 56 48 pm](https://user-images.githubusercontent.com/9756614/34268749-e3589a14-e64f-11e7-811b-012794c61d92.png)


Small Player: 
![screen shot 2017-12-21 at 12 56 39 pm](https://user-images.githubusercontent.com/9756614/34268649-8d748f90-e64f-11e7-9249-6ab1407ce2c0.png)
