### PR TITLE
guides: update react guide wrt components

### DIFF
--- a/docs/guides/react.md
+++ b/docs/guides/react.md
@@ -105,6 +105,11 @@ class vjsEpisodeList extends vjsComponent {
     player.ready(() => {
       this.mount();
     });
+    
+    /* Remove React root when component is destroyed */
+    this.on("dispose", () => {
+      ReactDOM.unmountComponentAtNode(this.el())
+    });
   }
 
   /**


### PR DESCRIPTION
## Description
When a component is disposed of, without calling `ReactDOM.unmountComponentAtNode()` on the `data-reactroot` in the destroyed component, the `React.Component` and `videojs.Component` (here `EpisodeList` and `vjsEpisodeList`) remain in memory.

## Specific Changes proposed
The `videojs.Component` should listen for its dispose event and unmount its React root in the corresponding `React.Component`.

I had some trouble creating a JSFiddle / CodePen to show an example, but I can produce an example project showing the memory leak if required.