### PR TITLE
fix: disable autoplay after it has been enabled

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2638,9 +2638,9 @@ class Player extends Component {
       this.play();
     } else {
       // reload to initial state if autoplay is disabled in desktop chrome
-      if(browser.IS_CHROME && !browser.IS_ANDROID) {
+      if (browser.IS_CHROME && !browser.IS_ANDROID) {
         this.load();
-      }      
+      }
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2636,11 +2636,11 @@ class Player extends Component {
         // only target desktop chrome
         (browser.IS_CHROME && !browser.IS_ANDROID)) {
       this.play();
-    } else {
-      // reload to initial state if autoplay is disabled in desktop chrome
-      if (browser.IS_CHROME && !browser.IS_ANDROID) {
-        this.load();
-      }
+    } else if ((!this.autoplay() || !this.options_.autoplay) &&
+              // only target desktop chrome
+              (browser.IS_CHROME && !browser.IS_ANDROID)) {
+      // reload to initial state if autoplay is disabled
+      this.load();
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2636,6 +2636,9 @@ class Player extends Component {
         // only target desktop chrome
         (browser.IS_CHROME && !browser.IS_ANDROID)) {
       this.play();
+    } else {
+      // reload to initial state if autoplay is disabled
+      this.load();
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2637,8 +2637,10 @@ class Player extends Component {
         (browser.IS_CHROME && !browser.IS_ANDROID)) {
       this.play();
     } else {
-      // reload to initial state if autoplay is disabled
-      this.load();
+      // reload to initial state if autoplay is disabled in desktop chrome
+      if(browser.IS_CHROME && !browser.IS_ANDROID) {
+        this.load();
+      }      
     }
   }
 


### PR DESCRIPTION
## Description
Permits disabling autoplay after it has been enabled in Chrome browser.
Fixes: #5005 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
