### PR TITLE
revert: Revert "fix: force autoplay in Chrome (#4804)"

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -475,8 +475,6 @@ class Player extends Component {
     this.changingSrc_ = false;
     this.playWaitingForReady_ = false;
     this.playOnLoadstart_ = null;
-
-    this.forceAutoplayInChrome_();
   }
 
   /**
@@ -2616,27 +2614,9 @@ class Player extends Component {
     if (value !== undefined) {
       this.techCall_('setAutoplay', value);
       this.options_.autoplay = value;
-      this.ready(this.forceAutoplayInChrome_);
       return;
     }
     return this.techGet_('autoplay', value);
-  }
-
-  /**
-   * chrome started pausing the video when moving in the DOM
-   * causing autoplay to not continue due to how Video.js functions.
-   * See #4720 for more info.
-   *
-   * @private
-   */
-  forceAutoplayInChrome_() {
-    if (this.paused() &&
-        // read from the video element or options
-        (this.autoplay() || this.options_.autoplay) &&
-        // only target desktop chrome
-        (browser.IS_CHROME && !browser.IS_ANDROID)) {
-      this.play();
-    }
   }
 
   /**


### PR DESCRIPTION
This reverts commit 6fe7a9a3dd4d3d4930a23cbb2b5ce23a86e97a42.

The PR #4804, which fixes #4720, causes a regression #5005. When testing for the regression, the original issue is no longer reproducible so the fix should be backed out. If someone is still using the old version of chrome and seeing the behavior of #4720, they can continue using the versions of Video.js that contain the fixed made in #4804: 6.5.2, 6.6x, 6.7.x.

Fixes #5005.