### PR TITLE
fix: load sourceset src

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -194,19 +194,19 @@ class Html5 extends Tech {
 
     const chooseSourceEl = (sources) => {
       for (let i = 0; i < sources.length; i++) {
-        if (!sources[0].src) {
+        if (!sources[i].src) {
           continue;
         }
 
-        if (sources[0].type && !Html5.canPlayType(sources[0].type)) {
+        if (sources[i].type && !Html5.canPlayType(sources[i].type)) {
           continue;
         }
 
-        if (sources[0].media) {
+        if (sources[i].media) {
           // ignored, as it isn't used for videos
         }
 
-        return sources[0].src;
+        return sources[i].src;
       }
 
       return '';

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -192,10 +192,39 @@ class Html5 extends Tech {
 
     const oldLoad = el.load;
 
+    const chooseSourceEl = (sources) => {
+      for (let i = 0; i < sources.length; i++) {
+        if (!sources[0].src) {
+          continue;
+        }
+
+        if (sources[0].type && !Html5.canPlayType(sources[0].type)) {
+          continue;
+        }
+
+        if (sources[0].media) {
+          // ignored, as it isn't used for videos
+        }
+
+        return sources[0].src;
+      }
+
+      return '';
+    };
+
     el.load = () => {
+      const sources = document.querySelectorAll('source');
       const retval = oldLoad.call(el);
 
-      this.triggerSourceset(el.src || el.currentSrc);
+      let src = '';
+
+      if (el.src) {
+        src = el.src;
+      } else if (sources.length) {
+        src = chooseSourceEl(sources);
+      }
+
+      this.triggerSourceset(src);
 
       return retval;
     };

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -423,10 +423,12 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       source.src = this.sourceOne.src;
       source.type = this.sourceOne.type;
 
-      this.player.one('sourceset', () => {
+      this.player.one('sourceset', (e) => {
+        assert.equal(e.src, this.sourceOne.src, 'first sourceset is for sourceOne');
         validateSource(assert, this.player, [this.sourceOne], false);
 
-        this.player.one('sourceset', () => {
+        this.player.one('sourceset', (e2) => {
+          assert.equal(e2.src, this.sourceTwo.src, 'first sourceset is for sourceOne');
           validateSource(assert, this.player, [this.sourceTwo], false);
           done();
         });


### PR DESCRIPTION
## Description
Currently `sourceset` on `load()` does not have the current source on the event object. This seeks to do the source selection algorithm to determine what source will be selected.