### PR TITLE
fix(sourceset): set evt.src to empty string or src attr from load

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1198,12 +1198,17 @@ class Player extends Component {
    *
    * It is also fired when `load` is called on the player (or media element)
    * because the {@link https://html.spec.whatwg.org/multipage/media.html#dom-media-load|specification for `load`}
-   * says that the resource selection algorithm
-   * needs to be aborted and restarted.
+   * says that the resource selection algorithm needs to be aborted and restarted.
+   * In this case, it is very likely that the `src` property will be set to the
+   * empty string `""` to indicate we do not know what the source will be but
+   * that it is changing.
    *
    * @event Player#sourceset
    * @type {EventTarget~Event}
-   * @prop {string} src The source url available when the `sourceset` was triggered
+   * @prop {string} src
+   *                The source url available when the `sourceset` was triggered.
+   *                It will be an empty string if we cannot know what the source is
+   *                but know that the source will change.
    */
   /**
    * Retrigger the `sourceset` event that was triggered by the {@link Tech}.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1186,7 +1186,7 @@ class Player extends Component {
   }
 
   /**
-   * Fired when the source is set or changed on the {@link Tech}
+   * *EXPERIMENTAL* Fired when the source is set or changed on the {@link Tech}
    * causing the media element to reload.
    *
    * It will fire for the initial source and each subsequent source.
@@ -1202,6 +1202,8 @@ class Player extends Component {
    * In this case, it is very likely that the `src` property will be set to the
    * empty string `""` to indicate we do not know what the source will be but
    * that it is changing.
+   *
+   * *This event is currently still experimental and may change in minor releases.*
    *
    * @event Player#sourceset
    * @type {EventTarget~Event}

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -195,7 +195,10 @@ class Html5 extends Tech {
     el.load = () => {
       const retval = oldLoad.call(el);
 
-      this.triggerSourceset(el.src || el.currentSrc);
+      // if `el.src` is set, that source will be loaded
+      // otherwise, we can't know for sure what source will be set, so,
+      // instead return an empty string to basically indicate source may change
+      this.triggerSourceset(el.src || '');
 
       return retval;
     };

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -196,7 +196,9 @@ class Html5 extends Tech {
       const retval = oldLoad.call(el);
 
       // if `el.src` is set, that source will be loaded
-      // otherwise, we can't know for sure what source will be set, so,
+      // otherwise, we can't know for sure what source will be set because
+      // source elements will be used but implementing the source selection algorithm
+      // is laborious and asynchronous, so,
       // instead return an empty string to basically indicate source may change
       this.triggerSourceset(el.src || '');
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -169,7 +169,7 @@ function getCustomLaunchers(){
       base: 'BrowserStack',
       browser: 'safari',
       os: 'OS X',
-      os_version: 'Yosemite'
+      os_version: 'El Capitan'
     },
 
     edge_bs: {

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -388,7 +388,6 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     });
 
     QUnit.test('mediaEl.load()', function(assert) {
-      const done = assert.async();
       const source = document.createElement('source');
 
       source.src = this.testSrc.src;
@@ -398,12 +397,11 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       // elements instead
       this.mediaEl.removeAttribute('src');
 
-      this.player.one('sourceset', () => {
-        validateSource(assert, this.player, [this.testSrc], false);
+      this.player.one('sourceset', (e1) => {
+        assert.equal(e1.src, '', 'we got a sourceset with an empty src');
 
-        this.player.one('sourceset', () => {
-          validateSource(assert, this.player, [this.sourceOne], false);
-          done();
+        this.player.one('sourceset', (e2) => {
+          assert.equal(e2.src, '', 'we got a sourceset with an empty src');
         });
 
         source.src = this.sourceOne.src;
@@ -417,7 +415,6 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     });
 
     QUnit.test('mediaEl.load() x2 at the same time', function(assert) {
-      const done = assert.async();
       const source = document.createElement('source');
 
       source.src = this.sourceOne.src;
@@ -440,8 +437,6 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       source.src = this.sourceTwo.src;
       source.type = this.sourceTwo.type;
       this.mediaEl.load();
-
-      done();
     });
 
     QUnit.test('adding a <source> without load()', function(assert) {

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -154,12 +154,12 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.player = videojs(this.mediaEl);
-      this.player.src(this.testSrc);
-
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
         done();
       });
+
+      this.player.src(this.testSrc);
     });
 
     // TODO: unskip when https://github.com/videojs/video.js/pull/4861 is merged
@@ -168,24 +168,26 @@ QUnit[qunitFn]('sourceset', function(hooks) {
 
       this.mediaEl.setAttribute('preload', 'auto');
       this.player = videojs(this.mediaEl);
-      this.player.src(this.testSrc);
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
         done();
       });
+
+      this.player.src(this.testSrc);
     });
 
     QUnit.test('player.src({...}) two sources', function(assert) {
       const done = assert.async();
 
       this.player = videojs(this.mediaEl);
-      this.player.src([this.sourceOne, this.sourceTwo]);
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.sourceOne, this.sourceTwo]);
         done();
       });
+
+      this.player.src([this.sourceOne, this.sourceTwo]);
     });
 
     QUnit.test('mediaEl.src = ...;', function(assert) {

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -423,12 +423,11 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       source.src = this.sourceOne.src;
       source.type = this.sourceOne.type;
 
-      this.player.one('sourceset', () => {
-        validateSource(assert, this.player, [this.sourceOne], false);
+      this.player.one('sourceset', (e1) => {
+        assert.equal(e1.src, '', 'we got a sourceset with an empty src');
 
-        this.player.one('sourceset', () => {
-          validateSource(assert, this.player, [this.sourceTwo], false);
-          done();
+        this.player.one('sourceset', (e2) => {
+          assert.equal(e2.src, '', 'we got a sourceset with an empty src');
         });
       });
 
@@ -441,6 +440,8 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       source.src = this.sourceTwo.src;
       source.type = this.sourceTwo.type;
       this.mediaEl.load();
+
+      done();
     });
 
     QUnit.test('adding a <source> without load()', function(assert) {

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -387,6 +387,27 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       this.mediaEl.setAttribute('src', this.sourceTwo.src);
     });
 
+    QUnit.test('load() with a src attribute', function(assert) {
+      const done = assert.async();
+
+      this.player = videojs(this.mediaEl);
+
+      this.totalSourcesets = 1;
+
+      window.setTimeout(() => {
+        this.sourcesets = 0;
+        this.totalSourcesets = 1;
+
+        this.player.one('sourceset', (e) => {
+          assert.equal(e.src, this.mediaEl.src, "the sourceset event's src matches the src attribute");
+
+          done();
+        });
+
+        this.player.load();
+      }, wait);
+    });
+
     QUnit.test('mediaEl.load()', function(assert) {
       const source = document.createElement('source');
 


### PR DESCRIPTION
If `.load()` is called, we don't know what the new source will be because of the asynchronous nature of the resource selection algorithm. However, we can know if the src attribute is set on the video element because that's what will be chosen. So, set the src property on the event object to be the src attribute or be the empty string. This matches how `currentSrc` works where it is an empty string when no source is set. So, when `sourceset` is triggered and `src` is `""` in the event object, it means that the source is changing.
In addition, we're going to be releasing `sourceset` as an *experimental* feature so we could improve the API and make changes in minor releases.

TODO:
* [x] More documentation for this change