### PR TITLE
fix: remove button outlines

### DIFF
--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -8,8 +8,8 @@
   padding: 0;
   height: 100%;
   width: 4em;
+  outline: 0;
   @include flex(none);
-
 }
 .vjs-button > .vjs-icon-placeholder:before {
   font-size: 1.8em;


### PR DESCRIPTION
## Description
This removes the button outlines that look out of place around the play and volume controls (and perhaps others)

## Specific Changes proposed
Removes the button outlines for the vjs-control class

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
