### PR TITLE
feat: require enableSourceset option for event

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -928,7 +928,8 @@ class Player extends Component {
       'language': this.language(),
       'playerElIngest': this.playerElIngest_ || false,
       'vtt.js': this.options_['vtt.js'],
-      'canOverridePoster': !!this.options_.techCanOverridePoster
+      'canOverridePoster': !!this.options_.techCanOverridePoster,
+      'enableSourceset': this.options_.enableSourceset
     };
 
     TRACK_TYPES.names.forEach((name) => {
@@ -1204,6 +1205,7 @@ class Player extends Component {
    * that it is changing.
    *
    * *This event is currently still experimental and may change in minor releases.*
+   * __To use this, pass `enableSourceset` option to the player.__
    *
    * @event Player#sourceset
    * @type {EventTarget~Event}

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -34,7 +34,9 @@ class Html5 extends Tech {
   constructor(options, ready) {
     super(options, ready);
 
-    this.setupSourcesetHandling_();
+    if (options.enableSourceset) {
+      this.setupSourcesetHandling_();
+    }
 
     const source = options.source;
     let crossoriginTracks = false;

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -163,6 +163,10 @@ class Tech extends Component {
    * @param {string} src The source string at the time of the source changing.
    */
   triggerSourceset(src) {
+    if (!this.options_.enableSourceset) {
+      return;
+    }
+
     if (!this.isReady_) {
       // on initial ready we have to trigger source set
       // 1ms after ready so that player can watch for it.

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -163,10 +163,6 @@ class Tech extends Component {
    * @param {string} src The source string at the time of the source changing.
    */
   triggerSourceset(src) {
-    if (!this.options_.enableSourceset) {
-      return;
-    }
-
     if (!this.isReady_) {
       // on initial ready we have to trigger source set
       // 1ms after ready so that player can watch for it.

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -94,7 +94,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('data-setup', JSON.stringify({sources: [this.testSrc]}));
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -108,7 +110,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
 
       this.mediaEl.setAttribute('data-setup', JSON.stringify({sources: [this.testSrc]}));
       this.mediaEl.setAttribute('preload', 'auto');
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -120,7 +124,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('data-setup', JSON.stringify({sources: [this.sourceOne, this.sourceTwo]}));
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.sourceOne, this.sourceTwo]);
@@ -131,7 +137,10 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('videojs({sources: [...]}) one source', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl, {sources: [this.testSrc]});
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true,
+        sources: [this.testSrc]
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -142,7 +151,10 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('videojs({sources: [...]}) two sources', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl, {sources: [this.sourceOne, this.sourceTwo]});
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true,
+        sources: [this.sourceOne, this.sourceTwo]
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.sourceOne, this.sourceTwo]);
@@ -153,7 +165,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('player.src({...}) one source', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
         done();
@@ -167,7 +181,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('preload', 'auto');
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -180,7 +196,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('player.src({...}) two sources', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.sourceOne, this.sourceTwo]);
@@ -194,7 +212,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.src = this.testSrc.src;
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -206,7 +226,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('src', this.testSrc.src);
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
@@ -223,7 +245,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
 
       this.mediaEl.appendChild(this.source);
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.testSrc]);
         done();
@@ -244,7 +268,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       this.mediaEl.appendChild(this.source);
       this.mediaEl.appendChild(this.source2);
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.player.one('sourceset', () => {
         validateSource(assert, this.player, [this.sourceOne, this.sourceTwo]);
@@ -255,7 +281,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('no source', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.totalSourcesets = 0;
 
@@ -275,7 +303,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
         setupEnv(this, testName);
 
         this.mediaEl.src = this.testSrc.src;
-        this.player = videojs(this.mediaEl);
+        this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
         this.player.ready(() => {
           this.mediaEl = this.player.tech_.el();
@@ -392,7 +422,9 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     QUnit.test('load() with a src attribute', function(assert) {
       const done = assert.async();
 
-      this.player = videojs(this.mediaEl);
+      this.player = videojs(this.mediaEl, {
+        enableSourceset: true
+      });
 
       this.totalSourcesets = 1;
 
@@ -529,6 +561,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     fixture.appendChild(vid);
 
     const player = videojs(vid, {
+      enableSourceset: true,
       techOrder: ['fakeFlash', 'html5']
     });
 

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -304,8 +304,8 @@ QUnit[qunitFn]('sourceset', function(hooks) {
 
         this.mediaEl.src = this.testSrc.src;
         this.player = videojs(this.mediaEl, {
-        enableSourceset: true
-      });
+          enableSourceset: true
+        });
 
         this.player.ready(() => {
           this.mediaEl = this.player.tech_.el();


### PR DESCRIPTION
While sourceset is experimental, require the option `enableSourceset`.
This can easily be reversed in a minor update.

Going forward with this because most of the core committers preferred a flag for this experimental feature and this gets it out the door sooner and can be flipped easily in the future.