### PR TITLE
Fix: `video-js` el sourceset

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -568,6 +568,13 @@ class Player extends Component {
       el.appendChild(tag);
 
       playerElIngest = this.playerElIngest_ = el;
+      // move properties over from our custom `video-js` element
+      // to our new `video` element. This will move things like
+      // `src` or `controls` that were set via js before the player
+      // was initialized.
+      Object.keys(el).forEach((k) => {
+        tag[k] = el[k];
+      });
     }
 
     // set tabindex to -1 so we could focus on the player element

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -34,7 +34,7 @@ const validateSource = function(assert, player, sources, checkMediaElSource = tr
 const setupEnv = function(env, testName) {
   env.fixture = document.getElementById('qunit-fixture');
 
-  if (testName === 'change video el' || testName === 'change audio el') {
+  if ((/^change/i).test(testName)) {
     Html5.prototype.movingMediaElementInDOM = false;
   }
 
@@ -42,7 +42,9 @@ const setupEnv = function(env, testName) {
   env.hook = (player) => player.on('sourceset', () => env.sourcesets++);
   videojs.hook('setup', env.hook);
 
-  if ((/audio/i).test(testName)) {
+  if ((/video-js/i).test(testName)) {
+    env.mediaEl = document.createElement('video-js');
+  } else if ((/audio/i).test(testName)) {
     env.mediaEl = document.createElement('audio');
   } else {
     env.mediaEl = document.createElement('video');
@@ -77,7 +79,7 @@ const setupAfterEach = function(totalSourcesets) {
   };
 };
 
-const testTypes = ['video el', 'change video el', 'audio el', 'change audio el'];
+const testTypes = ['video el', 'change video el', 'audio el', 'change audio el', 'video-js', 'change video-js el'];
 
 QUnit[qunitFn]('sourceset', function(hooks) {
   QUnit.module('source before player', (subhooks) => testTypes.forEach((testName) => {


### PR DESCRIPTION
## Description
Currently properties from `video-js` elements are not copied over to the `video` element when we do that. This means doing things like `videojsEl.src = ...;` will not carry over if they are done before player init. This also add `video-js` testing to our `sourceset` tests.