### PR TITLE
fix: several source setting inconsistencies and slight refactor

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2612,9 +2612,11 @@ class Player extends Component {
 
     if (!titleCaseEquals(sourceTech.tech, this.techName_)) {
       this.changingSrc_ = true;
-
       // load this technology with the chosen source
       this.loadTech_(sourceTech.tech, sourceTech.source);
+      this.tech_.ready(() => {
+        this.changingSrc_ = false;
+      });
       return false;
     }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -35,10 +35,6 @@ class Html5 extends Tech {
   constructor(options, ready) {
     super(options, ready);
 
-    if (options.enableSourceset) {
-      this.setupSourcesetHandling_();
-    }
-
     const source = options.source;
     let crossoriginTracks = false;
 
@@ -50,6 +46,11 @@ class Html5 extends Tech {
       this.setSource(source);
     } else {
       this.handleLateInit_(this.el_);
+    }
+
+    // setup sourceset after late sourceset/init
+    if (options.enableSourceset) {
+      this.setupSourcesetHandling_();
     }
 
     if (this.el_.hasChildNodes()) {
@@ -117,6 +118,9 @@ class Html5 extends Tech {
    * Dispose of `HTML5` media element and remove all tracks.
    */
   dispose() {
+    if (this.el_.resetSourceset_) {
+      this.el_.resetSourceset_();
+    }
     Html5.disposeMediaElement(this.el_);
     this.options_ = null;
 

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -35,10 +35,10 @@ const filterSource = function(src) {
     src = newsrc;
   } else if (typeof src === 'string' && src.trim()) {
     // convert string into object
-    src = [checkMimetype({src})];
+    src = [fixSource({src})];
   } else if (isObject(src) && typeof src.src === 'string' && src.src && src.src.trim()) {
     // src is already valid
-    src = [checkMimetype(src)];
+    src = [fixSource(src)];
   } else {
     // invalid source, turn it into an empty array
     src = [];
@@ -55,7 +55,7 @@ const filterSource = function(src) {
  * @return {Tech~SourceObject}
  *        src Object with known type
  */
-function checkMimetype(src) {
+function fixSource(src) {
   const mimetype = getMimetype(src.src);
 
   if (!src.type && mimetype) {

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -68,7 +68,9 @@ const setupEnv = function(env, testName) {
   }
 
   env.sourcesets = 0;
-  env.hook = (player) => player.on('sourceset', () => env.sourcesets++);
+  env.hook = (player) => player.on('sourceset', (e) => {
+    env.sourcesets++;
+  });
   videojs.hook('setup', env.hook);
 
   if ((/audio/i).test(testName)) {
@@ -268,6 +270,51 @@ QUnit[qunitFn]('sourceset', function(hooks) {
         assert.equal(this.sourcesets, 0, 'no sourceset');
         done();
       }, wait);
+    });
+
+    QUnit.test('relative sources are handled correctly', function(assert) {
+      const done = assert.async();
+      const one = {src: 'relative-one.mp4', type: 'video/mp4'};
+      const two = {src: '../relative-two.mp4', type: 'video/mp4'};
+      const three = {src: './relative-three.mp4?test=test', type: 'video/mp4'};
+
+      const source = document.createElement('source');
+
+      source.src = one.src;
+      source.type = one.type;
+
+      this.mediaEl.appendChild(source);
+      this.player = videojs(this.mediaEl, {enableSourceset: true});
+
+      // mediaEl changes on ready
+      this.player.ready(() => {
+        this.mediaEl = this.player.tech_.el();
+      });
+
+      this.totalSourcesets = 3;
+      this.player.one('sourceset', (e) => {
+        assert.ok(true, '** sourceset with relative source and <source> el');
+        // mediaEl attr is relative
+        validateSource(this.player, {src: getAbsoluteURL(one.src), type: one.type}, e, {attr: one.src});
+
+        this.player.one('sourceset', (e2) => {
+          assert.ok(true, '** sourceset with relative source and mediaEl.src');
+          // mediaEl attr is relative
+          validateSource(this.player, {src: getAbsoluteURL(two.src), type: two.type}, e2, {attr: two.src});
+
+          // setAttribute makes the source absolute
+          this.player.one('sourceset', (e3) => {
+            assert.ok(true, '** sourceset with relative source and mediaEl.setAttribute');
+            validateSource(this.player, {src: getAbsoluteURL(three.src), type: three.type}, e3, {attr: three.src});
+            done();
+          });
+
+          this.mediaEl.setAttribute('src', three.src);
+        });
+
+        this.mediaEl.src = two.src;
+      });
+
     });
   }));
 
@@ -540,7 +587,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       QUnit.test(`set, remove, load, and set again through ${appendObj.name}`, function(assert) {
         const done = assert.async();
 
-        this.totalSourcesets = 2;
+        this.totalSourcesets = 3;
         this.source = document.createElement('source');
         this.source.src = sourceTwo.src;
         this.source.type = sourceTwo.type;
@@ -551,8 +598,12 @@ QUnit[qunitFn]('sourceset', function(hooks) {
           validateSource(this.player, [sourceOne], e1);
 
           this.player.one('sourceset', (e2) => {
-            validateSource(this.player, sourceTwo, e2, {prop: '', attr: ''});
-            done();
+            validateSource(this.player, [{src: '', type: ''}], e2);
+
+            this.player.one('sourceset', (e3) => {
+              validateSource(this.player, sourceTwo, e3, {prop: '', attr: ''});
+              done();
+            });
           });
 
           // reset to no source
@@ -570,17 +621,10 @@ QUnit[qunitFn]('sourceset', function(hooks) {
     });
 
     QUnit.test('no source and load', function(assert) {
-      const done = assert.async();
-
       this.player = videojs(this.mediaEl, {enableSourceset: true});
       this.player.tech_.el_.load();
 
-      this.totalSourcesets = 0;
-
-      window.setTimeout(() => {
-        assert.equal(this.sourcesets, 0, 'no sourceset');
-        done();
-      }, wait);
+      this.totalSourcesets = 1;
     });
   }));
 


### PR DESCRIPTION
## Description
* `load` should always fire sourceset
  * because `mediaEl.src` -> `mediaEl.removeAttribute('src')` -> `load()` should fire a sourceset
* initial sourceset should fire the correct source
* handle empty string sources
* sourceset should always fire an absolute source
* player cache should be absolute urls
* reset souceset before dispose and init sourceset after initial `sourceset`

## TODO
* probably one more pr as some browsers support what I am calling "error recovery", which means that they will start watching for a source append after an error if there is currently no source.