### PR TITLE
feat: built-in HLS playback support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ dist/*
 es5/*
 
 .idea/
+
+core.js

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 !dist/**
 !es5/**
 !src/css/**
+!core.js

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -77,7 +77,7 @@ const coreEs = {
   },
   banner: compiledLicense(Object.assign({includesVtt: true}, bannerData)),
   useStrict: false,
-  format: 'es',
+  format: 'cjs',
   dest: 'core.js'
 };
 

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -55,7 +55,7 @@ const primedBabel = babel({
   plugins: ['external-helpers']
 });
 
-const noVhsEs = {
+const coreEs = {
   options: {
     entry: 'src/js/video.js',
     plugins: [
@@ -200,7 +200,7 @@ if (!args.watch) {
     runRollup(cjs);
     runRollup(umd);
     runRollup(novttUmd);
-    runRollup(noVhsEs);
+    runRollup(coreEs);
   }
 } else {
   const props = ['format', 'dest', 'banner', 'useStrict'];

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -45,7 +45,7 @@ const primedCjs = commonjs({
 });
 const primedBabel = babel({
   babelrc: false,
-  exclude: 'node_modules/**',
+  exclude: 'node_modules/**(!http-streaming)',
   presets: [
     ['es2015', {
       loose: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,17 @@
   "requires": true,
   "dependencies": {
     "@videojs/http-streaming": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-0.7.2.tgz",
-      "integrity": "sha512-caFoaoTcyuDmu43iw4m6/NLtebaryyNwLsvUveMbe4pi942dv+j4V6TthNIMxPsvbfm84xZIFG9AXF7T28kQkQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-0.8.0.tgz",
+      "integrity": "sha512-ZeYLRwiArCMC7lQTARRcn+Obqzmlv+Y3BRI6TA0HQzJWklIHPMUKlYF/rgNeeLuhrS/cLZY52qn/F77AY5ogXw==",
       "requires": {
         "aes-decrypter": "1.0.3",
-        "browserify-versionify": "1.0.6",
         "global": "4.3.2",
         "m3u8-parser": "4.2.0",
         "mpd-parser": "0.5.0",
         "mux.js": "4.4.1",
         "url-toolkit": "2.1.4",
-        "video.js": "6.6.0",
-        "webwackify": "0.1.5"
+        "video.js": "6.6.0"
       }
     },
     "JSONStream": {
@@ -2013,42 +2011,6 @@
         "through": "2.3.8"
       }
     },
-    "browserify-versionify": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/browserify-versionify/-/browserify-versionify-1.0.6.tgz",
-      "integrity": "sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=",
-      "requires": {
-        "find-root": "0.1.2",
-        "through2": "0.6.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
-          "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
@@ -3046,7 +3008,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coveralls": {
       "version": "2.13.3",
@@ -4812,11 +4775,6 @@
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
-    },
-    "find-root": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
     "find-up": {
       "version": "1.1.2",
@@ -7436,7 +7394,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
@@ -8088,7 +8047,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -15875,11 +15835,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
       "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
       "dev": true
-    },
-    "webwackify": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.5.tgz",
-      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw=="
     },
     "whatwg-encoding": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-0.7.2.tgz",
       "integrity": "sha512-caFoaoTcyuDmu43iw4m6/NLtebaryyNwLsvUveMbe4pi942dv+j4V6TthNIMxPsvbfm84xZIFG9AXF7T28kQkQ==",
-      "dev": true,
       "requires": {
         "aes-decrypter": "1.0.3",
         "browserify-versionify": "1.0.6",
@@ -190,7 +189,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-1.0.3.tgz",
       "integrity": "sha1-nAa4pUNaWtCduTP4oBSvzxhMw04=",
-      "dev": true,
       "requires": {
         "pkcs7": "0.2.3"
       }
@@ -2019,7 +2017,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-versionify/-/browserify-versionify-1.0.6.tgz",
       "integrity": "sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=",
-      "dev": true,
       "requires": {
         "find-root": "0.1.2",
         "through2": "0.6.3"
@@ -2029,7 +2026,6 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -2040,14 +2036,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "through2": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
-          "dev": true,
           "requires": {
             "readable-stream": "1.0.34",
             "xtend": "4.0.1"
@@ -3052,8 +3046,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
       "version": "2.13.3",
@@ -4083,8 +4076,7 @@
     "es5-shim": {
       "version": "4.5.10",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz",
-      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg==",
-      "dev": true
+      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg=="
     },
     "es6-iterator": {
       "version": "2.0.1",
@@ -4824,8 +4816,7 @@
     "find-root": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=",
-      "dev": true
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
     "find-up": {
       "version": "1.1.2",
@@ -7445,8 +7436,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.4",
@@ -8098,8 +8088,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -9645,8 +9634,7 @@
     "m3u8-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
-      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg==",
-      "dev": true
+      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
     },
     "magic-string": {
       "version": "0.22.4",
@@ -10196,7 +10184,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.5.0.tgz",
       "integrity": "sha512-eexEhIcAZO7zdqLAA3qwAQqxPSnvqdWHsvskYc9RNUj7g+/OXtwO2g0iEEewkeAVkLp7zOOWaI08bjeTMWRFXg==",
-      "dev": true,
       "requires": {
         "global": "4.3.2",
         "url-toolkit": "2.1.4"
@@ -10229,8 +10216,7 @@
     "mux.js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.4.1.tgz",
-      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw==",
-      "dev": true
+      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw=="
     },
     "mz": {
       "version": "2.7.0",
@@ -11516,8 +11502,7 @@
     "pkcs7": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-0.2.3.tgz",
-      "integrity": "sha1-ItYGZtAQZcXyRDkJjkpIMEUic74=",
-      "dev": true
+      "integrity": "sha1-ItYGZtAQZcXyRDkJjkpIMEUic74="
     },
     "pkg-up": {
       "version": "1.0.0",
@@ -15370,8 +15355,7 @@
     "url-toolkit": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.4.tgz",
-      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg==",
-      "dev": true
+      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg=="
     },
     "urljoin": {
       "version": "0.1.5",
@@ -15566,7 +15550,6 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.6.0.tgz",
       "integrity": "sha512-jtMn0PqQSGGes5Lcb5Ste0fG4HrcOIr51LYX57wrQbbrUhj/56U8c9LGhVeGAgpi1XBebw/R16xyENxh5yPllw==",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
@@ -15582,7 +15565,6 @@
           "version": "0.12.4",
           "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz",
           "integrity": "sha1-OPJJnjHvs/qTWQ3a1MtmMnWksWE=",
-          "dev": true,
           "requires": {
             "global": "4.3.2"
           }
@@ -15609,7 +15591,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
       "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
-      "dev": true,
       "requires": {
         "es5-shim": "4.5.10"
       }
@@ -15898,8 +15879,7 @@
     "webwackify": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.5.tgz",
-      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw==",
-      "dev": true
+      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw=="
     },
     "whatwg-encoding": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-0.7.2.tgz",
       "integrity": "sha512-caFoaoTcyuDmu43iw4m6/NLtebaryyNwLsvUveMbe4pi942dv+j4V6TthNIMxPsvbfm84xZIFG9AXF7T28kQkQ==",
+      "dev": true,
       "requires": {
         "aes-decrypter": "1.0.3",
         "browserify-versionify": "1.0.6",
@@ -189,6 +190,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-1.0.3.tgz",
       "integrity": "sha1-nAa4pUNaWtCduTP4oBSvzxhMw04=",
+      "dev": true,
       "requires": {
         "pkcs7": "0.2.3"
       }
@@ -2017,6 +2019,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-versionify/-/browserify-versionify-1.0.6.tgz",
       "integrity": "sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=",
+      "dev": true,
       "requires": {
         "find-root": "0.1.2",
         "through2": "0.6.3"
@@ -2026,6 +2029,7 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -2036,12 +2040,14 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "through2": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
           "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
+          "dev": true,
           "requires": {
             "readable-stream": "1.0.34",
             "xtend": "4.0.1"
@@ -3046,7 +3052,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coveralls": {
       "version": "2.13.3",
@@ -4076,7 +4083,8 @@
     "es5-shim": {
       "version": "4.5.10",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz",
-      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg=="
+      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg==",
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
@@ -4816,7 +4824,8 @@
     "find-root": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
-      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -7436,7 +7445,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
@@ -8088,7 +8098,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -9634,7 +9645,8 @@
     "m3u8-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
-      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
+      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg==",
+      "dev": true
     },
     "magic-string": {
       "version": "0.22.4",
@@ -10184,6 +10196,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.5.0.tgz",
       "integrity": "sha512-eexEhIcAZO7zdqLAA3qwAQqxPSnvqdWHsvskYc9RNUj7g+/OXtwO2g0iEEewkeAVkLp7zOOWaI08bjeTMWRFXg==",
+      "dev": true,
       "requires": {
         "global": "4.3.2",
         "url-toolkit": "2.1.4"
@@ -10216,7 +10229,8 @@
     "mux.js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.4.1.tgz",
-      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw=="
+      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw==",
+      "dev": true
     },
     "mz": {
       "version": "2.7.0",
@@ -11502,7 +11516,8 @@
     "pkcs7": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-0.2.3.tgz",
-      "integrity": "sha1-ItYGZtAQZcXyRDkJjkpIMEUic74="
+      "integrity": "sha1-ItYGZtAQZcXyRDkJjkpIMEUic74=",
+      "dev": true
     },
     "pkg-up": {
       "version": "1.0.0",
@@ -15355,7 +15370,8 @@
     "url-toolkit": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.4.tgz",
-      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg=="
+      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg==",
+      "dev": true
     },
     "urljoin": {
       "version": "0.1.5",
@@ -15550,6 +15566,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.6.0.tgz",
       "integrity": "sha512-jtMn0PqQSGGes5Lcb5Ste0fG4HrcOIr51LYX57wrQbbrUhj/56U8c9LGhVeGAgpi1XBebw/R16xyENxh5yPllw==",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
@@ -15565,6 +15582,7 @@
           "version": "0.12.4",
           "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz",
           "integrity": "sha1-OPJJnjHvs/qTWQ3a1MtmMnWksWE=",
+          "dev": true,
           "requires": {
             "global": "4.3.2"
           }
@@ -15591,6 +15609,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
       "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
+      "dev": true,
       "requires": {
         "es5-shim": "4.5.10"
       }
@@ -15879,7 +15898,8 @@
     "webwackify": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.5.tgz",
-      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw=="
+      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw==",
+      "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,22 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@videojs/http-streaming": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-0.7.2.tgz",
+      "integrity": "sha512-caFoaoTcyuDmu43iw4m6/NLtebaryyNwLsvUveMbe4pi942dv+j4V6TthNIMxPsvbfm84xZIFG9AXF7T28kQkQ==",
+      "requires": {
+        "aes-decrypter": "1.0.3",
+        "browserify-versionify": "1.0.6",
+        "global": "4.3.2",
+        "m3u8-parser": "4.2.0",
+        "mpd-parser": "0.5.0",
+        "mux.js": "4.4.1",
+        "url-toolkit": "2.1.4",
+        "video.js": "6.6.0",
+        "webwackify": "0.1.5"
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -168,6 +184,14 @@
       "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
       "dev": true,
       "optional": true
+    },
+    "aes-decrypter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-1.0.3.tgz",
+      "integrity": "sha1-nAa4pUNaWtCduTP4oBSvzxhMw04=",
+      "requires": {
+        "pkcs7": "0.2.3"
+      }
     },
     "after": {
       "version": "0.8.2",
@@ -1989,6 +2013,42 @@
         "through": "2.3.8"
       }
     },
+    "browserify-versionify": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-versionify/-/browserify-versionify-1.0.6.tgz",
+      "integrity": "sha1-qy3GHWoRnmJ77Eh1mNGYO3/bJ14=",
+      "requires": {
+        "find-root": "0.1.2",
+        "through2": "0.6.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "integrity": "sha1-eVKS/enyVMKjaLOPnMXRvUZjr7Y=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
@@ -2986,8 +3046,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
       "version": "2.13.3",
@@ -4017,8 +4076,7 @@
     "es5-shim": {
       "version": "4.5.10",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.10.tgz",
-      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg==",
-      "dev": true
+      "integrity": "sha512-vmryBdqKRO8Ei9LJ4yyEk/EOmAOGIagcHDYPpTAi6pot4IMHS1AC2q5cTKPmydpijg2iX8DVmCuqgrNxIWj8Yg=="
     },
     "es6-iterator": {
       "version": "2.0.1",
@@ -4754,6 +4812,11 @@
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
       }
+    },
+    "find-root": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz",
+      "integrity": "sha1-mNImfP8ZFsyvJ0OzoO6oHXnX3NE="
     },
     "find-up": {
       "version": "1.1.2",
@@ -7373,8 +7436,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.4",
@@ -8026,8 +8088,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -9570,6 +9631,11 @@
         "yallist": "2.1.2"
       }
     },
+    "m3u8-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.2.0.tgz",
+      "integrity": "sha512-LVHw0U6IPJjwk9i9f7Xe26NqaUHTNlIt4SSWoEfYFROeVKHN6MIjOhbRheI3dg8Jbq5WCuMFQ0QU3EgZpmzFPg=="
+    },
     "magic-string": {
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
@@ -10114,6 +10180,15 @@
         "on-headers": "1.0.1"
       }
     },
+    "mpd-parser": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.5.0.tgz",
+      "integrity": "sha512-eexEhIcAZO7zdqLAA3qwAQqxPSnvqdWHsvskYc9RNUj7g+/OXtwO2g0iEEewkeAVkLp7zOOWaI08bjeTMWRFXg==",
+      "requires": {
+        "global": "4.3.2",
+        "url-toolkit": "2.1.4"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -10137,6 +10212,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mux.js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.4.1.tgz",
+      "integrity": "sha512-KxeFqCXDWZS9ZflufC8PmPx8r3cAq+xWyPxYpgKiDmcImgwRyl/R0N5Eun4eWtxfJ98xZ7UdbBVKq0r06dFBOw=="
     },
     "mz": {
       "version": "2.7.0",
@@ -11418,6 +11498,11 @@
       "requires": {
         "pinkie": "2.0.4"
       }
+    },
+    "pkcs7": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-0.2.3.tgz",
+      "integrity": "sha1-ItYGZtAQZcXyRDkJjkpIMEUic74="
     },
     "pkg-up": {
       "version": "1.0.0",
@@ -12938,6 +13023,15 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.47.6.tgz",
       "integrity": "sha512-bH3eWh7MzbiKTQcHQN7Ievqbs/yY7T+ZcJYboBYkp7BkRlAr2DXHPfiqlvlEH/M95giEBpinHEi/s9CVIgYT6w==",
       "dev": true
+    },
+    "rollup-plugin-alias": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-alias/-/rollup-plugin-alias-1.4.0.tgz",
+      "integrity": "sha512-lB094zdi19FS+1bVarVp9kBN0Zk41PdTGoCk0z8xesKO7RGjOo18cp1hUzEqrOQ4bM9+KLD9nbnu/XUxQm9pbg==",
+      "dev": true,
+      "requires": {
+        "slash": "1.0.0"
+      }
     },
     "rollup-plugin-babel": {
       "version": "2.7.1",
@@ -15258,6 +15352,11 @@
         "prepend-http": "1.0.4"
       }
     },
+    "url-toolkit": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.4.tgz",
+      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg=="
+    },
     "urljoin": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/urljoin/-/urljoin-0.1.5.tgz",
@@ -15451,7 +15550,6 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-6.6.0.tgz",
       "integrity": "sha512-jtMn0PqQSGGes5Lcb5Ste0fG4HrcOIr51LYX57wrQbbrUhj/56U8c9LGhVeGAgpi1XBebw/R16xyENxh5yPllw==",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
@@ -15467,7 +15565,6 @@
           "version": "0.12.4",
           "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz",
           "integrity": "sha1-OPJJnjHvs/qTWQ3a1MtmMnWksWE=",
-          "dev": true,
           "requires": {
             "global": "4.3.2"
           }
@@ -15494,7 +15591,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
       "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
-      "dev": true,
       "requires": {
         "es5-shim": "4.5.10"
       }
@@ -15779,6 +15875,11 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
       "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
       "dev": true
+    },
+    "webwackify": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.5.tgz",
+      "integrity": "sha512-lWPhJ9nndaLZM4J+0W9/N1jJtR56VI7UsYfa9nL+dLBQcKw+skgUPirYSEUoCjX7A6I+S2Cwwx6NHWxAtr3dDw=="
     },
     "whatwg-encoding": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/videojs/video.js.git"
   },
   "dependencies": {
+    "@videojs/http-streaming": "^0.7.2",
     "babel-runtime": "^6.9.2",
     "global": "4.3.2",
     "safe-json-parse": "4.0.0",
@@ -57,7 +58,6 @@
     "xhr": "2.4.0"
   },
   "devDependencies": {
-    "@videojs/http-streaming": "^0.7.2",
     "aliasify": "^2.1.0",
     "babel-cli": "^6.11.4",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "url": "https://github.com/videojs/video.js.git"
   },
   "dependencies": {
-    "@videojs/http-streaming": "^0.7.2",
     "babel-runtime": "^6.9.2",
     "global": "4.3.2",
     "safe-json-parse": "4.0.0",
@@ -58,6 +57,7 @@
     "xhr": "2.4.0"
   },
   "devDependencies": {
+    "@videojs/http-streaming": "^0.7.2",
     "aliasify": "^2.1.0",
     "babel-cli": "^6.11.4",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/videojs/video.js.git"
   },
   "dependencies": {
-    "@videojs/http-streaming": "^0.7.2",
+    "@videojs/http-streaming": "^0.8.0",
     "babel-runtime": "^6.9.2",
     "global": "4.3.2",
     "safe-json-parse": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/videojs/video.js.git"
   },
   "dependencies": {
+    "@videojs/http-streaming": "^0.7.2",
     "babel-runtime": "^6.9.2",
     "global": "4.3.2",
     "safe-json-parse": "4.0.0",
@@ -130,6 +131,7 @@
     "remark-validate-links": "^7.0.0",
     "replace": "^0.3.0",
     "rollup": "^0.47.5",
+    "rollup-plugin-alias": "^1.4.0",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-filesize": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
       "**/es5/**",
       "**/build/**",
       "!build/rollup.js",
+      "core.js",
       "**/dist/**",
       "**/docs/**",
       "**/lang/**",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,3 @@
+import videojs from './video';
+import '@videojs/http-streaming';
+export default videojs;

--- a/test/require/webpack.js
+++ b/test/require/webpack.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-var */
 /* eslint-env qunit */
 var videojs = require('../../');
+var videojsCore = require('../../core');
 
 QUnit.module('Webpack Require');
 QUnit.test('videojs should be requirable and bundled via webpack', function(assert) {
   assert.ok(videojs, 'videojs is required properly');
+  assert.ok(videojsCore, 'videojs core is required properly');
 });


### PR DESCRIPTION
## Description
This PR is to add HLS playback support built into video.js for 7.0 via videojs-http-streaming (shorthand VHS). VHS is the next major version of videojs-contrib-hls that removes HLS Flash playback and includes some experimental DASH support (hence the rename). The purpose is to improve the out-of-the-box experience for video.js and allow cross browser HLS compatibility.

The proposed changes are to have the standard video.js browser and module scripts contain VHS and provide an alternate video.js browser script that does not contain VHS.

Requires https://github.com/videojs/http-streaming/pull/69

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors