### PR TITLE
Feature/queue playback events for zero playback rate (vjs6)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -229,6 +229,8 @@ const TECH_EVENTS_RETRIGGER = [
 ];
 
 // events to queue when playback rate is zero
+// this is a hash for the sole purpose of mapping non-camel-cased event names
+// to camel-cased function names
 const TECH_EVENTS_QUEUE = {
   canplay: 'CanPlay',
   canplaythrough: 'CanPlayThrough',

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -966,15 +966,15 @@ class Player extends Component {
     });
 
     Object.keys(TECH_EVENTS_QUEUE).forEach((event) => {
-      this.on(this.tech_, event, () => {
+      this.on(this.tech_, event, (eventObj) => {
         if (this.tech_.playbackRate() === 0 && this.tech_.seeking()) {
           this.queuedCallbacks_.push({
             callback: this[`handleTech${TECH_EVENTS_QUEUE[event]}_`].bind(this),
-            event
+            event: eventObj
           });
           return;
         }
-        this[`handleTech${TECH_EVENTS_QUEUE[event]}_`](event);
+        this[`handleTech${TECH_EVENTS_QUEUE[event]}_`](eventObj);
       });
     });
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -387,6 +387,9 @@ class Player extends Component {
 
     this.el_ = this.createEl();
 
+    // Set default value for lastPlaybackRate
+    this.cache_.lastPlaybackRate = this.defaultPlaybackRate();
+
     // Make this an evented object and use `el_` as its event bus.
     evented(this, {eventBusKey: 'el_'});
 
@@ -1297,11 +1300,11 @@ class Player extends Component {
    * @listens Tech#ratechange
    */
   handleTechRateChange_() {
-    if (this.tech_.playbackRate() > 0 && this.previousPlaybackRate === 0) {
+    if (this.tech_.playbackRate() > 0 && this.cache_.lastPlaybackRate === 0) {
       this.queuedCallbacks_.forEach((queued) => queued.callback(queued.event));
       this.queuedCallbacks_ = [];
     }
-    this.previousPlaybackRate = this.tech_.playbackRate();
+    this.cache_.lastPlaybackRate = this.tech_.playbackRate();
     /**
      * Fires when the playing speed of the audio/video is changed
      *
@@ -3101,12 +3104,14 @@ class Player extends Component {
    */
   playbackRate(rate) {
     if (rate !== undefined) {
+      // NOTE: this.cache_.lastPlaybackRate is set from the tech handler
+      // that is registered above
       this.techCall_('setPlaybackRate', rate);
       return;
     }
 
     if (this.tech_ && this.tech_.featuresPlaybackRate) {
-      return this.techGet_('playbackRate');
+      return this.cache_.lastPlaybackRate || this.techGet_('playbackRate');
     }
     return 1.0;
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -314,7 +314,8 @@ class Player extends Component {
     // Tracks when a tech changes the poster
     this.isPosterFromTech_ = false;
 
-    // TODO: Docs
+    // Holds callback info that gets queued when playback rate is zero
+    // and a seek is happening
     this.queuedCallbacks_ = [];
 
     // Turn off API access because we're loading a new tech that might load asynchronously

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1169,6 +1169,7 @@ Tech.withSourceHandlers = function(_Tech) {
    */
   const deferrable = [
     'seekable',
+    'seeking',
     'duration'
   ];
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1364,14 +1364,14 @@ QUnit.test('Remove waiting class on timeupdate after tech waiting', function(ass
   player.dispose();
 });
 
-QUnit.test('Queues playing events when playback rate is zero', function(assert) {
+QUnit.test('Queues playing events when playback rate is zero while seeking', function(assert) {
   const player = TestHelpers.makePlayer({techOrder: ['html5']});
 
   let canPlayCount = 0;
   let canPlayThroughCount = 0;
   let playingCount = 0;
   let seekedCount = 0;
-  let seeking = true;
+  let seeking = false;
 
   player.on('canplay', () => canPlayCount++);
   player.on('canplaythrough', () => canPlayThroughCount++);
@@ -1390,20 +1390,30 @@ QUnit.test('Queues playing events when playback rate is zero', function(assert) 
   player.tech_.trigger('playing');
   player.tech_.trigger('seeked');
 
-  assert.equal(canPlayCount, 0, 'canplay event not dispatched');
-  assert.equal(canPlayThroughCount, 0, 'canplaythrough event not dispatched');
-  assert.equal(playingCount, 0, 'playing event not dispatched');
-  assert.equal(seekedCount, 0, 'seeked event not dispatched');
+  assert.equal(canPlayCount, 1, 'canplay event dispatched when not seeking');
+  assert.equal(canPlayThroughCount, 1, 'canplaythrough event dispatched when not seeking');
+  assert.equal(playingCount, 1, 'playing event dispatched when not seeking');
+  assert.equal(seekedCount, 1, 'seeked event dispatched when not seeking');
+
+  seeking = true;
+  player.tech_.trigger('canplay');
+  player.tech_.trigger('canplaythrough');
+  player.tech_.trigger('playing');
+  player.tech_.trigger('seeked');
+
+  assert.equal(canPlayCount, 1, 'canplay event not dispatched');
+  assert.equal(canPlayThroughCount, 1, 'canplaythrough event not dispatched');
+  assert.equal(playingCount, 1, 'playing event not dispatched');
+  assert.equal(seekedCount, 1, 'seeked event not dispatched');
 
   seeking = false;
-
   player.tech_.setPlaybackRate(1);
   player.tech_.trigger('ratechange');
 
-  assert.equal(canPlayCount, 1, 'canplay event dispatched');
-  assert.equal(canPlayThroughCount, 1, 'canplaythrough event dispatched');
-  assert.equal(playingCount, 1, 'playing event dispatched');
-  assert.equal(seekedCount, 1, 'seeked event dispatched');
+  assert.equal(canPlayCount, 2, 'canplay event dispatched after playback rate restore');
+  assert.equal(canPlayThroughCount, 2, 'canplaythrough event dispatched after playback rate restore');
+  assert.equal(playingCount, 2, 'playing event dispatched after playback rate restore');
+  assert.equal(seekedCount, 2, 'seeked event dispatched after playback rate restore');
 
 });
 


### PR DESCRIPTION
This is a clone of PR #5024 made against the 6.x branch.

Needed because the [related PR for contrib-hls](https://github.com/videojs/videojs-contrib-hls/pull/1374) will also link against vjs6.