### PR TITLE
queue playback events when playback rate is zero and seeking is true (vjs5)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -363,6 +363,9 @@ class Player extends Component {
 
     this.el_ = this.createEl();
 
+    // Set default value for lastPlaybackRate
+    this.cache_.lastPlaybackRate = 1.0;
+
     // We also want to pass the original player options to each component and plugin
     // as well so they don't need to reach back into the player for options later.
     // We also need to do another copy of this.options_ so we don't end up with
@@ -1180,11 +1183,11 @@ class Player extends Component {
    * @listens Tech#ratechange
    */
   handleTechRateChange_() {
-    if (this.tech_.playbackRate() > 0 && this.previousPlaybackRate === 0) {
+    if (this.tech_.playbackRate() > 0 && this.cache_.lastPlaybackRate === 0) {
       this.queuedCallbacks_.forEach((queued) => queued.callback(queued.event));
       this.queuedCallbacks_ = [];
     }
-    this.previousPlaybackRate = this.tech_.playbackRate();
+    this.cache_.lastPlaybackRate = this.tech_.playbackRate();
     /**
      * Fires when the playing speed of the audio/video is changed
      *
@@ -2874,12 +2877,14 @@ class Player extends Component {
    */
   playbackRate(rate) {
     if (rate !== undefined) {
+      // NOTE: this.cache_.lastPlaybackRate is set from the tech handler
+      // that is registered above
       this.techCall_('setPlaybackRate', rate);
       return this;
     }
 
     if (this.tech_ && this.tech_.featuresPlaybackRate) {
-      return this.techGet_('playbackRate');
+      return this.cache_.lastPlaybackRate || this.techGet_('playbackRate');
     }
     return 1.0;
   }

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1124,6 +1124,7 @@ Tech.withSourceHandlers = function(_Tech) {
    */
   const deferrable = [
     'seekable',
+    'seeking',
     'duration'
   ];
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -107,7 +107,7 @@ QUnit.test('should get tag, source, and track settings', function(assert) {
   assert.equal(player.options_.id, 'example_1', 'id is set to example_1');
   assert.equal(player.options_.sources.length, 2, 'we have two sources');
   assert.equal(player.options_.sources[0].src, 'http://google.com', 'first source is google.com');
-  assert.equal(player.options_.sources[0].type, 'video/mp4', 'first time is video/mp4');
+  assert.equal(player.options_.sources[0].type, 'video/mp4', 'first type is video/mp4');
   assert.equal(player.options_.sources[1].type, 'video/webm', 'second type is video/webm');
   assert.equal(player.options_.tracks.length, 1, 'we have one text track');
   assert.equal(player.options_.tracks[0].kind, 'captions', 'the text track is a captions file');
@@ -1321,6 +1321,59 @@ QUnit.test('Remove waiting class on timeupdate after tech waiting', function(ass
   player.trigger('timeupdate');
   assert.ok(!(/vjs-waiting/).test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
   player.dispose();
+});
+
+QUnit.test('Queues playing events when playback rate is zero while seeking', function(assert) {
+  const player = TestHelpers.makePlayer({techOrder: ['html5']});
+
+  let canPlayCount = 0;
+  let canPlayThroughCount = 0;
+  let playingCount = 0;
+  let seekedCount = 0;
+  let seeking = false;
+
+  player.on('canplay', () => canPlayCount++);
+  player.on('canplaythrough', () => canPlayThroughCount++);
+  player.on('playing', () => playingCount++);
+  player.on('seeked', () => seekedCount++);
+
+  player.tech_.seeking = () => {
+    return seeking;
+  };
+
+  player.tech_.setPlaybackRate(0);
+  player.tech_.trigger('ratechange');
+
+  player.tech_.trigger('canplay');
+  player.tech_.trigger('canplaythrough');
+  player.tech_.trigger('playing');
+  player.tech_.trigger('seeked');
+
+  assert.equal(canPlayCount, 1, 'canplay event dispatched when not seeking');
+  assert.equal(canPlayThroughCount, 1, 'canplaythrough event dispatched when not seeking');
+  assert.equal(playingCount, 1, 'playing event dispatched when not seeking');
+  assert.equal(seekedCount, 1, 'seeked event dispatched when not seeking');
+
+  seeking = true;
+  player.tech_.trigger('canplay');
+  player.tech_.trigger('canplaythrough');
+  player.tech_.trigger('playing');
+  player.tech_.trigger('seeked');
+
+  assert.equal(canPlayCount, 1, 'canplay event not dispatched');
+  assert.equal(canPlayThroughCount, 1, 'canplaythrough event not dispatched');
+  assert.equal(playingCount, 1, 'playing event not dispatched');
+  assert.equal(seekedCount, 1, 'seeked event not dispatched');
+
+  seeking = false;
+  player.tech_.setPlaybackRate(1);
+  player.tech_.trigger('ratechange');
+
+  assert.equal(canPlayCount, 2, 'canplay event dispatched after playback rate restore');
+  assert.equal(canPlayThroughCount, 2, 'canplaythrough event dispatched after playback rate restore');
+  assert.equal(playingCount, 2, 'playing event dispatched after playback rate restore');
+  assert.equal(seekedCount, 2, 'seeked event dispatched after playback rate restore');
+
 });
 
 QUnit.test('Make sure that player\'s style el respects VIDEOJS_NO_DYNAMIC_STYLE option', function(assert) {

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -15,6 +15,20 @@ import TextTrackList from '../../../src/js/tracks/text-track-list';
 import sinon from 'sinon';
 import log from '../../../src/js/utils/log.js';
 
+function stubbedSourceHandler(handler) {
+  return {
+    canPlayType() {
+      return true;
+    },
+    canHandleSource() {
+      return true;
+    },
+    handleSource(source, tech, options) {
+      return handler;
+    }
+  };
+}
+
 QUnit.module('Media Tech', {
   beforeEach(assert) {
     this.noop = function() {};
@@ -453,9 +467,15 @@ QUnit.test('should track whether a video has played', function(assert) {
   assert.equal(tech.played().length, 1, 'has length after playing');
 });
 
-QUnit.test('delegates seekable to the source handler', function(assert) {
+QUnit.test('delegates deferrables to the source handler', function(assert) {
   const MyTech = extendFn(Tech, {
     seekable() {
+      throw new Error('You should not be calling me!');
+    },
+    seeking() {
+      throw new Error('You should not be calling me!');
+    },
+    duration() {
       throw new Error('You should not be calling me!');
     }
   });
@@ -463,24 +483,24 @@ QUnit.test('delegates seekable to the source handler', function(assert) {
   Tech.withSourceHandlers(MyTech);
 
   let seekableCount = 0;
+  let seekingCount = 0;
+  let durationCount = 0;
   const handler = {
     seekable() {
       seekableCount++;
       return createTimeRange(0, 0);
+    },
+    seeking() {
+      seekingCount++;
+      return false;
+    },
+    duration() {
+      durationCount++;
+      return 0;
     }
   };
 
-  MyTech.registerSourceHandler({
-    canPlayType() {
-      return true;
-    },
-    canHandleSource() {
-      return true;
-    },
-    handleSource(source, tech, options) {
-      return handler;
-    }
-  });
+  MyTech.registerSourceHandler(stubbedSourceHandler(handler));
 
   const tech = new MyTech();
 
@@ -489,7 +509,57 @@ QUnit.test('delegates seekable to the source handler', function(assert) {
     type: 'video/mp4'
   });
   tech.seekable();
+  tech.seeking();
+  tech.duration();
   assert.equal(seekableCount, 1, 'called the source handler');
+  assert.equal(seekingCount, 1, 'called the source handler');
+  assert.equal(durationCount, 1, 'called the source handler');
+});
+
+QUnit.test('delegates only deferred deferrables to the source handler', function(assert) {
+  let seekingCount = 0;
+  const MyTech = extendFn(Tech, {
+    seekable() {
+      throw new Error('You should not be calling me!');
+    },
+    seeking() {
+      seekingCount++;
+      return false;
+    },
+    duration() {
+      throw new Error('You should not be calling me!');
+    }
+  });
+
+  Tech.withSourceHandlers(MyTech);
+
+  let seekableCount = 0;
+  let durationCount = 0;
+  const handler = {
+    seekable() {
+      seekableCount++;
+      return createTimeRange(0, 0);
+    },
+    duration() {
+      durationCount++;
+      return 0;
+    }
+  };
+
+  MyTech.registerSourceHandler(stubbedSourceHandler(handler));
+
+  const tech = new MyTech();
+
+  tech.setSource({
+    src: 'example.mp4',
+    type: 'video/mp4'
+  });
+  tech.seekable();
+  tech.seeking();
+  tech.duration();
+  assert.equal(seekableCount, 1, 'called the source handler');
+  assert.equal(seekingCount, 1, 'called the tech itself');
+  assert.equal(durationCount, 1, 'called the source handler');
 });
 
 QUnit.test('Tech.isTech returns correct answers for techs and components', function(assert) {


### PR DESCRIPTION
This is a clone of PR #5024 made against the 5.x branch.

Needed because the [related PR for contrib-hls](https://github.com/videojs/videojs-contrib-hls/pull/1374) will also link against vjs5.