### PR TITLE
Add option to override native audio and video to html5 tech

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -204,7 +204,7 @@ class Html5 extends Tech {
    * Attempt to force override of native audiio/video tracks.
    *
    * @param {Boolean} override - If set to true native audio/video will be overridden,
-   * otherwise native video will potentially be used.
+   * otherwise native audio/video will potentially be used.
    */
   overrideNativeTracks(override) {
     // If there is no behavioral change don't add/remove listeners
@@ -257,6 +257,7 @@ class Html5 extends Tech {
           !elTracks.addEventListener) {
         return;
       }
+
       const listeners = {
         change(e) {
           techTracks.trigger({

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -200,10 +200,22 @@ class Html5 extends Tech {
     });
   }
 
+  /**
+   * Attempt to force override of native audio tracks.
+   *
+   * @param {Boolean} override - If set to true native audio will be overridden,
+   * otherwise native video will potentially be used.
+   */
   overrideNativeAudioTracks(override) {
     this.forceNativeAudioOverride = override;
   }
 
+  /**
+   * Attempt to force override of native video tracks.
+   *
+   * @param {Boolean} override - If set to true native video will be overridden,
+   * otherwise native video will potentially be used.
+   */
   overrideNativeVideoTracks(override) {
     this.forceNativeVideoOverride = override;
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -208,7 +208,7 @@ class Html5 extends Tech {
    */
   overrideNativeTracks(override) {
     // If there is no behavioral change don't add/remove listeners
-    if (override !== (this.featuresNativeAudioTracks && this.featuresNativeAudioTracks)) {
+    if (override !== (this.featuresNativeAudioTracks && this.featuresNativeVideoTracks)) {
       return;
     }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -200,6 +200,14 @@ class Html5 extends Tech {
     });
   }
 
+  overrideNativeAudioTracks(override) {
+    this.forceNativeAudioOverride = override;
+  }
+
+  overrideNativeVideoTracks(override) {
+    this.forceNativeVideoOverride = override;
+  }
+
   /**
    * Proxy all native track list events to our track lists if the browser we are playing
    * in supports that type of track list.
@@ -217,22 +225,36 @@ class Html5 extends Tech {
           !elTracks.addEventListener) {
         return;
       }
-      const listeners = {
-        change(e) {
+
+      const listeners = {};
+
+      listeners.change = (e) => {
+        if (!this[`forceNative${props.capitalName}Override_`]) {
           techTracks.trigger({
             type: 'change',
             target: techTracks,
             currentTarget: techTracks,
             srcElement: techTracks
           });
-        },
-        addtrack(e) {
+        }
+      };
+
+      listeners.addtrack = (e) => {
+        if (this[`forceNative${props.capitalName}Override_`] && elTracks.addTrack) {
+          elTracks.addTrack(e.track);
+        } else if (!this[`forceNative${props.capitalName}Override_`]) {
           techTracks.addTrack(e.track);
-        },
-        removetrack(e) {
+        }
+      };
+
+      listeners.removetrack = (e) => {
+        if (this[`forceNative${props.capitalName}Override_`] && elTracks.addTrack) {
+          elTracks.removeTrack(e.track);
+        } else if (!this[`forceNative${props.capitalName}Override_`]) {
           techTracks.removeTrack(e.track);
         }
       };
+
       const removeOldTracks = function() {
         const removeTracks = [];
 
@@ -605,12 +627,22 @@ class Html5 extends Tech {
    * @deprecated Since version 5.
    */
   src(src) {
+    this.forceNativeAudioOverride_ = this.forceNativeAudioOverride;
+    this.forceNativeVideoOverride_ = this.forceNativeVideoOverride;
+
     if (src === undefined) {
       return this.el_.src;
     }
 
     // Setting src through `src` instead of `setSrc` will be deprecated
     this.setSrc(src);
+  }
+
+  setSrc(src) {
+    this.forceNativeAudioOverride_ = this.forceNativeAudioOverride;
+    this.forceNativeVideoOverride_ = this.forceNativeVideoOverride;
+
+    super.setSrc(src);
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -208,7 +208,7 @@ class Html5 extends Tech {
    */
   overrideNativeTracks(override) {
     // If there is no behavioral change don't add/remove listeners
-    if (override === !(this.featuresNativeAudioTracks && this.featuresNativeAudioTracks)) {
+    if (override !== (this.featuresNativeAudioTracks && this.featuresNativeAudioTracks)) {
       return;
     }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -267,16 +267,13 @@ class Html5 extends Tech {
             srcElement: techTracks
           });
         },
-
         addtrack(e) {
           techTracks.addTrack(e.track);
         },
-
         removetrack(e) {
           techTracks.removeTrack(e.track);
         }
       };
-
       const removeOldTracks = function() {
         const removeTracks = [];
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -208,12 +208,9 @@ class Html5 extends Tech {
    */
   overrideNativeTracks(override) {
     // If there is no behavioral change don't add/remove listeners
-    if (override === this.override_) {
+    if (override === !(this.featuresNativeAudioTracks && this.featuresNativeAudioTracks)) {
       return;
     }
-
-    // Store this so that we don't re-run everything here if there is no change in state
-    this.override_ = override;
 
     if (this.audioTracksListeners_) {
       Object.keys(this.audioTracksListeners_).forEach((eventName) => {
@@ -297,13 +294,12 @@ class Html5 extends Tech {
         }
       };
 
+      this[props.getterName + 'Listeners_'] = listeners;
+
       Object.keys(listeners).forEach((eventName) => {
         const listener = listeners[eventName];
 
         elTracks.addEventListener(eventName, listener);
-
-        this[props.getterName + 'Listeners_'] = listeners;
-
         this.on('dispose', (e) => elTracks.removeEventListener(eventName, listener));
       });
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -257,7 +257,6 @@ class Html5 extends Tech {
           !elTracks.addEventListener) {
         return;
       }
-
       const listeners = {
         change(e) {
           techTracks.trigger({

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -201,7 +201,7 @@ class Html5 extends Tech {
   }
 
   /**
-   * Attempt to force override of native audiio/video tracks.
+   * Attempt to force override of native audio/video tracks.
    *
    * @param {Boolean} override - If set to true native audio/video will be overridden,
    * otherwise native audio/video will potentially be used.
@@ -231,8 +231,8 @@ class Html5 extends Tech {
     this.featuresNativeVideoTracks = !override;
     this.featuresNativeAudioTracks = !override;
 
-    this.audioTracksListeners_ = [];
-    this.videoTracksListeners_ = [];
+    this.audioTracksListeners_ = null;
+    this.videoTracksListeners_ = null;
 
     this.proxyNativeTracks_();
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -653,9 +653,6 @@ class Html5 extends Tech {
    * @deprecated Since version 5.
    */
   src(src) {
-    this.forceNativeAudioOverride_ = this.forceNativeAudioOverride;
-    this.forceNativeVideoOverride_ = this.forceNativeVideoOverride;
-
     if (src === undefined) {
       return this.el_.src;
     }
@@ -665,9 +662,6 @@ class Html5 extends Tech {
   }
 
   setSrc(src) {
-    this.forceNativeAudioOverride_ = this.forceNativeAudioOverride;
-    this.forceNativeVideoOverride_ = this.forceNativeVideoOverride;
-
     super.setSrc(src);
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -254,7 +254,6 @@ class Html5 extends Tech {
           !elTracks.addEventListener) {
         return;
       }
-
       const listeners = {
         change(e) {
           techTracks.trigger({

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -789,7 +789,7 @@ class Tech extends Component {
    * Attempt to force override of native audio.video tracks.
    *
    * @param {Boolean} override - If set to true native audio/video will be overridden,
-   * otherwise native video will potentially be used.
+   * otherwise native audio/video will potentially be used.
    *
    * @abstract
    */

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -785,6 +785,16 @@ class Tech extends Component {
    */
   setPlaysinline() {}
 
+  /**
+   * Attempt to force override of native video tracks.
+   *
+   * @param {Boolean} override - If set to true native video will be overridden,
+   * otherwise native video will potentially be used.
+   *
+   * @abstract
+   */
+  overrideNativeTracks() {}
+
   /*
    * Check if the tech can support the given mime-type.
    *

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -786,9 +786,9 @@ class Tech extends Component {
   setPlaysinline() {}
 
   /**
-   * Attempt to force override of native video tracks.
+   * Attempt to force override of native audio.video tracks.
    *
-   * @param {Boolean} override - If set to true native video will be overridden,
+   * @param {Boolean} override - If set to true native audio/video will be overridden,
    * otherwise native video will potentially be used.
    *
    * @abstract

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -1218,7 +1218,7 @@ Tech.withSourceHandlers = function(_Tech) {
       if (_Tech.nativeSourceHandler) {
         sh = _Tech.nativeSourceHandler;
       } else {
-        log.error('No source hander found for the current source.');
+        log.error('No source handler found for the current source.');
       }
     }
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -677,7 +677,7 @@ if (Html5.supportsNativeVideoTracks()) {
     assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 
-  QUnit.only('should use overrideNativeVideo correctly', function(assert) {
+  QUnit.test('should use overrideNativeVideo correctly', function(assert) {
     assert.expect(6);
     let elAddTrackCount = 0;
     let elRemoveTrackCount = 0;

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -535,6 +535,79 @@ if (Html5.supportsNativeAudioTracks()) {
     assert.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
     assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
+
+  QUnit.test('should use overrideNativeAudio correctly', function(assert) {
+    assert.expect(6);
+
+    let elAddTrackCount = 0;
+    let elRemoveTrackCount = 0;
+
+    const adds = [];
+    const rems = [];
+    const vt = {
+      length: 0,
+      addEventListener: (type, fn) => {
+        adds.push({ type, fn });
+      },
+      removeEventListener: (type, fn) => {
+        rems.push({ type, fn });
+      },
+      addTrack: (track) => elAddTrackCount++,
+      removeTrack: (track) => elRemoveTrackCount++
+    };
+
+    const getTrackFn = function(array, type) {
+      const arrayObj = array.filter(item => item.type === type);
+
+      if (arrayObj.length > 0) {
+        return arrayObj[0].fn;
+      }
+
+      return function() {};
+    };
+
+    const el = document.createElement('div');
+
+    el.audioTracks = vt;
+
+    const htmlTech = new Html5({el});
+
+    htmlTech.overrideNativeAudioTracks(true);
+
+    // overrideNative only takes effect after the source is set,
+    // by default this should proxy the tracks
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 0,
+      'override hasnt taken effect, shouldnt increment');
+    assert.equal(elRemoveTrackCount, 0,
+      'override hasnt taken effect, shouldnt increment');
+
+    htmlTech.src('im a source');
+
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 1,
+      'override has taken effect, shouldnt increment once');
+    assert.equal(elRemoveTrackCount, 1,
+      'override has taken effect, shouldnt increment once');
+
+    htmlTech.overrideNativeVideoTracks(false);
+
+    htmlTech.src('im another source');
+
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 1,
+      'override disabled effect, shouldnt increment');
+    assert.equal(elRemoveTrackCount, 1,
+      'override disabled effect, shouldnt increment');
+
+    htmlTech.dispose();
+  });
 }
 
 if (Html5.supportsNativeVideoTracks()) {
@@ -602,6 +675,78 @@ if (Html5.supportsNativeVideoTracks()) {
     assert.equal(adds[0][0], rems[0][0], 'change event handler removed');
     assert.equal(adds[1][0], rems[1][0], 'addtrack event handler removed');
     assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
+  });
+
+  QUnit.only('should use overrideNativeVideo correctly', function(assert) {
+    assert.expect(6);
+    let elAddTrackCount = 0;
+    let elRemoveTrackCount = 0;
+
+    const adds = [];
+    const rems = [];
+    const vt = {
+      length: 0,
+      addEventListener: (type, fn) => {
+        adds.push({ type, fn });
+      },
+      removeEventListener: (type, fn) => {
+        rems.push({ type, fn });
+      },
+      addTrack: (track) => elAddTrackCount++,
+      removeTrack: (track) => elRemoveTrackCount++
+    };
+
+    const getTrackFn = function(array, type) {
+      const arrayObj = array.filter(item => item.type === type);
+
+      if (arrayObj.length > 0) {
+        return arrayObj[0].fn;
+      }
+
+      return function() {};
+    };
+
+    const el = document.createElement('div');
+
+    el.videoTracks = vt;
+
+    const htmlTech = new Html5({el});
+
+    htmlTech.overrideNativeVideoTracks(true);
+
+    // overrideNative only takes effect after the source is set,
+    // by default this should proxy the tracks
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 0,
+      'override hasnt taken effect, shouldnt increment');
+    assert.equal(elRemoveTrackCount, 0,
+      'override hasnt taken effect, shouldnt increment');
+
+    htmlTech.src('im a source');
+
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 1,
+      'override has taken effect, shouldnt increment once');
+    assert.equal(elRemoveTrackCount, 1,
+      'override has taken effect, shouldnt increment once');
+
+    htmlTech.overrideNativeVideoTracks(false);
+
+    htmlTech.src('im another source');
+
+    getTrackFn(adds, 'addtrack')({ track: '' });
+    getTrackFn(adds, 'removetrack')({ track: '' });
+
+    assert.equal(elAddTrackCount, 1,
+      'override disabled effect, shouldnt increment');
+    assert.equal(elRemoveTrackCount, 1,
+      'override disabled effect, shouldnt increment');
+
+    htmlTech.dispose();
   });
 }
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -536,75 +536,45 @@ if (Html5.supportsNativeAudioTracks()) {
     assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 
-  QUnit.test('should use overrideNativeAudio correctly', function(assert) {
+  QUnit.test('should use overrideNativeTracks on audio correctly', function(assert) {
     assert.expect(6);
-
-    let elAddTrackCount = 0;
-    let elRemoveTrackCount = 0;
 
     const adds = [];
     const rems = [];
-    const vt = {
+    const at = {
       length: 0,
       addEventListener: (type, fn) => {
         adds.push({ type, fn });
       },
       removeEventListener: (type, fn) => {
         rems.push({ type, fn });
-      },
-      addTrack: (track) => elAddTrackCount++,
-      removeTrack: (track) => elRemoveTrackCount++
-    };
-
-    const getTrackFn = function(array, type) {
-      const arrayObj = array.filter(item => item.type === type);
-
-      if (arrayObj.length > 0) {
-        return arrayObj[0].fn;
       }
-
-      return function() {};
     };
 
     const el = document.createElement('div');
 
-    el.audioTracks = vt;
+    el.audioTracks = at;
 
     const htmlTech = new Html5({el});
 
-    htmlTech.overrideNativeAudioTracks(true);
+    assert.equal(adds.length, 3,
+      'should have added change, remove, add listeners');
+    assert.equal(rems.length, 0,
+      'no listeners should be removed');
 
-    // overrideNative only takes effect after the source is set,
-    // by default this should proxy the tracks
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
+    htmlTech.overrideNativeTracks(true);
 
-    assert.equal(elAddTrackCount, 0,
-      'override hasnt taken effect, shouldnt increment');
-    assert.equal(elRemoveTrackCount, 0,
-      'override hasnt taken effect, shouldnt increment');
+    assert.equal(adds.length, 3,
+      'should not have added additional listeners');
+    assert.equal(rems.length, 3,
+      'should have removed previous three listeners');
 
-    htmlTech.src('im a source');
+    htmlTech.overrideNativeTracks(false);
 
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
-
-    assert.equal(elAddTrackCount, 1,
-      'override has taken effect, shouldnt increment once');
-    assert.equal(elRemoveTrackCount, 1,
-      'override has taken effect, shouldnt increment once');
-
-    htmlTech.overrideNativeVideoTracks(false);
-
-    htmlTech.src('im another source');
-
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
-
-    assert.equal(elAddTrackCount, 1,
-      'override disabled effect, shouldnt increment');
-    assert.equal(elRemoveTrackCount, 1,
-      'override disabled effect, shouldnt increment');
+    assert.equal(adds.length, 6,
+      'should have added 3 listeners back');
+    assert.equal(rems.length, 3,
+      'no listeners should be removed');
 
     htmlTech.dispose();
   });
@@ -677,10 +647,8 @@ if (Html5.supportsNativeVideoTracks()) {
     assert.equal(adds[2][0], rems[2][0], 'removetrack event handler removed');
   });
 
-  QUnit.test('should use overrideNativeVideo correctly', function(assert) {
+  QUnit.test('should use overrideNativeTracks on video correctly', function(assert) {
     assert.expect(6);
-    let elAddTrackCount = 0;
-    let elRemoveTrackCount = 0;
 
     const adds = [];
     const rems = [];
@@ -691,19 +659,7 @@ if (Html5.supportsNativeVideoTracks()) {
       },
       removeEventListener: (type, fn) => {
         rems.push({ type, fn });
-      },
-      addTrack: (track) => elAddTrackCount++,
-      removeTrack: (track) => elRemoveTrackCount++
-    };
-
-    const getTrackFn = function(array, type) {
-      const arrayObj = array.filter(item => item.type === type);
-
-      if (arrayObj.length > 0) {
-        return arrayObj[0].fn;
       }
-
-      return function() {};
     };
 
     const el = document.createElement('div');
@@ -712,39 +668,24 @@ if (Html5.supportsNativeVideoTracks()) {
 
     const htmlTech = new Html5({el});
 
-    htmlTech.overrideNativeVideoTracks(true);
+    assert.equal(adds.length, 3,
+      'should have added change, remove, add listeners');
+    assert.equal(rems.length, 0,
+      'no listeners should be removed');
 
-    // overrideNative only takes effect after the source is set,
-    // by default this should proxy the tracks
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
+    htmlTech.overrideNativeTracks(true);
 
-    assert.equal(elAddTrackCount, 0,
-      'override hasnt taken effect, shouldnt increment');
-    assert.equal(elRemoveTrackCount, 0,
-      'override hasnt taken effect, shouldnt increment');
+    assert.equal(adds.length, 3,
+      'should not have added additional listeners');
+    assert.equal(rems.length, 3,
+      'should have removed previous three listeners');
 
-    htmlTech.src('im a source');
+    htmlTech.overrideNativeTracks(false);
 
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
-
-    assert.equal(elAddTrackCount, 1,
-      'override has taken effect, shouldnt increment once');
-    assert.equal(elRemoveTrackCount, 1,
-      'override has taken effect, shouldnt increment once');
-
-    htmlTech.overrideNativeVideoTracks(false);
-
-    htmlTech.src('im another source');
-
-    getTrackFn(adds, 'addtrack')({ track: '' });
-    getTrackFn(adds, 'removetrack')({ track: '' });
-
-    assert.equal(elAddTrackCount, 1,
-      'override disabled effect, shouldnt increment');
-    assert.equal(elRemoveTrackCount, 1,
-      'override disabled effect, shouldnt increment');
+    assert.equal(adds.length, 6,
+      'should have added 3 listeners back');
+    assert.equal(rems.length, 3,
+      'no listeners should be removed');
 
     htmlTech.dispose();
   });

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -555,7 +555,6 @@ if (Html5.supportsNativeAudioTracks()) {
       addEventListener: (type, fn) => null,
       removeEventListener: (type, fn) => null
     };
-
     const el = document.createElement('div');
 
     el.audioTracks = at;
@@ -674,13 +673,11 @@ if (Html5.supportsNativeVideoTracks()) {
         rems.push({ type, fn });
       }
     };
-
     const at = {
       length: 0,
       addEventListener: (type, fn) => null,
       removeEventListener: (type, fn) => null
     };
-
     const el = document.createElement('div');
 
     el.audioTracks = at;

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -537,7 +537,7 @@ if (Html5.supportsNativeAudioTracks()) {
   });
 
   QUnit.test('should use overrideNativeTracks on audio correctly', function(assert) {
-    assert.expect(6);
+    assert.expect(8);
 
     const adds = [];
     const rems = [];
@@ -550,10 +550,16 @@ if (Html5.supportsNativeAudioTracks()) {
         rems.push({ type, fn });
       }
     };
+    const vt = {
+      length: 0,
+      addEventListener: (type, fn) => null,
+      removeEventListener: (type, fn) => null
+    };
 
     const el = document.createElement('div');
 
     el.audioTracks = at;
+    el.videoTracks = vt;
 
     const htmlTech = new Html5({el});
 
@@ -569,12 +575,19 @@ if (Html5.supportsNativeAudioTracks()) {
     assert.equal(rems.length, 3,
       'should have removed previous three listeners');
 
+    htmlTech.overrideNativeTracks(true);
+
+    assert.equal(adds.length, 3,
+      'no state change so do not add listeners');
+    assert.equal(rems.length, 3,
+      'no state change so do not remove listeners');
+
     htmlTech.overrideNativeTracks(false);
 
     assert.equal(adds.length, 6,
-      'should have added 3 listeners back');
+      'should add listeners because native tracks should be proxied');
     assert.equal(rems.length, 3,
-      'no listeners should be removed');
+      'should not remove listeners because there where none added on previous state');
 
     htmlTech.dispose();
   });
@@ -648,7 +661,7 @@ if (Html5.supportsNativeVideoTracks()) {
   });
 
   QUnit.test('should use overrideNativeTracks on video correctly', function(assert) {
-    assert.expect(6);
+    assert.expect(8);
 
     const adds = [];
     const rems = [];
@@ -662,8 +675,15 @@ if (Html5.supportsNativeVideoTracks()) {
       }
     };
 
+    const at = {
+      length: 0,
+      addEventListener: (type, fn) => null,
+      removeEventListener: (type, fn) => null
+    };
+
     const el = document.createElement('div');
 
+    el.audioTracks = at;
     el.videoTracks = vt;
 
     const htmlTech = new Html5({el});
@@ -680,12 +700,19 @@ if (Html5.supportsNativeVideoTracks()) {
     assert.equal(rems.length, 3,
       'should have removed previous three listeners');
 
+    htmlTech.overrideNativeTracks(true);
+
+    assert.equal(adds.length, 3,
+      'no state change so do not add listeners');
+    assert.equal(rems.length, 3,
+      'no state change so do not remove listeners');
+
     htmlTech.overrideNativeTracks(false);
 
     assert.equal(adds.length, 6,
-      'should have added 3 listeners back');
+      'should add listeners because native tracks should be proxied');
     assert.equal(rems.length, 3,
-      'no listeners should be removed');
+      'should not remove listeners because there where none added on previous state');
 
     htmlTech.dispose();
   });


### PR DESCRIPTION
## Description
Adding an option to override native audio/video tracks.  This is being added to ease enabling and disabling it within https://github.com/videojs/http-streaming.  This is partly to make enabling/disabling native playback easier when integrating videojs/http-streaming into this project.

I'm in the process of adding tests.  I'd like eyes on this while I'm doing that to ensure that the implementation makes sense/if I'm missing anything that might break playback that I'm unaware of.

## Specific Changes proposed
Adds 2 flags on the Html5 tech, `overrideNativeAudioTracks` and `overrideNativeVideoTracks` that can be set at any time.  The change will take effect any time the source is set.

One question I'm unclear on... what should the version compatibility be with video.js with this change?  I can modify things to be backwards compatible (checking to see if the APIs exist and handling things one way or another).  Do we care about this?  Or are we okay removing this (since leaving it in for backwards compatibility purposes would add a little bit of tech debt).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Verified in Edge with VHS)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
