### PR TITLE
Use valid json in translation example

### DIFF
--- a/docs/guides/languages.md
+++ b/docs/guides/languages.md
@@ -46,8 +46,7 @@ Video.js uses a JSON object to describe a language, where the keys are English a
   "Pause": "Pausa",
   "Current Time": "Tiempo reproducido",
   "Duration Time": "Duración total",
-  "Remaining Time": "Tiempo restante",
-  ...
+  "Remaining Time": "Tiempo restante"
 }
 ```
 


### PR DESCRIPTION
It's currently printed red in the github markdown pages, aka syntax error:

https://github.com/videojs/video.js/blob/master/docs/guides/languages.md#json-format