### PR TITLE
fix: avoid black borders if poster doesn't fit 100% to ratio

### DIFF
--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -30,3 +30,8 @@
 .vjs-using-native-controls .vjs-poster {
   display: none;
 }
+
+// avoid black borders if poster doesn't fit 100% to ratio
+.vjs-fluid .vjs-poster {
+  background-size: cover;
+}


### PR DESCRIPTION
## Description
sometimes there are rounding issues or the poster is not sized 100% correctly leading to black borders at top/bottom or left/right.

## Specific Changes proposed
make the poster cover the available space

## Requirements Checklist
- [x] Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
