### PR TITLE
fix: init inactivity checker not until first play event

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -467,8 +467,8 @@ class Player extends Component {
     // like the control bar show themselves if needed
     this.userActive(true);
     this.reportUserActivity();
-    this.listenForUserActivity_();
 
+    this.one('play', this.listenForUserActivity_);
     this.on('fullscreenchange', this.handleFullscreenChange_);
     this.on('stageclick', this.handleStageClick_);
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -913,6 +913,7 @@ QUnit.test('should honor default inactivity timeout', function(assert) {
 
   // default timeout is 2000ms
   const player = TestHelpers.makePlayer({});
+  
   player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');
@@ -932,6 +933,7 @@ QUnit.test('should honor configured inactivity timeout', function(assert) {
   const player = TestHelpers.makePlayer({
     inactivityTimeout: 200
   });
+  
   player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -913,7 +913,7 @@ QUnit.test('should honor default inactivity timeout', function(assert) {
 
   // default timeout is 2000ms
   const player = TestHelpers.makePlayer({});
-  
+
   player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');
@@ -933,7 +933,7 @@ QUnit.test('should honor configured inactivity timeout', function(assert) {
   const player = TestHelpers.makePlayer({
     inactivityTimeout: 200
   });
-  
+
   player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -913,6 +913,7 @@ QUnit.test('should honor default inactivity timeout', function(assert) {
 
   // default timeout is 2000ms
   const player = TestHelpers.makePlayer({});
+  player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');
   clock.tick(1800);
@@ -931,6 +932,7 @@ QUnit.test('should honor configured inactivity timeout', function(assert) {
   const player = TestHelpers.makePlayer({
     inactivityTimeout: 200
   });
+  player.trigger('play');
 
   assert.equal(player.userActive(), true, 'User is active on creation');
   clock.tick(150);


### PR DESCRIPTION
## Description
see #5076


## Requirements Checklist
- [x] Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
