### PR TITLE
Moving seekbar event handler bindings into a function

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -38,7 +38,21 @@ class SeekBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
+    this.setEventHandlers_(player, options);
+  }
 
+  /**
+   * Sets the event handlers
+   *
+   * @param {Player} player
+   *        The `Player` that this class should be attached to.
+   *
+   * @param {Object} [options]
+   *        The key/value store of player options.
+   *
+   * @private
+   */
+  setEventHandlers_(player, options) {
     this.update = Fn.throttle(Fn.bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
     this.on(player, 'timeupdate', this.update);

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -38,31 +38,25 @@ class SeekBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
-    this.setEventHandlers_(player, options);
+    this.setEventHandlers_();
   }
 
   /**
    * Sets the event handlers
    *
-   * @param {Player} player
-   *        The `Player` that this class should be attached to.
-   *
-   * @param {Object} [options]
-   *        The key/value store of player options.
-   *
    * @private
    */
-  setEventHandlers_(player, options) {
+  setEventHandlers_() {
     this.update = Fn.throttle(Fn.bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
-    this.on(player, 'timeupdate', this.update);
-    this.on(player, 'ended', this.handleEnded);
+    this.on(this.player_, 'timeupdate', this.update);
+    this.on(this.player_, 'ended', this.handleEnded);
 
     // when playing, let's ensure we smoothly update the play progress bar
     // via an interval
     this.updateInterval = null;
 
-    this.on(player, ['playing'], () => {
+    this.on(this.player_, ['playing'], () => {
       this.clearInterval(this.updateInterval);
 
       this.updateInterval = this.setInterval(() =>{
@@ -72,11 +66,11 @@ class SeekBar extends Slider {
       }, UPDATE_REFRESH_INTERVAL);
     });
 
-    this.on(player, ['ended', 'pause', 'waiting'], () => {
+    this.on(this.player_, ['ended', 'pause', 'waiting'], () => {
       this.clearInterval(this.updateInterval);
     });
 
-    this.on(player, ['timeupdate', 'ended'], this.update);
+    this.on(this.player_, ['timeupdate', 'ended'], this.update);
   }
 
   /**


### PR DESCRIPTION
## Description
Move all eventHandler bindings into a function.

## Specific Changes proposed
This allows for easier customisation of the the seekbar component.
If you extend the seekbar component you can choose to override `setEventHandlers_` or keep it default.

If you do override `setEventHandlers_`  and call `super()` in the constructor, you get your own event handlers + the functionality provided by `Slider`

Currently extending slider and wanting different bindings, means either copy pasting from the  existing slider or writing a function to undo the bindings (which is not possible in this case since they are anonymous functions).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
