### PR TITLE
Fix IDs and ARIA attributes in Captions Settings Dialog

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -313,19 +313,20 @@ class TextTrackSettings extends ModalDialog {
   createElSelect_(key, legendId = '', type = 'label') {
     const config = selectConfigs[key];
     const id = config.id.replace('%s', this.id_);
+    const selectLabelledbyIds = [legendId, id].join(' ').trim();
 
     return [
       `<${type} id="${id}" class="${type === 'label' ? 'vjs-label' : ''}">`,
       this.localize(config.label),
       `</${type}>`,
-      `<select aria-labelledby="${legendId !== '' ? legendId + ' ' : ''}${id}">`
+      `<select aria-labelledby="${selectLabelledbyIds}">`
     ].
       concat(config.options.map(o => {
-        const optionId = id + '-' + o[1];
+        const optionId = id + '-' + o[1].replace(/\W+/g, '');
 
         return [
           `<option id="${optionId}" value="${o[0]}" `,
-          `aria-labelledby="${legendId !== '' ? legendId + ' ' : ''}${id} ${optionId}">`,
+          `aria-labelledby="${selectLabelledbyIds} ${optionId}">`,
           this.localize(o[1]),
           '</option>'
         ].join('');


### PR DESCRIPTION
## Description
Remove spaces in the element IDs and ARIA attributes in the Captions Settings Dialog.
Fixes #4688 and #4884; supercedes 855adf3.
 
## Specific Changes proposed
Remove spaces in the construction of IDs and aria-labelledby attributes in the Captions Settings Dialog constructor.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome DOM inspection, Firefox+NVDA, IE11+JAWS)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [x] Reviewed by Two Core Contributors
