### PR TITLE
Remove unnecessary ARIA role on the Control Bar. Fixes #5134

### DIFF
--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -40,9 +40,6 @@ class ControlBar extends Component {
       className: 'vjs-control-bar',
       dir: 'ltr'
     }, {
-      // The control bar is a group, but we don't aria-label it to avoid
-      //  over-announcing by JAWS
-      role: 'group'
     });
   }
 }

--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -39,7 +39,6 @@ class ControlBar extends Component {
     return super.createEl('div', {
       className: 'vjs-control-bar',
       dir: 'ltr'
-    }, {
     });
   }
 }


### PR DESCRIPTION
## Description
Remove unnecessary ARIA role on the Control Bar. Fixes #5134

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Firefox+NVDA, IE+JAWS)
- [x] Reviewed by Two Core Contributors
