### PR TITLE
Reduce the multiple-announcement by screen readers of the new name of a button when its text label changes. Partial fix to #5023

### DIFF
--- a/src/js/button.js
+++ b/src/js/button.js
@@ -41,10 +41,7 @@ class Button extends ClickableComponent {
     attributes = assign({
 
       // Necessary since the default button type is "submit"
-      'type': 'button',
-
-      // let the screen reader user know that the text of the button may change
-      'aria-live': 'polite'
+      type: 'button'
     }, attributes);
 
     const el = Component.prototype.createEl.call(this, tag, props, attributes);

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -62,10 +62,7 @@ class ClickableComponent extends Component {
 
     // Add ARIA attributes for clickable element which is not a native HTML button
     attributes = assign({
-      'role': 'button',
-
-      // let the screen reader user know that the text of the element may change
-      'aria-live': 'polite'
+      role: 'button'
     }, attributes);
 
     this.tabIndex_ = props.tabIndex;
@@ -96,6 +93,9 @@ class ClickableComponent extends Component {
   createControlTextEl(el) {
     this.controlTextEl_ = Dom.createEl('span', {
       className: 'vjs-control-text'
+    }, {
+      // let the screen reader user know that the text of the element may change
+      'aria-live': 'polite'
     });
 
     if (el) {

--- a/test/unit/button.test.js
+++ b/test/unit/button.test.js
@@ -22,7 +22,7 @@ QUnit.test('should localize its text', function(assert) {
   const el = testButton.createEl();
 
   assert.ok(el.nodeName.toLowerCase().match('button'));
-  assert.ok(el.innerHTML.match(/vjs-control-text"?>Juego/));
+  assert.ok(el.innerHTML.match(/vjs-control-text"?[^<>]*>Juego/));
   assert.equal(el.getAttribute('title'), 'Juego');
 
   testButton.dispose();


### PR DESCRIPTION
## Description
Reduce the multiple-announcement by screen readers of the new name of a button when its text label changes. Partial fix to #5023

## Specific Changes proposed
Move the `aria-live` attribute to the control text element within buttons, rather than on the whole button, so it is not affected by the change of the `title` attribute, only by the change of the control text.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
