### PR TITLE
fix: ensure aria-valuenow attribute in seek-bar is not NaN (#4960)

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -171,7 +171,7 @@ class SeekBar extends Slider {
   getPercent() {
     const percent = this.getCurrentTime_() / this.player_.duration();
 
-    return percent >= 1 ? 1 : percent;
+    return percent >= 1 ? 1 : (percent || 0);
   }
 
   /**


### PR DESCRIPTION
## Description
Under certain situations the value of `getPercent()` was returning `NaN` which lead to the error described in this ticket: https://github.com/videojs/video.js/issues/4960

## Specific Changes proposed
Updated the `getPercent` function to return 0 instead of NaN. This is in accordance with the return value in the function's jsdocs.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
