### PR TITLE
Workaround for #4583 (JAWS+IE doesn't announce BPB or play button)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -32,6 +32,7 @@ import * as middleware from './tech/middleware.js';
 import {ALL as TRACK_TYPES} from './tracks/track-types';
 import filterSource from './utils/filter-source';
 import {findMimetype} from './utils/mimetypes';
+import {IE_VERSION} from './utils/browser';
 
 // The following imports are used only to ensure that the corresponding modules
 // are always included in the video.js package. Importing the modules will
@@ -579,8 +580,15 @@ class Player extends Component {
       });
     }
 
-    // set tabindex to -1 so we could focus on the player element
+    // set tabindex to -1 to remove the video element from the focus order
     tag.setAttribute('tabindex', '-1');
+    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button)
+    // See https://github.com/FreedomScientific/VFO-standards-support/issues/78
+    // Note that we can't detect if JAWS is being used, but this ARIA attribute
+    //  doesn't change behavior of IE11 if JAWS is not being used
+    if (IE_VERSION) {
+      tag.setAttribute('role', 'application');
+    }
 
     // Remove width/height attrs from tag so CSS can make it 100% width/height
     tag.removeAttribute('width');


### PR DESCRIPTION
## Description
Workaround for #4583 (JAWS+IE doesn't announce BPB or play button)

## Specific Changes proposed
Add ARIA `role="application"` to the `<video>` element if the browser is IE, as recommended by @stevefaulkner in https://github.com/FreedomScientific/VFO-standards-support/issues/78#issuecomment-388327926.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (IE11 & JAWS 2018)
- [ ] Reviewed by Two Core Contributors
