### PR TITLE
tests: do not throw on tech/player dispose

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -97,7 +97,9 @@ class ResizeManager extends Component {
 
   dispose() {
     if (this.resizeObserver_) {
-      this.resizeObserver_.unobserve(this.player_.el());
+      if (this.player_.el()) {
+        this.resizeObserver_.unobserve(this.player_.el());
+      }
       this.resizeObserver_.disconnect();
     }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -49,6 +49,48 @@ QUnit.test('dispose should not throw if styleEl is missing', function(assert) {
   assert.ok(player.el() === null, 'element disposed');
 });
 
+QUnit.test('dispose should not throw if techEl is missing', function(assert) {
+  const videoTag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(videoTag);
+
+  const player = new Player(videoTag);
+
+  player.tech_.el_.parentNode.removeChild(player.tech_.el_);
+  player.tech_.el_ = null;
+  let error;
+
+  try {
+    player.dispose();
+  } catch (e) {
+    error = e;
+  }
+
+  assert.notOk(error, 'Function did not throw an error on dispose');
+});
+
+QUnit.test('dispose should not throw if playerEl is missing', function(assert) {
+  const videoTag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(videoTag);
+
+  const player = new Player(videoTag);
+
+  player.el_.parentNode.removeChild(player.el_);
+  player.el_ = null;
+  let error;
+
+  try {
+    player.dispose();
+  } catch (e) {
+    error = e;
+  }
+
+  assert.notOk(error, 'Function did not throw an error on dispose');
+});
+
 // technically, all uses of videojs.options should be replaced with
 // Player.prototype.options_ in this file and a equivalent test using
 // videojs.options should be made in video.test.js. Keeping this here


### PR DESCRIPTION
Currently we don't have any way to check for/prevent issues like #5175. This adds a test to player/tech dispose to make sure nothing throws if the element is removed before dispose.