### PR TITLE
Remove IE9 text track HTML markup in the doc/examples, and update to use video.js v7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 Thanks to the awesome folks over at [Fastly][fastly], there's a free, CDN hosted version of Video.js that anyone can use. Add these tags to your document's `<head>`:
 
 ```html
-<link href="//vjs.zencdn.net/6.7/video-js.min.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/6.7/video.min.js"></script>
+<link href="//vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/7.0/video.min.js"></script>
 ```
 > For the latest version of video.js and URLs to use, check out the [Getting Started][getting-started] page on our website.
 

--- a/docs/examples/elephantsdream/index.html
+++ b/docs/examples/elephantsdream/index.html
@@ -5,9 +5,8 @@
   <meta charset="utf-8" />
   <title>Video.js Text Descriptions, Chapters &amp; Captions Example</title>
 
-  <link href="http://vjs.zencdn.net/5.19/video-js.css" rel="stylesheet">
-  <script src="http://vjs.zencdn.net/ie8/1.1/videojs-ie8.min.js"></script>
-  <script src="http://vjs.zencdn.net/5.19/video.js"></script>
+  <link href="http://vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
+  <script src="http://vjs.zencdn.net/7.0/video.min.js"></script>
 
 </head>
 <body>

--- a/docs/examples/elephantsdream/index.html
+++ b/docs/examples/elephantsdream/index.html
@@ -24,15 +24,15 @@
     <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4" type="video/mp4">
     <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.ogg" type="video/ogg">
 
-    <track kind="captions" src="captions.en.vtt" srclang="en" label="English" default></track><!-- Tracks need an ending tag thanks to IE9 -->
-    <track kind="captions" src="captions.sv.vtt" srclang="sv" label="Swedish"></track>
-    <track kind="captions" src="captions.ru.vtt" srclang="ru" label="Russian"></track>
-    <track kind="captions" src="captions.ja.vtt" srclang="ja" label="Japanese"></track>
-    <track kind="captions" src="captions.ar.vtt" srclang="ar" label="Arabic"></track>
+    <track kind="captions" src="captions.en.vtt" srclang="en" label="English" default>
+    <track kind="captions" src="captions.sv.vtt" srclang="sv" label="Swedish">
+    <track kind="captions" src="captions.ru.vtt" srclang="ru" label="Russian">
+    <track kind="captions" src="captions.ja.vtt" srclang="ja" label="Japanese">
+    <track kind="captions" src="captions.ar.vtt" srclang="ar" label="Arabic">
 
-    <track kind="descriptions" src="descriptions.en.vtt" srclang="en" label="English"></track>
+    <track kind="descriptions" src="descriptions.en.vtt" srclang="en" label="English">
 
-    <track kind="chapters" src="chapters.en.vtt" srclang="en" label="English"></track>
+    <track kind="chapters" src="chapters.en.vtt" srclang="en" label="English">
 
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -3,9 +3,8 @@
 <head>
 
     <title>Video.js | HTML5 Video Player</title>
-    <link href="http://vjs.zencdn.net/5.19/video-js.css" rel="stylesheet">
-    <script src="http://vjs.zencdn.net/ie8/1.1/videojs-ie8.min.js"></script>
-    <script src="http://vjs.zencdn.net/5.19/video.js"></script>
+    <link href="http://vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
+    <script src="http://vjs.zencdn.net/7.0/video.min.js"></script>
 
 </head>
 <body>

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -14,10 +14,8 @@
     <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
     <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
     <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
-    <track kind="captions" src="../shared/example-captions.vtt" srclang="en" label="English"></track>
-    <!-- Tracks need an ending tag thanks to IE9 -->
-    <track kind="subtitles" src="../shared/example-captions.vtt" srclang="en" label="English"></track>
-    <!-- Tracks need an ending tag thanks to IE9 -->
+    <track kind="captions" src="../shared/example-captions.vtt" srclang="en" label="English">
+    <track kind="subtitles" src="../shared/example-captions.vtt" srclang="en" label="English">
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
 


### PR DESCRIPTION
## Description
Since video.js V7 no longer supports IE9, remove the </track> tags from the doc/example HTML files, and while we're about it update those examples to use video.js v7.0 (from the CDN). Fixes #5165.

And then, while we're about that, update the README.md to also describe using v7.0.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Reviewed by Two Core Contributors
