### PR TITLE
play promise silence

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -3,7 +3,7 @@
  */
 import Button from './button.js';
 import Component from './component.js';
-import {isPromise} from './utils/promise';
+import {isPromise, silencePromise} from './utils/promise';
 
 /**
  * The initial play button that shows before the video has played. The hiding of the
@@ -46,6 +46,7 @@ class BigPlayButton extends Button {
 
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
+      silencePromise(playPromise);
       return;
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1637,7 +1637,7 @@ class Player extends Component {
     }
 
     if (this.paused()) {
-      this.play();
+      silencePromise(this.play());
     } else {
       this.pause();
     }

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -5,6 +5,7 @@ import ClickableComponent from './clickable-component.js';
 import Component from './component.js';
 import * as Fn from './utils/fn.js';
 import * as Dom from './utils/dom.js';
+import {silencePromise} from './utils/promise';
 
 /**
  * A `ClickableComponent` that handles showing the poster image for the player.
@@ -112,7 +113,7 @@ class PosterImage extends ClickableComponent {
     }
 
     if (this.player_.paused()) {
-      this.player_.play();
+      silencePromise(this.player_.play());
     } else {
       this.player_.pause();
     }


### PR DESCRIPTION
## Description
On Safari and Chrome a promise for play() throws an AbortError DOMException error if a pause() occurs before playback starts. No impact on player functionality but logs an annoying error to the console.
## Specific Changes proposed
Just catch the exception and do nothing.

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
