### PR TITLE
fix: menu sizing when using longer caption labels

### DIFF
--- a/src/css/components/_subs-caps.scss
+++ b/src/css/components/_subs-caps.scss
@@ -15,7 +15,8 @@
 }
 
 .video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
-  position: absolute;
+  vertical-align: middle;
+  display: inline-block;
 }
 .video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
   font-family: VideoJS;

--- a/src/css/components/_subs-caps.scss
+++ b/src/css/components/_subs-caps.scss
@@ -17,6 +17,7 @@
 .video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
   vertical-align: middle;
   display: inline-block;
+  margin-bottom: -0.1em;
 }
 .video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
   font-family: VideoJS;


### PR DESCRIPTION
## Description
Proposed solution for #4758 

Currently, if longer captions labels are used the SubsCaps menu gets all messed up in IE11/Edge. This occurs due to the menu size is not adjusted correctly not taking into consideration the CC icon. This, as a result, causes the captions items not to fit in the menu and because they end up too wide and the menu has `overflow: auto` style,  the horizontal scrollbars show up and cause the menu not to render correctly.

## Specific Changes proposed
Do not position the CC icon absolutely. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created ([starter template on JSBin](http://output.jsbin.com/xaducaq))
- [ ] Reviewed by Two Core Contributors
