### PR TITLE
Extend the constructColor function to handle 6 digit hex codes

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -35,16 +35,13 @@ const fontMap = {
 export function constructColor(color, opacity) {
   let hex;
 
-  switch (color.length) {
-  case 4:
+  if (color.length === 4) {
     // color looks like "#f0e"
     hex = color[1] + color[1] + color[2] + color[2] + color[3] + color[3];
-    break;
-  case 7:
+  } else if (color.length === 7) {
     // color looks like "#f604e2"
     hex = color.slice(1);
-    break;
-  default:
+  } else {
     throw new Error('Invalid color code provided, ' + color + '; must be formatted as e.g. #f0e or #f604e2.');
   }
   return 'rgba(' +

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -36,22 +36,23 @@ const fontMap = {
  */
 function constructColor(color, opacity) {
   let hex;
+
   switch (color.length) {
-    case 4:
-      // color looks like "#f0e"
-      hex = color[1] + color[1] + color[2] + color[2] + color[3] + color[3];
-      break;
-    case 7:
-      // color looks like "#f604e2"
-      hex = color.slice(1);
-      break;
-    default:
-      throw new Error('Invalid color code provided (' + color + '). Expecting code formatted as e.g. #f0e or #f604e2.');
+  case 4:
+    // color looks like "#f0e"
+    hex = color[1] + color[1] + color[2] + color[2] + color[3] + color[3];
+    break;
+  case 7:
+    // color looks like "#f604e2"
+    hex = color.slice(1);
+    break;
+  default:
+    throw new Error('Invalid color code provided (' + color + '). Expecting code formatted as e.g. #f0e or #f604e2.');
   }
   return 'rgba(' +
-    parseInt(hex.slice(0,2), 16) + ',' +
-    parseInt(hex.slice(2,4), 16) + ',' +
-    parseInt(hex.slice(4,6), 16) + ',' +
+    parseInt(hex.slice(0, 2), 16) + ',' +
+    parseInt(hex.slice(2, 4), 16) + ',' +
+    parseInt(hex.slice(4, 6), 16) + ',' +
     opacity + ')';
 }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -24,7 +24,7 @@ const fontMap = {
  * Construct an rgba color from a given hex color code.
  *
  * @param {number} color
- *        Hex number for color, like #f0e.
+ *        Hex number for color, like #f0e or #f604e2.
  *
  * @param {number} opacity
  *        Value for opacity, 0.0 - 1.0.
@@ -35,11 +35,23 @@ const fontMap = {
  * @private
  */
 function constructColor(color, opacity) {
+  let hex;
+  switch (color.length) {
+    case 4:
+      // color looks like "#f0e"
+      hex = color[1] + color[1] + color[2] + color[2] + color[3] + color[3];
+      break;
+    case 7:
+      // color looks like "#f604e2"
+      hex = color.slice(1);
+      break;
+    default:
+      throw new Error('Invalid color code provided (' + color + '). Expecting code formatted as e.g. #f0e or #f604e2.');
+  }
   return 'rgba(' +
-    // color looks like "#f0e"
-    parseInt(color[1] + color[1], 16) + ',' +
-    parseInt(color[2] + color[2], 16) + ',' +
-    parseInt(color[3] + color[3], 16) + ',' +
+    parseInt(hex.slice(0,2), 16) + ',' +
+    parseInt(hex.slice(2,4), 16) + ',' +
+    parseInt(hex.slice(4,6), 16) + ',' +
     opacity + ')';
 }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -31,10 +31,8 @@ const fontMap = {
  *
  * @return {string}
  *         The rgba color that was created, like 'rgba(255, 0, 0, 0.3)'.
- *
- * @private
  */
-function constructColor(color, opacity) {
+export function constructColor(color, opacity) {
   let hex;
 
   switch (color.length) {
@@ -47,7 +45,7 @@ function constructColor(color, opacity) {
     hex = color.slice(1);
     break;
   default:
-    throw new Error('Invalid color code provided (' + color + '). Expecting code formatted as e.g. #f0e or #f604e2.');
+    throw new Error('Invalid color code provided, ' + color + '; must be formatted as e.g. #f0e or #f604e2.');
   }
   return 'rgba(' +
     parseInt(hex.slice(0, 2), 16) + ',' +

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -1,5 +1,6 @@
 /* eslint-env qunit */
 import Html5 from '../../../src/js/tech/html5.js';
+import { constructColor } from '../../../src/js/tracks/text-track-display.js';
 import Component from '../../../src/js/component.js';
 
 import * as browser from '../../../src/js/utils/browser.js';
@@ -319,4 +320,33 @@ if (!Html5.supportsNativeTextTracks()) {
     player.dispose();
   });
 
+  QUnit.test('a color can be constructed from a three digit hex code', function(assert) {
+    const hex = '#f0e';
+
+    // f gets mapped to ff -> 255 in decimal,
+    // 0 gets mapped to 00 -> 0 in decimal,
+    // e gets mapped to ee -> 238 in decimal.
+    assert.equal(constructColor(hex, 1), 'rgba(255,0,238,1)');
+  });
+
+  QUnit.test('a color can be constructed from a six digit hex code', function(assert) {
+    const hex = '#f604e2';
+
+    // f6 -> 246 in decimal,
+    // 04 -> 4 in decimal,
+    // e2 -> 226 in decimal.
+    assert.equal(constructColor(hex, 1), 'rgba(246,4,226,1)');
+  });
+
+  QUnit.test('an invalid hex code will throw an error', function(assert) {
+    const hex = '#f';
+
+    assert.throws(
+      function() {
+        constructColor(hex, 1);
+      },
+      new Error('Invalid color code provided, #f; must be formatted as e.g. #f0e or #f604e2.'),
+      'colors must be valid hex codes.'
+    );
+  });
 }


### PR DESCRIPTION
## Description
When providing the TextTrackDisplay component with track settings overrides, currently colour codes with only three digits are supported. I would like to make this more flexible by also allowing six digit hex codes.

CC @arski 

## Specific Changes proposed
Updates the TextTrackDisplay component's `constructColor` function to accept and process both three and six digit colour codes.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
