### PR TITLE
fix: make sure source options are passed through

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1258,7 +1258,7 @@ class Player extends Component {
     }
 
     // update `currentSource` cache always
-    this.cache_.source = {src, type};
+    this.cache_.source = mergeOptions({}, srcObj, {src, type});
 
     const matchingSources = this.cache_.sources.filter((s) => s.src && s.src === src);
     const sourceElSources = [];

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1907,3 +1907,17 @@ QUnit.test('disposing a tech that dit NOT set a poster, should keep the poster',
 
   player.dispose();
 });
+
+QUnit.test('source options are retained', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  const source = {
+    src: 'https://some.url',
+    type: 'someType',
+    sourceOption: 'someOption'
+  };
+
+  player.src(source);
+
+  assert.equal(player.currentSource().sourceOption, 'someOption', 'source option retained');
+});


### PR DESCRIPTION
## Description
The changes to source caching in #5156 introduced a regression where the source options were no longer available to plugins. This PR makes sure the cached source object retains any source options passed along.

## Specific Changes proposed
Merge the entire source object into the cached source

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors

-----

Please let me know if you think I should check something other than `player.currentSource()` for the unit test.