### PR TITLE
Add zip file to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 # Exclude everything but the contents of the dist directory.
 **/*
 !dist/**
+dist/video-js-*.zip
 !es5/**
 !src/css/**
 !core.js


### PR DESCRIPTION
## Description
Excludes zip file with souces from being published to npm.
This closes videojs/video.js#5248

## Specific Changes proposed
Adds dist/video-js-*.zip pattern to .npmignore file

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
