### PR TITLE
feat: include iOS Chrome UA pattern when detecting Chrome in browser module

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1010,7 +1010,7 @@ Html5.canOverrideAttributes = function() {
  *         - False otherwise
  */
 Html5.supportsNativeTextTracks = function() {
-  return browser.IS_ANY_SAFARI;
+  return browser.IS_ANY_SAFARI || (browser.IS_IOS && browser.IS_CHROME);
 };
 
 /**

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -61,10 +61,10 @@ export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_EDGE = (/Edge/i).test(USER_AGENT);
 export const IS_CHROME = !IS_EDGE && ((/Chrome/i).test(USER_AGENT) || (/CriOS/i).test(USER_AGENT));
 export const CHROME_VERSION = (function() {
-  const match = USER_AGENT.match(/Chrome\/(\d+)/);
+  const match = USER_AGENT.match(/(Chrome|CriOS)\/(\d+)/);
 
-  if (match && match[1]) {
-    return parseFloat(match[1]);
+  if (match && match[2]) {
+    return parseFloat(match[2]);
   }
   return null;
 }());

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -59,7 +59,7 @@ export const IS_NATIVE_ANDROID = IS_ANDROID && ANDROID_VERSION < 5 && appleWebki
 
 export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
 export const IS_EDGE = (/Edge/i).test(USER_AGENT);
-export const IS_CHROME = !IS_EDGE && (/Chrome/i).test(USER_AGENT);
+export const IS_CHROME = !IS_EDGE && ((/Chrome/i).test(USER_AGENT) || (/CriOS/i).test(USER_AGENT));
 export const CHROME_VERSION = (function() {
   const match = USER_AGENT.match(/Chrome\/(\d+)/);
 

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -81,7 +81,7 @@ export const IE_VERSION = (function() {
 }());
 
 export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
-export const IS_ANY_SAFARI = IS_SAFARI || IS_IOS;
+export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;
 
 export const TOUCH_ENABLED = Dom.isReal() && (
   'ontouchstart' in window ||


### PR DESCRIPTION
## Description
`IS_CHROME` in browser module currently returns `false` for iOS Chrome. 

## Specific Changes proposed
Include iOS Chrome UA string pattern when detecting Chrome. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
