### PR TITLE
feat: allow plugin deregistration from videojs

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -452,6 +452,20 @@ videojs.bind = Fn.bind;
 videojs.registerPlugin = Plugin.registerPlugin;
 
 /**
+ * Deregister a Video.js plugin.
+ *
+ * @borrows plugin:deregisterPlugin as videojs.deregisterPlugin
+ * @method deregisterPlugin
+ *
+ * @param  {string} name
+ *         The name of the plugin to be deregistered. Must be a string and
+ *         must match an existing plugin or a method on the `Player`
+ *         prototype.
+ *
+ */
+videojs.deregisterPlugin = Plugin.deregisterPlugin;
+
+/**
  * Deprecated method to register a plugin with Video.js
  *
  * @deprecated


### PR DESCRIPTION
Currently you have to get the base plugin class and then deregister from there, which is a bit weird since you can directly register a plugin from `videojs`. This pr allows plugin de-registration from `videojs` as well.