### PR TITLE
feat: new text track event - ttChange

### DIFF
--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -31,6 +31,14 @@ class TextTrackList extends TrackList {
       this.trigger('change');
     }));
 
+    /**
+     * @listens TextTrack#textTrackChange
+     * @fires TrackList#ttChange
+     */
+    track.addEventListener('textTrackChange', Fn.bind(this, function() {
+      this.trigger('ttChange');
+    }));
+
     const nonLanguageTextTrackKind = ['metadata', 'chapters'];
 
     if (nonLanguageTextTrackKind.indexOf(track.kind) === -1) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -217,6 +217,7 @@ class TextTrack extends Track {
        * @instance
        *
        * @fires TextTrack#modechange
+       * @fires TextTrack#textTrackChange
        */
       mode: {
         get() {
@@ -228,6 +229,16 @@ class TextTrack extends Track {
           }
           mode = newMode;
           if (mode === 'showing') {
+          /**
+           * An event that fires when the mode change to showing. This allows
+           * listening for a singular text track event.
+           *
+           * > Note: This is not part of the spec!
+           *
+           * @event TextTrack#modechange
+           * @type {EventTarget~Event}
+           */
+            this.trigger('textTrackChange');
 
             this.tech_.ready(() => {
               this.tech_.on('timeupdate', timeupdateHandler);

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -42,3 +42,21 @@ QUnit.test('trigger "change" event when mode changes on a TextTrack', function(a
 
   assert.equal(changes, 3, 'three change events should have fired');
 });
+
+QUnit.test('trigger "change" event when "textTrackChange" is fired on a track', function(assert) {
+  const tt = new EventTarget();
+  const ttl = new TextTrackList([tt]);
+  let changes = 0;
+  const changeHandler = function() {
+    changes++;
+  };
+
+  ttl.on('ttChange', changeHandler);
+  tt.trigger('textTrackChange');
+
+  ttl.off('ttChange', changeHandler);
+  ttl.onchange = changeHandler;
+
+  tt.trigger('textTrackChange');
+  assert.equal(changes, 1, 'one ttChange events should have fired');
+});


### PR DESCRIPTION
## Description
As discussed in #5159 , the current event "change" is fired when modechange is triggered. This means for every text track change, there are multiple events fired and hence requires manual filtering of the events to have the single event. Ideally, when a text track is changed, there should only be one event fired.

## Specific Changes proposed
The change proposed is to add a new event as to not affect or change the behavior of text-tracks functions which is dependent on modechange. To reduce the event to only fire for the text track which is showing, the new event is triggered only when the textTrackMode is 'showing' which would only fire once for each text track change.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
