### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "An HTML5 and Flash video player with a common API and skin for both.",
   "version": "7.0.5",
   "main": "./dist/video.cjs.js",
+  "module": "./dist/video.es.js",
   "style": "./dist/video-js.css",
   "copyright": "Copyright Brightcove, Inc. <https://www.brightcove.com/>",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description
This PR adds the module field to the package json in order to improve interoperability with some JS bundlers.

Closes #5288

## Specific Changes proposed
- Added `module` field

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
