### PR TITLE
feat(middleware): make setSource be optional

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -25,7 +25,9 @@ There are a few special methods that affect middleware: `setSource` and `setTech
 
 This method will setup the routing between a specific source and middleware and eventually sets the source on the `Tech`.
 
-If your middleware is not manipulating, redirecting or rejecting the source, you can pass along the source by doing the following:
+If your middleware is not manipulating, redirecting or rejecting the source, you may leave this method out on newer versions of Video.js. Doing so will make the middleware be selected implicitly.
+
+In versions 7.0.5 and older, to get your middleware selected, you can pass along the source by doing the following:
 
 ```javascript
 videojs.use('*', function(player) {
@@ -37,8 +39,6 @@ videojs.use('*', function(player) {
   };
 });
 ```
-
-Alternative, in versions greater than 7.0.5, you may omit `setSource` entirely and the middleware will get selected implicitly.
 
 ### setTech
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -25,7 +25,7 @@ There are a few special methods that affect middleware: `setSource` and `setTech
 
 This method will setup the routing between a specific source and middleware and eventually sets the source on the `Tech`.
 
-If your middleware is not manipulating, redirecting or rejecting the source, you may leave this method out on newer versions of Video.js. Doing so will make the middleware be selected implicitly.
+If your middleware is not manipulating, redirecting or rejecting the source, you may leave this method out on newer versions of Video.js. Doing so will select middleware implicitly.
 
 In versions 7.0.5 and older, to get your middleware selected, you can pass along the source by doing the following:
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -21,8 +21,9 @@ Middleware are functions that return an object, a class instance, a prototype, e
 There are a few special methods that affect middleware: `setSource` and `setTech`. These are called internally by Video.js when you call `player.src()`.
 
 ### setSource
+> *NOTE*: In versions of Video.js 7.0.5 and older, `setSource` was required for all middleware and had be included in the returned objects.
 
-`setSource` is a required method for all middleware and must be included in the returned object. This method will setup the routing between a specific source and middleware and eventually sets the source on the `Tech`.
+This method will setup the routing between a specific source and middleware and eventually sets the source on the `Tech`.
 
 If your middleware is not manipulating, redirecting or rejecting the source, you can pass along the source by doing the following:
 
@@ -36,6 +37,8 @@ videojs.use('*', function(player) {
   };
 });
 ```
+
+Alternative, in versions greater than 7.0.5, you may omit `setSource` entirely and the middleware will get selected implicitly.
 
 ### setTech
 
@@ -133,6 +136,23 @@ var myMiddleware = function(player) {
       // pass null as the first argument to indicate that the source is not rejected
       next(null, srcObj);
     },
+    currentTime: function(ct) {
+      return ct / 2;
+    },
+    setCurrentTime: function(time) {
+      return time * 2;
+    }
+  };
+};
+
+videojs.use('*', myMiddleware);
+```
+
+And the same example with `setSource` omitted:
+
+```javascript
+var myMiddleware = function(player) {
+  return {
     currentTime: function(ct) {
       return ct / 2;
     },

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -152,6 +152,12 @@ function setSourceHelper(src = {}, middleware = [], next, player, acc = [], last
   } else if (mwFactory) {
     const mw = getOrCreateFactory(player, mwFactory);
 
+    // if setSource isn't present, implicitly select this middleware
+    if (!mw.setSource) {
+      acc.push(mw);
+      return setSourceHelper(src, mwrest, next, player, acc, lastRun);
+    }
+
     mw.setSource(assign({}, src), function(err, _src) {
 
       // something happened, try the next middleware on the current level
@@ -172,6 +178,7 @@ function setSourceHelper(src = {}, middleware = [], next, player, acc = [], last
           acc,
           lastRun);
     });
+
   } else if (mwrest.length) {
     setSourceHelper(src, mwrest, next, player, acc, lastRun);
   } else if (lastRun) {

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -510,3 +510,29 @@ QUnit.test('a middleware factory is called on a new source with a new player', f
 
   middleware.getMiddleware('video/foo').pop();
 });
+
+QUnit.test('a middleware without a setSource gets chosen implicitly', function(assert) {
+  let mws = [];
+  const mw = {
+    currentTime(ct) {
+    }
+  };
+  const mwFactory = () => mw;
+
+  middleware.use('video/foo', mwFactory);
+
+  middleware.setSource({
+    id() {
+      return 'vid1';
+    },
+    setTimeout: window.setTimeout
+  }, {src: 'foo', type: 'video/foo'}, function(src, _mws) {
+    mws = _mws;
+  });
+
+  this.clock.tick(1);
+
+  assert.equal(mws.length, 1, 'we have 1 middleware set');
+
+  middleware.getMiddleware('video/foo').pop();
+});

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -405,6 +405,7 @@ QUnit.test('setSource will select all middleware of a given type, until src chan
 
   middleware.getMiddleware('video/foo').pop();
   middleware.getMiddleware('video/foo').pop();
+  middleware.getMiddleware('video/foo').pop();
 });
 
 QUnit.test('a middleware without a mediator method will not throw an error', function(assert) {


### PR DESCRIPTION
Adding tests first and implementation will be available after tests fail.

setSource is useful if you care to be fiddling with the source or doing some work depending on what source is set. However, sometimes, you don't need a setSource and want the middleware to always be selected.
Now, if setSource is missing, it will implicitly be included in the middleware chain.