### PR TITLE
Fullscreen button will be disabled if fullscreen is unavailable

### DIFF
--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -3,6 +3,8 @@
  */
 import Button from '../button.js';
 import Component from '../component.js';
+import FullscreenApi from '../fullscreen-api.js';
+import document from 'global/document';
 
 /**
  * Toggle fullscreen video
@@ -23,6 +25,10 @@ class FullscreenToggle extends Button {
   constructor(player, options) {
     super(player, options);
     this.on(player, 'fullscreenchange', this.handleFullscreenChange);
+
+    if (document[FullscreenApi.fullscreenEnabled] === false) {
+      this.disable();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
In the event that fullscreen is unavailable, such as when the player is in an iframe that does not have the allowfullscreen attribute, the fullscreen button will be disabled. This fixes #5290

## Specific Changes proposed
fullscreen-toggle.js will check if fullscreen is enabled, and if not, set the button to "disabled"

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
