### PR TITLE
Copy all tag attributes after the tags attributes are modified

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -562,10 +562,6 @@ class Player extends Component {
       el = this.el_ = super.createEl('div');
     }
 
-    // Copy over all the attributes from the tag, including ID and class
-    // ID will now reference player box, not the video tag
-    const attrs = Dom.getAttributes(tag);
-
     if (divEmbed) {
       el = this.el_ = tag;
       tag = this.tag = document.createElement('video');
@@ -602,6 +598,10 @@ class Player extends Component {
     // Remove width/height attrs from tag so CSS can make it 100% width/height
     tag.removeAttribute('width');
     tag.removeAttribute('height');
+
+    // Copy over all the attributes from the tag, including ID and class
+    // ID will now reference player box, not the video tag
+    const attrs = Dom.getAttributes(tag);
 
     Object.getOwnPropertyNames(attrs).forEach(function(attr) {
       // don't copy over the class attribute to the player element when we're in a div embed


### PR DESCRIPTION
## Description
In the existing code, the attributes of the tag is grabbed copied over first, but then a few modifications are applied afterwards (tabindex, role, width, height). The will make the attrs variable missing all the modifications had been applied.

## Specific Changes proposed
Only copy over the attributes once all modifications are done

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
