### PR TITLE
Player reset text track unwanted copy

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1058,8 +1058,7 @@ class Player extends Component {
         this[props.privateName] = this[props.getterName]();
       });
       this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
-    } 
-    
+    }
     this.isReady_ = false;
 
     this.tech_.dispose();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1056,7 +1056,7 @@ class Player extends Component {
       this[props.privateName] = this[props.getterName]();
     });
     this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
-    
+
     this.isReady_ = false;
 
     this.tech_.dispose();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2764,7 +2764,7 @@ class Player extends Component {
    */
   reset() {
     if (this.tech_) {
-      this.tech_.clearTracks(['text']);
+      this.tech_.clearTracks('text');
     }
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2763,7 +2763,7 @@ class Player extends Component {
    * and calls `reset` on the tech`.
    */
   reset() {
-    this.tech_.clearTracks(["text"]);
+    this.tech_.clearTracks(['text']);
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -913,11 +913,11 @@ class Player extends Component {
    *
    * @private
    */
-  loadTech_(techName, source, isResetting) {
+  loadTech_(techName, source) {
 
     // Pause and remove current playback technology
     if (this.tech_) {
-      this.unloadTech_(isResetting);
+      this.unloadTech_();
     }
 
     const titleTechName = toTitleCase(techName);
@@ -1048,17 +1048,15 @@ class Player extends Component {
    *
    * @private
    */
-  unloadTech_(isResetting) {
-    this.textTracksJson_ = [];
+  unloadTech_() {
     // Save the current text tracks so that we can reuse the same text tracks with the next tech
-    if (!isResetting) {
-      TRACK_TYPES.names.forEach((name) => {
-        const props = TRACK_TYPES[name];
+    TRACK_TYPES.names.forEach((name) => {
+      const props = TRACK_TYPES[name];
 
-        this[props.privateName] = this[props.getterName]();
-      });
-      this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
-    }
+      this[props.privateName] = this[props.getterName]();
+    });
+    this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
+    
     this.isReady_ = false;
 
     this.tech_.dispose();
@@ -2765,6 +2763,7 @@ class Player extends Component {
    * and calls `reset` on the tech`.
    */
   reset() {
+    this.tech_.clearTracks(["text"]);
     this.loadTech_(this.options_.techOrder[0], null, true);
     this.techCall_('reset');
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2764,7 +2764,7 @@ class Player extends Component {
    */
   reset() {
     this.tech_.clearTracks(["text"]);
-    this.loadTech_(this.options_.techOrder[0], null, true);
+    this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -913,11 +913,11 @@ class Player extends Component {
    *
    * @private
    */
-  loadTech_(techName, source) {
+  loadTech_(techName, source, isResetting) {
 
     // Pause and remove current playback technology
     if (this.tech_) {
-      this.unloadTech_();
+      this.unloadTech_(isResetting);
     }
 
     const titleTechName = toTitleCase(techName);
@@ -1048,15 +1048,18 @@ class Player extends Component {
    *
    * @private
    */
-  unloadTech_() {
+  unloadTech_(isResetting) {
+    this.textTracksJson_ = [];
     // Save the current text tracks so that we can reuse the same text tracks with the next tech
-    TRACK_TYPES.names.forEach((name) => {
-      const props = TRACK_TYPES[name];
+    if (!isResetting) {
+      TRACK_TYPES.names.forEach((name) => {
+        const props = TRACK_TYPES[name];
 
-      this[props.privateName] = this[props.getterName]();
-    });
-    this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
-
+        this[props.privateName] = this[props.getterName]();
+      });
+      this.textTracksJson_ = textTrackConverter.textTracksToJson(this.tech_);
+    } 
+    
     this.isReady_ = false;
 
     this.tech_.dispose();
@@ -2763,7 +2766,7 @@ class Player extends Component {
    * and calls `reset` on the tech`.
    */
   reset() {
-    this.loadTech_(this.options_.techOrder[0], null);
+    this.loadTech_(this.options_.techOrder[0], null, true);
     this.techCall_('reset');
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2763,7 +2763,9 @@ class Player extends Component {
    * and calls `reset` on the tech`.
    */
   reset() {
-    this.tech_.clearTracks(['text']);
+    if (this.tech_) {
+      this.tech_.clearTracks(['text']);
+    }
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
   }


### PR DESCRIPTION
Add a isResetting flag to loadTech, and unloadTech, so not to copy text tracks.

## Description
When reset is called, text tracks are being kept. By adding the appropriate flag, we keep text tracks, but not when we are resetting the player.
https://github.com/videojs/video.js/issues/5140

## Specific Changes proposed
Added a isResetting flag to the loadTech_  and unloadTech_ methods which controls text tracks copy.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
