### PR TITLE
feat: prefer to use MSE over native for HLS playback

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,7 @@
 import videojs from './video';
 import '@videojs/http-streaming';
+
+// Prefer to use MSE for playback over native
+videojs.options.hls.overrideNative = !videojs.browser.IS_ANY_SAFARI;
+
 export default videojs;


### PR DESCRIPTION
## Description
This PR is to experiment with using MSE for playback when available (excluding Safari)

## Specific Changes proposed
Set the VHS override for all browsers save Safari.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
