### PR TITLE
remove duplicate @deprecated which throws error when minifying via go…

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1599,7 +1599,7 @@ class Player extends Component {
    * @fires Player#firstplay
    * @listens Tech#firstplay
    * @deprecated As of 6.0 firstplay event is deprecated.
-   * @deprecated As of 6.0 passing the `starttime` option to the player and the firstplay event are deprecated.
+   *             As of 6.0 passing the `starttime` option to the player and the firstplay event are deprecated.
    * @private
    */
   handleTechFirstPlay_() {


### PR DESCRIPTION
remove duplicate @deprecated which throws error when minifying via google closure compiler

jsdoc doesn't allow duplicate tags for a given function header. This is the only place in the project where this rule isn't respected. This change causes closure compiler to run without errors or warnings.