### PR TITLE
Changed position to absolute

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -114,7 +114,7 @@
   font-size: 1em;
   padding: 6px 8px 8px 8px;
   pointer-events: none;
-  position: relative;
+  position: absolute;
   top: -3.4em;
   visibility: hidden;
   z-index: 1;


### PR DESCRIPTION
## Description
Changed tooltips position from relative to absolute 
Issue videojs/video.js#5354 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
