### PR TITLE
Update notice about tracking pixel in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,19 @@
 Thanks to the awesome folks over at [Fastly][fastly], there's a free, CDN hosted version of Video.js that anyone can use. Add these tags to your document's `<head>`:
 
 ```html
-<link href="//vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/7.0/video.min.js"></script>
+<link href="//vjs.zencdn.net/7.2.0/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/7.2.0/video.min.js"></script>
 ```
 > For the latest version of video.js and URLs to use, check out the [Getting Started][getting-started] page on our website.
 
-> In the `vjs.zencdn.net` CDN-hosted versions of Video.js we include a [stripped down Google Analytics pixel](https://github.com/videojs/cdn/blob/master/src/analytics.js) that tracks a random sampling (currently 1%) of players loaded from the CDN. This allows us to see (roughly) what browsers are in use in the wild, along with other useful metrics such as OS and device. If you'd like to disable analytics, you can simply include the following global before including Video.js via the free CDN:
->
-> ```html
-> <script>window.HELP_IMPROVE_VIDEOJS = false;</script>
-> ```
-> Alternatively, you can include Video.js by getting it from [npm](http://videojs.com/getting-started/#download-npm), downloading from [GitHub releases](https://github.com/videojs/video.js/releases) or by including it via [unpkg](https://unpkg.com) or another JavaScript CDN like CDNjs. These releases *do not* include Google Analytics tracking at all.
 > ```html
 > <!-- unpkg -->
 > <link href="https://unpkg.com/video.js/dist/video-js.css" rel="stylesheet">
 > <script src="https://unpkg.com/video.js/dist/video.js"></script>
 >
 > <!-- cdnjs -->
-> <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.7.3/video-js.css" rel="stylesheet">
-> <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/6.7.3/video.js"></script>
+> <link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.2.0/video-js.css" rel="stylesheet">
+> <script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.2.0/video.js"></script>
 > ```
 
 Next, using Video.js is as simple as creating a `<video>` element, but with an additional `data-setup` attribute. At a minimum, this attribute must have a value of `'{}'`, but it can include any Video.js [options][options] - just make sure it contains valid JSON!
@@ -49,7 +43,7 @@ Next, using Video.js is as simple as creating a `<video>` element, but with an a
 ```html
 <video
     id="my-player"
-    class="video-js"
+    class="video-js vjs-default-skin"
     controls
     preload="auto"
     poster="//vjs.zencdn.net/v/oceans.png"


### PR DESCRIPTION
Afaik the tracking pixel has been removed so this message can be removed from the readme.

Also bumped version nrs and added vjs-default-skin class to example.