### PR TITLE
fix: call component dispose in resize manager to fix leak

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -115,6 +115,7 @@ class ResizeManager extends Component {
     this.resizeObserver = null;
     this.debouncedHandler_ = null;
     this.loadListener_ = null;
+    super.dispose();
   }
 
 }


### PR DESCRIPTION
Currently most event listeners that are being added are not removed because we don't trigger dispose in the ResizeManager. I think that it makes sense to just call the parents dispose here instead though.