### PR TITLE
fix(sourceset): ignore blob urls when updating source cache

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1291,6 +1291,12 @@ class Player extends Component {
       src = srcObj.src;
       type = srcObj.type;
     }
+
+    // if we are a blob url, don't update the source cache
+    if (/^blob:/.test(src)) {
+      return;
+    }
+
     // make sure all the caches are set to default values
     // to prevent null checking
     this.cache_.source = this.cache_.source || {};

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1293,6 +1293,8 @@ class Player extends Component {
     }
 
     // if we are a blob url, don't update the source cache
+    // blob urls can arise when playback is done via Media Source Extension (MSE)
+    // such as m3u8 sources with @videojs/http-streaming (VHS)
     if (/^blob:/.test(src)) {
       return;
     }


### PR DESCRIPTION
It's possible for us to get a blob url for sourceset, but when we do, we
shouldn't update the source caches with that information.