### PR TITLE
fix: add debounced.cancel and use it in ResizeManager

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -114,6 +114,10 @@ class ResizeManager extends Component {
       this.off('load', this.loadListener_);
     }
 
+    if (this.debouncedHandler_) {
+      this.debouncedHandler_.cancel();
+    }
+
     this.ResizeObserver = null;
     this.resizeObserver = null;
     this.debouncedHandler_ = null;

--- a/src/js/utils/fn.js
+++ b/src/js/utils/fn.js
@@ -98,8 +98,13 @@ export const throttle = function(fn, wait) {
 export const debounce = function(func, wait, immediate, context = window) {
   let timeout;
 
+  const cancel = () => {
+    context.clearTimeout(timeout);
+    timeout = null;
+  };
+
   /* eslint-disable consistent-this */
-  return function() {
+  const debounced = function() {
     const self = this;
     const args = arguments;
 
@@ -119,4 +124,8 @@ export const debounce = function(func, wait, immediate, context = window) {
     timeout = context.setTimeout(later, wait);
   };
   /* eslint-enable consistent-this */
+
+  debounced.cancel = cancel;
+
+  return debounced;
 };


### PR DESCRIPTION
It's possible that ResizeManager will trigger its debounce handler but
then get disposed before the handler runs. This can cause tests to fail,
so, instead, we should cancel the debounce when ResizeManager is
disposed.