### PR TITLE
fix: use consistent id after loadTech_()

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -945,7 +945,7 @@ class Player extends Component {
       autoplay,
       'nativeControlsForTouch': this.options_.nativeControlsForTouch,
       'playerId': this.id(),
-      'techId': `${this.id()}_${titleTechName}_api`,
+      'techId': `${this.id()}_${camelTechName}_api`,
       'playsinline': this.options_.playsinline,
       'preload': this.options_.preload,
       'loop': this.options_.loop,


### PR DESCRIPTION
## Description
Change the constant used in the techId prop to the camelCased version, this will result on consistent id when loadTech_() is executed.
this closes videojs/video.js#5411 

## Specific Changes proposed
change line 948 to use camelTechName

## Requirements Checklist
- [x] Bug fixed
- [ ] Reviewed by Two Core Contributors
