### PR TITLE
player.usePlugin - shortcut to register & init

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3892,13 +3892,13 @@ TECH_EVENTS_RETRIGGER.forEach(function(event) {
  */
 
 /**
- * Register and immediately use plugin on Player.
+ * Apply plugin to player.
  *
  * @method Player#usePlugin
  * @param   {string} name
- *          The name of the plugin to be registered. Must be a string and
- *          must not match an existing plugin or a method on the `Player`
- *          prototype.
+ *          The name under witch the plugin will be saved. Under this same
+ *          name `player.usingPlugin(name)`. Must be a string and must not
+ *          match an existing plugin or a method on the `Player` prototype.
  *
  * @param   {Function} plugin
  *          A sub-class of `Plugin` or a function for basic plugins.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -8,7 +8,7 @@ import {version} from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import tsml from 'tsml';
-import evented from './mixins/evented';
+import evented from './mixins/evented';i
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
@@ -3892,7 +3892,7 @@ TECH_EVENTS_RETRIGGER.forEach(function(event) {
  */
 
 /**
- * Register and imediatly use plugin on Player.
+ * Register and immediately use plugin on Player.
  *
  * @method Player#usePlugin
  * @param   {string} name

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -8,7 +8,7 @@ import {version} from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import tsml from 'tsml';
-import evented from './mixins/evented';i
+import evented from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3896,14 +3896,14 @@ TECH_EVENTS_RETRIGGER.forEach(function(event) {
  *
  * @method Player#usePlugin
  * @param   {string} name
- *          The name under witch the plugin will be saved. Under this same
+ *          The name under which the plugin will be saved. Under this same
  *          name `player.usingPlugin(name)`. Must be a string and must not
  *          match an existing plugin or a method on the `Player` prototype.
  *
  * @param   {Function} plugin
  *          A sub-class of `Plugin` or a function for basic plugins.
  *
- * @param   {...any} options
+ * @param   {...any} args
  *          Options that the plugin should be called with.
  */
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3892,6 +3892,22 @@ TECH_EVENTS_RETRIGGER.forEach(function(event) {
  */
 
 /**
+ * Register and imediatly use plugin on Player.
+ *
+ * @method Player#usePlugin
+ * @param   {string} name
+ *          The name of the plugin to be registered. Must be a string and
+ *          must not match an existing plugin or a method on the `Player`
+ *          prototype.
+ *
+ * @param   {Function} plugin
+ *          A sub-class of `Plugin` or a function for basic plugins.
+ *
+ * @param   {...any} options
+ *          Options that the plugin should be called with.
+ */
+
+/**
  * Reports whether or not a player has a plugin available.
  *
  * This does not report whether or not the plugin has ever been initialized

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -456,7 +456,7 @@ Plugin.registerPlugin(BASE_PLUGIN_NAME, Plugin);
  *
  * @ignore
  */
-Player.prototype.usePlugin = function(name, plugin, ...options) {
+Player.prototype.usePlugin = function(name, plugin, ...args) {
   let wrappedPlugin;
 
   if (name !== BASE_PLUGIN_NAME) {
@@ -465,7 +465,7 @@ Player.prototype.usePlugin = function(name, plugin, ...options) {
     } else {
       wrappedPlugin = createPluginFactory(name, plugin);
     }
-    wrappedPlugin(...options);
+    wrappedPlugin(...args);
   } else {
     throw new Error('Please help with nice error...');
   }

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -456,6 +456,16 @@ Plugin.registerPlugin(BASE_PLUGIN_NAME, Plugin);
  *
  * @ignore
  */
+Player.prototype.usePlugin = function(name, plugin, ...options) {
+  Plugin.registerPlugin(name, plugin);
+  this[name](...options);
+};
+
+/**
+ * Documented in player.js
+ *
+ * @ignore
+ */
 Player.prototype.usingPlugin = function(name) {
   return !!this[PLUGIN_CACHE_KEY] && this[PLUGIN_CACHE_KEY][name] === true;
 };

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -457,8 +457,18 @@ Plugin.registerPlugin(BASE_PLUGIN_NAME, Plugin);
  * @ignore
  */
 Player.prototype.usePlugin = function(name, plugin, ...options) {
-  Plugin.registerPlugin(name, plugin);
-  this[name](...options);
+  let wrappedPlugin;
+
+  if (name !== BASE_PLUGIN_NAME) {
+    if (Plugin.isBasic(plugin)) {
+      wrappedPlugin = createBasicPlugin(name, plugin);
+    } else {
+      wrappedPlugin = createPluginFactory(name, plugin);
+    }
+    wrappedPlugin(...options);
+  } else {
+    throw new Error('Please help with nice error...');
+  }
 };
 
 /**

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -434,26 +434,6 @@ videojs.bind = Fn.bind;
 /**
  * Register a Video.js plugin.
  *
- * @borrows plugin:usePlugin as videojs.usePlugin
- * @method usePlugin
- *
- * @param  {string} name
- *         The name of the plugin to be registered. Must be a string and
- *         must not match an existing plugin or a method on the `Player`
- *         prototype.
- *
- * @param  {Function} plugin
- *         A sub-class of `Plugin` or a function for basic plugins.
- *
- * @return {Function}
- *         For advanced plugins, a factory function for that plugin. For
- *         basic plugins, a wrapper function that initializes the plugin.
- */
-videojs.usePlugin = Plugin.usePlugin;
-
-/**
- * Register a Video.js plugin.
- *
  * @borrows plugin:registerPlugin as videojs.registerPlugin
  * @method registerPlugin
  *

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -434,6 +434,26 @@ videojs.bind = Fn.bind;
 /**
  * Register a Video.js plugin.
  *
+ * @borrows plugin:usePlugin as videojs.usePlugin
+ * @method usePlugin
+ *
+ * @param  {string} name
+ *         The name of the plugin to be registered. Must be a string and
+ *         must not match an existing plugin or a method on the `Player`
+ *         prototype.
+ *
+ * @param  {Function} plugin
+ *         A sub-class of `Plugin` or a function for basic plugins.
+ *
+ * @return {Function}
+ *         For advanced plugins, a factory function for that plugin. For
+ *         basic plugins, a wrapper function that initializes the plugin.
+ */
+videojs.usePlugin = Plugin.usePlugin;
+
+/**
+ * Register a Video.js plugin.
+ *
  * @borrows plugin:registerPlugin as videojs.registerPlugin
  * @method registerPlugin
  *

--- a/test/unit/plugin-advanced.test.js
+++ b/test/unit/plugin-advanced.test.js
@@ -85,6 +85,15 @@ QUnit.test('usePlugin syntax', function(assert) {
   assert.ok(spy.calledOnceWith('advanced1'));
 });
 
+QUnit.test('usePlugin does not register plugin to other', function(assert) {
+  const advancedPlugin = new class SingleUsePlugin extends Plugin { }();
+  const otherPlayer = TestHelpers.makePlayer();
+  const name = 'advanced';
+
+  this.player.usePlugin(name, advancedPlugin, 'advanced1');
+  assert.notOk(otherPlayer[name]);
+});
+
 QUnit.test('all "pluginsetup" events', function(assert) {
   const setupSpy = sinon.spy();
   const events = [

--- a/test/unit/plugin-advanced.test.js
+++ b/test/unit/plugin-advanced.test.js
@@ -71,6 +71,20 @@ QUnit.test('setup', function(assert) {
   );
 });
 
+QUnit.test('usePlugin syntax', function(assert) {
+  const spy = sinon.spy();
+  const advancedPlugin = new class SingleUsePlugin extends Plugin {
+    constructor(...args) {
+      super(...args);
+      spy.apply(this, args);
+    }
+  };
+
+  this.player.usePlugin('advanced', advancedPlugin, 'advanced1');
+  assert.ok(this.player.usingPlugin('advanced'));
+  assert.ok(spy.calledOnceWith('advanced1'));
+});
+
 QUnit.test('all "pluginsetup" events', function(assert) {
   const setupSpy = sinon.spy();
   const events = [

--- a/test/unit/plugin-basic.test.js
+++ b/test/unit/plugin-basic.test.js
@@ -47,6 +47,36 @@ QUnit.test('setup', function(assert) {
   assert.ok(this.player.hasPlugin('basic'), 'player has the plugin available');
 });
 
+QUnit.test('usePlugin syntax', function(assert) {
+  const argumentLessPlugin = sinon.spy(() => {});
+  const simplePlugin = sinon.spy(arg1 => {});
+  const multipleArgumentPlugin = sinon.spy((arg1, arg2) => {});
+
+  const spy = sinon.spy();
+  const advancedPlugin = new class MockPlugin extends Plugin {
+    constructor(...args) {
+      super(...args);
+      spy.apply(this, args);
+    }
+  };
+
+  this.player.usePlugin('argumentLess', argumentLessPlugin);
+  assert.ok(this.player.usingPlugin('argumentLess'));
+  assert.ok(argumentLessPlugin.calledOnceWith());
+
+  this.player.usePlugin('simple', simplePlugin, 'simple1');
+  assert.ok(this.player.usingPlugin('simple'));
+  assert.ok(simplePlugin.calledOnceWith('simple1'));
+
+  this.player.usePlugin('multipleArgument', multipleArgumentPlugin, 'multiple1', 'multiple2');
+  assert.ok(this.player.usingPlugin('multipleArgument'));
+  assert.ok(multipleArgumentPlugin.calledOnceWith('multiple1', 'multiple2'));
+
+  this.player.usePlugin('advanced', advancedPlugin, 'advanced1');
+  assert.ok(this.player.usingPlugin('advanced'));
+  assert.ok(spy.calledOnceWith('advanced1'));
+});
+
 QUnit.test('all "pluginsetup" events', function(assert) {
   const setupSpy = sinon.spy();
   const events = [

--- a/test/unit/plugin-basic.test.js
+++ b/test/unit/plugin-basic.test.js
@@ -52,14 +52,6 @@ QUnit.test('usePlugin syntax', function(assert) {
   const simplePlugin = sinon.spy(arg1 => {});
   const multipleArgumentPlugin = sinon.spy((arg1, arg2) => {});
 
-  const spy = sinon.spy();
-  const advancedPlugin = new class MockPlugin extends Plugin {
-    constructor(...args) {
-      super(...args);
-      spy.apply(this, args);
-    }
-  };
-
   this.player.usePlugin('argumentLess', argumentLessPlugin);
   assert.ok(this.player.usingPlugin('argumentLess'));
   assert.ok(argumentLessPlugin.calledOnceWith());
@@ -71,10 +63,15 @@ QUnit.test('usePlugin syntax', function(assert) {
   this.player.usePlugin('multipleArgument', multipleArgumentPlugin, 'multiple1', 'multiple2');
   assert.ok(this.player.usingPlugin('multipleArgument'));
   assert.ok(multipleArgumentPlugin.calledOnceWith('multiple1', 'multiple2'));
+});
 
-  this.player.usePlugin('advanced', advancedPlugin, 'advanced1');
-  assert.ok(this.player.usingPlugin('advanced'));
-  assert.ok(spy.calledOnceWith('advanced1'));
+QUnit.test('usePlugin does not register plugin to other', function(assert) {
+  const simplePlugin = () => {};
+  const otherPlayer = TestHelpers.makePlayer();
+  const name = 'simple';
+
+  this.player.usePlugin(name, simplePlugin);
+  assert.notOk(otherPlayer[name]);
 });
 
 QUnit.test('all "pluginsetup" events', function(assert) {


### PR DESCRIPTION
## Description
videojs/video.js#5360 Added new function `usePlugin` to Player prototype. It will register the plugin as well as initialise it with given parameters.

## Motivation behing
When `registerPlugin` and its initialisation is merged into one function, many will be satisfied as usually only one player exists per page. Also this will help TS as it would make it possible to strongly check plugin's options.

## Requirements Checklist
- [x] Feature implemented
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
    - [ ] Test is working
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
  - [ ] Updated TypeScript type declaration file
- [ ] Reviewed by Two Core Contributors

Does it need example? it could potentially replace current plugin example set up.

PS: Testing by hand works, but unit fails. May I get some help?
