### PR TITLE
fix: typo in resize manager

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -67,7 +67,7 @@ class ResizeManager extends Component {
 
     } else {
       this.loadListener_ = () => {
-        if (!this.el_ || this.el_.contentWindow) {
+        if (!this.el_ || !this.el_.contentWindow) {
           return;
         }
 


### PR DESCRIPTION
Noticed this when working on the `v6` version of the test fixes. I think this code may be broken right now.