### PR TITLE
fix(text-tracks): cuechange handler not triggering correctly

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -230,7 +230,7 @@ class TextTrack extends Track {
             this.tech_.ready(() => {
               this.tech_.on('timeupdate', timeupdateHandler);
             }, true);
-          } else if (mode === 'disabled') {
+          } else {
             this.tech_.off('timeupdate', timeupdateHandler);
           }
           /**

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -226,11 +226,12 @@ class TextTrack extends Track {
             return;
           }
           mode = newMode;
-          if (mode === 'showing') {
-
+          if (mode !== 'disabled') {
             this.tech_.ready(() => {
               this.tech_.on('timeupdate', timeupdateHandler);
             }, true);
+          } else if (mode === 'disabled') {
+            this.tech_.off('timeupdate', timeupdateHandler);
           }
           /**
            * An event that fires when mode changes on this track. This allows

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -325,6 +325,58 @@ QUnit.test('fires cuechange when cues become active and inactive', function(asse
   player.dispose();
 });
 
+QUnit.test('enabled and disabled cuechange handler when changing mode', function(assert) {
+  const player = TestHelpers.makePlayer();
+  let changes = 0;
+  const tt = new TextTrack({
+    tech: player.tech_
+  });
+  const cuechangeHandler = function() {
+    changes++;
+  };
+
+  tt.mode = 'hidden';
+
+  tt.addCue({
+    id: '1',
+    startTime: 1,
+    endTime: 5
+  });
+
+  tt.addEventListener('cuechange', cuechangeHandler);
+
+  player.tech_.currentTime = function() {
+    return 2;
+  };
+  player.tech_.trigger('timeupdate');
+
+  assert.equal(changes, 1, 'a cuechange event trigger');
+
+  tt.mode = 'disabled';
+
+  player.tech_.currentTime = function() {
+    return 7;
+  };
+  player.tech_.trigger('timeupdate');
+
+  assert.equal(changes, 1, 'NO cuechange event trigger');
+
+  tt.mode = 'showing';
+
+  player.tech_.currentTime = function() {
+    return 0;
+  };
+  player.tech_.trigger('timeupdate');
+  player.tech_.currentTime = function() {
+    return 2;
+  };
+  player.tech_.trigger('timeupdate');
+
+  assert.equal(changes, 2, 'a cuechange event trigger');
+
+  player.dispose();
+});
+
 QUnit.test('tracks are parsed if vttjs is loaded', function(assert) {
   const clock = sinon.useFakeTimers();
   const oldVTT = window.WebVTT;

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -325,7 +325,7 @@ QUnit.test('fires cuechange when cues become active and inactive', function(asse
   player.dispose();
 });
 
-QUnit.test('enabled and disabled cuechange handler when changing mode', function(assert) {
+QUnit.test('enabled and disabled cuechange handler when changing mode to hidden', function(assert) {
   const player = TestHelpers.makePlayer();
   let changes = 0;
   const tt = new TextTrack({
@@ -352,6 +352,7 @@ QUnit.test('enabled and disabled cuechange handler when changing mode', function
 
   assert.equal(changes, 1, 'a cuechange event trigger');
 
+  changes = 0;
   tt.mode = 'disabled';
 
   player.tech_.currentTime = function() {
@@ -359,20 +360,47 @@ QUnit.test('enabled and disabled cuechange handler when changing mode', function
   };
   player.tech_.trigger('timeupdate');
 
-  assert.equal(changes, 1, 'NO cuechange event trigger');
+  assert.equal(changes, 0, 'NO cuechange event trigger');
+
+  player.dispose();
+});
+
+QUnit.test('enabled and disabled cuechange handler when changing mode to showing', function(assert) {
+  const player = TestHelpers.makePlayer();
+  let changes = 0;
+  const tt = new TextTrack({
+    tech: player.tech_
+  });
+  const cuechangeHandler = function() {
+    changes++;
+  };
 
   tt.mode = 'showing';
 
-  player.tech_.currentTime = function() {
-    return 0;
-  };
-  player.tech_.trigger('timeupdate');
+  tt.addCue({
+    id: '1',
+    startTime: 1,
+    endTime: 5
+  });
+
+  tt.addEventListener('cuechange', cuechangeHandler);
+
   player.tech_.currentTime = function() {
     return 2;
   };
   player.tech_.trigger('timeupdate');
 
-  assert.equal(changes, 2, 'a cuechange event trigger');
+  assert.equal(changes, 1, 'a cuechange event trigger');
+
+  changes = 0;
+  tt.mode = 'disabled';
+
+  player.tech_.currentTime = function() {
+    return 7;
+  };
+  player.tech_.trigger('timeupdate');
+
+  assert.equal(changes, 0, 'NO cuechange event trigger');
 
   player.dispose();
 });


### PR DESCRIPTION
We were only triggering cuechange events if a metadata track started out as not disabled or only when setting the mode to 'showing'

Fixes #5308