### PR TITLE
fix(text track display): update on playerresize and orientationchange

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -118,7 +118,7 @@ class TextTrackDisplay extends Component {
       player.on('playerresize', updateDisplayHandler);
 
       window.addEventListener('orientationchange', updateDisplayHandler);
-      player.on('dipose', () => window.removeEventListener('orientationchange', updateDisplayHandler));
+      player.on('dispose', () => window.removeEventListener('orientationchange', updateDisplayHandler));
 
       const tracks = this.options_.playerOptions.tracks || [];
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -98,8 +98,10 @@ class TextTrackDisplay extends Component {
   constructor(player, options, ready) {
     super(player, options, ready);
 
+    const updateDisplayHandler = Fn.bind(this, this.updateDisplay);
+
     player.on('loadstart', Fn.bind(this, this.toggleDisplay));
-    player.on('texttrackchange', Fn.bind(this, this.updateDisplay));
+    player.on('texttrackchange', updateDisplayHandler);
     player.on('loadstart', Fn.bind(this, this.preselectTrack));
 
     // This used to be called during player init, but was causing an error
@@ -112,7 +114,11 @@ class TextTrackDisplay extends Component {
         return;
       }
 
-      player.on('fullscreenchange', Fn.bind(this, this.updateDisplay));
+      player.on('fullscreenchange', updateDisplayHandler);
+      player.on('playerresize', updateDisplayHandler);
+
+      window.addEventListener('orientationchange', updateDisplayHandler);
+      player.on('dipose', () => window.removeEventListener('orientationchange', updateDisplayHandler));
 
       const tracks = this.options_.playerOptions.tracks || [];
 


### PR DESCRIPTION
On mobile devices, when changing orientation, or if the player gets resized, the captions won't update to reflect the new orientation or player size. However, they do get updated the next time they are redrawn. Instead, we should redraw the captions whenever `orientationchange` and `playerresize` get triggered.