### PR TITLE
fix: Set correct techName after call to reset() (6.x)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -962,7 +962,7 @@ class Player extends Component {
       autoplay,
       'nativeControlsForTouch': this.options_.nativeControlsForTouch,
       'playerId': this.id(),
-      'techId': `${this.id()}_${titleTechName}_api`,
+      'techId': `${this.id()}_${camelTechName}_api`,
       'playsinline': this.options_.playsinline,
       'preload': this.options_.preload,
       'loop': this.options_.loop,


### PR DESCRIPTION
## Description
Prevent video.js from throwing errors when reloading the tech a after using reset().
This was already fixed for version 7 here: https://github.com/videojs/video.js/pull/5415

Fixes #5411 for 6.x

## Specific Changes proposed
Use `camelTechName` instead of `titleTechName`

## Requirements Checklist
- [x] Bug fixed
- [ ] Reviewed by Two Core Contributors
