### PR TITLE
fix: global is undefinded

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -3,8 +3,8 @@
  * @module videojs
  */
 import {version} from '../../package.json';
-import window from 'global/window';
-import document from 'global/document';
+const window$1 = require('global/window');
+const document = require('global/document');
 import * as setup from './setup';
 import * as stylesheet from './utils/stylesheet.js';
 import Component from './component';


### PR DESCRIPTION
fix: global is undefinded

## Description
when I import video.js.  It can`t run where the print 'document of undenfinded'

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [*] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
