### PR TITLE
Add missing message to en.json translation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -31,6 +31,7 @@
   "A network error caused the media download to fail part-way.": "A network error caused the media download to fail part-way.",
   "The media could not be loaded, either because the server or network failed or because the format is not supported.": "The media could not be loaded, either because the server or network failed or because the format is not supported.",
   "The media playback was aborted due to a corruption problem or because the media used features your browser did not support.": "The media playback was aborted due to a corruption problem or because the media used features your browser did not support.",
+  "The media playback was aborted because too many consecutive download errors occurred.": "The media playback was aborted because too many consecutive download errors occurred.",
   "No compatible source was found for this media.": "No compatible source was found for this media.",
   "The media is encrypted and we do not have the keys to decrypt it.": "The media is encrypted and we do not have the keys to decrypt it.",
   "Play Video": "Play Video",


### PR DESCRIPTION
## Description
An error message in the player can be displayed during network issues that isn't present in the en.json translation file.

## Specific Changes proposed
Add it to the json file.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
