### PR TITLE
feat: Add responsive option, which enables breakpoints support.

### DIFF
--- a/docs/guides/layout.md
+++ b/docs/guides/layout.md
@@ -2,10 +2,12 @@
 
 Video.js generally lays out the player to the dimensions that are set as attributes or via CSS, like other DOM elements. However, we provide a few ways to make the player be more fluid.
 
-## Fluid mode
+## Fluid Mode
 
 Video.js has a fluid mode that keeps the player sized to a particular aspect ratio.
+
 By default, fluid mode will use the intrinsic size of the video once loaded but you can change it with classes or with the `aspectRatio` option.
+
 Enabling fluid mode will disable fill mode. If both are enabled, fluid mode takes precedence.
 
 You can enable fluid in a few ways:
@@ -19,10 +21,12 @@ You can enable fluid in a few ways:
 ### Classes
 
 There are three classes associated with fluid mode, `vjs-fluid`, `vjs-16-9`, and `vjs-4-3`.
+
 `vjs-fluid` turns on the general fluid mode which will wait for the video to load to calculate the aspect ratio of the video.
+
 Alternatively, because 16:9 and 4:3 aspect ratios are so common, we provided them as classes by default for you to use if you know that your videos are 16:9 or 4:3.
 
-### Enabling fluid mode
+### Enabling Fluid Mode
 
 You can pass in the `fluid` option to the player or call `player.fluid(true)`. This will enable the generic fluid mode.
 
@@ -38,7 +42,7 @@ var player = videojs('vid2');
 player.fluid(true);
 ```
 
-#### Setting Aspect Ratio
+### Setting Aspect Ratio
 
 You can specify an aspect ratio for us to use if you don't want to use the intrinsic values from the video element or if you have a specific ratio in mind. It works as either a method call or an option to the player.
 
@@ -58,7 +62,7 @@ var player = videojs('vid2');
 player.aspectRatio('1:1');
 ```
 
-### Disabling fluid mode
+### Disabling Fluid Mode
 
 You can disable fluid mode by remove the associated classes or by calling passing in `false` to the method.
 
@@ -66,17 +70,17 @@ You can disable fluid mode by remove the associated classes or by calling passin
 player.fluid(false);
 ```
 
-## Fill mode
+## Fill Mode
 
 Fill mode will make the player fit and fill out its container. This is often useful if you have a responsive website and already have a container for Video.js that resizes properly to your design. It can be set either via a class or an option.
 
 If fill is enabled, it'll turn off fluid mode. If the player is configured with both fluid and fill options, fluid mode takes precedence.
 
-## Class
+### Class
 
 There's just one class for this one: `vjs-fill`. When available, Video.js will enter fill mode.
 
-## Enabling fill mode
+### Enabling Fill Mode
 
 You can pass in the `fill` option to the player or call `player.fill(true)`. This will enable fill mode.
 
@@ -92,10 +96,90 @@ var player = videojs('vid2');
 player.fill(true);
 ```
 
-## Disabling fill mode
+### Disabling Fill Mode
 
 You can disable fill mode by removing the associated class or by passing `false` in to the method.
 
 ```js
 player.fill(false);
 ```
+
+## Responsive Mode
+
+Responsive mode will make the player's UI customize itself based on the size of the player. This is useful if you have embeds of varying sizes - or if you want a fluid/fill player to adjust its UI based on its size.
+
+Responsive mode is independent of fluid mode or fill mode - it only deals with the arrangements of the UI within the player.
+
+### Class
+
+A player in responsive mode will add and remove classes based on its size breakpoints. The default breakpoints, classes, and sizes are outlined below:
+
+Name     | Class                | Min. Width | Max. Width
+---------|----------------------|------------|-----------
+`tiny`   | `vjs-layout-tiny`    | 0          | 210
+`xsmall` | `vjs-layout-x-small` | 211        | 320
+`small`  | `vjs-layout-small`   | 321        | 425
+`medium` | `vjs-layout-medium`  | 426        | 768
+`large`  | `vjs-layout-large`   | 769        | 1440
+`xlarge` | `vjs-layout-x-large` | 1441       | 2560
+`huge`   | `vjs-layout-huge`    | 2561       | Infinity
+
+### Enabling Responsive Mode
+
+You can enable responsive mode by passing the `responsive` option or by calling `player.responsive(true)`.
+
+```js
+var player = videojs('vid1', {
+  responsive: true
+});
+```
+
+```js
+var player = videojs('vid2');
+
+player.responsive(true);
+```
+
+### Disabling Responsive Mode
+
+You can disable responsive mode by passing `false` to the method.
+
+```js
+player.responsive(false);
+```
+
+### Customizing Breakpoints
+
+The default breakpoints can be customized by passing the `breakpoints` option or by calling `player.breakpoints({...})`.
+
+```js
+var player = videojs('vid1', {
+  breakpoints: {
+    medium: 500
+  }
+});
+```
+
+```js
+var player = videojs('vid2');
+
+player.breakpoints({
+  medium: 500
+});
+```
+
+The breakpoints object should have keys matching the **Name** from the table above and values matching the **Max. Width** from the table above. The **Min. Width** is calculated by adding one to the previous breakpoint's **Max. Width**.
+
+Anytime breakpoints are customized, previous customizations are discarded.
+
+### Restoring Default Breakpoints
+
+The default breakpoints can be restored by calling `player.breakpoints(true)`.
+
+```js
+var player = videojs('vid1');
+
+player.breakpoints(true);
+```
+
+This is only useful if breakpoints had previously been customized.

--- a/docs/guides/layout.md
+++ b/docs/guides/layout.md
@@ -108,7 +108,7 @@ player.fill(false);
 
 Responsive mode will make the player's UI customize itself based on the size of the player. This is useful if you have embeds of varying sizes - or if you want a fluid/fill player to adjust its UI based on its size.
 
-Responsive mode is independent of fluid mode or fill mode - it only deals with the arrangements of the UI within the player.
+Responsive mode is independent of fluid mode or fill mode - it only deals with the arrangements of the UI within the player, not with the size of the player. However, it is often useful to use responsive mode in conjunction with either fluid mode or fill mode!
 
 ### Class
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -165,11 +165,11 @@ Prevents the player from running the autoSetup for media elements with `data-set
 
 ### `breakpoints`
 
-> Type: `boolean|Array`, Default: `false`
+> Type: `Object`
 
-Set layout breakpoints that will configure how class names are toggled on the player to adjust the UI based on the player's dimensions.
+When used with the [`responsive` option](#responsive), sets breakpoints that will configure how class names are toggled on the player to adjust the UI based on the player's dimensions.
 
-By default, no breakpoints are supported, but passing `true` will set some sensible default breakpoints:
+By default, the breakpoints are:
 
 Class Name           | Width Range
 ---------------------|------------
@@ -203,7 +203,7 @@ When the player's size changes, the merged breakpoints will be inspected in the 
 
 That breakpoint's associated class name will be added as a class to the player. The previous breakpoint's class will be removed.
 
-See the file `sandbox/responsive.html.example` for an example of a fluid/responsive player using the default breakpoints.
+See the file `sandbox/responsive.html.example` for an example of a responsive player using the default breakpoints.
 
 ### `children`
 
@@ -302,6 +302,14 @@ player.boo({baz: false});
 Although, since the `plugins` option is an object, the order of initialization is not guaranteed!
 
 See [the plugins guide][plugins] for more information on Video.js plugins.
+
+### `responsive`
+
+> Type: `boolean`, Default: `false`
+
+Setting this option to `true` will cause the player to customize itself based on responsive breakpoints (see: [`breakpoints` option](#breakpoints)).
+
+When this option is `false` (the default), responsive breakpoints will be ignored.
 
 ### `sources`
 

--- a/sandbox/responsive.html.example
+++ b/sandbox/responsive.html.example
@@ -132,7 +132,7 @@
 
   <script>
     var vid = document.querySelector('video-js');
-    var player = videojs(vid, {breakpoints: true});
+    var player = videojs(vid, {responsive: true});
     var tbody = document.querySelector('table tbody');
 
     player.on('playerresize', function() {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -522,8 +522,8 @@ class Player extends Component {
     this.on('fullscreenchange', this.handleFullscreenChange_);
     this.on('stageclick', this.handleStageClick_);
 
-    this.setBreakpoints(this.options_.breakpoints);
-    this.setResponsive(Boolean(this.options_.responsive));
+    this.breakpoints(this.options_.breakpoints);
+    this.responsive(this.options_.responsive);
 
     this.changingSrc_ = false;
     this.playWaitingForReady_ = false;
@@ -3719,7 +3719,7 @@ class Player extends Component {
    * @private
    */
   updateCurrentBreakpoint_() {
-    if (!this.isResponsive()) {
+    if (!this.responsive()) {
       return;
     }
 
@@ -3765,99 +3765,94 @@ class Player extends Component {
   }
 
   /**
-   * Set breakpoints on the player.
+   * Get or set breakpoints on the player.
    *
-   * Calling this method will remove any previous custom breakpoints and start
-   * from the defaults again.
+   * Calling this method with an object or `true` will remove any previous
+   * custom breakpoints and start from the defaults again.
    *
-   * @param {Object} [breakpoints]
-   *        An object describing custom breakpoints. Leave this option off to
-   *        set default breakpoints.
+   * @param  {Object|boolean} [breakpoints]
+   *         If an object is given, it can be used to provide custom
+   *         breakpoints. If `true` is given, will set default breakpoints.
+   *         If this argument is not given, will simply return the current
+   *         breakpoints.
    *
-   * @param {number} [breakpoints.tiny]
-   *        The maximum width for the "vjs-layout-tiny" class.
+   * @param  {number} [breakpoints.tiny]
+   *         The maximum width for the "vjs-layout-tiny" class.
    *
-   * @param {number} [breakpoints.xsmall]
-   *        The maximum width for the "vjs-layout-x-small" class.
+   * @param  {number} [breakpoints.xsmall]
+   *         The maximum width for the "vjs-layout-x-small" class.
    *
-   * @param {number} [breakpoints.small]
-   *        The maximum width for the "vjs-layout-small" class.
+   * @param  {number} [breakpoints.small]
+   *         The maximum width for the "vjs-layout-small" class.
    *
-   * @param {number} [breakpoints.medium]
-   *        The maximum width for the "vjs-layout-medium" class.
+   * @param  {number} [breakpoints.medium]
+   *         The maximum width for the "vjs-layout-medium" class.
    *
-   * @param {number} [breakpoints.large]
-   *        The maximum width for the "vjs-layout-large" class.
+   * @param  {number} [breakpoints.large]
+   *         The maximum width for the "vjs-layout-large" class.
    *
-   * @param {number} [breakpoints.xlarge]
-   *        The maximum width for the "vjs-layout-x-large" class.
+   * @param  {number} [breakpoints.xlarge]
+   *         The maximum width for the "vjs-layout-x-large" class.
    *
-   * @param {number} [breakpoints.huge]
-   *        The maximum width for the "vjs-layout-huge" class.
+   * @param  {number} [breakpoints.huge]
+   *         The maximum width for the "vjs-layout-huge" class.
+   *
+   * @return {Object}
+   *         An object mapping breakpoint names to maximum width values.
    */
-  setBreakpoints(breakpoints = {}) {
-    this.breakpoint_ = '';
-    this.breakpoints_ = assign({}, DEFAULT_BREAKPOINTS, breakpoints);
+  breakpoints(breakpoints) {
+    if (breakpoints !== undefined) {
+      this.breakpoint_ = '';
+      this.breakpoints_ = assign({}, DEFAULT_BREAKPOINTS, breakpoints);
 
-    // When breakpoint definitions change, we need to update the currently
-    // selected breakpoint.
-    this.updateCurrentBreakpoint_();
+      // When breakpoint definitions change, we need to update the currently
+      // selected breakpoint.
+      this.updateCurrentBreakpoint_();
+    }
+
+    // Clone the breakpoints before returning.
+    return assign(this.breakpoints_);
   }
 
   /**
-   * Set a flag indicating whether or not this player should adjust its UI
-   * based on its dimensions.
+   * Get or set a flag indicating whether or not this player should adjust
+   * its UI based on its dimensions.
    *
    * @param  {boolean} value
    *         Should be `true` if the player should adjust its UI based on its
    *         dimensions; otherwise, should be `false`.
-   */
-  setResponsive(value) {
-    value = Boolean(value);
-    const current = this.responsive_;
-
-    // Nothing changed.
-    if (value === current) {
-      return;
-    }
-
-    // The value actually changed, set it.
-    this.responsive_ = value;
-
-    // Start listening for breakpoints and set the initial breakpoint if the
-    // player is now responsive.
-    if (value) {
-      this.on('playerresize', this.updateCurrentBreakpoint_);
-      this.updateCurrentBreakpoint_();
-
-    // Stop listening for breakpoints if the player is no longer responsive.
-    } else {
-      this.off('playerresize', this.updateCurrentBreakpoint_);
-      this.removeCurrentBreakpoint_();
-    }
-  }
-
-  /**
-   * Get a value indicating whether or not this player should adjust its UI
-   * based on its dimensions.
    *
    * @return {boolean}
-   *         Will be `true` if the player should adjust its UI based on its
+   *         Will be `true` if this player should adjust its UI based on its
    *         dimensions; otherwise, will be `false`.
    */
-  isResponsive() {
-    return this.responsive_;
-  }
+  responsive(value) {
+    if (value !== undefined) {
+      value = Boolean(value);
+      const current = this.responsive_;
 
-  /**
-   * Get current breakpoints for the player.
-   *
-   * @return {Object}
-   *         An object describing the current breakpoints and their
-   *         max widths.
-   */
-  getBreakpoints() {
-    return this.breakpoints_ && assign(this.breakpoints_);
+      // Nothing changed.
+      if (value === current) {
+        return;
+      }
+
+      // The value actually changed, set it.
+      this.responsive_ = value;
+
+      // Start listening for breakpoints and set the initial breakpoint if the
+      // player is now responsive.
+      if (value) {
+        this.on('playerresize', this.updateCurrentBreakpoint_);
+        this.updateCurrentBreakpoint_();
+
+      // Stop listening for breakpoints if the player is no longer responsive.
+      } else {
+        this.off('playerresize', this.updateCurrentBreakpoint_);
+        this.removeCurrentBreakpoint_();
+      }
+    }
+
+    return this.responsive_;
   }
 
   /**
@@ -3872,20 +3867,6 @@ class Player extends Component {
   }
 
   /**
-   * Gets the class name of a breakpoint by its name.
-   *
-   * @param  {string} name
-   *         The name of a breakpoint (e.g. `"tiny"` or `"large"`).
-   *
-   * @return {string}
-   *         The matching class name (e.g. `"vjs-layout-tiny"` or
-   *         `"vjs-layout-large"`). Empty string if not found.
-   */
-  getBreakpointClass(name) {
-    return BREAKPOINT_CLASSES[name] || '';
-  }
-
-  /**
    * Get the current breakpoint class name.
    *
    * @return {string}
@@ -3894,7 +3875,7 @@ class Player extends Component {
    *         there is no current breakpoint.
    */
   currentBreakpointClass() {
-    return this.getBreakpointClass(this.breakpoint_);
+    return BREAKPOINT_CLASSES[this.breakpoint_] || '';
   }
 
   /**
@@ -4098,7 +4079,8 @@ Player.prototype.options_ = {
   // Default message to show when a video cannot be played.
   notSupportedMessage: 'No compatible source was found for this media.',
 
-  breakpoints: false
+  breakpoints: {},
+  responsive: false
 };
 
 [

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3801,14 +3801,18 @@ class Player extends Component {
    *         An object mapping breakpoint names to maximum width values.
    */
   breakpoints(breakpoints) {
-    if (breakpoints !== undefined) {
-      this.breakpoint_ = '';
-      this.breakpoints_ = assign({}, DEFAULT_BREAKPOINTS, breakpoints);
 
-      // When breakpoint definitions change, we need to update the currently
-      // selected breakpoint.
-      this.updateCurrentBreakpoint_();
+    // Used as a getter.
+    if (breakpoints === undefined) {
+      return assign(this.breakpoints_);
     }
+
+    this.breakpoint_ = '';
+    this.breakpoints_ = assign({}, DEFAULT_BREAKPOINTS, breakpoints);
+
+    // When breakpoint definitions change, we need to update the currently
+    // selected breakpoint.
+    this.updateCurrentBreakpoint_();
 
     // Clone the breakpoints before returning.
     return assign(this.breakpoints_);
@@ -3827,32 +3831,36 @@ class Player extends Component {
    *         dimensions; otherwise, will be `false`.
    */
   responsive(value) {
-    if (value !== undefined) {
-      value = Boolean(value);
-      const current = this.responsive_;
 
-      // Nothing changed.
-      if (value === current) {
-        return;
-      }
-
-      // The value actually changed, set it.
-      this.responsive_ = value;
-
-      // Start listening for breakpoints and set the initial breakpoint if the
-      // player is now responsive.
-      if (value) {
-        this.on('playerresize', this.updateCurrentBreakpoint_);
-        this.updateCurrentBreakpoint_();
-
-      // Stop listening for breakpoints if the player is no longer responsive.
-      } else {
-        this.off('playerresize', this.updateCurrentBreakpoint_);
-        this.removeCurrentBreakpoint_();
-      }
+    // Used as a getter.
+    if (value === undefined) {
+      return this.responsive_;
     }
 
-    return this.responsive_;
+    value = Boolean(value);
+    const current = this.responsive_;
+
+    // Nothing changed.
+    if (value === current) {
+      return;
+    }
+
+    // The value actually changed, set it.
+    this.responsive_ = value;
+
+    // Start listening for breakpoints and set the initial breakpoint if the
+    // player is now responsive.
+    if (value) {
+      this.on('playerresize', this.updateCurrentBreakpoint_);
+      this.updateCurrentBreakpoint_();
+
+    // Stop listening for breakpoints if the player is no longer responsive.
+    } else {
+      this.off('playerresize', this.updateCurrentBreakpoint_);
+      this.removeCurrentBreakpoint_();
+    }
+
+    return value;
   }
 
   /**

--- a/test/unit/player-breakpoints.test.js
+++ b/test/unit/player-breakpoints.test.js
@@ -26,67 +26,93 @@ QUnit.module('Player: Breakpoints', {
   }
 });
 
-QUnit.test('breakpoints are disabled by default', function(assert) {
-  assert.strictEqual(this.player.getBreakpoints(), null, 'no breakpoints defined');
-  assert.strictEqual(this.player.currentBreakpoint(), null, 'no current breakpoint set');
+QUnit.test('getBreakpointClass', function(assert) {
+  assert.strictEqual(this.player.getBreakpointClass('tiny'), 'vjs-layout-tiny', 'the tiny breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('xsmall'), 'vjs-layout-x-small', 'the xsmall breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('small'), 'vjs-layout-small', 'the small breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('medium'), 'vjs-layout-medium', 'the medium breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('large'), 'vjs-layout-large', 'the large breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('xlarge'), 'vjs-layout-x-large', 'the xlarge breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('huge'), 'vjs-layout-huge', 'the huge breakpoint has the correct class');
+  assert.strictEqual(this.player.getBreakpointClass('asdf'), '', 'there is no asdf breakpoint');
 });
 
-QUnit.test('setting default breakpoints', function(assert) {
-  this.player.setBreakpoints(true);
-  assert.deepEqual(this.player.getBreakpoints(), getExpectedBreakpoints(), 'breakpoints defined');
+QUnit.test('breakpoints are disabled by default', function(assert) {
+  assert.deepEqual(this.player.getBreakpoints(), getExpectedBreakpoints(), 'default breakpoints defined');
+  assert.notOk(this.player.isResponsive(), 'player is not responsive');
+  assert.strictEqual(this.player.currentBreakpoint(), '', 'no current breakpoint set');
+  assert.strictEqual(this.player.currentBreakpointClass(), '', 'no current breakpoint set');
+});
+
+QUnit.test('enabling responsive mode', function(assert) {
+  this.player.setResponsive(true);
+
+  assert.ok(this.player.isResponsive(), 'player is responsive');
 
   // Player should be 300x150 by default.
   assert.strictEqual(this.player.currentBreakpoint(), 'xsmall', 'current breakpoint set');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-x-small', 'current breakpoint set');
 });
 
-QUnit.test('setting custom breakpoints', function(assert) {
+QUnit.test('setting custom breakpoints and enabling responsive mode', function(assert) {
   this.player.setBreakpoints({tiny: 300});
+  this.player.setResponsive(true);
+
   assert.deepEqual(this.player.getBreakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
 
   // Player should be 300x150 by default.
   assert.strictEqual(this.player.currentBreakpoint(), 'tiny', 'current breakpoint set');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-tiny', 'current breakpoint set');
 });
 
-QUnit.test('setting breakpoints via option', function(assert) {
-  const player = TestHelpers.makePlayer({breakpoints: {tiny: 300}});
+QUnit.test('setting breakpoints/responsive via option', function(assert) {
+  const player = TestHelpers.makePlayer({breakpoints: {tiny: 300}, responsive: true});
 
   assert.deepEqual(player.getBreakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
 
   // Player should be 300x150 by default.
   assert.strictEqual(player.currentBreakpoint(), 'tiny', 'current breakpoint set');
+  assert.strictEqual(player.currentBreakpointClass(), 'vjs-layout-tiny', 'current breakpoint set');
 });
 
 QUnit.test('changing the player size triggers breakpoints', function(assert) {
   let currentWidth;
 
-  this.player.setBreakpoints(true);
+  this.player.setResponsive(true);
   this.player.currentWidth = () => currentWidth;
 
   currentWidth = 200;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'tiny', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-tiny', 'current breakpoint set');
 
   currentWidth = 300;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'xsmall', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-x-small', 'current breakpoint set');
 
   currentWidth = 400;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'small', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-small', 'current breakpoint set');
 
   currentWidth = 600;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'medium', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-medium', 'current breakpoint set');
 
   currentWidth = 900;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'large', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-large', 'current breakpoint set');
 
   currentWidth = 1600;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'xlarge', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-x-large', 'current breakpoint set');
 
   currentWidth = 3000;
   this.player.trigger('playerresize');
   assert.strictEqual(this.player.currentBreakpoint(), 'huge', 'current breakpoint is correct');
+  assert.strictEqual(this.player.currentBreakpointClass(), 'vjs-layout-huge', 'current breakpoint set');
 });

--- a/test/unit/player-breakpoints.test.js
+++ b/test/unit/player-breakpoints.test.js
@@ -26,28 +26,17 @@ QUnit.module('Player: Breakpoints', {
   }
 });
 
-QUnit.test('getBreakpointClass', function(assert) {
-  assert.strictEqual(this.player.getBreakpointClass('tiny'), 'vjs-layout-tiny', 'the tiny breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('xsmall'), 'vjs-layout-x-small', 'the xsmall breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('small'), 'vjs-layout-small', 'the small breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('medium'), 'vjs-layout-medium', 'the medium breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('large'), 'vjs-layout-large', 'the large breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('xlarge'), 'vjs-layout-x-large', 'the xlarge breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('huge'), 'vjs-layout-huge', 'the huge breakpoint has the correct class');
-  assert.strictEqual(this.player.getBreakpointClass('asdf'), '', 'there is no asdf breakpoint');
-});
-
 QUnit.test('breakpoints are disabled by default', function(assert) {
-  assert.deepEqual(this.player.getBreakpoints(), getExpectedBreakpoints(), 'default breakpoints defined');
-  assert.notOk(this.player.isResponsive(), 'player is not responsive');
+  assert.deepEqual(this.player.breakpoints(), getExpectedBreakpoints(), 'default breakpoints defined');
+  assert.notOk(this.player.responsive(), 'player is not responsive');
   assert.strictEqual(this.player.currentBreakpoint(), '', 'no current breakpoint set');
   assert.strictEqual(this.player.currentBreakpointClass(), '', 'no current breakpoint set');
 });
 
 QUnit.test('enabling responsive mode', function(assert) {
-  this.player.setResponsive(true);
+  this.player.responsive(true);
 
-  assert.ok(this.player.isResponsive(), 'player is responsive');
+  assert.ok(this.player.responsive(), 'player is responsive');
 
   // Player should be 300x150 by default.
   assert.strictEqual(this.player.currentBreakpoint(), 'xsmall', 'current breakpoint set');
@@ -55,10 +44,10 @@ QUnit.test('enabling responsive mode', function(assert) {
 });
 
 QUnit.test('setting custom breakpoints and enabling responsive mode', function(assert) {
-  this.player.setBreakpoints({tiny: 300});
-  this.player.setResponsive(true);
+  this.player.breakpoints({tiny: 300});
+  this.player.responsive(true);
 
-  assert.deepEqual(this.player.getBreakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
+  assert.deepEqual(this.player.breakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
 
   // Player should be 300x150 by default.
   assert.strictEqual(this.player.currentBreakpoint(), 'tiny', 'current breakpoint set');
@@ -68,7 +57,7 @@ QUnit.test('setting custom breakpoints and enabling responsive mode', function(a
 QUnit.test('setting breakpoints/responsive via option', function(assert) {
   const player = TestHelpers.makePlayer({breakpoints: {tiny: 300}, responsive: true});
 
-  assert.deepEqual(player.getBreakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
+  assert.deepEqual(player.breakpoints(), getExpectedBreakpoints({tiny: 300}), 'breakpoints defined');
 
   // Player should be 300x150 by default.
   assert.strictEqual(player.currentBreakpoint(), 'tiny', 'current breakpoint set');
@@ -78,7 +67,7 @@ QUnit.test('setting breakpoints/responsive via option', function(assert) {
 QUnit.test('changing the player size triggers breakpoints', function(assert) {
   let currentWidth;
 
-  this.player.setResponsive(true);
+  this.player.responsive(true);
   this.player.currentWidth = () => currentWidth;
 
   currentWidth = 200;


### PR DESCRIPTION
Follow-up for #5471 

This makes the `breakpoints` option and `setBreakpoints()` method clearer and introduces the `responsive` option and `setResponsive()` method, which will turn on the breakpoints.

The return value of `currentBreakpoint()` was simplified to only ever return a string (empty if none).

Also, added convenience methods: `isResponsive()`, `getBreakpointClass()`, and `currentBreakpointClass()`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
