### PR TITLE
feat: Clicking live display seeks to live edge, improved live UI

### DIFF
--- a/sandbox/fake-live.html.example
+++ b/sandbox/fake-live.html.example
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Sandbox</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started make a copy of index.html.example and rename it to index.html.</p>
+    <pre>cp sandbox/index.html.example sandbox/index.html</pre>
+    <pre>npm run start</pre>
+    <pre>open http://localhost:9999/sandbox/index.html</pre>
+  </div>
+
+  <video-js id="vid1" controls preload="auto" width="640"  height="264">
+    <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video-js>
+
+  <script>
+    // fake a livestream for easy testing
+    var vid = document.getElementById('vid1');
+    var player = videojs(vid, {muted: true, loop: true});
+    var segmentLength = 6;
+
+    window.currentLiveTimeRange = videojs.createTimeRanges(0, 0);
+
+    player.ready(function() {
+      player.tech_.duration = function() {return Infinity;};
+      player.tech_.trigger('durationchange');
+      player.tech_.seekable = function() {return window.currentLiveTimeRange;};
+
+      player.play().then(function() {
+        // every segmentLength seconds set the seekable end to segmentLength seconds further
+        window.setInterval(function() {
+          var currentEnd = window.currentLiveTimeRange.end(0);
+
+          window.currentLiveTimeRange = videojs.createTimeRanges(0, currentEnd + segmentLength);
+        }, segmentLength * 1000);
+      });
+
+    });
+  </script>
+
+</body>
+</html>

--- a/src/css/components/_live.scss
+++ b/src/css/components/_live.scss
@@ -12,3 +12,18 @@
   width: auto;
   text-align: left;
 }
+
+.vjs-live-circle {
+  border-radius: 50%;
+  width: 1.25em;
+  height: 1.25em;
+  margin-top: auto;
+  margin-bottom: auto;
+  margin-right: 0.3em;
+  margin-left: 0.3em;
+  background: radial-gradient(#808080, #666666);
+}
+
+.video-js .vjs-live-control.vjs-control.vjs-at-live-edge .vjs-live-circle {
+  background: radial-gradient(#ff0000, #990000);
+}


### PR DESCRIPTION
## Changes
* Add a "fake-live" example to sandbox, which should emulate live well enough for code reviews
* Added a circle to the live display that indicates if you are at the live edge or not. It is red when you are on the live edge, and gray when you are not.
* Clicking the live display brings you to the live edge, but it takes a segment length amount of time before we can do that. 