### PR TITLE
docs(player.js): make reset() method more clear

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2879,7 +2879,8 @@ class Player extends Component {
 
   /**
    * Reset the player. Loads the first tech in the techOrder,
-   * and calls `reset` on the tech`.
+   * removes all the text tracks in the existing `tech`,
+   * and calls `reset` on the `tech`.
    */
   reset() {
     if (this.tech_) {


### PR DESCRIPTION
## Description
Docs were not clear that it removed the text track when resetting a video.

## Specific Changes proposed
Updating docs around `reset()` method in player.js

## Requirements Checklist
- [x] Feature implemented
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
- [x] Ran `npm run lint -- --errors`