### PR TITLE
fix: stop the vertical volume slider from showing up after mouse hover

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -51,8 +51,9 @@
     visibility: visible;
     opacity: 1;
     position: relative;
+    transform: scale(1) translate(0, 0) !important;
 
-    $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
+    $transition-property: transform 0.1s, visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
     @include transition($transition-property);
   }
 
@@ -76,8 +77,12 @@
   height: 8em;
   width: 3em;
   left: -3.5em;
+  
+  &.vjs-volume-vertical {
+      transform: scale(0) translate(0, 100%);
+    }
 
-  $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
+  $transition-property: transform 0.1s, visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
   @include transition($transition-property)
 }
 .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {


### PR DESCRIPTION
## Description
Hovering over vertical volume slider when it has `opacity: 0` (i.e. when it is hidden) triggers the volume slider to transition to `opacity: 1` (i.e. shown), which is undesirable - it seems like there is a "ghost" element. 

See videojs/video.js#5502 for more

Could simply use `display:none` instead of `opacity: 0`, and `display: flex` instead of `opacity: 1`, but this would remove the transition animation.

## Specific Changes proposed
In the _volume.scss file, this change/fix adds `transform: scale(0) translate(0, 100%)` property to the vertical volume control default state SCSS rule, and `transform: scale(1) translate(0, 0)` to its `:hover` state. These changes only affect the behavior of the vertical volume control - the horizontal volume control remains unchanged. `transform 0.1s` has been added to the corresponding `$transition-property` variables. 

Additionally, scale and translate values have been chosen to make the `:hover` transition feel similar to the progress bar time tooltip `:hover` transition. 

Have appended `!important` to `transform: scale(1) translate(0, 0)` to make this work. Not sure if this could be avoided by reordering some of the SCSS?

Fixes #5502.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created (https://codepen.io/14willh/pen/ReLNWZ)
- [ ] Reviewed by Two Core Contributors
