### PR TITLE
fix: Do not use default button type.

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -464,11 +464,11 @@ class TextTrackSettings extends ModalDialog {
     return createEl('div', {
       className: 'vjs-track-settings-controls',
       innerHTML: [
-        `<button class="vjs-default-button" title="${defaultsDescription}">`,
+        `<button type="button" class="vjs-default-button" title="${defaultsDescription}">`,
         this.localize('Reset'),
         `<span class="vjs-control-text"> ${defaultsDescription}</span>`,
         '</button>',
-        `<button class="vjs-done-button">${this.localize('Done')}</button>`
+        `<button type="button" class="vjs-done-button">${this.localize('Done')}</button>`
       ].join('')
     });
   }


### PR DESCRIPTION
The default button type is "submit" which triggers a form submit. Thus
if videojs is embedded in a form element the button triggers a form
submit.

This is the same problem with same solution as discussed in https://github.com/videojs/video.js/issues/2470
