### PR TITLE
chore: fix rollup watch bulid with globals/externals

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,9 +129,7 @@ export default cliargs => [
         'video.js': path.resolve(__dirname, './src/js/video.js'),
         '@videojs/http-streaming': path.resolve(__dirname, './node_modules/@videojs/http-streaming/dist/videojs-http-streaming.es.js')
       }),
-      primedResolve,
       json(),
-      primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,7 +73,15 @@ const externals = {
     'xhr',
     'tsml',
     'safe-json-parse/tuple',
-    'videojs-vtt.js'
+    'videojs-vtt.js',
+    'url-toolkit',
+    'm3u8-parser',
+    'mpd-parser',
+    'mux.js',
+    'mux.js/lib/mp4',
+    'mux.js/lib/tools/ts-inspector.js',
+    'mux.js/lib/mp4/probe',
+    'aes-decrypter'
   ]),
   test: Object.keys(globals.test).concat([
   ])
@@ -174,9 +182,7 @@ export default cliargs => [
     },
     external: externals.module,
     plugins: [
-      primedResolve,
       json(),
-      primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,8 +14,19 @@ const compiledLicense = _.template(fs.readFileSync('./build/license-header.txt',
 const bannerData = _.pick(pkg, ['version', 'copyright']);
 const banner = compiledLicense(Object.assign({includesVtt: true}, bannerData));
 
-// to prevent going into a screen during rollup
-process.stderr.isTTY = false;
+const watch = {
+  clearScreen: false
+};
+
+const onwarn = (warning) => {
+  // ignore unknow option for --no-progress
+  if (warning.code === 'UNKNOWN_OPTION' && warning.message.indexOf('progress') !== -1) {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(warning.message);
+};
 
 const primedIgnore = ignore(['videojs-vtt.js']);
 const primedResolve = resolve({
@@ -90,7 +101,9 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   },
   // es, cjs
   {
@@ -121,7 +134,9 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   },
   // novtt umd
   {
@@ -145,7 +160,9 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   },
   // core
   {
@@ -164,7 +181,9 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   },
   // core umd
   {
@@ -184,7 +203,9 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   },
   // core novtt umd
   {
@@ -205,6 +226,8 @@ export default cliargs => [
       primedCjs,
       primedBabel,
       cliargs.progress !== false ? progress() : {}
-    ]
+    ],
+    onwarn,
+    watch
   }
 ];


### PR DESCRIPTION
Currently rollup watch is broken for most "module" (cjs/es) builds. All it took was some externals/globals to get it to work correctly. 
