### PR TITLE
Don't remove vjs-waiting until time changes

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1593,7 +1593,18 @@ class Player extends Component {
      * @type {EventTarget~Event}
      */
     this.trigger('waiting');
-    this.one('timeupdate', () => this.removeClass('vjs-waiting'));
+
+    // Browsers may emit a timeupdate event after a waiting event. In order to prevent
+    // premature removal of the waiting class, wait for the time to change.
+    const timeWhenWaiting = this.currentTime();
+    const timeUpdateListener = () => {
+      if (timeWhenWaiting !== this.currentTime()) {
+        this.removeClass('vjs-waiting');
+        this.off('timeupdate', timeUpdateListener);
+      }
+    };
+
+    this.on('timeupdate', timeUpdateListener);
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1460,13 +1460,26 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
   assert.equal(techCallMethod, 'reset', 'we then reset the tech');
 });
 
-QUnit.test('Remove waiting class on timeupdate after tech waiting', function(assert) {
+QUnit.test('Remove waiting class after tech waiting when timeupdate shows a time change', function(assert) {
   const player = TestHelpers.makePlayer();
 
+  player.currentTime = () => 1;
   player.tech_.trigger('waiting');
-  assert.ok(/vjs-waiting/.test(player.el().className), 'vjs-waiting is added to the player el on tech waiting');
+  assert.ok(
+    /vjs-waiting/.test(player.el().className),
+    'vjs-waiting is added to the player el on tech waiting'
+  );
   player.trigger('timeupdate');
-  assert.ok(!(/vjs-waiting/).test(player.el().className), 'vjs-waiting is removed from the player el on timeupdate');
+  assert.ok(
+    /vjs-waiting/.test(player.el().className),
+    'vjs-waiting still exists on the player el when time hasn\'t changed on timeupdate'
+  );
+  player.currentTime = () => 2;
+  player.trigger('timeupdate');
+  assert.notOk(
+    (/vjs-waiting/).test(player.el().className),
+    'vjs-waiting removed from the player el when time has changed on timeupdate'
+  );
   player.dispose();
 });
 


### PR DESCRIPTION
## Description
Sometimes the `vjs-waiting` class is removed prematurely after the player gets into a waiting state. This removes the graphic waiting spinner while the player is still waiting. To see this behavior on Chrome:

1) Go to https://videojs.github.io/http-streaming/
2) Open the console
3) Enter:
```
player.on('waiting', () => console.log('waiting'));
player.on('timeupdate', () => console.log('timeupdate: ' + player.currentTime()));
player.play();
```
4) Click "Offline" in the network tab

The console logs `timeupdate` events of the same time sandwiching a `waiting` event, e.g.:

```
...
timeupdate: 49.675262
timeupdate: 49.812381
waiting
timeupdate: 49.812381
```

## Specific Changes proposed
This PR waits to remove the `vjs-waiting` class until the time changes on `timeupdate` events.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
