### PR TITLE
feat: responsive caption settings

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -17,7 +17,7 @@
 }
 
 .vjs-text-track-settings .vjs-track-settings-controls {
-  text-align: right;
+  text-align: center;
   vertical-align: bottom;
 }
 
@@ -41,21 +41,36 @@
   }
 
   .vjs-text-track-settings .vjs-track-settings-controls {
-    grid-column: 2;
+    grid-column: 1 / -1;
     grid-row: 2;
-
   }
+
+
+  // 1 column for small players
+  @media (max-width: 425px) {
+
+    .vjs-text-track-settings .vjs-track-settings-font {
+      grid-column: 1;
+      grid-row: 2;
+    }
+
+    .vjs-text-track-settings .vjs-track-settings-controls {
+      grid-column: 1 / -1;
+      grid-row: 3;
+    }
+  }
+
 }
 
 // Form elements
 .vjs-track-setting > select {
-  margin-right: 5px;
+  width: 15em;
 }
 
 .vjs-text-track-settings fieldset {
-  margin: 5px;
-  padding: 3px;
   border: none;
+  height: 8em;
+  width: 1em;
 }
 
 .vjs-text-track-settings fieldset span {
@@ -64,7 +79,7 @@
 
 .vjs-text-track-settings legend {
   color: $primary-foreground-color;
-  margin: 0 0 5px 0;
+  margin: 0 0 1px 0;
 }
 
 // Hide labels, so they are only for screen reader users
@@ -102,4 +117,5 @@
 
 .vjs-track-settings-controls .vjs-default-button {
   margin-right: 1em;
+  margin-bottom: 1em;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -27,7 +27,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr;
-    // flex an grid for firefox, ie, edge remove bottom padding/margin in a container as size decreases
+    // Flex and Grid for Firefox, IE, and Edge remove the bottom padding/margin in a container as size decreases
     // so we add bottom padding/margin to the last item in the grid instead of here
     // see https://stackoverflow.com/a/23754080
     padding: 20px 24px 0px 24px;

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -34,7 +34,9 @@
   }
 
   // 1 column for small players
-  .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content {
+  .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content ,
+  .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
+  .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
     grid-template-columns: 1fr;
   }
 
@@ -43,7 +45,7 @@
 
 // Form elements
 .vjs-track-setting > select {
-  width: 15em;
+  width: 10em;
 }
 
 .vjs-text-track-settings fieldset {

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -25,24 +25,18 @@
 @supports (display: grid) {
   .vjs-text-track-settings .vjs-modal-dialog-content {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    // grid-template-rows: repeat(425, minmax(1fr 1fr));
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
   }
 
-  /*
+  .vjs-text-track-settings .vjs-track-settings-controls {
+    grid-column: 1 / -1;
+  }
+
   // 1 column for small players
-  @media (max-width: 425px) {
-
-    .vjs-text-track-settings .vjs-track-settings-font {
-      grid-column: 1;
-      grid-row: 2;
-    }
-
-    .vjs-text-track-settings .vjs-track-settings-controls {
-      grid-column: 1 / -1;
-      grid-row: 3;
-    }
-  }*/
+  .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content {
+    grid-template-columns: 1fr;
+  }
 
 }
 
@@ -99,6 +93,5 @@
 }
 
 .vjs-track-settings-controls .vjs-default-button {
-  margin-right: 1em;
-  margin-bottom: 1em;
+  margin: 1em;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -27,6 +27,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr;
+    min-height: 23em;
   }
 
   .vjs-text-track-settings .vjs-track-settings-controls {
@@ -38,6 +39,7 @@
   .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
   .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
     grid-template-columns: 1fr;
+    min-height: 34.2em;
   }
 
 }
@@ -46,7 +48,6 @@
 .vjs-track-setting > select {
   margin-right: 1em;
   margin-bottom: 0.5em;
-  width: 10em;
 }
 
 .vjs-text-track-settings fieldset {
@@ -57,6 +58,11 @@
 
 .vjs-text-track-settings fieldset span {
   display: inline-block;
+}
+
+// style the second select for text colors
+.vjs-text-track-settings fieldset span > select {
+  max-width: 7.3em;
 }
 
 .vjs-text-track-settings legend {
@@ -99,31 +105,4 @@
 
 .vjs-track-settings-controls .vjs-default-button {
   margin-right: 1em;
-}
-
-
-// halfway through vjs-layout-medium side-by-side selects in
-// track-settings-colors collapse, apply fixes as needed
-@media (max-width: 563px) {
-  // font settings become un-aligned, re-align them
-  .vjs-layout-medium .vjs-track-settings-font fieldset {
-    padding-bottom: 2.2em;
-  }
-}
-
-
-// at small sizes the settings controls touch the bottom of the modal
-// to fix that we have to add padding
-.vjs-layout-small .vjs-track-settings-controls,
-.vjs-layout-x-small .vjs-track-settings-controls,
-.vjs-layout-tiny .vjs-track-settings-controls,
-.vjs-layout-medium .vjs-track-settings-controls {
-  padding-bottom: 20px;
-}
-
-// at tiny and x-small the settings controls get too close
-// to the last select, so we add some padding to the top
-.vjs-layout-tiny .vjs-track-settings-controls,
-.vjs-layout-x-small .vjs-track-settings-controls {
-  padding-top: 20px;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -27,7 +27,15 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr;
-    min-height: 23em;
+    // flex an grid for firefox, ie, edge remove bottom padding/margin in a container as size decreases
+    // so we add bottom padding/margin to the last item in the grid instead of here
+    // see https://stackoverflow.com/a/23754080
+    padding: 20px 24px 0px 24px;
+  }
+
+  // see the comment for padding above
+  .vjs-track-settings-controls .vjs-default-button {
+    margin-bottom: 20px;
   }
 
   .vjs-text-track-settings .vjs-track-settings-controls {
@@ -39,7 +47,6 @@
   .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
   .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
     grid-template-columns: 1fr;
-    min-height: 34.2em;
   }
 
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -44,7 +44,8 @@
 
 // Form elements
 .vjs-track-setting > select {
-  margin-right: 5px;
+  margin-right: 1em;
+  margin-bottom: 0.5em;
   width: 10em;
 }
 
@@ -99,6 +100,17 @@
 .vjs-track-settings-controls .vjs-default-button {
   margin-right: 1em;
 }
+
+
+// halfway through vjs-layout-medium side-by-side selects in
+// track-settings-colors collapse, apply fixes as needed
+@media (max-width: 563px) {
+  // font settings become un-aligned, re-align them
+  .vjs-layout-medium .vjs-track-settings-font fieldset {
+    padding-bottom: 2.2em;
+  }
+}
+
 
 // at small sizes the settings controls touch the bottom of the modal
 // to fix that we have to add padding

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -8,9 +8,6 @@
 // Layout divs
 .vjs-text-track-settings .vjs-modal-dialog-content {
   display: table;
-  // we use this so that the bottom of the
-  // modal dialog keeps its padding at small sizes
-  overflow: scroll;
 }
 
 .vjs-text-track-settings .vjs-track-settings-colors,
@@ -101,4 +98,20 @@
 
 .vjs-track-settings-controls .vjs-default-button {
   margin-right: 1em;
+}
+
+// at small sizes the settings controls touch the bottom of the modal
+// to fix that we have to add padding
+.vjs-layout-small .vjs-track-settings-controls,
+.vjs-layout-x-small .vjs-track-settings-controls,
+.vjs-layout-tiny .vjs-track-settings-controls,
+.vjs-layout-medium .vjs-track-settings-controls {
+  padding-bottom: 20px;
+}
+
+// at tiny and x-small the settings controls get too close
+// to the last select, so we add some padding to the top
+.vjs-layout-tiny .vjs-track-settings-controls,
+.vjs-layout-x-small .vjs-track-settings-controls {
+  padding-top: 20px;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -39,6 +39,7 @@
   }
 
   .vjs-text-track-settings .vjs-track-settings-controls {
+    // make this take up both columns
     grid-column: 1 / -1;
   }
 

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -17,7 +17,7 @@
 }
 
 .vjs-text-track-settings .vjs-track-settings-controls {
-  text-align: center;
+  text-align: right;
   vertical-align: bottom;
 }
 
@@ -42,13 +42,15 @@
 
 }
 
-
 // Form elements
 .vjs-track-setting > select {
+  margin-right: 5px;
   width: 10em;
 }
 
 .vjs-text-track-settings fieldset {
+  margin: 5px;
+  padding: 3px;
   border: none;
 }
 
@@ -58,7 +60,7 @@
 
 .vjs-text-track-settings legend {
   color: $primary-foreground-color;
-  margin: 0 0 1px 0;
+  margin: 0 0 5px 0;
 }
 
 // Hide labels, so they are only for screen reader users

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -8,6 +8,9 @@
 // Layout divs
 .vjs-text-track-settings .vjs-modal-dialog-content {
   display: table;
+  // we use this so that the bottom of the
+  // modal dialog keeps its padding at small sizes
+  overflow: scroll;
 }
 
 .vjs-text-track-settings .vjs-track-settings-colors,
@@ -97,5 +100,5 @@
 }
 
 .vjs-track-settings-controls .vjs-default-button {
-  margin: 1em;
+  margin-right: 1em;
 }

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -25,27 +25,11 @@
 @supports (display: grid) {
   .vjs-text-track-settings .vjs-modal-dialog-content {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr auto;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    // grid-template-rows: repeat(425, minmax(1fr 1fr));
   }
 
-  .vjs-text-track-settings .vjs-track-settings-colors {
-    display: block;
-    grid-column: 1;
-    grid-row: 1;
-  }
-
-  .vjs-text-track-settings .vjs-track-settings-font {
-    grid-column: 2;
-    grid-row: 1;
-  }
-
-  .vjs-text-track-settings .vjs-track-settings-controls {
-    grid-column: 1 / -1;
-    grid-row: 2;
-  }
-
-
+  /*
   // 1 column for small players
   @media (max-width: 425px) {
 
@@ -58,9 +42,10 @@
       grid-column: 1 / -1;
       grid-row: 3;
     }
-  }
+  }*/
 
 }
+
 
 // Form elements
 .vjs-track-setting > select {
@@ -69,8 +54,6 @@
 
 .vjs-text-track-settings fieldset {
   border: none;
-  height: 8em;
-  width: 1em;
 }
 
 .vjs-text-track-settings fieldset span {

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -351,7 +351,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Text'),
       '</legend>',
       this.createElSelect_('color', legendId),
-      '<span class="vjs-text-opacity vjs-opacity">',
+      '<span class="vjs-text-opacity vjs-opacity vjs-track-setting">',
       this.createElSelect_('textOpacity', legendId),
       '</span>',
       '</fieldset>'
@@ -375,7 +375,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Background'),
       '</legend>',
       this.createElSelect_('backgroundColor', legendId),
-      '<span class="vjs-bg-opacity vjs-opacity">',
+      '<span class="vjs-bg-opacity vjs-opacity vjs-track-setting">',
       this.createElSelect_('backgroundOpacity', legendId),
       '</span>',
       '</fieldset>'
@@ -399,7 +399,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Window'),
       '</legend>',
       this.createElSelect_('windowColor', legendId),
-      '<span class="vjs-window-opacity vjs-opacity">',
+      '<span class="vjs-window-opacity vjs-opacity vjs-track-setting">',
       this.createElSelect_('windowOpacity', legendId),
       '</span>',
       '</fieldset>'

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -351,7 +351,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Text'),
       '</legend>',
       this.createElSelect_('color', legendId),
-      '<span class="vjs-text-opacity vjs-opacity vjs-track-setting">',
+      '<span class="vjs-text-opacity vjs-opacity">',
       this.createElSelect_('textOpacity', legendId),
       '</span>',
       '</fieldset>'
@@ -375,7 +375,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Background'),
       '</legend>',
       this.createElSelect_('backgroundColor', legendId),
-      '<span class="vjs-bg-opacity vjs-opacity vjs-track-setting">',
+      '<span class="vjs-bg-opacity vjs-opacity">',
       this.createElSelect_('backgroundOpacity', legendId),
       '</span>',
       '</fieldset>'
@@ -399,7 +399,7 @@ class TextTrackSettings extends ModalDialog {
       this.localize('Window'),
       '</legend>',
       this.createElSelect_('windowColor', legendId),
-      '<span class="vjs-window-opacity vjs-opacity vjs-track-setting">',
+      '<span class="vjs-window-opacity vjs-opacity">',
       this.createElSelect_('windowOpacity', legendId),
       '</span>',
       '</fieldset>'


### PR DESCRIPTION
* Makes reset/done buttons take up two columns and centers them
* Makes the width of all selects the same 
* When the caption settings are open on a small player, move to a single column layout. Currently there is a horizontal scroll bar.