### PR TITLE
feat(lang): es6 import of a language file

### DIFF
--- a/build/grunt.js
+++ b/build/grunt.js
@@ -31,6 +31,7 @@ module.exports = function(grunt) {
     },
     copy: {
       fonts: { cwd: 'node_modules/videojs-font/fonts/', src: ['*'], dest: 'build/temp/font/', expand: true, filter: 'isFile' },
+      lang:  { cwd: 'lang/', src: ['*'], dest: 'dist/lang/', expand: true, filter: 'isFile' },
       dist:  { cwd: 'build/temp/', src: ['**/**', '!test*'], dest: 'dist/', expand: true, filter: 'isFile' },
       a11y:  { src: 'sandbox/descriptions.html.example', dest: 'sandbox/descriptions.test-a11y.html' }, // Can only test a file with a .html or .htm extension
       examples: { cwd: 'docs/examples/', src: ['**/**'], dest: 'dist/examples/', expand: true, filter: 'isFile' }
@@ -189,6 +190,7 @@ module.exports = function(grunt) {
     'shell:cssmin',
 
     'copy:fonts',
+    'copy:lang',
     'vjslanguages'
   ]);
 


### PR DESCRIPTION
## Description
A temporary solution to enable es6 import of the language files.
Related issue: #5092

### How to use:
```es6
import es from 'video.js/dist/lang/es.json';

videojs(element, {
  language: 'es',
  languages: {
    es
  }
});
```

If you use typescript, you need to add the following compilerOptions to the tsconfig:
```json
"resolveJsonModule": true,
"esModuleInterop": true,
"allowSyntheticDefaultImports": true
```

## Specific Changes proposed
Add a grunt task to copy all json files to dist/lang directory.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
