### PR TITLE
fix: default subtitles not enabled

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -102,7 +102,7 @@ class TextTrackDisplay extends Component {
 
     player.on('loadstart', Fn.bind(this, this.toggleDisplay));
     player.on('texttrackchange', updateDisplayHandler);
-    player.on('loadstart', Fn.bind(this, this.preselectTrack));
+    player.on('loadedmetadata', Fn.bind(this, this.preselectTrack));
 
     // This used to be called during player init, but was causing an error
     // if a track should show by default and the display hadn't loaded yet.

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -218,7 +218,7 @@ if (!Html5.supportsNativeTextTracks()) {
 
     // Force es as "user-selected" track
     player.cache_.selectedLanguage = { enabled: true, language: 'es', kind: 'captions' };
-    player.trigger('loadstart');
+    player.trigger('loadedmetadata');
 
     assert.equal(spanishTrack.mode, 'showing', 'Spanish captions should be showing');
     assert.equal(englishTrack.mode, 'disabled', 'English captions should be disabled');


### PR DESCRIPTION
## Description
This is a follow-up to [this fix in VHS](https://github.com/videojs/http-streaming/pull/239), after which default in-manifest subtitles were still not being correctly enabled. The reason is because video.js's text track [preselection](https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track-display.js#L105) logic was running before the media groups were set up in VHS.

## Solution
Text track preselection should happen on `'loadedmetadata'` instead of `'loadstart'`. According to the HTML [spec](https://html.spec.whatwg.org/multipage/media.html#event-media-loadedmetadata), text track data is available on `'loadedmetadata'`, so we should be waiting until then to make preselection decisions.

Test content w/ default subtitles: https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8
