### PR TITLE
Tests/fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,25 @@
+dist: xenial
 language: node_js
-node_js:
-  - lts/*
+cache: npm
 before_install:
   - npm install -g greenkeeper-lockfile@1
-  - export CHROME_BIN=/usr/bin/google-chrome
+before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-before_script: greenkeeper-lockfile-update
+  - greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
-
 after_failure:
   - npm ls --depth=1
 after_success:
   - npm run assets
+addons:
+  chrome: stable
+
+env:
+  global:
+    - secure: K6JpKwMkfNaJix3Bb0tLjVMzHMJgtBXdd/dvfw1BMb9DCBpd81PqXbDs7yXCddUxnUPTBPxZCrQgWsw71Wn+qEoIG5MU3uOT5A2rBbx/yZonVAGv5ed/9w0xk0OzO383CmPMFqwqtp9YmdmqGjQBkYXVXJjTvNTOAExFSdhO+3U=
+    - secure: GIbhjUJapvC70nIZVlhVyK+3KAD2TVKpiY/q412OO7V2izbvcM1tvU3LBoMZbROzrt5TT84tCoJDvHnrpL0OvxPwrzL5CUU7h4UTxhTOyQkEinbYAnWlW9wdrvtdczsEvANkFPqBZ53B3hVHZHMLOG8QRWaTBicF68vSHEJFqb4=
+
 notifications:
   irc:
     channels:
@@ -23,17 +30,4 @@ notifications:
     - http://pam.videojs.com/savage/travis
   slack:
     secure: LrF8K6mCYWlUt6SvdbGHazyQZSk/opKoiB/wgoGYaGc9+3wYXkVexY0WkO1m6wBKhUqXRAMVMFszr1wqKgdcxtItmFMMj8HqTLI1MVqgKqYX4Ux3CnEHJQiwxIk0aVL7lHLsZTXV/2Y0QIOYmAnCrgy46klETrk0ZuXf5okpu2Q=
-env:
-  global:
-    - secure: K6JpKwMkfNaJix3Bb0tLjVMzHMJgtBXdd/dvfw1BMb9DCBpd81PqXbDs7yXCddUxnUPTBPxZCrQgWsw71Wn+qEoIG5MU3uOT5A2rBbx/yZonVAGv5ed/9w0xk0OzO383CmPMFqwqtp9YmdmqGjQBkYXVXJjTvNTOAExFSdhO+3U=
-    - secure: GIbhjUJapvC70nIZVlhVyK+3KAD2TVKpiY/q412OO7V2izbvcM1tvU3LBoMZbROzrt5TT84tCoJDvHnrpL0OvxPwrzL5CUU7h4UTxhTOyQkEinbYAnWlW9wdrvtdczsEvANkFPqBZ53B3hVHZHMLOG8QRWaTBicF68vSHEJFqb4=
-sudo: false
-dist: trusty
-cache:
-  directories:
-    - node_modules
-addons:
-  firefox: latest
-  apt:
-    packages:
-      - google-chrome-stable
+

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,6 +15,15 @@ module.exports = function(config) {
 
   config = generate(config, options);
 
+  config.proxies = config.proxies || {};
+
+  // disable warning logs for sourceset tests, by proxing to a remote host
+  Object.assign(config.proxies, {
+    '/test/relative-one.mp4': 'http://example.com/relative-one.mp4',
+    '/test/relative-two.mp4': 'http://example.com/relative-two.mp4',
+    '/test/relative-three.mp4': 'http://example.com/relative-three.mp4'
+  });
+
   config.files = [
     'dist/video-js.css',
     'test/globals-shim.js',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -7,6 +7,10 @@ module.exports = function(config) {
   // see https://github.com/videojs/videojs-generate-karma-config
   // for options
   const options = {
+    travisLaunchers(defaults) {
+      delete defaults.travisFirefox;
+      return defaults;
+    },
     serverBrowsers(defaults) {
       return [];
     },

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -14,7 +14,7 @@ const blobSrc = {
   type: 'video/mp4'
 };
 const testSrc = {
-  src: 'http://vjs.zencdn.net/v/oceans.mp4',
+  src: 'http://example.com/testSrc.mp4',
   type: 'video/mp4'
 };
 const sourceOne = {src: 'http://example.com/one.mp4', type: 'video/mp4'};
@@ -126,6 +126,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
       const done = assert.async();
 
       this.mediaEl.setAttribute('data-setup', JSON.stringify({sources: [testSrc]}));
+      console.log(this.mediaEl.dataset.setup) // eslint-disable-line
       this.player = videojs(this.mediaEl, {
         enableSourceset: true
       });


### PR DESCRIPTION
1. This should fix tests on travis by stopping tests from running on Firefox in travis. Tests will still run on browserstack Firefox. Testing on firefox was added in #5528, an investigation issue to get this working has been created as #5626

2. This pull request also updates the travis config as outlined in: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

3. Finally this pull request silences the logging from sourceset tests