### PR TITLE
feat: Add loadMedia and getMedia methods

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2931,7 +2931,9 @@ class Player extends Component {
     if (this.tech_) {
       this.tech_.clearTracks('text');
     }
-    this.cache_.media = null;
+    if (this.cache_) {
+      this.cache_.media = null;
+    }
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     if (isEvented(this)) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4029,19 +4029,38 @@ class Player extends Component {
   }
 
   /**
-   * Get a clone of the current {@link Player~MediaObject} for this player or
-   * `null` if there is none.
+   * Get a clone of the current {@link Player~MediaObject} for this player.
    *
-   * @return {Player~MediaObject|null}
+   * If the `loadMedia` method has not been used, will attempt to return a
+   * {@link Player~MediaObject} based on the current state of the player.
+   *
+   * @return {Player~MediaObject}
    */
   getMedia() {
     if (!this.cache_.media) {
-      return null;
+      const poster = this.poster();
+      const src = this.currentSources();
+      const textTracks = Array.prototype.map.call(this.remoteTextTracks(), (tt) => ({
+        kind: tt.kind,
+        label: tt.label,
+        language: tt.language,
+        src: tt.src
+      }));
+
+      const media = {src, textTracks};
+
+      if (poster) {
+        media.poster = poster;
+        media.artwork = [{
+          src: media.poster,
+          type: getMimetype(media.poster)
+        }];
+      }
+
+      return media;
     }
 
-    const media = mergeOptions(this.cache_.media);
-
-    return media;
+    return mergeOptions(this.cache_.media);
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2934,6 +2934,7 @@ class Player extends Component {
     if (this.cache_) {
       this.cache_.media = null;
     }
+    this.poster('');
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     if (isEvented(this)) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3980,8 +3980,8 @@ class Player extends Component {
    *           For ease of removal, these will be created as "remote" text
    *           tracks and set to automatically clean up on source changes.
    *
-   *           For more information on what properties are available for
-   *           creating remote text tracks, see {@link Tech#createRemoteTextTrack}.
+   *           These objects may have properties like `src`, `kind`, `label`,
+   *           and `language`, see {@link Tech#createRemoteTextTrack}.
    */
 
   /**
@@ -4022,9 +4022,7 @@ class Player extends Component {
     }
 
     if (Array.isArray(textTracks)) {
-      this.ready(() => {
-        textTracks.forEach(tt => this.addRemoteTextTrack(tt, false));
-      });
+      textTracks.forEach(tt => this.addRemoteTextTrack(tt, false));
     }
 
     this.ready(ready);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2931,7 +2931,7 @@ class Player extends Component {
     if (this.tech_) {
       this.tech_.clearTracks('text');
     }
-    this.media_ = null;
+    this.cache_.media = null;
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     if (isEvented(this)) {
@@ -3998,13 +3998,13 @@ class Player extends Component {
     this.reset();
 
     // Clone the media object so it cannot be mutated from outside.
-    this.media_ = mergeOptions(media);
+    this.cache_.media = mergeOptions(media);
 
-    const {artwork, poster, src, textTracks} = this.media_;
+    const {artwork, poster, src, textTracks} = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
-      this.media_.artwork = [{
+      this.cache_.media.artwork = [{
         src: poster,
         type: getMimetype(poster)
       }];
@@ -4034,11 +4034,11 @@ class Player extends Component {
    * @return {Player~MediaObject|null}
    */
   getMedia() {
-    if (!this.media_) {
+    if (!this.cache_.media) {
       return null;
     }
 
-    const media = mergeOptions(this.media_);
+    const media = mergeOptions(this.cache_.media);
 
     return media;
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3960,7 +3960,7 @@ class Player extends Component {
    *           API. If not specified, will be populated via the `poster`, if
    *           available.
    *
-   * @property {Object[]} [poster]
+   * @property {string} [poster]
    *           URL to an image that will display before playback.
    *
    * @property {Tech~SourceObject|Tech~SourceObject[]|string} [src]

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -32,7 +32,7 @@ import Tech from './tech/tech.js';
 import * as middleware from './tech/middleware.js';
 import {ALL as TRACK_TYPES} from './tracks/track-types';
 import filterSource from './utils/filter-source';
-import {findMimetype} from './utils/mimetypes';
+import {getMimetype, findMimetype} from './utils/mimetypes';
 import {IE_VERSION} from './utils/browser';
 
 // The following imports are used only to ensure that the corresponding modules
@@ -2931,6 +2931,7 @@ class Player extends Component {
     if (this.tech_) {
       this.tech_.clearTracks('text');
     }
+    this.media_ = null;
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     if (isEvented(this)) {
@@ -3933,6 +3934,113 @@ class Player extends Component {
    */
   currentBreakpointClass() {
     return BREAKPOINT_CLASSES[this.breakpoint_] || '';
+  }
+
+  /**
+   * An object that describes a single piece of media.
+   *
+   * Properties that are not part of this type description will be retained; so,
+   * this can be viewed as a generic metadata storage mechanism as well.
+   *
+   * @see      {@link https://wicg.github.io/mediasession/#the-mediametadata-interface}
+   * @typedef  {Object} Player~MediaObject
+   *
+   * @property {string} [album]
+   *           Unused, except if this object is passed to the `MediaSession`
+   *           API.
+   *
+   * @property {string} [artist]
+   *           Unused, except if this object is passed to the `MediaSession`
+   *           API.
+   *
+   * @property {Object[]} [artwork]
+   *           Unused, except if this object is passed to the `MediaSession`
+   *           API. If not specified, will be populated via the `poster`, if
+   *           available.
+   *
+   * @property {Object[]} [poster]
+   *           URL to an image that will display before playback.
+   *
+   * @property {Tech~SourceObject|Tech~SourceObject[]|string} [src]
+   *           A single source object, an array of source objects, or a string
+   *           referencing a URL to a media source. It is _highly recommended_
+   *           that an object or array of objects is used here, so that source
+   *           selection algorithms can take the `type` into account.
+   *
+   * @property {string} [title]
+   *           Unused, except if this object is passed to the `MediaSession`
+   *           API.
+   *
+   * @property {Object[]} [textTracks]
+   *           An array of objects to be used to create text tracks, following
+   *           the {@link https://www.w3.org/TR/html50/embedded-content-0.html#the-track-element|native track element format}.
+   *           For ease of removal, these will be created as "remote" text
+   *           tracks and set to automatically clean up on source changes.
+   *
+   *           For more information on what properties are available for
+   *           creating remote text tracks, see {@link Tech#createRemoteTextTrack}.
+   */
+
+  /**
+   * Populate the player using a {@link Player~MediaObject|MediaObject}.
+   *
+   * @param  {Player~MediaObject} media
+   *         A media object.
+   *
+   * @param  {Function} ready
+   *         A callback to be called when the player is ready.
+   */
+  loadMedia(media, ready) {
+    if (!media || typeof media !== 'object') {
+      return;
+    }
+
+    this.reset();
+
+    // Clone the media object so it cannot be mutated from outside.
+    this.media_ = mergeOptions(media);
+
+    const {artwork, poster, src, textTracks} = this.media_;
+
+    // If `artwork` is not given, create it using `poster`.
+    if (!artwork && poster) {
+      this.media_.artwork = [{
+        src: poster,
+        type: getMimetype(poster)
+      }];
+    }
+
+    if (src) {
+      this.src(src);
+    }
+
+    if (poster) {
+      this.poster(poster);
+    }
+
+    if (Array.isArray(textTracks)) {
+      this.ready(() => {
+        textTracks.forEach(tt => this.addRemoteTextTrack(tt, false));
+      });
+    }
+
+    this.ready(ready);
+  }
+
+  /**
+   * Get a clone of the current {@link Player~MediaObject} for this player or
+   * `null` if there is none.
+   *
+   * @return {Player~MediaObject|null}
+   */
+  getMedia() {
+    if (!this.media_) {
+      return null;
+    }
+
+    const media = mergeOptions(this.media_);
+
+    return media;
   }
 
   /**

--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -17,7 +17,17 @@ export const MimetypesKind = {
   mp3: 'audio/mpeg',
   aac: 'audio/aac',
   oga: 'audio/ogg',
-  m3u8: 'application/x-mpegURL'
+  m3u8: 'application/x-mpegURL',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  tif: 'image/tiff',
+  tiff: 'image/tiff',
+  webp: 'image/webp'
 };
 
 /**

--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -18,15 +18,11 @@ export const MimetypesKind = {
   aac: 'audio/aac',
   oga: 'audio/ogg',
   m3u8: 'application/x-mpegURL',
-  bmp: 'image/bmp',
-  ico: 'image/x-icon',
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   gif: 'image/gif',
   png: 'image/png',
   svg: 'image/svg+xml',
-  tif: 'image/tiff',
-  tiff: 'image/tiff',
   webp: 'image/webp'
 };
 

--- a/test/unit/player-loadmedia.test.js
+++ b/test/unit/player-loadmedia.test.js
@@ -139,6 +139,8 @@ QUnit.test('getMedia returns a clone of the media object', function(assert) {
   }, 'the object has the expected structure');
 });
 
+// This only tests the relevant aspect of the reset function. The rest of its
+// effects are tested in player.test.js
 QUnit.test('reset discards the media object', function(assert) {
   this.player.loadMedia({
     src: 'foo.mp4'

--- a/test/unit/player-loadmedia.test.js
+++ b/test/unit/player-loadmedia.test.js
@@ -1,0 +1,150 @@
+/* eslint-env qunit */
+import sinon from 'sinon';
+import TestHelpers from './test-helpers';
+
+QUnit.module('Player: loadMedia/getMedia', {
+
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer({});
+  },
+
+  afterEach() {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+QUnit.test('loadMedia sets source from a string', function(assert) {
+  this.player.loadMedia({
+    src: 'foo.mp4'
+  });
+
+  assert.strictEqual(this.player.currentSrc(), 'foo.mp4', 'currentSrc was correct');
+});
+
+QUnit.test('loadMedia sets source from an object', function(assert) {
+  this.player.loadMedia({
+    src: {
+      src: 'foo.mp4',
+      type: 'video/mp4'
+    }
+  });
+
+  assert.strictEqual(this.player.currentSrc(), 'foo.mp4', 'currentSrc was correct');
+});
+
+QUnit.test('loadMedia sets source from an array', function(assert) {
+  this.player.loadMedia({
+    src: [{
+      src: 'foo.mp4',
+      type: 'video/mp4'
+    }]
+  });
+
+  assert.strictEqual(this.player.currentSrc(), 'foo.mp4', 'currentSrc was correct');
+});
+
+QUnit.test('loadMedia sets poster and backfills artwork', function(assert) {
+  this.player.loadMedia({
+    poster: 'foo.jpg'
+  });
+
+  assert.strictEqual(this.player.poster(), 'foo.jpg', 'poster was correct');
+});
+
+QUnit.test('loadMedia sets artwork via poster', function(assert) {
+  this.player.loadMedia({
+    poster: 'foo.jpg'
+  });
+
+  const {artwork} = this.player.getMedia();
+
+  assert.deepEqual(artwork, [{
+    src: 'foo.jpg',
+    type: 'image/jpeg'
+  }], 'the artwork was set to match the poster');
+});
+
+QUnit.test('loadMedia sets artwork and poster independently', function(assert) {
+  this.player.loadMedia({
+    poster: 'foo.jpg',
+    artwork: [{
+      src: 'bar.png',
+      type: 'image/png'
+    }]
+  });
+
+  assert.strictEqual(this.player.poster(), 'foo.jpg', 'poster was correct');
+  assert.deepEqual(this.player.getMedia().artwork, [{
+    src: 'bar.png',
+    type: 'image/png'
+  }], 'the artwork was provided, so does not match poster');
+});
+
+QUnit.test('loadMedia creates text tracks', function(assert) {
+  this.player.loadMedia({
+    textTracks: [{
+      kind: 'captions',
+      src: 'foo.vtt',
+      language: 'en',
+      label: 'English'
+    }]
+  });
+
+  this.clock.tick(1);
+
+  const rtt = this.player.remoteTextTracks()[0];
+
+  assert.ok(Boolean(rtt), 'the track exists');
+  assert.strictEqual(rtt.kind, 'captions', 'the kind is correct');
+  assert.strictEqual(rtt.src, 'foo.vtt', 'the src is correct');
+  assert.strictEqual(rtt.language, 'en', 'the language is correct');
+  assert.strictEqual(rtt.label, 'English', 'the label is correct');
+});
+
+QUnit.test('getMedia returns a clone of the media object', function(assert) {
+  const original = {
+    arbitrary: true,
+    src: 'foo.mp4',
+    poster: 'foo.gif',
+    textTracks: [{
+      kind: 'captions',
+      src: 'foo.vtt',
+      language: 'en',
+      label: 'English'
+    }]
+  };
+
+  this.player.loadMedia(original);
+  this.clock.tick(1);
+
+  const result = this.player.getMedia();
+
+  assert.notStrictEqual(result, original, 'a new object is returned');
+  assert.deepEqual(result, {
+    arbitrary: true,
+    artwork: [{
+      src: 'foo.gif',
+      type: 'image/gif'
+    }],
+    src: 'foo.mp4',
+    poster: 'foo.gif',
+    textTracks: [{
+      kind: 'captions',
+      src: 'foo.vtt',
+      language: 'en',
+      label: 'English'
+    }]
+  }, 'the object has the expected structure');
+});
+
+QUnit.test('reset discards the media object', function(assert) {
+  this.player.loadMedia({
+    src: 'foo.mp4'
+  });
+
+  this.player.reset();
+
+  assert.strictEqual(this.player.getMedia(), null, 'the media object no longer exists');
+});

--- a/test/unit/player-loadmedia.test.js
+++ b/test/unit/player-loadmedia.test.js
@@ -99,8 +99,6 @@ QUnit.test('loadMedia creates text tracks', function(assert) {
     }]
   });
 
-  this.clock.tick(1);
-
   const rtt = this.player.remoteTextTracks()[0];
 
   assert.ok(Boolean(rtt), 'the track exists');
@@ -124,7 +122,6 @@ QUnit.test('getMedia returns a clone of the media object', function(assert) {
   };
 
   this.player.loadMedia(original);
-  this.clock.tick(1);
 
   const result = this.player.getMedia();
 

--- a/test/unit/player-loadmedia.test.js
+++ b/test/unit/player-loadmedia.test.js
@@ -35,14 +35,21 @@ QUnit.test('loadMedia sets source from an object', function(assert) {
 });
 
 QUnit.test('loadMedia sets source from an array', function(assert) {
+  const sources = [{
+    src: 'foo.mp4',
+    type: 'video/mp4'
+  }, {
+    src: 'foo.webm',
+    type: 'video/webm'
+  }];
+
   this.player.loadMedia({
-    src: [{
-      src: 'foo.mp4',
-      type: 'video/mp4'
-    }]
+    src: sources
   });
 
-  assert.strictEqual(this.player.currentSrc(), 'foo.mp4', 'currentSrc was correct');
+  assert.strictEqual(this.player.currentSrc(), sources[0].src, 'currentSrc was correct');
+  assert.deepEqual(this.player.currentSource(), sources[0], 'currentSource was correct');
+  assert.deepEqual(this.player.currentSources(), sources, 'currentSources were correct');
 });
 
 QUnit.test('loadMedia sets poster and backfills artwork', function(assert) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1473,6 +1473,23 @@ QUnit.test('player#reset removes the poster', function(assert) {
   assert.strictEqual(player.poster(), '', 'the poster was reset');
 });
 
+QUnit.test('player#reset removes remote text tracks', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  this.clock.tick(1);
+
+  player.addRemoteTextTrack({
+    kind: 'captions',
+    src: 'foo.vtt',
+    language: 'en',
+    label: 'English'
+  });
+
+  assert.strictEqual(player.remoteTextTracks().length, 1, 'there is one RTT');
+  player.reset();
+  assert.strictEqual(player.remoteTextTracks().length, 0, 'there are zero RTTs');
+});
+
 QUnit.test('Remove waiting class after tech waiting when timeupdate shows a time change', function(assert) {
   const player = TestHelpers.makePlayer();
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1425,7 +1425,8 @@ QUnit.test('player#reset loads the Html5 tech and then techCalls reset', functio
     },
     techCall_(method) {
       techCallMethod = method;
-    }
+    },
+    poster() {}
   };
 
   Player.prototype.reset.call(testPlayer);
@@ -1450,7 +1451,8 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
     },
     techCall_(method) {
       techCallMethod = method;
-    }
+    },
+    poster() {}
   };
 
   Player.prototype.reset.call(testPlayer);
@@ -1458,6 +1460,17 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
   assert.equal(loadedTech, 'flash', 'we loaded the Flash tech');
   assert.equal(loadedSource, null, 'with a null source');
   assert.equal(techCallMethod, 'reset', 'we then reset the tech');
+});
+
+QUnit.test('player#reset removes the poster', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  this.clock.tick(1);
+
+  player.poster('foo.jpg');
+  assert.strictEqual(player.poster(), 'foo.jpg', 'the poster was set');
+  player.reset();
+  assert.strictEqual(player.poster(), '', 'the poster was reset');
 });
 
 QUnit.test('Remove waiting class after tech waiting when timeupdate shows a time change', function(assert) {


### PR DESCRIPTION
## Description
This adds methods for loading media into a player.

## Specific Changes proposed
- `loadMedia` will set source, poster, and text tracks. It will create an `artworks` array for uses with the `MediaSession` API.
- `getMedia` will return a clone of the media object.

Fixes #4342

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
