### PR TITLE
Fix hidden Control Text in Progress bar (Fixes #5251)

### DIFF
--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -35,7 +35,7 @@ class LoadProgressBar extends Component {
   createEl() {
     return super.createEl('div', {
       className: 'vjs-load-progress',
-      innerHTML: `<span class="vjs-control-text"><span>${this.localize('Loaded')}</span>: 0%</span>`
+      innerHTML: `<span class="vjs-control-text"><span>${this.localize('Loaded')}</span>: <span class="vjs-control-text-loaded-percentage">0%</span></span>`
     });
   }
 
@@ -59,6 +59,7 @@ class LoadProgressBar extends Component {
     const duration = liveTracker.isLive() ? liveTracker.seekableEnd() : this.player_.duration();
     const bufferedEnd = this.player_.bufferedEnd();
     const children = this.partEls_;
+    const controlTextPercentage = this.$('.vjs-control-text-loaded-percentage');
 
     // get the percent width of a time compared to the total end
     const percentify = function(time, end, rounded) {
@@ -78,8 +79,7 @@ class LoadProgressBar extends Component {
     this.el_.style.width = percentify(bufferedEnd, duration);
 
     // update the control-text
-    // TODO: Need a better way to reference the node that needs its textContent set
-    Dom.textContent(this.el_.childNodes[0].childNodes[1], ': ' + percentify(bufferedEnd, duration, true));
+    Dom.textContent(controlTextPercentage, percentify(bufferedEnd, duration, true));
 
     // add child elements to represent the individual buffered time ranges
     for (let i = 0; i < buffered.length; i++) {

--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -61,15 +61,25 @@ class LoadProgressBar extends Component {
     const children = this.partEls_;
 
     // get the percent width of a time compared to the total end
-    const percentify = function(time, end) {
+    const percentify = function(time, end, rounded) {
       // no NaN
-      const percent = (time / end) || 0;
+      let percent = (time / end) || 0;
 
-      return ((percent >= 1 ? 1 : percent) * 100) + '%';
+      percent = (percent >= 1 ? 1 : percent) * 100;
+
+      if (rounded) {
+        percent = percent.toFixed(2);
+      }
+
+      return percent + '%';
     };
 
     // update the width of the progress bar
     this.el_.style.width = percentify(bufferedEnd, duration);
+
+    // update the control-text
+    // TODO: Need a better way to reference the node that needs its textContent set
+    Dom.textContent(this.el_.childNodes[0].childNodes[1], ': ' + percentify(bufferedEnd, duration, true));
 
     // add child elements to represent the individual buffered time ranges
     for (let i = 0; i < buffered.length; i++) {

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -22,8 +22,9 @@ class PlayProgressBar extends Component {
    */
   createEl() {
     return super.createEl('div', {
-      className: 'vjs-play-progress vjs-slider-bar',
-      innerHTML: `<span class="vjs-control-text"><span>${this.localize('Progress')}</span>: 0%</span>`
+      className: 'vjs-play-progress vjs-slider-bar'
+    }, {
+      'aria-hidden': 'true'
     });
   }
 

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -21,6 +21,8 @@ class TimeTooltip extends Component {
   createEl() {
     return super.createEl('div', {
       className: 'vjs-time-tooltip'
+    }, {
+      'aria-hidden': 'true'
     });
   }
 


### PR DESCRIPTION
## Description
Fix the hidden Control Text (intended for screen reader users) in the Progress Bar, which never gets updated by loading or playback. Fixes #5251.

## Specific Changes proposed
* Update the Control Text in the load-progress-bar during loading
* Remove unnecessary Control Text from the play-progress-bar
* Hide the time-tooltip feature from Assistive Technology using ARIA.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
