### PR TITLE
Move the "-" in remaining-time-display.js so it is not announced by screen readers. Fixes #5168

### DIFF
--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -43,7 +43,7 @@ class RemainingTimeDisplay extends TimeDisplay {
    * @return {Element}
    *         The element that was created.
    */
-  createEl(plainName) {
+  createEl() {
     const el = super.createEl();
 
     el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -48,7 +48,7 @@ class RemainingTimeDisplay extends TimeDisplay {
    */
   formatTime_(time) {
     // TODO: The "-" should be decorative, and not announced by a screen reader
-    return '-' + super.formatTime_(time);
+    return super.formatTime_(time);
   }
 
   /**

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -3,6 +3,8 @@
  */
 import TimeDisplay from './time-display';
 import Component from '../../component.js';
+import * as Dom from '../../utils/dom.js';
+
 /**
  * Displays the time left in the video
  *
@@ -36,19 +38,16 @@ class RemainingTimeDisplay extends TimeDisplay {
   }
 
   /**
-   * The remaining time display prefixes numbers with a "minus" character.
+   * Create the `Component`'s DOM element with the "minus" characted prepend to the time
    *
-   * @param  {number} time
-   *         A numeric time, in seconds.
-   *
-   * @return {string}
-   *         A formatted time
-   *
-   * @private
+   * @return {Element}
+   *         The element that was created.
    */
-  formatTime_(time) {
-    // TODO: The "-" should be decorative, and not announced by a screen reader
-    return super.formatTime_(time);
+  createEl(plainName) {
+    const el = super.createEl();
+
+    el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);
+    return el;
   }
 
   /**

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -35,7 +35,7 @@ class TimeDisplay extends Component {
    * @return {Element}
    *         The element that was created.
    */
-  createEl(plainName) {
+  createEl() {
     const className = this.buildCSSClass();
     const el = super.createEl('div', {
       className: `${className} vjs-time-control vjs-control`,

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -51,6 +51,10 @@ class TimeDisplay extends Component {
 
     this.updateTextNode_();
     el.appendChild(this.contentEl_);
+    if (className === 'vjs-remaining-time') {
+      el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);
+    }
+
     return el;
   }
 

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -51,10 +51,6 @@ class TimeDisplay extends Component {
 
     this.updateTextNode_();
     el.appendChild(this.contentEl_);
-    if (className === 'vjs-remaining-time') {
-      el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);
-    }
-
     return el;
   }
 

--- a/src/js/utils/fn.js
+++ b/src/js/utils/fn.js
@@ -55,7 +55,7 @@ export const bind = function(context, fn, uid) {
  * @param    {Function} fn
  *           The function to be throttled.
  *
- * @param    {Number}   wait
+ * @param    {number}   wait
  *           The number of milliseconds by which to throttle.
  *
  * @return   {Function}

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -126,7 +126,7 @@ export const getAbsoluteURL = function(url) {
  * @param    {string} path
  *           The fileName path like '/path/to/file.mp4'
  *
- * @returns  {string}
+ * @return  {string}
  *           The extension in lower case or an empty string if no
  *           extension could be found.
  */


### PR DESCRIPTION
## Description
Fixes issue videojs/video.js#5168  @gkatsev 
Remaining time is now a positive value by it's own and the negative sign is added decoratively.

## Specific Changes proposed
- Removed negative sign in when returning the remaining time
- Added the negative ('-') sign to the number's container and make it 'aria-hidden' so screen readers can't read it

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
