### PR TITLE
fix: make sure sources, volume, and playback rate are reset along with the player

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2012,11 +2012,19 @@ class Player extends Component {
    */
   resetCache_() {
     this.cache_ = {
+
+      // Right now, the currentTime is not _really_ cached because it is always
+      // retrieved from the tech (see: currentTime). However, for completeness,
+      // we set it to zero here to ensure that if we do start actually caching
+      // it, we reset it along with everything else.
+      currentTime: 0,
+      duration: NaN,
       lastVolume: 1,
       lastPlaybackRate: this.defaultPlaybackRate(),
       src: '',
       source: {},
-      sources: []
+      sources: [],
+      volume: 1
     };
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -401,17 +401,13 @@ class Player extends Component {
       this.languages_ = Player.prototype.options_.languages;
     }
 
-    // Cache for video property values.
-    this.cache_ = {};
+    this.resetCache_();
 
     // Set poster
     this.poster_ = options.poster || '';
 
     // Set controls
     this.controls_ = !!options.controls;
-
-    // Set default values for lastVolume
-    this.cache_.lastVolume = 1;
 
     // Original tag settings stored in options
     // now remove immediately so native controls don't flash.
@@ -437,9 +433,6 @@ class Player extends Component {
     this.scrubbing_ = false;
 
     this.el_ = this.createEl();
-
-    // Set default value for lastPlaybackRate
-    this.cache_.lastPlaybackRate = this.defaultPlaybackRate();
 
     // Make this an evented object and use `el_` as its event bus.
     evented(this, {eventBusKey: 'el_'});
@@ -2010,6 +2003,24 @@ class Player extends Component {
   }
 
   /**
+   * Resets the internal cache object.
+   *
+   * Using this function outside the player constructor or reset method may
+   * have unintended side-effects.
+   *
+   * @private
+   */
+  resetCache_() {
+    this.cache_ = {
+      lastVolume: 1,
+      lastPlaybackRate: this.defaultPlaybackRate(),
+      src: '',
+      source: {},
+      sources: []
+    };
+  }
+
+  /**
    * Pass values to the playback tech
    *
    * @param {string} [method]
@@ -2931,6 +2942,7 @@ class Player extends Component {
     if (this.tech_) {
       this.tech_.clearTracks('text');
     }
+    this.resetCache_();
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     if (isEvented(this)) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1475,12 +1475,14 @@ QUnit.test('player#reset clears the player cache', function(assert) {
   this.clock.tick(1);
 
   player.src(sources);
+  player.duration(10);
   player.playbackRate(0.5);
   player.volume(0.2);
 
   assert.strictEqual(player.currentSrc(), sources[0].src, 'currentSrc is correct');
   assert.deepEqual(player.currentSource(), sources[0], 'currentSource is correct');
   assert.deepEqual(player.currentSources(), sources, 'currentSources is correct');
+  assert.strictEqual(player.duration(), 10, 'duration is correct');
   assert.strictEqual(player.playbackRate(), 0.5, 'playbackRate is correct');
   assert.strictEqual(player.volume(), 0.2, 'volume is correct');
   assert.strictEqual(player.lastVolume_(), 0.2, 'lastVolume_ is correct');
@@ -1490,8 +1492,15 @@ QUnit.test('player#reset clears the player cache', function(assert) {
   assert.strictEqual(player.currentSrc(), '', 'currentSrc is correct');
   assert.deepEqual(player.currentSource(), {}, 'currentSource is correct');
   assert.deepEqual(player.currentSources(), [], 'currentSources is correct');
+
+  // Right now, the currentTime is not _really_ cached because it is always
+  // retrieved from the tech. However, for completeness, we set it to zero in
+  // the `resetCache_` method to ensure that if we do start actually caching it,
+  // we reset it along with everything else.
+  assert.strictEqual(player.getCache().currentTime, 0, 'currentTime is correct');
+  assert.ok(isNaN(player.duration()), 'duration is correct');
   assert.strictEqual(player.playbackRate(), 1, 'playbackRate is correct');
-  assert.strictEqual(player.volume(), 0, 'volume is correct');
+  assert.strictEqual(player.volume(), 1, 'volume is correct');
   assert.strictEqual(player.lastVolume_(), 1, 'lastVolume_ is correct');
 });
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1419,6 +1419,7 @@ QUnit.test('player#reset loads the Html5 tech and then techCalls reset', functio
     options_: {
       techOrder: ['html5', 'flash']
     },
+    resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;
       loadedSource = source;
@@ -1444,6 +1445,7 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
     options_: {
       techOrder: ['flash', 'html5']
     },
+    resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;
       loadedSource = source;
@@ -1458,6 +1460,39 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
   assert.equal(loadedTech, 'flash', 'we loaded the Flash tech');
   assert.equal(loadedSource, null, 'with a null source');
   assert.equal(techCallMethod, 'reset', 'we then reset the tech');
+});
+
+QUnit.test('player#reset clears the player cache', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const sources = [{
+    src: '//vjs.zencdn.net/v/oceans.mp4',
+    type: 'video/mp4'
+  }, {
+    src: '//vjs.zencdn.net/v/oceans.webm',
+    type: 'video/webm'
+  }];
+
+  this.clock.tick(1);
+
+  player.src(sources);
+  player.playbackRate(0.5);
+  player.volume(0.2);
+
+  assert.strictEqual(player.currentSrc(), sources[0].src, 'currentSrc is correct');
+  assert.deepEqual(player.currentSource(), sources[0], 'currentSource is correct');
+  assert.deepEqual(player.currentSources(), sources, 'currentSources is correct');
+  assert.strictEqual(player.playbackRate(), 0.5, 'playbackRate is correct');
+  assert.strictEqual(player.volume(), 0.2, 'volume is correct');
+  assert.strictEqual(player.lastVolume_(), 0.2, 'lastVolume_ is correct');
+
+  player.reset();
+
+  assert.strictEqual(player.currentSrc(), '', 'currentSrc is correct');
+  assert.deepEqual(player.currentSource(), {}, 'currentSource is correct');
+  assert.deepEqual(player.currentSources(), [], 'currentSources is correct');
+  assert.strictEqual(player.playbackRate(), 1, 'playbackRate is correct');
+  assert.strictEqual(player.volume(), 0, 'volume is correct');
+  assert.strictEqual(player.lastVolume_(), 1, 'lastVolume_ is correct');
 });
 
 QUnit.test('Remove waiting class after tech waiting when timeupdate shows a time change', function(assert) {

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -10,6 +10,10 @@ class TechFaker extends Tech {
   constructor(options, handleReady) {
     super(options, handleReady);
 
+    this.featuresPlaybackRate = true;
+    this.defaultPlaybackRate_ = 1;
+    this.playbackRate_ = 1;
+
     if (this.options_ && this.options_.sourceset) {
       this.fakeSourceset();
     }
@@ -37,7 +41,9 @@ class TechFaker extends Tech {
 
   setControls(val) {}
 
-  setVolume(newVolume) {}
+  setVolume(value) {
+    this.volume_ = value;
+  }
 
   setMuted() {}
 
@@ -47,6 +53,27 @@ class TechFaker extends Tech {
     }
 
     this.options_.autoplay = true;
+  }
+
+  defaultPlaybackRate(value) {
+    if (value !== undefined) {
+      this.defaultPlaybackRate_ = parseFloat(value);
+    }
+    return this.defaultPlaybackRate_;
+  }
+
+  setPlaybackRate(value) {
+    const last = this.playbackRate_;
+
+    this.playbackRate_ = parseFloat(value);
+
+    if (value !== last) {
+      this.trigger('ratechange');
+    }
+  }
+
+  playbackRate() {
+    return this.playbackRate_;
   }
 
   currentTime() {
@@ -73,7 +100,7 @@ class TechFaker extends Tech {
     return 'movie.mp4';
   }
   volume() {
-    return 0;
+    return this.volume_ || 0;
   }
   muted() {
     return false;

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -13,6 +13,7 @@ class TechFaker extends Tech {
     this.featuresPlaybackRate = true;
     this.defaultPlaybackRate_ = 1;
     this.playbackRate_ = 1;
+    this.currentTime_ = 0;
 
     if (this.options_ && this.options_.sourceset) {
       this.fakeSourceset();
@@ -76,9 +77,20 @@ class TechFaker extends Tech {
     return this.playbackRate_;
   }
 
-  currentTime() {
-    return 0;
+  setCurrentTime(value) {
+    const last = this.currentTime_;
+
+    this.currentTime_ = parseFloat(value);
+
+    if (value !== last) {
+      this.trigger('timeupdate');
+    }
   }
+
+  currentTime() {
+    return this.currentTime_;
+  }
+
   seekable() {
     return createTimeRanges(0, 0);
   }


### PR DESCRIPTION
Fixes videojs/video.js#5675 

This PR will fully clear the `player.cache_` when calling `Player#reset`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
