### PR TITLE
Fixed Issue-5557

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5865,12 +5865,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5885,17 +5887,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6012,7 +6017,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6024,6 +6030,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6038,6 +6045,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6045,12 +6053,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6069,6 +6079,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6149,7 +6160,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6161,6 +6173,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6282,6 +6295,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -344,7 +344,7 @@ class MenuButton extends Component {
         return;
       }
 
-      this.menu.focus();
+      this.menu.setSelectedFocus();
     }
   }
 

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -37,6 +37,19 @@ class Menu extends Component {
     this.on('keydown', this.handleKeyPress);
   }
 
+
+  setSelectedFocus() {
+    const children = this.children().slice();
+    for(let i=0; i < children.length;i++) {
+      if(children[i].isSelected_){
+        this.focusedChild_ = i;
+
+        children[i].el_.focus();
+        break;
+      }
+    }
+  }
+
   /**
    * Add a {@link MenuItem} to the menu.
    *

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -37,11 +37,11 @@ class Menu extends Component {
     this.on('keydown', this.handleKeyPress);
   }
 
-
   setSelectedFocus() {
     const children = this.children().slice();
-    for(let i=0; i < children.length;i++) {
-      if(children[i].isSelected_){
+
+    for (let i = 0; i < children.length; i++) {
+      if (children[i].isSelected_) {
         this.focusedChild_ = i;
 
         children[i].el_.focus();

--- a/src/js/utils/fn.js
+++ b/src/js/utils/fn.js
@@ -55,7 +55,7 @@ export const bind = function(context, fn, uid) {
  * @param    {Function} fn
  *           The function to be throttled.
  *
- * @param    {Number}   wait
+ * @param    {number}   wait
  *           The number of milliseconds by which to throttle.
  *
  * @return   {Function}

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -126,7 +126,7 @@ export const getAbsoluteURL = function(url) {
  * @param    {string} path
  *           The fileName path like '/path/to/file.mp4'
  *
- * @returns  {string}
+ * @return  {string}
  *           The extension in lower case or an empty string if no
  *           extension could be found.
  */


### PR DESCRIPTION
## Description
Provides a better solution to issue #5557. Instead of removing the background on the CSS file the focus is now attributed to menu-item that is currently selected. 
@gkatsev 

## Specific Changes proposed
Added a function that sets the focus of the menu to the item that is currently selected after receiving the click event.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
