### PR TITLE
Function to set crossorigin programmatically.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -752,12 +752,11 @@ class Player extends Component {
    *         The current crossorigin value of the `Player`.
    */
   crossOrigin(value){
-    if(value != "anonymous" && value != "use-credentials")
+    if(value !== "anonymous" && value !== "use-credentials")
     {
       log.error(`Improper value "${value}" supplied for crossorigin`);
       return;
     }
-
     this.el_.setAttribute('crossorigin', value); 
     return this.el_.getAttribute('crossorigin');
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -759,7 +759,7 @@ class Player extends Component {
     this.el_.setAttribute('crossorigin', value);
     return this.el_.getAttribute('crossorigin');
   }
-  
+
   /**
    * A getter/setter for the `Player`'s width. Returns the player's configured value.
    * To get the current width use `currentWidth()`.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -742,8 +742,8 @@ class Player extends Component {
     return el;
   }
 
-   /**
-   * A setter for the `Player`'s crossOrigin. Returns the player's configured value.
+  /**
+   * A getter/setter for the `Player`'s crossOrigin. Returns the player's configured value.
    *
    * @param {number} [value]
    *        The value to set the `Player`'s crossorigin to.
@@ -751,13 +751,12 @@ class Player extends Component {
    * @return {number}
    *         The current crossorigin value of the `Player`.
    */
-  crossOrigin(value){
-    if(value !== "anonymous" && value !== "use-credentials")
-    {
+  crossOrigin(value) {
+    if (value !== 'anonymous' && value !== 'use-credentials') {
       log.error(`Improper value "${value}" supplied for crossorigin`);
       return;
     }
-    this.el_.setAttribute('crossorigin', value); 
+    this.el_.setAttribute('crossorigin', value);
     return this.el_.getAttribute('crossorigin');
   }
   

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -742,6 +742,26 @@ class Player extends Component {
     return el;
   }
 
+   /**
+   * A setter for the `Player`'s crossOrigin. Returns the player's configured value.
+   *
+   * @param {number} [value]
+   *        The value to set the `Player`'s crossorigin to.
+   *
+   * @return {number}
+   *         The current crossorigin value of the `Player`.
+   */
+  crossOrigin(value){
+    if(value != "anonymous" && value != "use-credentials")
+    {
+      log.error(`Improper value "${value}" supplied for crossorigin`);
+      return;
+    }
+
+    this.el_.setAttribute('crossorigin', value); 
+    return this.el_.getAttribute('crossorigin');
+  }
+  
   /**
    * A getter/setter for the `Player`'s width. Returns the player's configured value.
    * To get the current width use `currentWidth()`.


### PR DESCRIPTION
## Description
Possible fix to issue videojs/video.js#5438 by creating a way to change crossorigin attribute programmatically. 

## Specific Changes proposed
Added crossOrigin(value) function to player.js that validates value and change it in 'el'.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
