### PR TITLE
fix(fs): make sure there's only one fullscreenchange event

### DIFF
--- a/src/js/fullscreen-api.js
+++ b/src/js/fullscreen-api.js
@@ -64,6 +64,7 @@ const apiMap = [
 
 const specApi = apiMap[0];
 let browserApi;
+let prefixedAPI = true;
 
 // determine the supported set of functions
 for (let i = 0; i < apiMap.length; i++) {
@@ -79,9 +80,9 @@ if (browserApi) {
   for (let i = 0; i < browserApi.length; i++) {
     FullscreenApi[specApi[i]] = browserApi[i];
   }
-}
 
-const prefixedAPI = browserApi[0] !== specApi[0];
+  prefixedAPI = browserApi[0] !== specApi[0];
+}
 
 export default FullscreenApi;
 export { prefixedAPI };

--- a/src/js/fullscreen-api.js
+++ b/src/js/fullscreen-api.js
@@ -81,4 +81,7 @@ if (browserApi) {
   }
 }
 
+const prefixedAPI = browserApi[0] !== specApi[0];
+
 export default FullscreenApi;
+export { prefixedAPI };

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -519,7 +519,7 @@ class Player extends Component {
     this.reportUserActivity();
 
     this.one('play', this.listenForUserActivity_);
-    this.on('fullscreenchange', this.handleFullscreenChange_);
+    this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
     this.on('stageclick', this.handleStageClick_);
 
     this.breakpoints(this.options_.breakpoints);
@@ -1913,12 +1913,24 @@ class Player extends Component {
    *
    * @private
    * @listens Player#fullscreenchange
+   * @listens Player#webkitfullscreenchange
+   * @listens Player#mozfullscreenchange
+   * @listens Player#MSFullscreenChange
+   * @fires Player#fullscreenchange
    */
-  handleFullscreenChange_() {
+  handleFullscreenChange_(event = {}) {
     if (this.isFullscreen()) {
       this.addClass('vjs-fullscreen');
     } else {
       this.removeClass('vjs-fullscreen');
+    }
+
+    if (event.type !== 'fullscreenchange') {
+      /**
+       * @event Player#fullscreenchange
+       * @type {EventTarget~Event}
+       */
+      this.trigger('fullscreenchange');
     }
   }
 
@@ -2579,12 +2591,8 @@ class Player extends Component {
         // If cancelling fullscreen, remove event listener.
         if (this.isFullscreen() === false) {
           Events.off(document, fsApi.fullscreenchange, documentFullscreenChange);
+          this.handleFullscreenChange_();
         }
-        /**
-         * @event Player#fullscreenchange
-         * @type {EventTarget~Event}
-         */
-        this.trigger('fullscreenchange');
       }));
 
       this.el_[fsApi.requestFullscreen]();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -15,6 +15,7 @@ import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
+import {IE_VERSION} from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
 import toTitleCase, { titleCaseEquals } from './utils/to-title-case.js';
 import { createTimeRange } from './utils/time-ranges.js';
@@ -33,7 +34,6 @@ import * as middleware from './tech/middleware.js';
 import {ALL as TRACK_TYPES} from './tracks/track-types';
 import filterSource from './utils/filter-source';
 import {getMimetype, findMimetype} from './utils/mimetypes';
-import {IE_VERSION} from './utils/browser';
 
 // The following imports are used only to ensure that the corresponding modules
 // are always included in the video.js package. Importing the modules will
@@ -520,6 +520,11 @@ class Player extends Component {
 
     this.one('play', this.listenForUserActivity_);
     this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+
+    if (IE_VERSION) {
+      this.on(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+    }
+
     this.on('stageclick', this.handleStageClick_);
 
     this.breakpoints(this.options_.breakpoints);
@@ -548,6 +553,11 @@ class Player extends Component {
     this.trigger('dispose');
     // prevent dispose from being called twice
     this.off('dispose');
+
+    // make sure to remove fs handler on IE from the document
+    if (IE_VERSION) {
+      this.off(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+    }
 
     if (this.styleEl_ && this.styleEl_.parentNode) {
       this.styleEl_.parentNode.removeChild(this.styleEl_);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1955,8 +1955,8 @@ class Player extends Component {
     // If cancelling fullscreen, remove event listener.
     if (this.isFullscreen() === false) {
       Events.off(document, fsApi.fullscreenchange, Fn.bind(this, this.documentFullscreenChange_));
-      this.handleFullscreenChange_();
-      // this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+      // this.handleFullscreenChange_();
+      this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
     }
   }
 
@@ -2606,7 +2606,7 @@ class Player extends Component {
       // the browser supports going fullscreen at the element level so we can
       // take the controls fullscreen as well as the video
 
-      // this.off(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+      this.off(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
 
       // Trigger fullscreenchange event after change
       // We have to specifically add this each time, and remove

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -523,7 +523,7 @@ class Player extends Component {
     if (FullscreenApi.fullscreenchange) {
       this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
 
-      if (IE_VERSION) {
+      if (IE_VERSION || browser.IS_FIREFOX && prefixedFS) {
         this.on(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
       }
     }
@@ -558,7 +558,7 @@ class Player extends Component {
     this.off('dispose');
 
     // make sure to remove fs handler on IE from the document
-    if (IE_VERSION) {
+    if (IE_VERSION || browser.IS_FIREFOX && prefixedFS) {
       this.off(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1919,6 +1919,17 @@ class Player extends Component {
   }
 
   /**
+   * native click events on the SWF aren't triggered on IE11, Win8.1RT
+   * use stageclick events triggered from inside the SWF instead
+   *
+   * @private
+   * @listens stageclick
+   */
+  handleStageClick_() {
+    this.reportUserActivity();
+  }
+
+  /**
    * Fired when the player switches in or out of fullscreen mode
    *
    * @private
@@ -1958,17 +1969,6 @@ class Player extends Component {
       // this.handleFullscreenChange_();
       this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
     }
-  }
-
-  /**
-   * native click events on the SWF aren't triggered on IE11, Win8.1RT
-   * use stageclick events triggered from inside the SWF instead
-   *
-   * @private
-   * @listens stageclick
-   */
-  handleStageClick_() {
-    this.reportUserActivity();
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -519,10 +519,13 @@ class Player extends Component {
     this.reportUserActivity();
 
     this.one('play', this.listenForUserActivity_);
-    this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
 
-    if (IE_VERSION) {
-      this.on(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+    if (FullscreenApi.fullscreenchange) {
+      this.on(FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+
+      if (IE_VERSION) {
+        this.on(document, FullscreenApi.fullscreenchange, this.handleFullscreenChange_);
+      }
     }
 
     this.on('stageclick', this.handleStageClick_);


### PR DESCRIPTION
Before the fullscreen API was un-prefixed, we listened to triggered a
`fullscreenchange` event on the player manually. This worked fine
because a prefixed `fullscreenchange` event was triggered on the player
element itself. But when it was unprefixed, we ended up with two events
now, the unprefixed event and the one we triggered.

Instead, we should listen the event the browser supports and re-trigger
it as the unprefixed event as necessary.

We also make sure that the handler gets calls when the document level
fullscreenchange handler gets called so that it is cancelled properly.

Fixes #5685.