### PR TITLE
Fix css animation order

### DIFF
--- a/src/css/components/_loading.scss
+++ b/src/css/components/_loading.scss
@@ -24,7 +24,7 @@
 .vjs-waiting .vjs-loading-spinner {
   display: block;
   // add a delay before actual show the spinner
-  animation: 0s linear 0.3s forwards vjs-spinner-show;
+  animation: vjs-spinner-show 0s linear 0.3s forwards;
 }
 
 .vjs-loading-spinner:before,


### PR DESCRIPTION
## Description
This PR fixes the animation shorthand order.

Animation shorthand order can be found here:
https://alligator.io/css/animation-shorthand/
https://css-tricks.com/almanac/properties/a/animation/

name | duration | ease-in-out | delay | iteration-count | backwards

BEFORE

```css
.vjs-seeking .vjs-loading-spinner,
.vjs-waiting .vjs-loading-spinner {
  display: block;
  animation: 0s linear 0.3s forwards vjs-spinner-show ;
}
```

AFTER

```css
.vjs-seeking .vjs-loading-spinner,
.vjs-waiting .vjs-loading-spinner {
  display: block;
  animation: vjs-spinner-show 0s linear 0.3s forwards;
}
```
This will fix css minimization issues when using https://github.com/webpack-contrib/mini-css-extract-plugin#minimizing-for-production.

**incorrect vs correct**  css syntax

![bug](https://user-images.githubusercontent.com/7534346/50033839-34d95300-ffc8-11e8-9860-bee4f7277eb0.gif)


## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
