### PR TITLE
feat: Close subtitles menu when clicking the seek bar

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -230,6 +230,9 @@ class SeekBar extends Slider {
     this.videoWasPlaying = !this.player_.paused();
     this.player_.pause();
 
+    // To close the subtitles menu when clicking the progress bar
+    this.player().getChild('controlBar').getChild('subsCapsButton').unpressButton();
+
     super.handleMouseDown(event);
   }
 

--- a/test/unit/subtitle-menu.test.js
+++ b/test/unit/subtitle-menu.test.js
@@ -1,0 +1,31 @@
+/* eslint-env qunit */
+import TestHelpers from './test-helpers.js';
+import * as Events from '../../src/js/utils/events.js';
+
+QUnit.module('Subtitles Menu');
+
+QUnit.test('should close when clicking the control bar', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const subsCapsButton = player.getChild('controlBar').getChild('subsCapsButton');
+  const seekBar = player.getChild('controlBar').getChild('progressControl').getChild('seekBar');
+
+  const el = subsCapsButton.menuButton_.el();
+  const el2 = seekBar.el();
+
+  // Open menu
+  Events.trigger(el, 'click');
+
+  // Verify menu is now open
+  assert.ok(subsCapsButton.buttonPressed_, 'Button was pressed');
+  assert.ok(!subsCapsButton.menu.hasClass('vjs-hidden'), 'Menu is showing');
+
+  // Click progress bar
+  Events.trigger(el2, 'mousedown');
+
+  // Verify that menu is now closed
+  assert.ok(seekBar.enabled(), 'Progress bar is enabled');
+  assert.ok(!subsCapsButton.buttonPressed_, 'Button is no longer pressed');
+  assert.ok(subsCapsButton.menu.hasClass('vjs-hidden'), 'Menu is no longer showing');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
Adds a feature to close the subtitles menu when clicking the seek bar in order to increase consistency with the other control bar components. It correlates to issue videojs/video.js#5404 (although not directly mentioned there). 

## Specific Changes proposed
Adds a call to the subtitles menu button 'unpressButton()' function inside the seek bar 'mousedown' event handler.

## Requirements Checklist
- [x] Feature implemented
- [x] Change has been verified in Firefox and Chrome
- [x] Test cases passed
- [ ] Reviewed by Two Core Contributors
