### PR TITLE
fix: Control-bar autohide when cursor placed over it #5258

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3444,17 +3444,22 @@ class Player extends Component {
     this.on('mousemove', handleMouseMove);
     this.on('mouseup', handleMouseUp);
 
-    this.on(this.getChild('controlBar'), 'mouseenter', function(event) {
+    const controlBar = this.getChild('controlBar');
 
-      this.cache_.inactivityTimeout = this.options_.inactivityTimeout;
-      this.options_.inactivityTimeout = 0;
+    if (controlBar) {
 
-    });
+      controlBar.on('mouseenter', function(event) {
 
-    this.on(this.getChild('controlBar'), 'mouseleave', function(event) {
-      this.options_.inactivityTimeout = this.cache_.inactivityTimeout;
+        this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
+        this.player().options_.inactivityTimeout = 0;
 
-    });
+      });
+
+      controlBar.on('mouseleave', function(event) {
+        this.player().options_.inactivityTimeout = this.player().cache_.inactivityTimeout;
+      });
+
+    }
 
     // Listen for keyboard navigation
     // Shouldn't need to use inProgress interval because of key repeat

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3444,6 +3444,16 @@ class Player extends Component {
     this.on('mousemove', handleMouseMove);
     this.on('mouseup', handleMouseUp);
 
+    this.on(this.getChild('controlBar'), 'mouseenter', function(event) {
+      this.options_.inactivityTimeout = 0;
+
+    });
+
+    this.on(this.getChild('controlBar'), 'mouseleave', function(event) {
+      this.options_.inactivityTimeout = 2000;
+
+    });
+
     // Listen for keyboard navigation
     // Shouldn't need to use inProgress interval because of key repeat
     this.on('keydown', handleActivity);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3445,12 +3445,14 @@ class Player extends Component {
     this.on('mouseup', handleMouseUp);
 
     this.on(this.getChild('controlBar'), 'mouseenter', function(event) {
+
+      this.cache_.inactivityTimeout = this.options_.inactivityTimeout;
       this.options_.inactivityTimeout = 0;
 
     });
 
     this.on(this.getChild('controlBar'), 'mouseleave', function(event) {
-      this.options_.inactivityTimeout = 2000;
+      this.options_.inactivityTimeout = this.cache_.inactivityTimeout;
 
     });
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2046,7 +2046,7 @@ QUnit.test('controlBar behaviour with mouseenter and mouseleave events', functio
   // move mouse out of controlBar bounds
   Events.trigger(el, 'mouseleave');
 
-  assert.equal(player.options_.inactivityTimeout, 2000, 'mouse leaves control-bar, inactivityTimeout is set to default value (2000)');
+  assert.equal(player.options_.inactivityTimeout, player.cache_.inactivityTimeout, 'mouse leaves control-bar, inactivityTimeout is set to default value (2000)');
 
   player.dispose();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -13,6 +13,7 @@ import document from 'global/document';
 import sinon from 'sinon';
 import window from 'global/window';
 import * as middleware from '../../src/js/tech/middleware.js';
+import * as Events from '../../src/js/utils/events.js';
 
 QUnit.module('Player', {
   beforeEach() {
@@ -2025,4 +2026,27 @@ QUnit.test('setting all children to false, does not cause an assertion', functio
 
   player.dispose();
   assert.ok(true, 'did not cause an assertion');
+});
+
+QUnit.test('controlBar behaviour with mouseenter and mouseleave events', function(assert) {
+
+  const player = TestHelpers.makePlayer();
+
+  player.listenForUserActivity_();
+
+  assert.equal(player.options_.inactivityTimeout, 2000, 'inactivityTimeout default value is 2000');
+
+  const el = player.getChild('controlBar').el();
+
+  // move mouse to controlBar
+  Events.trigger(el, 'mouseenter');
+
+  assert.equal(player.options_.inactivityTimeout, 0, 'mouseenter on control-bar, inactivityTimeout is set to 0');
+
+  // move mouse out of controlBar bounds
+  Events.trigger(el, 'mouseleave');
+
+  assert.equal(player.options_.inactivityTimeout, 2000, 'mouse leaves control-bar, inactivityTimeout is set to default value (2000)');
+
+  player.dispose();
 });


### PR DESCRIPTION
## Description
Solves videojs/video.js#5258 


## Specific Changes proposed
Adds two event handlers for 'mouseenter' and 'mouseleave' events on the control-bar.
When the 'mouseenter' is triggered the inactivityTimeout is set to 0 and on 'mouseleave' is set to the default value (2s).

Expected behavior: 

* cursor stops inside control bar -> sets timeout 0s so nothing happens
* cursor leaves player bounds -> sets timeout 2s before going inactive


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome, Firefox)
- [x] Tests cases passed
- [ ] Reviewed by Two Core Contributors
