### PR TITLE
Fix: duration display when changing video duration or source

### DIFF
--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -51,6 +51,7 @@ class DurationDisplay extends TimeDisplay {
 
   /**
    * Update duration time display.
+   * In case of the duration passed as argument being NaN, the result of the formatted time will be '-:-'.
    *
    * @param {EventTarget~Event} [event]
    *        The `durationchange`, `timeupdate`, or `loadedmetadata` event that caused
@@ -63,6 +64,8 @@ class DurationDisplay extends TimeDisplay {
   updateContent(event) {
     const duration = this.player_.duration();
 
+    // If the duration isn't the previous duration, the duration display will
+    // be updated with a formatted time.
     if (this.duration_ !== duration) {
       this.duration_ = duration;
       this.updateFormattedTime_(duration);

--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -28,11 +28,6 @@ class DurationDisplay extends TimeDisplay {
     // it has changed
     this.on(player, 'durationchange', this.updateContent);
 
-    // Listen to loadstart because the player duration is reset when a new media element is loaded,
-    // but the durationchange on the user agent will not fire.
-    // @see [Spec]{@link https://www.w3.org/TR/2011/WD-html5-20110113/video.html#media-element-load-algorithm}
-    this.on(player, 'loadstart', this.updateContent);
-
     // Also listen for timeupdate (in the parent) and loadedmetadata because removing those
     // listeners could have broken dependent applications/libraries. These
     // can likely be removed for 7.0.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2296,16 +2296,12 @@ class Player extends Component {
         this.removeClass('vjs-live');
         this.removeClass('vjs-liveui');
       }
-      if (!isNaN(seconds)) {
-        // Do not fire durationchange unless the duration value is known.
-        // @see [Spec]{@link https://www.w3.org/TR/2011/WD-html5-20110113/video.html#media-element-load-algorithm}
 
-        /**
-         * @event Player#durationchange
-         * @type {EventTarget~Event}
-         */
-        this.trigger('durationchange');
-      }
+      /**
+       * @event Player#durationchange
+       * @type {EventTarget~Event}
+       */
+      this.trigger('durationchange');
     }
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1291,9 +1291,6 @@ class Player extends Component {
     // reset the error state
     this.error(null);
 
-    // Update the duration
-    this.handleTechDurationChange_();
-
     // If it's already playing we want to trigger a firstplay event now.
     // The firstplay event relies on both the play and loadstart events
     // which can happen in any order for a new source
@@ -2823,6 +2820,12 @@ class Player extends Component {
 
     // intial sources
     this.changingSrc_ = true;
+
+    // Sets the duration in case of preload='none'.
+    // Since preload='none', this.duration is NaN and '-:-' will be displayed.
+    if (this.options_.preload === 'none') {
+      this.duration(this.duration);
+    }
 
     this.cache_.sources = sources;
     this.updateSourceCaches_(sources[0]);


### PR DESCRIPTION
## Description
Solves [issue #5347](https://github.com/videojs/video.js/issues/5347).
In this pull request, I propose a different way of solving this issue along with more comments in the code explaining my resolution.

## Specific Changes proposed

For case A (duration change), I removed the if condition to check if the time is different than `NaN`. I don't think that condition is necessary because the time display formatting already handles values that are not numbers and displays `'-:-'` instead.

As for case B (video source change), I don't think the events added are needed and, instead, I added a condition to check if `preload` is `none` when changing source and update the duration to the current duration, which should be `NaN` since `preload='none'`. This duration update is necessary because when the duration updates to `NaN`, the `durationchange` event isn't triggered and we must change the duration manually.

## Requirements Checklist
- [x] Bug fixed
- [x] Change has been verified in an actual browser (Firefox)
- [x] Test cases passed 
- [ ] Reviewed by Two Core Contributors
