### PR TITLE
Fix - Firefox Outline on player

### DIFF
--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -29,7 +29,7 @@
     width: 100% !important;
     height: 100% !important;
   }
-
+  
   // reset word-break inside the player div
   word-break: initial;
 }

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -29,7 +29,7 @@
     width: 100% !important;
     height: 100% !important;
   }
-  
+
   // reset word-break inside the player div
   word-break: initial;
 }
@@ -96,6 +96,13 @@
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+// Prevents the focus outline appearing on the .vjs-tech div, without breaking
+// the accessibility for keyboard users, as tabindex=-1 is not accessible via
+// keyboard.
+.video-js .vjs-tech[tabindex="-1"]:focus{
+  outline: none;
 }
 
 // Fullscreen Styles


### PR DESCRIPTION
## Description
This commit removes the outline visible on Firefox, as requested on Issue #5472.

## Specific Changes proposed
An "outline: none" was added to the css class .vjs-tech where tabIndex="-1".
The html video tag has tabIndex= -1, which means it is not accessible through keyboard.
So, having the outline bothers people who use mouse to focus the video, and since it is not accessible through keyboard, we can remove the outline safely.
Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [x] Test cases passed
- [ ] Reviewed by Two Core Contributors
