### PR TITLE
fix: autoplay issue on Chrome #5233

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -112,6 +112,12 @@ class Html5 extends Tech {
     this.proxyWebkitFullscreen_();
 
     this.triggerReady();
+
+    // On load, confirms if autoplay is turned on and if the
+    // player is paused, forcing the video to be played
+    if (this.autoplay() && this.paused()) {
+      this.play();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
This commit fixes the autoplay issue (#5233) on Chrome.

## Specific Changes proposed
In order for the autoplay to work on Chrome, after the video is loaded we check if autoplay is turned on and if the video is paused, thus forcing the video to be played. On tech/HTML5.js, autoplay is forced as the last command


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chome, Firefox, IE)
- [x] Unit Tests passed
- [ ] Reviewed by Two Core Contributors
