### PR TITLE
Issue fixed

### DIFF
--- a/src/css/components/menu/_menu-popup.scss
+++ b/src/css/components/menu/_menu-popup.scss
@@ -16,7 +16,36 @@
   position: absolute;
   width: 100%;
   bottom: 1.5em; // Same bottom as vjs-menu border-top
-  max-height: 15em;
+}
+
+@media (min-width: 321px) and (max-width: 425px) { // small
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 100px;
+  }
+}
+
+@media (min-width: 426px) and (max-width: 768px) { // medium
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 150px;
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1440px) { // large
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 275px;
+  }
+}
+
+@media (min-width: 1441px) and (max-width: 2560px) { // x-large
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 350px;
+  }
+}
+
+@media (min-width: 2561px) { // huge
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 400px;
+  }
 }
 
 .vjs-workinghover .vjs-menu-button-popup:hover .vjs-menu,


### PR DESCRIPTION
## Description
This commit fixes the subtitle box issue (#5524), where when the height of the player was very small or the number of subtitles was big, the subtitle box would exceed the players height.

## Specific Changes proposed
We fixed this issue by adding responsive classes to the already established breakpoints that display the subtitles menu icon.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
