### PR TITLE
Update player.js

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1857,10 +1857,12 @@ class Player extends Component {
     );
 
     if (!inAllowedEls) {
-      if (this.isFullscreen()) {
+      if(this.player_.controlBar.fullscreenToggle.el_){
+       if (this.isFullscreen()) {
         this.exitFullscreen();
-      } else {
+       } else {
         this.requestFullscreen();
+       }
       }
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1857,15 +1857,15 @@ class Player extends Component {
     );
 
     if (!inAllowedEls) {
-      if(this.player_.controlBar.fullscreenToggle.el_){
-       if (this.isFullscreen()) {
-        this.exitFullscreen();
-       } else {
-        this.requestFullscreen();
-       }
-      }
+      if (this.player_.controlBar.fullscreenToggle.el_) {
+        if (this.isFullscreen()) {
+          this.exitFullscreen();
+        } else {
+          this.requestFullscreen();
+        }
     }
   }
+}
 
   /**
    * Handle a tap on the media element. It will toggle the user

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1863,9 +1863,9 @@ class Player extends Component {
         } else {
           this.requestFullscreen();
         }
+      }
     }
   }
-}
 
   /**
    * Handle a tap on the media element. It will toggle the user


### PR DESCRIPTION
## Description
Pull request for issue #5604 

## Specific Changes proposed
Changing handleTechDoubleClick_(event) {} function in order to not trigger fullscreen even when the video is double-clicked. This will only happen when the option fullscreenToggle is set to false, of course.

## Requirements Checklist
Improved functionality of disabling fullscreen mode.
