### PR TITLE
Using src attribute instead of source element

### DIFF
--- a/src/js/tech/loader.js
+++ b/src/js/tech/loader.js
@@ -36,22 +36,34 @@ class MediaLoader extends Component {
     // load the first supported playback technology.
 
     if (!options.playerOptions.sources || options.playerOptions.sources.length === 0) {
-      for (let i = 0, j = options.playerOptions.techOrder; i < j.length; i++) {
-        const techName = toTitleCase(j[i]);
-        let tech = Tech.getTech(techName);
+      if (typeof(options.playerOptions.src) == 'undefined') {
+          for (let i = 0, j = options.playerOptions.techOrder; i < j.length; i++) {
+            const techName = toTitleCase(j[i]);
+            let tech = Tech.getTech(techName);
 
-        // Support old behavior of techs being registered as components.
-        // Remove once that deprecated behavior is removed.
-        if (!techName) {
-          tech = Component.getComponent(techName);
-        }
+            // Support old behavior of techs being registered as components.
+            // Remove once that deprecated behavior is removed.
+            if (!techName) {
+              tech = Component.getComponent(techName);
+            }
 
-        // Check if the browser supports this technology
-        if (tech && tech.isSupported()) {
-          player.loadTech_(techName);
-          break;
+            // Check if the browser supports this technology
+            if (tech && tech.isSupported()) {
+              player.loadTech_(techName);
+              break;
+            }
+          }
         }
-      }
+        else {
+          var src = options.playerOptions.src;
+          var type = "video/" + src.slice((src.lastIndexOf(".")  - 1 >>> 0) +2 );
+          options.playerOptions.sources = [
+            {
+              type: type,
+              src: src
+            }
+          ];
+        }
     } else {
       // Loop through playback technologies (HTML5, Flash) and check for support.
       // Then load the best source.


### PR DESCRIPTION
## Description
Possible fix to issue [#4851](https://github.com/videojs/video.js/issues/4851) by using src attribute to generate the source element when the last is undefined.

## Specific Changes proposed
In the _loader.js_, I tried modify the player data structure to add the _source_ object (with _src_ and _type_) using simply the _src_ attribute, when the _video-js_ class is created in the _index.html_ file. But, sadly, it doesn't work, because the playerOptions object is edited and not the player object.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
