### PR TITLE
fix(seekbar): don't disable if live tracker's seekable is infinity

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -39,6 +39,7 @@ class SeekBar extends Slider {
   constructor(player, options) {
     super(player, options);
     this.setEventHandlers_();
+    this.disabledForLive_ = false;
   }
 
   /**
@@ -116,8 +117,12 @@ class SeekBar extends Slider {
     }
 
     if (liveTracker && liveTracker.seekableEnd() === Infinity) {
-      this.disable();
-    } else {
+      if (this.player_.readyState() === 0) {
+        this.disabledForLive_ = true;
+        this.disable();
+      }
+    } else if (this.disabledForLive_) {
+      this.disabledForLive_ = false;
       this.enable();
     }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -39,7 +39,6 @@ class SeekBar extends Slider {
   constructor(player, options) {
     super(player, options);
     this.setEventHandlers_();
-    this.disabledForLive_ = false;
   }
 
   /**
@@ -114,16 +113,6 @@ class SeekBar extends Slider {
 
     if (liveTracker && liveTracker.isLive()) {
       duration = this.player_.liveTracker.liveCurrentTime();
-    }
-
-    if (liveTracker && liveTracker.seekableEnd() === Infinity) {
-      if (this.player_.readyState() === 0) {
-        this.disabledForLive_ = true;
-        this.disable();
-      }
-    } else if (this.disabledForLive_) {
-      this.disabledForLive_ = false;
-      this.enable();
     }
 
     // machine readable value of progress bar (percentage complete)


### PR DESCRIPTION
The seekbar is disabled if the seekable end is Infinity and re-enabled
when it isn't. Instead, we should only disable if seekable end is
Infinity and re-enable only if we disabled for the seekable end.

This auto disabling and re-enabling, without this fix, caused issues
with disabling the progress control since the seekbar got re-enabled.