### PR TITLE
fix(menu-button): make menu button title a component

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -108,7 +108,7 @@ class MenuButton extends Component {
 
     // Add a title list item to the top
     if (this.options_.title) {
-      const title = Dom.createEl('li', {
+      const titleEl = Dom.createEl('li', {
         className: 'vjs-menu-title',
         innerHTML: toTitleCase(this.options_.title),
         tabIndex: -1
@@ -116,8 +116,9 @@ class MenuButton extends Component {
 
       this.hideThreshold_ += 1;
 
-      menu.children_.unshift(title);
-      Dom.prependTo(title, menu.contentEl());
+      const titleComponent = new Component(this.player_, {el: titleEl});
+
+      menu.addItem(titleComponent);
     }
 
     this.items = this.createItems();


### PR DESCRIPTION
## Description
Currently menu titles are not components, but Dom elements instead.  This is an issue specifically for existing code such as in [src/js/menu/menu.js:114](https://github.com/videojs/video.js/blob/3d093ede98f2ad6204ff44c9631b0aa18bbf0cc5/src/js/menu/menu.js#L114,L115) where each child element is expected to be a videojs component (`element.el()`) though when a title is provided to `MenuButton`, it is created as a Dom element in `src/js/menu/menu-button.js:111`

Relevant issue already exists, though it has only popped up as an issue for me after VJS 7.x updates:
videojs/video.js#3612 

```
 /**
   * Called when a `MenuItem` loses focus.
   *
   * @param {EventTarget~Event} event
   *        The `blur` event that caused this function to be called.
   *
   * @listens blur
   */
  handleBlur(event) {
    const relatedTarget = event.relatedTarget || document.activeElement;

    // Close menu popup when a user clicks outside the menu
    if (!this.children().some((element) => {
      return element.el() === relatedTarget;
    })) {
      const btn = this.menuButton_;

      if (btn && btn.buttonPressed_ && relatedTarget !== btn.el().firstChild) {
        btn.unpressButton();
      }
    }
  }
```

## Specific Changes proposed
This update simply adds the created DOM element as a component, rather than the current dom manipulation and children array manipulation.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
