### PR TITLE
fix(player): remove vjs-ended class on seeked

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1710,6 +1710,7 @@ class Player extends Component {
    */
   handleTechSeeked_() {
     this.removeClass('vjs-seeking');
+    this.removeClass('vjs-ended');
     /**
      * Fired when the player has finished jumping to a new time
      *


### PR DESCRIPTION
Whenever we seek after the video has ended, we are no longer ended and
therefore we should remove the vjs-ended class.

Fixes #5654.