### PR TITLE
fix: TextTrackMenuItem components should not disable text tracks of different kind(s).

### DIFF
--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -102,7 +102,8 @@ class TextTrackMenuItem extends MenuItem {
       return;
     }
 
-    // Determine the relevant kind(s) of tracks for this component.
+    // Determine the relevant kind(s) of tracks for this component and filter
+    // out empty kinds.
     const kinds = (referenceTrack.kinds || [referenceTrack.kind]).filter(Boolean);
 
     for (let i = 0; i < tracks.length; i++) {

--- a/src/js/control-bar/text-track-controls/text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/text-track-menu-item.js
@@ -93,13 +93,8 @@ class TextTrackMenuItem extends MenuItem {
    * @listens click
    */
   handleClick(event) {
-    const kind = this.track.kind;
-    let kinds = this.track.kinds;
+    const referenceTrack = this.track;
     const tracks = this.player_.textTracks();
-
-    if (!kinds) {
-      kinds = [kind];
-    }
 
     super.handleClick(event);
 
@@ -107,13 +102,27 @@ class TextTrackMenuItem extends MenuItem {
       return;
     }
 
+    // Determine the relevant kind(s) of tracks for this component.
+    const kinds = (referenceTrack.kinds || [referenceTrack.kind]).filter(Boolean);
+
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
 
-      if (track === this.track && (kinds.indexOf(track.kind) > -1)) {
+      // If the track from the text tracks list is not of the right kind,
+      // skip it. We do not want to affect tracks of incompatible kind(s).
+      if (kinds.indexOf(track.kind) === -1) {
+        continue;
+      }
+
+      // If this text track is the component's track and it is not showing,
+      // set it to showing.
+      if (track === referenceTrack) {
         if (track.mode !== 'showing') {
           track.mode = 'showing';
         }
+
+      // If this text track is not the component's track and it is not
+      // disabled, set it to disabled.
       } else if (track.mode !== 'disabled') {
         track.mode = 'disabled';
       }

--- a/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
+++ b/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
@@ -1,0 +1,65 @@
+/* eslint-env qunit */
+import TextTrackMenuItem from '../../../../src/js/control-bar/text-track-controls/text-track-menu-item.js';
+import TestHelpers from '../../test-helpers.js';
+import sinon from 'sinon';
+
+QUnit.module('TextTrackMenuItem', {
+  beforeEach(assert) {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer();
+  },
+  afterEach(assert) {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+QUnit.test('clicking should enable the selected track', function(assert) {
+  assert.expect(2);
+
+  const foo = this.player.addTextTrack('captions', 'foo', 'en');
+
+  const fooItem = new TextTrackMenuItem(this.player, {
+    track: foo
+  });
+
+  assert.strictEqual(foo.mode, 'disabled', 'track "foo" begins "disabled"');
+
+  fooItem.trigger('click');
+
+  assert.strictEqual(foo.mode, 'showing', 'clicking set track "foo" to "showing"');
+});
+
+QUnit.test('clicking should disable non-selected tracks of the same kind', function(assert) {
+  assert.expect(9);
+
+  const foo = this.player.addTextTrack('captions', 'foo', 'en');
+  const bar = this.player.addTextTrack('captions', 'bar', 'es');
+  const bop = this.player.addTextTrack('metadata', 'bop');
+
+  bop.mode = 'hidden';
+
+  const fooItem = new TextTrackMenuItem(this.player, {
+    track: foo
+  });
+
+  const barItem = new TextTrackMenuItem(this.player, {
+    track: bar
+  });
+
+  assert.strictEqual(foo.mode, 'disabled', 'captions track "foo" begins "disabled"');
+  assert.strictEqual(bar.mode, 'disabled', 'captions track "bar" begins "disabled"');
+  assert.strictEqual(bop.mode, 'hidden', 'metadata track "bop" is "hidden"');
+
+  barItem.trigger('click');
+
+  assert.strictEqual(foo.mode, 'disabled', 'captions track "foo" is still "disabled"');
+  assert.strictEqual(bar.mode, 'showing', 'captions track "bar" is now "showing"');
+  assert.strictEqual(bop.mode, 'hidden', 'metadata track "bop" is still "hidden"');
+
+  fooItem.trigger('click');
+
+  assert.strictEqual(foo.mode, 'showing', 'captions track "foo" is now "showing"');
+  assert.strictEqual(bar.mode, 'disabled', 'captions track "bar" is now "disabled"');
+  assert.strictEqual(bop.mode, 'hidden', 'metadata track "bop" is still "hidden"');
+});

--- a/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
+++ b/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
@@ -1,16 +1,13 @@
 /* eslint-env qunit */
 import TextTrackMenuItem from '../../../../src/js/control-bar/text-track-controls/text-track-menu-item.js';
 import TestHelpers from '../../test-helpers.js';
-import sinon from 'sinon';
 
 QUnit.module('TextTrackMenuItem', {
   beforeEach(assert) {
-    this.clock = sinon.useFakeTimers();
     this.player = TestHelpers.makePlayer();
   },
   afterEach(assert) {
     this.player.dispose();
-    this.clock.restore();
   }
 });
 

--- a/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
+++ b/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
@@ -25,6 +25,8 @@ QUnit.test('clicking should enable the selected track', function(assert) {
   fooItem.trigger('click');
 
   assert.strictEqual(foo.mode, 'showing', 'clicking set track "foo" to "showing"');
+
+  fooItem.dispose();
 });
 
 QUnit.test('clicking should disable non-selected tracks of the same kind', function(assert) {
@@ -59,4 +61,7 @@ QUnit.test('clicking should disable non-selected tracks of the same kind', funct
   assert.strictEqual(foo.mode, 'showing', 'captions track "foo" is now "showing"');
   assert.strictEqual(bar.mode, 'disabled', 'captions track "bar" is now "disabled"');
   assert.strictEqual(bop.mode, 'hidden', 'metadata track "bop" is still "hidden"');
+
+  fooItem.dispose();
+  barItem.dispose();
 });


### PR DESCRIPTION
## Description
While investigating a non-public issue, I happened to notice that metadata tracks were being disabled when switching captions languages. Upon investigation, I found [this code](https://github.com/videojs/video.js/blob/175f77325346af9ec5fa7f090eba8be2076a54e2/src/js/control-bar/text-track-controls/text-track-menu-item.js#L113-L119), which is the culprit. It will disable any track that's not the selected track.

## Specific Changes proposed
Instead of disabling all tracks when switching, only disable tracks of the appropriate kind(s).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
