### PR TITLE
use https links in documentation

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -463,7 +463,7 @@ This collaborator guide was heavily inspired by [node.js's guide](https://github
 
 [conventions]: https://github.com/videojs/conventional-changelog-videojs/blob/master/convention.md
 
-[vjs npm]: http://npmjs.com/org/videojs
+[vjs npm]: https://www.npmjs.com/org/videojs
 
 [npm org]: https://docs.npmjs.com/misc/orgs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ A good bug report should be as detailed as possible, so that others won't have t
 
 ### Requesting a Feature
 
-1. [Check the plugin list](http://videojs.com/plugins/) for any plugins that may already support the feature.
+1. [Check the plugin list](https://videojs.com/plugins/) for any plugins that may already support the feature.
 1. [Search the issues](https://github.com/videojs/video.js/issues) for any previous requests for the same feature, and give a thumbs up or +1 on existing requests.
 1. If no previous requests exist, create a new issue. Please be as clear as possible about why the feautre is needed and the intended use case.
 1. Once again, be as details as possible and follow the [issue template][]
@@ -284,7 +284,7 @@ See [Running tests](#running-tests) for more information.
 git push origin my-branch
 ```
 
-Then go to the [repo page](http://github.com/videojs/video.js) and click the "Pull Request" button and fill out the [pull request template](/.github/PULL_REQUEST_TEMPLATE.md)
+Then go to the [repo page](https://github.com/videojs/video.js) and click the "Pull Request" button and fill out the [pull request template](/.github/PULL_REQUEST_TEMPLATE.md)
 
 ### Code Style Guide
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In older versions of Video.js (6 and earlier), in the `vjs.zencdn.net` CDN-hoste
 <script>window.HELP_IMPROVE_VIDEOJS = false;</script>
 ```
 
-Alternatively, you can include Video.js by getting it from [npm](http://videojs.com/getting-started/#download-npm), downloading from [GitHub releases](https://github.com/videojs/video.js/releases) or by including it via [unpkg](https://unpkg.com) or another JavaScript CDN like CDNjs. These releases _do not_ include Google Analytics tracking at all.
+Alternatively, you can include Video.js by getting it from [npm](https://videojs.com/getting-started/#download-npm), downloading from [GitHub releases](https://github.com/videojs/video.js/releases) or by including it via [unpkg](https://unpkg.com) or another JavaScript CDN like CDNjs. These releases _do not_ include Google Analytics tracking at all.
 
 ```html
 <!-- unpkg : use the latest version of Video.js -->
@@ -69,7 +69,7 @@ Next, using Video.js is as simple as creating a `<video>` element, but with an a
   <p class="vjs-no-js">
     To view this video please enable JavaScript, and consider upgrading to a
     web browser that
-    <a href="http://videojs.com/html5-video-support/" target="_blank">
+    <a href="https://videojs.com/html5-video-support/" target="_blank">
       supports HTML5 video
     </a>
   </p>
@@ -129,15 +129,15 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 
 [coveralls-link]: https://coveralls.io/github/videojs/video.js?branch=master
 
-[docs]: http://docs.videojs.com
+[docs]: https://docs.videojs.com
 
-[fastly]: http://www.fastly.com/
+[fastly]: https://www.fastly.com/
 
-[getting-started]: http://videojs.com/getting-started/
+[getting-started]: https://videojs.com/getting-started/
 
 [license]: LICENSE
 
-[logo]: http://videojs.com/img/logo.png
+[logo]: https://videojs.com/img/logo.png
 
 [npm-icon]: https://nodei.co/npm/video.js.png?downloads=true&downloadRank=true
 
@@ -145,7 +145,7 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 
 [options]: docs/guides/options.md
 
-[plugins]: http://videojs.com/plugins/
+[plugins]: https://videojs.com/plugins/
 
 [slack-icon]: http://slack.videojs.com/badge.svg
 
@@ -155,6 +155,6 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 
 [travis-link]: https://travis-ci.org/videojs/video.js
 
-[vjs]: http://videojs.com
+[vjs]: https://videojs.com
 
 [coc]: CODE_OF_CONDUCT.md

--- a/docs/examples/elephantsdream/index.html
+++ b/docs/examples/elephantsdream/index.html
@@ -33,7 +33,7 @@
 
     <track kind="chapters" src="chapters.en.vtt" srclang="en" label="English">
 
-    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
 
 </body>

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -15,7 +15,7 @@
     <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <track kind="captions" src="../shared/example-captions.vtt" srclang="en" label="English">
     <track kind="subtitles" src="../shared/example-captions.vtt" srclang="en" label="English">
-    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
 
 </body>


### PR DESCRIPTION
Some links were still using http (even though they redirect to https).