### PR TITLE
[A11y Fix] - Ensure resizeManager is not focusable via tab

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -80,7 +80,10 @@ class ResizeManager extends Component {
 
   createEl() {
     return super.createEl('iframe', {
-      className: 'vjs-resize-manager'
+      className: 'vjs-resize-manager',
+      tabIndex: -1
+    }, {
+      'aria-hidden': 'true'
     });
   }
 

--- a/test/unit/resize-manager.test.js
+++ b/test/unit/resize-manager.test.js
@@ -18,6 +18,8 @@ QUnit.test('ResizeManager creates an iframe if ResizeObserver is not available',
   const rm = new ResizeManager(this.player, {ResizeObserver: null});
 
   assert.equal(rm.el().tagName.toLowerCase(), 'iframe', 'we got an iframe');
+  assert.equal(rm.el().getAttribute('tabIndex'), '-1', 'TabIndex is set to -1');
+  assert.equal(rm.el().getAttribute('aria-hidden'), 'true', 'aria-hidden property is set');
 
   rm.dispose();
 });


### PR DESCRIPTION
The ResizeManager's iframe element is able to be focused via tabbing, which results in a bad user experience for users that rely on a screen reader to navigate the video and its sibling elements. The fix is to set the tabIndex to "-1", and the aria-hidden property to `true` for good measure. Confirmed the fix by spinning up a local server and attempting to tab to the resizeManager's iframe element. This was possible prior to the fix, and not possible after the fix. In addition, I added to the existing resizeManager unit test.

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
