### PR TITLE
Fullscreen api changes to support custome fullscreen element

### DIFF
--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -24,7 +24,7 @@ class FullscreenToggle extends Button {
    */
   constructor(player, options) {
     super(player, options);
-    this.on(player, 'fullscreenchange', this.handleFullscreenChange);
+    this.on(document, 'fullscreenchange', this.handleFullscreenChange);
 
     if (document[FullscreenApi.fullscreenEnabled] === false) {
       this.disable();


### PR DESCRIPTION
## Description of feature changes
### Modify isFullscreen to check the available fullscreen api if it exists.
I believe that the fullscreen api is available in every browser that is supported in vjs 7 since ie10 support has been dropped. This change will use the api if it is available, but the code should maybe be changed to only use the api. I would like feedback from the maintainers about this.

### Update jsdoc to indicate that undefined can be returned by setter.
A minor change. jsdoc pedantism.

### Modify requestFullscreen api call to use an element defined in options if it exists.
Setting options.fullscreenElement will cause the fullscreen routines to use that element as the fullscreen target isntead of the el_ target.

### Update fullscreen handling events to target document instead of bubbled player events.
This was required to get multiple players in a single page to syncronise their fullscreen states. Unfortunately, it has broken the fullscreen control bar unit test. I don't have the neccessary familiarity to rewrite the test in a satisfactory way and would like help from the videojs maintainers. I believe the unit test is incorrect, as true fullscreening of an element has been locked to user gesture events by the browser developers, so this feature can't actually be tested in an automated environment unless Karma can emit isTrusted user gesture events. All browsers that I tested in a live environment work as expected.

## Requirements Checklist

### Note
documentation still needs to be updated. I would like to wait till all unit tests pass before completing the documentation. As well, I have noticed that this code change fixes issue videojs/video.js#5745 as a sideeffect, although the change was not intentional.

- [Y ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [Y ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
