### PR TITLE
Set cache before 'mouseenter' event for inactivityTimeout

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2066,6 +2066,7 @@ class Player extends Component {
       // we set it to zero here to ensure that if we do start actually caching
       // it, we reset it along with everything else.
       currentTime: 0,
+      inactivityTimeout: this.options_.inactivityTimeout,
       duration: NaN,
       lastVolume: 1,
       lastPlaybackRate: this.defaultPlaybackRate(),
@@ -3647,7 +3648,6 @@ class Player extends Component {
     const controlBar = this.getChild('controlBar');
 
     if (controlBar) {
-      this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
 
       controlBar.on('mouseenter', function(event) {
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3647,6 +3647,7 @@ class Player extends Component {
     const controlBar = this.getChild('controlBar');
 
     if (controlBar) {
+      this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
 
       controlBar.on('mouseenter', function(event) {
 


### PR DESCRIPTION
## Description
We need to define the cache for `inactivityTImeouot` before the `mouseenter` event, because if you do play on the `controlBar` for example and go out, the actual `mouseenter` event of it never gets triggerd, and so the cache is gonna be always undefined. 

It's a really visible bug when you have a custom player with the control-bar all the way bottom (-40px) and you set a `inactivityTimeout: 0`, it gets overriden by the undefined and gets hidden always.
