### PR TITLE
Fix polymer issue by marking click event with stopPropagation

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -61,6 +61,7 @@ class PlayToggle extends Button {
     } else {
       this.player_.pause();
     }
+    event.stopPropagation();
   }
 
   /**


### PR DESCRIPTION
## Description
The play button stops working when recent versions of Google's Polymer
is in use on the page because of the way Polymer synthesizes 'tap'
events on non-touch devices. The Polymer tap code thinks the click
event was ignored unless the DOM event's stopPropagation method is
called. 

Demo of issue: https://codepen.io/mscalora/pen/mQzQmp

Fixes: videojs/video.js#5624 In chrome 70 the small play/pause control doesn't work with Polymer 1.x Gestures tap is used on document

## Specific Changes proposed
The play-pause button's click handler now calls event.stopPropagation() after the click event is handled.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
