### PR TITLE
Allow displaying of multiple text tracks at once

### DIFF
--- a/sandbox/double-sub-video.html.example
+++ b/sandbox/double-sub-video.html.example
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Text Descriptions, Chapters &amp; Captions Example</title>
+
+  <!-- Load the source files -->
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+
+  <!-- Set the location of the flash SWF -->
+  <script>
+    videojs.options.flash.swf = '../node_modules/videojs-flash/node_modules/videojs-swf/dist/video-js.swf';
+  </script>
+
+</head>
+<body>
+
+  <!-- NOTE: we have to disable native Text Track support for the HTML5 tech,
+             since even HTML5 video players with native Text Track support
+             don't currently support 'description' text tracks in any
+             useful way! Currently this means that iOS will not display
+            ANY text tracks -->
+  <video id="example_video_1" class="video-js" controls preload="none" width="640" height="360"
+      data-setup='{ "html5" : { "nativeTextTracks" : false } }'
+      poster="http://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png">
+
+    <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4" type="video/mp4">
+    <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.ogg" type="video/ogg">
+
+    <track kind="captions" src="../docs/examples/elephantsdream/captions.en.vtt" srclang="en" label="English" default>
+    <track kind="captions" src="../docs/examples/elephantsdream/captions.sv.vtt" srclang="sv" label="Swedish">
+    <track kind="captions" src="../docs/examples/elephantsdream/captions.ru.vtt" srclang="ru" label="Russian">
+    <track kind="captions" src="../docs/examples/elephantsdream/captions.ja.vtt" srclang="ja" label="Japanese">
+    <track kind="captions" src="../docs/examples/elephantsdream/captions.ar.vtt" srclang="ar" label="Arabic">
+
+    <track kind="descriptions" src="../docs/examples/elephantsdream/descriptions.en.vtt" srclang="en" label="English">
+
+    <track kind="chapters" src="../docs/examples/elephantsdream/chapters.en.vtt" srclang="en" label="English">
+
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video>
+
+</body>
+</html>

--- a/sandbox/double-sub-video.html.example
+++ b/sandbox/double-sub-video.html.example
@@ -48,11 +48,11 @@
     });
     
     player.on('loadedmetadata', function() {
-      player.textTracks()[0].mode = true;
-      player.textTracks()[1].mode = true;
-      player.textTracks()[2].mode = true;
-      player.textTracks()[3].mode = true;
-      player.textTracks()[4].mode = true;
+      player.textTracks()[0].mode = 'showing';
+      player.textTracks()[1].mode = 'showing';
+      player.textTracks()[2].mode = 'showing';
+      player.textTracks()[3].mode = 'showing';
+      player.textTracks()[4].mode = 'showing';
     });
   </script>
 

--- a/sandbox/double-sub-video.html.example
+++ b/sandbox/double-sub-video.html.example
@@ -45,7 +45,9 @@
       textTrackDisplay: {
         allowMultipleShowingTracks: true
       }
-    }, function() {
+    });
+    
+    player.on('loadedmetadata', function() {
       player.textTracks()[0].mode = true;
       player.textTracks()[1].mode = true;
       player.textTracks()[2].mode = true;

--- a/sandbox/double-sub-video.html.example
+++ b/sandbox/double-sub-video.html.example
@@ -22,7 +22,6 @@
              useful way! Currently this means that iOS will not display
             ANY text tracks -->
   <video id="example_video_1" class="video-js" controls preload="none" width="640" height="360"
-      data-setup='{ "html5" : { "nativeTextTracks" : false } }'
       poster="http://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png">
 
     <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4" type="video/mp4">
@@ -40,6 +39,20 @@
 
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
+  <script>
+    var vid = document.getElementById('example_video_1');
+    var player = videojs(vid, {
+      textTrackDisplay: {
+        allowMultipleShowingTracks: true
+      }
+    }, function() {
+      player.textTracks()[0].mode = true;
+      player.textTracks()[1].mode = true;
+      player.textTracks()[2].mode = true;
+      player.textTracks()[3].mode = true;
+      player.textTracks()[4].mode = true;
+    });
+  </script>
 
 </body>
 </html>

--- a/sandbox/double-sub-video.html.example
+++ b/sandbox/double-sub-video.html.example
@@ -22,7 +22,7 @@
              useful way! Currently this means that iOS will not display
             ANY text tracks -->
   <video id="example_video_1" class="video-js" controls preload="none" width="640" height="360"
-      poster="http://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png">
+      poster="//d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png">
 
     <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.mp4" type="video/mp4">
     <source src="//d2zihajmogu5jn.cloudfront.net/elephantsdream/ed_hd.ogg" type="video/ogg">
@@ -37,7 +37,7 @@
 
     <track kind="chapters" src="../docs/examples/elephantsdream/chapters.en.vtt" srclang="en" label="English">
 
-    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
   <script>
     var vid = document.getElementById('example_video_1');

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -4,7 +4,7 @@
 import Component from '../component';
 import * as Fn from '../utils/fn.js';
 import window from 'global/window';
-import document from 'global/document';
+import * as Dom from '../utils/dom.js';
 
 const darkGray = '#222';
 const lightGray = '#ccc';
@@ -249,7 +249,11 @@ class TextTrackDisplay extends Component {
     if (allowMultipleShowingTracks) {
       for (let i = 0; i < tracks.length; ++i) {
         const track = tracks[i];
-        const textTrackDisplayLang = document.createElement('div');
+
+        if (track.mode !== 'showing') {
+          return;
+        }
+        const textTrackDisplayLang = Dom.createEl('div');
 
         textTrackDisplayLang.className = 'vjs-text-track-display-' + ((track.language) ? track.language : i);
         const child = this.el_.appendChild(textTrackDisplayLang);

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -387,7 +387,7 @@ class TextTrackDisplay extends Component {
    */
   updateForTrack(tracks) {
     if (!Array.isArray(tracks)) {
-      tracks = Array.from(tracks);
+      tracks = [tracks];
     }
     if (typeof window.WebVTT !== 'function' ||
       tracks.every((track)=> {

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -293,55 +293,18 @@ class TextTrackDisplay extends Component {
   }
 
   /**
-   * Add an {@link TextTrack} to to the {@link Tech}s {@link TextTrackList}.
+   * Style {@Link TextTrack} activeCues according to {@Link TextTrackSettings}.
    *
-   * @param {TextTrack || TextTrack[]} tracks
-   *        Text track object or text track array to be added to the list.
+   * @param {TextTrack} track
+   *        Text track object containing active cues to style.
    */
-  updateForTrack(tracks) {
-    if (!Array.isArray(tracks)) {
-      tracks = Array.from(tracks);
-    }
-    if (typeof window.WebVTT !== 'function' ||
-      tracks.every((track)=> {
-        return !track.activeCues;
-      })) {
-      return;
-    }
-
-    const cues = [];
-
-    // push all active track cues
-    for (let i = 0; i < tracks.length; ++i) {
-      const track = tracks[i];
-
-      for (let j = 0; j < track.activeCues.length; ++j) {
-        cues.push(track.activeCues[j]);
-      }
-    }
-
-    // removes all cues before it processes new ones
-    window.WebVTT.processCues(window, cues, this.el_);
-
-    // add unique class to each language in order to style individually if necessary
-    for (let i = 0; i < tracks.length; ++i) {
-      const track = tracks[i];
-
-      for (let j = 0; j < track.activeCues.length; ++j) {
-        track.activeCues[j].displayState.classList.add('vjs-text-track-display-' + ((track.language) ? track.language : i));
-      }
-    }
-
-    if (!this.player_.textTrackSettings) {
-      return;
-    }
-
+  updateDisplayState(track) {
     const overrides = this.player_.textTrackSettings.getValues();
 
-    let i = cues.length;
+    let i = track.activeCues.length;
 
     while (i--) {
-      const cue = cues[i];
+      const cue = track.activeCues[i];
 
       if (!cue) {
         continue;
@@ -411,6 +374,50 @@ class TextTrackDisplay extends Component {
         } else {
           cueDiv.firstChild.style.fontFamily = fontMap[overrides.fontFamily];
         }
+      }
+    }
+  }
+
+  /**
+   * Add an {@link TextTrack} to to the {@link Tech}s {@link TextTrackList}.
+   *
+   * @param {TextTrack || TextTrack[]} tracks
+   *        Text track object or text track array to be added to the list.
+   */
+  updateForTrack(tracks) {
+    if (!Array.isArray(tracks)) {
+      tracks = Array.from(tracks);
+    }
+    if (typeof window.WebVTT !== 'function' ||
+      tracks.every((track)=> {
+        return !track.activeCues;
+      })) {
+      return;
+    }
+
+    const cues = [];
+
+    // push all active track cues
+    for (let i = 0; i < tracks.length; ++i) {
+      const track = tracks[i];
+
+      for (let j = 0; j < track.activeCues.length; ++j) {
+        cues.push(track.activeCues[j]);
+      }
+    }
+
+    // removes all cues before it processes new ones
+    window.WebVTT.processCues(window, cues, this.el_);
+
+    // add unique class to each language text track & add settings styling if necessary
+    for (let i = 0; i < tracks.length; ++i) {
+      const track = tracks[i];
+
+      for (let j = 0; j < track.activeCues.length; ++j) {
+        track.activeCues[j].displayState.classList.add('vjs-text-track-display-' + ((track.language) ? track.language : i));
+      }
+      if (this.player_.textTrackSettings) {
+        this.updateDisplayState(track);
       }
     }
   }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -300,11 +300,12 @@ class TextTrackDisplay extends Component {
    */
   updateDisplayState(track) {
     const overrides = this.player_.textTrackSettings.getValues();
+    const cues = track.activeCues;
 
-    let i = track.activeCues.length;
+    let i = cues.length;
 
     while (i--) {
-      const cue = track.activeCues[i];
+      const cue = cues[i];
 
       if (!cue) {
         continue;

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -3,6 +3,7 @@
  */
 import Component from '../component';
 import * as Fn from '../utils/fn.js';
+import * as Dom from '../utils/dom.js';
 import window from 'global/window';
 
 const darkGray = '#222';
@@ -415,7 +416,9 @@ class TextTrackDisplay extends Component {
       const track = tracks[i];
 
       for (let j = 0; j < track.activeCues.length; ++j) {
-        track.activeCues[j].displayState.classList.add('vjs-text-track-display-' + ((track.language) ? track.language : i));
+        const cueEl = track.activeCues[j].displayState;
+        Dom.addClass(cueEl, 'vjs-text-track-cue');
+        Dom.addClass(cueEl, 'vjs-text-track-cue-' + ((track.language) ? track.language : i));
       }
       if (this.player_.textTrackSettings) {
         this.updateDisplayState(track);

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -417,6 +417,7 @@ class TextTrackDisplay extends Component {
 
       for (let j = 0; j < track.activeCues.length; ++j) {
         const cueEl = track.activeCues[j].displayState;
+
         Dom.addClass(cueEl, 'vjs-text-track-cue');
         Dom.addClass(cueEl, 'vjs-text-track-cue-' + ((track.language) ? track.language : i));
       }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -251,7 +251,7 @@ class TextTrackDisplay extends Component {
         const track = tracks[i];
 
         if (track.mode !== 'showing') {
-          return;
+          continue;
         }
         const textTrackDisplayLang = Dom.createEl('div');
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -259,7 +259,7 @@ class TextTrackDisplay extends Component {
       return;
     }
 
-    // Track display prioritization model: if multiple tracks are 'showing',
+    //  Track display prioritization model: if multiple tracks are 'showing',
     //  display the first 'subtitles' or 'captions' track which is 'showing',
     //  otherwise display the first 'descriptions' track which is 'showing'
 
@@ -311,10 +311,11 @@ class TextTrackDisplay extends Component {
 
     const cues = [];
 
+    // push all active track cues
     for (let i = 0; i < tracks.length; ++i) {
       const track = tracks[i];
 
-      for (let j = 0; j < track.activeCues.length; j++) {
+      for (let j = 0; j < track.activeCues.length; ++j) {
         cues.push(track.activeCues[j]);
       }
     }
@@ -322,11 +323,12 @@ class TextTrackDisplay extends Component {
     // removes all cues before it processes new ones
     window.WebVTT.processCues(window, cues, this.el_);
 
+    // add unique class to each language in order to style individually if necessary
     for (let i = 0; i < tracks.length; ++i) {
       const track = tracks[i];
 
-      for (let j = 0; j < track.activeCues.length; j++) {
-        track.activeCues[j].displayState.classList.add('vjs-text-track-display-' + i);
+      for (let j = 0; j < track.activeCues.length; ++j) {
+        track.activeCues[j].displayState.classList.add('vjs-text-track-display-' + ((track.language) ? track.language : i));
       }
     }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -383,7 +383,7 @@ class TextTrackDisplay extends Component {
   /**
    * Add an {@link TextTrack} to to the {@link Tech}s {@link TextTrackList}.
    *
-   * @param {TextTrack || TextTrack[]} tracks
+   * @param {TextTrack|TextTrack[]} tracks
    *        Text track object or text track array to be added to the list.
    */
   updateForTrack(tracks) {


### PR DESCRIPTION
## Description
Allows users to set the `allowMultipleShowingTracks` option on the textTrackDisplay in order view multiple texttracks at once on the player. Once this setting is set to true, you can view multiple text tracks in the player by setting `textTrack.mode = "showing"` on the tracks you want to view.

![2467e53c-09cc-4a5d-8a7a-7255feee47b5](https://user-images.githubusercontent.com/2967721/53269471-cdadde00-369d-11e9-9056-90783e277e2a.GIF)

![snag_b080c2d](https://user-images.githubusercontent.com/2967721/53269581-1bc2e180-369e-11e9-91e0-936b107ab547.png)

## Specific Changes proposed
* add below as an option on the video js player.
```
      textTrackDisplay: {
        allowMultipleShowingTracks:true
      }
```
* Allow mutliple texttracks to be displayed at once.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
