### PR TITLE
fix: if play is delayed till loadstart, call load

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2234,7 +2234,7 @@ class Player extends Component {
 
       // if we are in Safari, there is a high chance that loadstart will trigger after the gesture timeperiod
       // in that case, we need to prime the video element by calling load so it'll be ready in time
-      if (browser.IS_ANY_SAFARI) {
+      if (browser.IS_ANY_SAFARI || browser.IS_IOS) {
         this.load();
       }
       this.one('loadstart', this.playOnLoadstart_);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2232,6 +2232,11 @@ class Player extends Component {
         callback(this.play());
       };
 
+      // if we are in Safari, there is a high chance that loadstart will trigger after the gesture timeperiod
+      // in that case, we need to prime the video element by calling load so it'll be ready in time
+      if (browser.IS_ANY_SAFARI) {
+        this.load();
+      }
       this.one('loadstart', this.playOnLoadstart_);
     }
 

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -108,6 +108,8 @@ class TechFaker extends Tech {
     }
     return 'movie.mp4';
   }
+  load() {
+  }
   currentSrc() {
     return 'movie.mp4';
   }


### PR DESCRIPTION
In Safari, if we call play early and we are going to be waiting till
loadstart, it's possible this will take too long for the user activition
flag to still be available. In this case, we should call load() on the
player to prime the video element so for when loadstart happens.