### PR TITLE
fix warning - element supplied is not included in the DOM

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -142,6 +142,12 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
+  // document.contains(el) will only check if el is contained within that one document.
+  // This causes problems for elements in iframes.
+  // Instead, use the element's ownerDocument instead of the global document.
+  // This will make sure that the element is indeed in the dom of that document.
+  // Additionally, check that the document in question has a default view.
+  // If the document is no longer attached to the dom, the defaultView of the document will be null.
   if (!el.ownerDocument.defaultView || !el.ownerDocument.contains(el)) {
     log.warn('The element supplied is not included in the DOM');
   }

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -4,7 +4,6 @@
  */
 import {version} from '../../package.json';
 import window from 'global/window';
-import document from 'global/document';
 import * as setup from './setup';
 import * as stylesheet from './utils/stylesheet.js';
 import Component from './component';
@@ -143,7 +142,7 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
-  if (!document.body.contains(el)) {
+  if (!el.ownerDocument.defaultView || !el.ownerDocument.contains(el)) {
     log.warn('The element supplied is not included in the DOM');
   }
 


### PR DESCRIPTION
Videojs currently relies on the document object from the window that videojs script is instantiated in, in order to determine if the element it will use for initialization is attached to the dom. The method used to determine dom attachment is incorrect. This fixes that method.

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
document.contains(el) will only check if el is contained within that one document. This causes problems for elements in iframes.

Instead, use the element's ownerdocument instead of the global document. Additionally, check that the document in question has a default view. If the document is no longer attached to the dom, the defaultView of the document will be null.

## Requirements Checklist
- [X ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
