### PR TITLE
Fix bug preventing control bar from hiding on mobile

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3647,15 +3647,13 @@ class Player extends Component {
 
     const controlBar = this.getChild('controlBar');
 
-    if (controlBar) {
+    // Fixes bug on Android & iOS where when tapping progressBar (when control bar is displayed)
+    // controlBar would no longer be hidden by default timeout.
+    if (controlBar && !browser.IS_IOS && !browser.IS_ANDROID) {
 
       controlBar.on('mouseenter', function(event) {
-        // Fixes bug on Android & iOS where when tapping progressBar (when control bar is displayed)
-        // controlBar would no longer be hidden by default timeout.
-        if (!browser.IS_IOS && !browser.IS_ANDROID) {
-          this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
-          this.player().options_.inactivityTimeout = 0;
-        }
+        this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
+        this.player().options_.inactivityTimeout = 0;
       });
 
       controlBar.on('mouseleave', function(event) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3650,10 +3650,12 @@ class Player extends Component {
     if (controlBar) {
 
       controlBar.on('mouseenter', function(event) {
-
-        this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
-        this.player().options_.inactivityTimeout = 0;
-
+        // Fixes bug on Android & iOS where when tapping progressBar (when control bar is displayed)
+        // controlBar would no longer be hidden by default timeout.
+        if (!browser.IS_IOS && !browser.IS_ANDROID) {
+          this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
+          this.player().options_.inactivityTimeout = 0;
+        }
       });
 
       controlBar.on('mouseleave', function(event) {


### PR DESCRIPTION
## Description
Bug fix that prevented the control bar from being hidden when progress bar was tapped on on mobile (not seeked on, and only after control bar was already showing).
This was due to a mouseenter event firing (on mobile) that would set the `inactivityTimeout = 0` right before the below bit of code was executed.

```
      const timeout = this.options_.inactivityTimeout;

      if (timeout <= 0) {
        return;
      }

      // In <timeout> milliseconds, if no more activity has occurred the
      // user will be considered inactive
      inactivityTimeout = this.setTimeout(function() {
        // Protect against the case where the inactivityTimeout can trigger just
        // before the next user activity is picked up by the activity check loop
        // causing a flicker
        if (!this.userActivity_) {
          this.userActive(false);
        }
      }, timeout);
```

## Specific Changes proposed
Ensures the mouseenter event never applies to mobile by checking ios & android flags

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
