### PR TITLE
added a baseURL option so media access can be relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "bluebird": "^3.5.3",
     "browserify": "^16.2.3",
     "browserify-istanbul": "^3.0.1",
-    "chokidar-cli": "^1.2.1",
+    "chokidar-cli": "^1.2.2",
     "clean-css-cli": "^4.2.1",
     "cli-table": "^0.3.1",
     "conventional-changelog-cli": "^2.0.11",
@@ -115,7 +115,7 @@
     "humanize-duration": "^3.16.0",
     "husky": "^1.2.0",
     "jsdoc": "^3.5.5",
-    "karma": "^4.0.0",
+    "karma": "^4.0.1",
     "karma-browserify": "^5.3.0",
     "klaw-sync": "^6.0.0",
     "lint-staged": "^8.1.0",
@@ -155,7 +155,7 @@
     "videojs-generate-karma-config": "~5.0.0",
     "videojs-languages": "^2.0.0",
     "videojs-standard": "^8.0.2",
-    "watchify": "^3.11.0",
+    "watchify": "^3.11.1",
     "webpack": "^1.15.0"
   },
   "vjsstandard": {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -323,6 +323,7 @@ class Player extends Component {
     // don't auto mixin the evented mixin
     options.evented = false;
 
+    // options.baseUrl = '';
     // we don't want the player to report touch activity on itself
     // see enableTouchActivity in Component
     options.reportTouchActivity = false;
@@ -2976,7 +2977,7 @@ class Player extends Component {
     }
     // filter out invalid sources and turn our source into
     // an array of source objects
-    const sources = filterSource(source);
+    const sources = filterSource(source, this.options_.baseUrl);
 
     // if a source was passed in then it is invalid because
     // it was filtered to a zero length Array. So we have to
@@ -3165,6 +3166,13 @@ class Player extends Component {
    */
   currentSource() {
     return this.cache_.source || {};
+  }
+
+  baseUrl(url) {
+    if (typeof url === 'string' && url.length !== 0) {
+      this.options_.baseUrl = url;
+    }
+    return this.options_.baseUrl;
   }
 
   /**

--- a/src/js/utils/filter-source.js
+++ b/src/js/utils/filter-source.js
@@ -17,13 +17,14 @@ import {getMimetype} from './mimetypes';
  *
  * @private
  */
-const filterSource = function(src) {
+const filterSource = function(src, baseUrl) {
   // traverse array
+
   if (Array.isArray(src)) {
     let newsrc = [];
 
     src.forEach(function(srcobj) {
-      srcobj = filterSource(srcobj);
+      srcobj = filterSource(srcobj, baseUrl);
 
       if (Array.isArray(srcobj)) {
         newsrc = newsrc.concat(srcobj);
@@ -35,10 +36,10 @@ const filterSource = function(src) {
     src = newsrc;
   } else if (typeof src === 'string' && src.trim()) {
     // convert string into object
-    src = [fixSource({src})];
+    src = [fixSource({src}, baseUrl)];
   } else if (isObject(src) && typeof src.src === 'string' && src.src && src.src.trim()) {
     // src is already valid
-    src = [fixSource(src)];
+    src = [fixSource(src, baseUrl)];
   } else {
     // invalid source, turn it into an empty array
     src = [];
@@ -55,13 +56,14 @@ const filterSource = function(src) {
  * @return {Tech~SourceObject}
  *        src Object with known type
  */
-function fixSource(src) {
+function fixSource(src, baseUrl) {
   const mimetype = getMimetype(src.src);
 
   if (!src.type && mimetype) {
     src.type = mimetype;
   }
 
+  src.src = baseUrl + src.src;
   return src;
 }
 


### PR DESCRIPTION
## Description
This is an enhancement. I added a new option that allows media access for a relative URL.  this means by getting a directory listing, all the media can be played.  I did this so I could automate machine learning using OpenCV.  

## Specific Changes proposed
Added a new option baseUrl and a new method baseUrl([URL]).  
The argument URL is optional for setting the new URL. it always returns the URL. If baseUrl is not set it has no effect 

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [x ] If necessary, more likely in a feature request than a bug fix
  - [x ] Change has been verified in an actual browser (Chome, Firefox, IE)
     both chrome and Firefox
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
