### PR TITLE
fix: Remove `playerEvent` and extra `timeupdate` handler in SeekBar

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -81,7 +81,7 @@ class SeekBar extends Slider {
       this.clearInterval(this.updateInterval);
     });
 
-    this.on(this.player_, ['timeupdate', 'ended'], this.update);
+    this.on(this.player_, 'timeupdate', this.update);
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -53,6 +53,7 @@ class SeekBar extends Slider {
   setEventHandlers_() {
     this.update = Fn.throttle(Fn.bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
+    this.on(this.player_, 'timeupdate', this.update);
     this.on(this.player_, 'ended', this.handleEnded);
     this.on(this.player_, 'durationchange', this.update);
     if (this.player_.liveTracker) {
@@ -81,7 +82,6 @@ class SeekBar extends Slider {
       this.clearInterval(this.updateInterval);
     });
 
-    this.on(this.player_, 'timeupdate', this.update);
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -53,7 +53,6 @@ class SeekBar extends Slider {
   setEventHandlers_() {
     this.update = Fn.throttle(Fn.bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
-    this.on(this.player_, 'timeupdate', this.update);
     this.on(this.player_, 'ended', this.handleEnded);
     this.on(this.player_, 'durationchange', this.update);
     if (this.player_.liveTracker) {
@@ -427,13 +426,6 @@ SeekBar.prototype.options_ = {
 if (!IS_IOS && !IS_ANDROID) {
   SeekBar.prototype.options_.children.splice(1, 0, 'mouseTimeDisplay');
 }
-
-/**
- * Call the update event for this Slider when this event happens on the player.
- *
- * @type {string}
- */
-SeekBar.prototype.playerEvent = 'timeupdate';
 
 Component.registerComponent('SeekBar', SeekBar);
 export default SeekBar;


### PR DESCRIPTION
## Description
SeekBar ends up adding two extra `timeupdate` handlers for the `update` function.
1. One is added in `Slider` via the `playerEvent` on `SeekBar`s prototype. This one may be worse because it will be added on the original update function before we throttle it.
2. The other is just added in `setEventHandlers_`.