### PR TITLE
fix: trigger dispose on resize manager

### DIFF
--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -109,7 +109,6 @@ class ResizeManager extends Component {
   }
 
   dispose() {
-    this.trigger('dispose');
     if (this.debouncedHandler_) {
       this.debouncedHandler_.cancel();
     }
@@ -133,6 +132,7 @@ class ResizeManager extends Component {
     this.resizeObserver = null;
     this.debouncedHandler_ = null;
     this.loadListener_ = null;
+    super.dispose();
   }
 
 }

--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -109,6 +109,7 @@ class ResizeManager extends Component {
   }
 
   dispose() {
+    this.trigger('dispose');
     if (this.debouncedHandler_) {
       this.debouncedHandler_.cancel();
     }

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -431,7 +431,7 @@ export function trigger(elem, event, hash) {
     trigger.call(null, parent, event, hash);
 
   // If at the top of the DOM, triggers the default action unless disabled.
-  } else if (!parent && !event.defaultPrevented) {
+  } else if (!parent && !event.defaultPrevented && event.target && event.target[event.type]) {
     const targetData = DomData.getData(event.target);
 
     // Checks if the target has a default action for this event.

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -431,7 +431,7 @@ export function trigger(elem, event, hash) {
     trigger.call(null, parent, event, hash);
 
   // If at the top of the DOM, triggers the default action unless disabled.
-  } else if (!parent && !event.defaultPrevented && event.target && event.target[event.type]) {
+  } else if (!parent && !event.defaultPrevented) {
     const targetData = DomData.getData(event.target);
 
     // Checks if the target has a default action for this event.


### PR DESCRIPTION
Right now we leak one event handler in DomData on every player dispose. Funnily enough we are leaking a dispose event handler from the evented mixin: https://github.com/videojs/video.js/blob/master/src/js/mixins/evented.js#L395