### PR TITLE
Fix BPB announcement and operation on Chrome with JAWS screen reader

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -15,7 +15,7 @@ import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import {IE_VERSION} from './utils/browser.js';
+import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
 import toTitleCase, { titleCaseEquals } from './utils/to-title-case.js';
 import { createTimeRange } from './utils/time-ranges.js';
@@ -636,11 +636,12 @@ class Player extends Component {
     tag.setAttribute('tabindex', '-1');
     attrs.tabindex = '-1';
 
-    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button)
+    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button), and
+    // for the same issue with Chrome (on Windows) with JAWS.
     // See https://github.com/FreedomScientific/VFO-standards-support/issues/78
     // Note that we can't detect if JAWS is being used, but this ARIA attribute
-    //  doesn't change behavior of IE11 if JAWS is not being used
-    if (IE_VERSION) {
+    //  doesn't change behavior of IE11 or Chrome if JAWS is not being used
+    if (IE_VERSION || (IS_CHROME && IS_WINDOWS)) {
       tag.setAttribute('role', 'application');
       attrs.role = 'application';
     }

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -193,6 +193,15 @@ export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDRO
 export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;
 
 /**
+ * Whether or not this is a Windows machine.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+export const IS_WINDOWS = (/Windows/i).test(USER_AGENT);
+
+/**
  * Whether or not this device is touch-enabled.
  *
  * @static


### PR DESCRIPTION
## Description

Similar to #5173, this PR adds role='application' to the video element on Chrome on Windows, to work around a JAWS screen reader bug (see https://github.com/FreedomScientific/VFO-standards-support/issues/78). We only add the ARIA attribute on Chrome _on Windows_ to avoid having any impact on Chrome on other platforms (macOS, iOS, Android, etc.)

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome on Windows with JAWS, and with NVDA to ensure that it doesn't introduce a problem with NVDA)
- [ ] Reviewed by Two Core Contributors
