### PR TITLE
fix: turn off all track list listeners on dispose

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -583,6 +583,16 @@ class Player extends Component {
 
     middleware.clearCacheForPlayer(this);
 
+    // remove all event handlers for track lists
+    // all tracks and track listeners are removed on
+    // tech dispose
+    TRACK_TYPES.names.forEach((name) => {
+      const props = TRACK_TYPES[name];
+      const list = this[props.getterName]();
+
+      list.off();
+    });
+
     // the actual .el_ is removed here
     super.dispose();
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -592,7 +592,7 @@ class Player extends Component {
 
       // if it is not a native list
       // we have to manually remove event listeners
-      if (list.off) {
+      if (list && list.off) {
         list.off();
       }
     });

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -590,7 +590,11 @@ class Player extends Component {
       const props = TRACK_TYPES[name];
       const list = this[props.getterName]();
 
-      list.off();
+      // if it is not a native list
+      // we have to manually remove event listeners
+      if (list.off) {
+        list.off();
+      }
     });
 
     // the actual .el_ is removed here


### PR DESCRIPTION
## Description
Call `off` on `TrackList`s when the player is disposed so that we don't leak memory via `DomData.elData`
