### PR TITLE
fix: use ownerDocument.body.contains for IE11

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -142,13 +142,13 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
-  // document.contains(el) will only check if el is contained within that one document.
+  // document.body.contains(el) will only check if el is contained within that one document.
   // This causes problems for elements in iframes.
   // Instead, use the element's ownerDocument instead of the global document.
   // This will make sure that the element is indeed in the dom of that document.
   // Additionally, check that the document in question has a default view.
   // If the document is no longer attached to the dom, the defaultView of the document will be null.
-  if (!el.ownerDocument.defaultView || !el.ownerDocument.contains(el)) {
+  if (!el.ownerDocument.defaultView || !el.ownerDocument.body.contains(el)) {
     log.warn('The element supplied is not included in the DOM');
   }
 


### PR DESCRIPTION
PR #5831 made the not-in-DOM warning work with elements from other
documents. This works in modern browsers but IE11 doesn't include a
contains method on the document. Instead, we should check to see if the
body contains the element.