### PR TITLE
feat: respect preload none

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3038,16 +3038,19 @@ class Player extends Component {
     this.cache_.sources = sources;
     this.updateSourceCaches_(sources[0]);
 
+    // clear any previous src call that is waiting for `playcalled`
     if (this.srcAfterPlayCalled_) {
       this.off('playcalled', this.srcAfterPlayCalled_);
     }
 
+    // if preload is none, there is no autoplay, and play has not been called
     if (!this.playCalled() && this.preload() === 'none' && !this.autoplay()) {
       this.srcAfterPlayCalled_ = () => this.src(source);
       this.one('playcalled', this.srcAfterPlayCalled_);
       return;
     }
 
+    // reset play called to false now that we are past the loop
     this.playCalled(false);
 
     // middlewareSource is the source after it has been changed by middleware


### PR DESCRIPTION
> I am not sure this pull request is the correct way to accomplish this, but I want to get a discussion started. 

## Description
Currently we attempt to set the source right away, regardless of the preload option. This seems like it goes against `preload` `none` to me. The browser itself does appear to set the source, but it cancels any pending source request if it detects that we have `preload` set to  `none`. On our end we can't really do that as there isn't a way for middleware to postpone source setting until the user wants to play, without doing crazy things like overriding the players `play` function. The way I see it we have two options to handle this.

Below I have two options laid out, personally I think option 1 is better, because it lets us delay more than just middleware source setting.

### Option 1
Do it in Video.js similar to how it is done here

### Option 2
Do something to allow middleware to postpone source setting until a play:
1. Add a new `playcalled` event that will trigger on tech play, or when `Player#play()` is called
2. Add a new `playCalled` getter to `Player` that is set to true when `playcalled` triggers
3. Make sure that we reset `playCalled` to `false` before going through middleware sourceset.
4. probably add a helper function to make this easier. 

This will allow middleware to delay `sourcesetting` until a `playcalled` event and even when it gets delayed, as long as the `playcalled` getter is respected downstream middleware will still set their source. 


Example:
```js
/**
 * preferably we would provide this on videojs.middleware
 * Returns true if we will delay, false otherwise
 */
const delayForPreloadNone = videojs.middleware.delayForPreloadNone = function(player, cb) {
  // respect preload none and delay until play is called
  if (player.playCalled() || player.preload() !== 'none' || player.autoplay()) {
    return false;
  }

  // turn off previous delay function as a new src call happened
  if (this.delayForPreloadNone_) {
    player.off('playcalled', this.delayForPreloadNone_);
  }

  this.delayForPreloadNone_ = () => {
    this.delayForPreloadNone_ = null;
    cb();
  };
  player.one('playcalled', this.delayForPreloadNone_);
  return true;
};

videojs.use('content/vmap', (player) => ({
  setSource(source, next) {

    if (delayForPreloadNone.call(this, () => this.setSource(source, next))) {
      return;
    }

    /**
     * for this demo:
     * 1. assume the the content/vmap is handled
     * 2. we find that the type and source should now be content/m3u8
     */
    next(source, next);
  }
}));

videojs.use('content/m3u8', (player) => ({
  setSource(source, next) {

    /**
     * In this case this middleware is downstream from
     * content/vmap middleware. So we will only ever get here
     * when `player.playCalled()` is true. But if a `content/m3u8`
     * were passed in we would delay just like in `content/vmap`
     */
    if (delayForPreloadNone.call(this, () => this.setSource(source, next))) {
      return;
    }

    next(source, next);
  }
}));
```