### PR TITLE
fix: Correctly resolve play on middleware terminate

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -416,6 +416,10 @@ class Player extends Component {
     tag.controls = false;
     tag.removeAttribute('controls');
 
+    this.changingSrc_ = false;
+    this.playCallbacks_ = [];
+    this.playTerminatedQueue_ = [];
+
     // the attribute overrides the option
     if (tag.hasAttribute('autoplay')) {
       this.autoplay(true);
@@ -530,9 +534,6 @@ class Player extends Component {
     this.breakpoints(this.options_.breakpoints);
     this.responsive(this.options_.responsive);
 
-    this.changingSrc_ = false;
-    this.playCallbacks_ = [];
-    this.playTerminatedQueue_ = [];
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1371,7 +1371,7 @@ class Player extends Component {
       promise = this.play();
 
       if (isPromise(promise)) {
-        promise.catch(muted);
+        promise = promise.catch(muted);
       }
     } else if (type === 'muted' && this.muted() !== true) {
       promise = muted();
@@ -3306,7 +3306,7 @@ class Player extends Component {
       this.options_.autoplay = true;
     }
 
-    techAutoplay = techAutoplay || this.options_.autoplay;
+    techAutoplay = typeof techAutoplay === 'undefined' ? this.options_.autoplay : techAutoplay;
 
     // if we don't have a tech then we do not queue up
     // a setAutoplay call on tech ready. We do this because the

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2213,6 +2213,7 @@ class Player extends Component {
 
     const isSrcReady = Boolean(!this.changingSrc_ && (this.src() || this.currentSrc()));
 
+    // treat calls to play_ somewhat like the `one` event function
     if (this.waitToPlay_) {
       this.off(['ready', 'loadstart'], this.waitToPlay_);
       this.waitToPlay_ = null;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2233,7 +2233,8 @@ class Player extends Component {
     // If the player/tech is ready and we have a source, we can attempt playback.
     const val = this.techGet_('play');
 
-    if (val === middleware.TERMINATOR) {
+    // play was terminated if the returned value is null
+    if (val === null) {
       this.trigger('play-terminated');
     } else {
       this.runPlayCallbacks_(val);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -532,7 +532,7 @@ class Player extends Component {
 
     this.changingSrc_ = false;
     this.waitForPlay_ = false;
-    this.playSuccessCallbacks_ = [];
+    this.playCallbacks_ = [];
   }
 
   /**
@@ -2209,7 +2209,7 @@ class Player extends Component {
    *        The callback that should be called when the techs play is actually called
    */
   play_(callback = silencePromise) {
-    this.playSuccessCallbacks_.push(callback);
+    this.playCallbacks_.push(callback);
 
     const isSrcReady = Boolean(!this.changingSrc_ && (this.src() || this.currentSrc()));
 
@@ -2241,7 +2241,7 @@ class Player extends Component {
     if (val === middleware.TERMINATOR) {
       this.trigger('play-terminated');
     } else {
-      this.runPlaySuccessCallbacks_(val);
+      this.runPlayCallbacks_(val);
     }
   }
 
@@ -2254,10 +2254,10 @@ class Player extends Component {
    * @param {undefined|Promise} val
    *        The return value from the tech.
    */
-  runPlaySuccessCallbacks_(val) {
-    const callbacks = this.playSuccessCallbacks_.slice(0);
+  runPlayCallbacks_(val) {
+    const callbacks = this.playCallbacks_.slice(0);
 
-    this.playSuccessCallbacks_ = [];
+    this.playCallbacks_ = [];
 
     callbacks.forEach(function(cb) {
       cb(val);

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -5,7 +5,7 @@
 import { assign } from '../utils/obj.js';
 import toTitleCase from '../utils/to-title-case.js';
 
-const middlewares = {};
+export const middlewares = {};
 const middlewareInstances = {};
 
 export const TERMINATOR = {};
@@ -166,7 +166,7 @@ export function mediate(middleware, tech, method, arg = null) {
   const callMethod = 'call' + toTitleCase(method);
   const middlewareValue = middleware.reduce(middlewareIterator(callMethod), arg);
   const terminated = middlewareValue === TERMINATOR;
-  const returnValue = terminated ? null : tech[method](middlewareValue);
+  const returnValue = terminated ? TERMINATOR : tech[method](middlewareValue);
 
   executeRight(middleware, method, returnValue, terminated);
 

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -5,7 +5,7 @@
 import { assign } from '../utils/obj.js';
 import toTitleCase from '../utils/to-title-case.js';
 
-export const middlewares = {};
+const middlewares = {};
 const middlewareInstances = {};
 
 export const TERMINATOR = {};

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -166,7 +166,9 @@ export function mediate(middleware, tech, method, arg = null) {
   const callMethod = 'call' + toTitleCase(method);
   const middlewareValue = middleware.reduce(middlewareIterator(callMethod), arg);
   const terminated = middlewareValue === TERMINATOR;
-  const returnValue = terminated ? TERMINATOR : tech[method](middlewareValue);
+  // deprecated. The `null` return value should instead return TERMINATOR to
+  // prevent confusion if a techs method actually returns null.
+  const returnValue = terminated ? null : tech[method](middlewareValue);
 
   executeRight(middleware, method, returnValue, terminated);
 

--- a/test/unit/autoplay.test.js
+++ b/test/unit/autoplay.test.js
@@ -170,7 +170,7 @@ QUnit.test('option = null, should be set to false no play/muted', function(asser
   assert.equal(this.counts.failure, 0, 'failure count');
 });
 
-QUnit.test('options = "play" play, no muted', function(assert) {
+QUnit.test('option = "play" play, no muted', function(assert) {
   this.createPlayer({autoplay: 'play'}, {}, this.resolvePromise);
 
   assert.equal(this.player.autoplay(), 'play', 'player.autoplay getter');

--- a/test/unit/autoplay.test.js
+++ b/test/unit/autoplay.test.js
@@ -3,6 +3,7 @@ import Player from '../../src/js/player.js';
 import videojs from '../../src/js/video.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
+import window from 'global/window';
 import sinon from 'sinon';
 
 QUnit.module('autoplay', {
@@ -21,7 +22,9 @@ QUnit.module('autoplay', {
 
     this.counts = {
       play: 0,
-      muted: 0
+      muted: 0,
+      success: 0,
+      failure: 0
     };
 
     fixture.appendChild(videoTag);
@@ -38,6 +41,16 @@ QUnit.module('autoplay', {
       }
     };
 
+    this.resolvePromise = {
+      then(fn) {
+        fn();
+        return this;
+      },
+      catch(fn) {
+        return this;
+      }
+    };
+
     this.createPlayer = (options = {}, attributes = {}, playRetval = null) => {
       Object.keys(attributes).forEach((a) => {
         videoTag.setAttribute(a, attributes[a]);
@@ -49,19 +62,25 @@ QUnit.module('autoplay', {
       this.player.play = () => {
         this.counts.play++;
 
-        if (playRetval) {
-          return playRetval;
+        if (playRetval || this.playRetval) {
+          return playRetval || this.playRetval;
         }
       };
+
+      this.mutedValue = this.player.muted();
 
       this.player.muted = (v) => {
 
         if (typeof v !== 'undefined') {
           this.counts.muted++;
+          this.mutedValue = v;
         }
 
         return oldMuted.call(this.player, v);
       };
+
+      this.player.on('autoplay-success', () => this.counts.success++);
+      this.player.on('autoplay-failure', () => this.counts.failure++);
 
       // we have to trigger ready so that we
       // are waiting for loadstart
@@ -84,10 +103,14 @@ QUnit.test('option = false no play/muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = true no play/muted', function(assert) {
@@ -99,10 +122,14 @@ QUnit.test('option = true no play/muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "random" no play/muted', function(assert) {
@@ -114,10 +141,14 @@ QUnit.test('option = "random" no play/muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = null, should be set to false no play/muted', function(assert) {
@@ -129,14 +160,18 @@ QUnit.test('option = null, should be set to false no play/muted', function(asser
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('options = "play" play, no muted', function(assert) {
-  this.createPlayer({autoplay: 'play'});
+  this.createPlayer({autoplay: 'play'}, {}, this.resolvePromise);
 
   assert.equal(this.player.autoplay(), 'play', 'player.autoplay getter');
   assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
@@ -144,14 +179,18 @@ QUnit.test('options = "play" play, no muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 2, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "any" play, no muted', function(assert) {
-  this.createPlayer({autoplay: 'any'});
+  this.createPlayer({autoplay: 'any'}, {}, this.resolvePromise);
 
   assert.equal(this.player.autoplay(), 'any', 'player.autoplay getter');
   assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
@@ -159,14 +198,18 @@ QUnit.test('option = "any" play, no muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 2, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "muted" play and muted', function(assert) {
-  this.createPlayer({autoplay: 'muted'});
+  this.createPlayer({autoplay: 'muted'}, {}, this.resolvePromise);
 
   assert.equal(this.player.autoplay(), 'muted', 'player.autoplay getter');
   assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
@@ -174,10 +217,14 @@ QUnit.test('option = "muted" play and muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 1, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.counts.success, 2, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "play" play, no muted, rejection ignored', function(assert) {
@@ -189,10 +236,14 @@ QUnit.test('option = "play" play, no muted, rejection ignored', function(assert)
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 1, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 2, 'failure count');
 });
 
 QUnit.test('option = "any" play, no muted, rejection leads to muted then play', function(assert) {
@@ -205,10 +256,14 @@ QUnit.test('option = "any" play, no muted, rejection leads to muted then play', 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 1, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 4, 'play count');
   assert.equal(this.counts.muted, 4, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 2, 'failure count');
 });
 
 QUnit.test('option = "muted" play and muted, rejection ignored', function(assert) {
@@ -221,10 +276,14 @@ QUnit.test('option = "muted" play and muted, rejection ignored', function(assert
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 1, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 4, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 2, 'failure count');
 });
 
 QUnit.test('option = "muted", attr = true, play and muted', function(assert) {
@@ -236,10 +295,14 @@ QUnit.test('option = "muted", attr = true, play and muted', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "play", attr = true, play only', function(assert) {
@@ -251,10 +314,14 @@ QUnit.test('option = "play", attr = true, play only', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });
 
 QUnit.test('option = "any", attr = true, play only', function(assert) {
@@ -266,8 +333,116 @@ QUnit.test('option = "any", attr = true, play only', function(assert) {
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 
   this.player.tech_.trigger('loadstart');
   assert.equal(this.counts.play, 0, 'play count');
   assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+});
+
+QUnit.test('option = "any", play terminated restores muted', function(assert) {
+  this.createPlayer({autoplay: 'any'});
+
+  this.playRetval = {
+    then(fn) {
+      fn();
+      return this;
+    },
+    catch: (fn) => {
+      assert.equal(this.counts.play, 1, 'play count');
+      assert.equal(this.counts.muted, 0, 'muted count');
+      assert.equal(this.counts.success, 0, 'success count');
+      assert.equal(this.counts.failure, 0, 'failure count');
+
+      this.playRetval = {
+        then(_fn) {
+          window.setTimeout(_fn, 1);
+          return this;
+        },
+        catch(_fn) {
+          return this;
+        }
+      };
+      const retval = fn();
+
+      assert.equal(this.counts.play, 2, 'play count');
+      assert.equal(this.counts.muted, 1, 'muted count');
+      assert.equal(this.mutedValue, true, 'is muted');
+      assert.equal(this.counts.success, 0, 'success count');
+      assert.equal(this.counts.failure, 0, 'failure count');
+
+      return retval;
+    }
+  };
+
+  assert.equal(this.player.autoplay(), 'any', 'player.autoplay getter');
+  assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
+  assert.equal(this.mutedValue, false, 'is not muted');
+
+  this.player.tech_.trigger('loadstart');
+
+  this.player.trigger('play-terminated');
+
+  assert.equal(this.counts.play, 2, 'play count');
+  assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.mutedValue, false, 'is not muted');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+
+  this.player.trigger('play-terminated');
+
+  assert.equal(this.counts.play, 2, 'play count');
+  assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.mutedValue, false, 'is not muted');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+
+  // verify autoplay success
+  this.clock.tick(1);
+  assert.equal(this.counts.play, 2, 'play count');
+  assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+});
+
+QUnit.test('option = "muted", play terminated restores muted', function(assert) {
+  this.createPlayer({autoplay: 'muted'}, {}, {
+    then(fn) {
+      window.setTimeout(() => {
+        fn();
+      }, 1);
+      return this;
+    },
+    catch(fn) {
+      return this;
+    }
+  });
+
+  assert.equal(this.player.autoplay(), 'muted', 'player.autoplay getter');
+  assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
+
+  this.player.tech_.trigger('loadstart');
+
+  assert.equal(this.counts.play, 1, 'play count');
+  assert.equal(this.counts.muted, 1, 'muted count');
+  assert.equal(this.mutedValue, true, 'is muted');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+
+  this.player.trigger('play-terminated');
+  assert.equal(this.counts.play, 1, 'play count');
+  assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.mutedValue, false, 'no longer muted');
+  assert.equal(this.counts.success, 0, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+
+  // verify autoplay success
+  this.clock.tick(1);
+  assert.equal(this.counts.play, 1, 'play count');
+  assert.equal(this.counts.muted, 2, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
 });

--- a/test/unit/autoplay.test.js
+++ b/test/unit/autoplay.test.js
@@ -384,7 +384,7 @@ QUnit.test('option = "any", play terminated restores muted', function(assert) {
 
   this.player.tech_.trigger('loadstart');
 
-  this.player.trigger('play-terminated');
+  this.player.runPlayTerminatedQueue_();
 
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
@@ -392,7 +392,7 @@ QUnit.test('option = "any", play terminated restores muted', function(assert) {
   assert.equal(this.counts.success, 0, 'success count');
   assert.equal(this.counts.failure, 0, 'failure count');
 
-  this.player.trigger('play-terminated');
+  this.player.runPlayTerminatedQueue_();
 
   assert.equal(this.counts.play, 2, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
@@ -432,7 +432,7 @@ QUnit.test('option = "muted", play terminated restores muted', function(assert) 
   assert.equal(this.counts.success, 0, 'success count');
   assert.equal(this.counts.failure, 0, 'failure count');
 
-  this.player.trigger('play-terminated');
+  this.player.runPlayTerminatedQueue_();
   assert.equal(this.counts.play, 1, 'play count');
   assert.equal(this.counts.muted, 2, 'muted count');
   assert.equal(this.mutedValue, false, 'no longer muted');

--- a/test/unit/play.test.js
+++ b/test/unit/play.test.js
@@ -12,6 +12,7 @@ const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
   subhooks.beforeEach(function(assert) {
     this.clock = sinon.useFakeTimers();
     this.techPlayCalls = 0;
+    this.playsTerminated = 0;
     this.playTests = [];
     this.terminate = false;
 
@@ -75,10 +76,11 @@ const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
       assert.deepEqual(currentState, expectedState, assertName);
     };
 
+    this.playTerminatedQueue = () => this.playsTerminated++;
+
     this.playTest = (assertName, options = {}) => {
-      if (this.player && typeof this.playsTerminated !== 'number') {
-        this.playsTerminated = 0;
-        this.player.on('play-terminated', () => this.playsTerminated++);
+      if (this.player.playTerminatedQueue_ !== this.playTerminatedQueue) {
+        this.player.runPlayTerminatedQueue_ = this.playTerminatedQueue;
       }
       if (this.player && this.player.tech_ && this.player.tech_.play !== this.techPlay) {
         this.player.tech_.play = this.techPlay;

--- a/test/unit/play.test.js
+++ b/test/unit/play.test.js
@@ -87,7 +87,7 @@ const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
       this.checkState(assertName, options);
     };
 
-    middleware.use('*', () => {
+    this.middleware = () => {
       return {
         // pass along source
         setSource(srcObj, next) {
@@ -99,14 +99,20 @@ const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
           }
         }
       };
-    });
+    };
+
+    middleware.use('*', this.middleware);
   });
 
   subhooks.afterEach(function() {
     // remove added middleware
-    Object.keys(middleware.middlewares).forEach(function(k) {
-      delete middleware.middlewares[k];
-    });
+    const middlewareList = middleware.getMiddleware('*');
+
+    for (let i = 0; i < middlewareList.length; i++) {
+      if (middlewareList[i] === this.middleware) {
+        middlewareList.splice(i, 1);
+      }
+    }
     if (this.player) {
       this.player.dispose();
     }

--- a/test/unit/play.test.js
+++ b/test/unit/play.test.js
@@ -6,11 +6,7 @@ import * as middleware from '../../src/js/tech/middleware.js';
 import videojs from '../../src/js/video.js';
 
 const middleWareTerminations = ['terminates', 'does not-terminate'];
-const playReturnValues = ['non-promise'];
-
-if (window.Promise) {
-  playReturnValues.push('promise');
-}
+const playReturnValues = ['non-promise', 'promise'];
 
 const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
   subhooks.beforeEach(function(assert) {

--- a/test/unit/play.test.js
+++ b/test/unit/play.test.js
@@ -1,0 +1,442 @@
+/* eslint-env qunit */
+import TestHelpers from './test-helpers.js';
+import sinon from 'sinon';
+import window from 'global/window';
+import * as middleware from '../../src/js/tech/middleware.js';
+import videojs from '../../src/js/video.js';
+
+const middleWareTerminations = ['terminates', 'does not-terminate'];
+const playReturnValues = ['non-promise'];
+
+if (window.Promise) {
+  playReturnValues.push('promise');
+}
+
+const mainModule = function(playReturnValue, middlewareTermination, subhooks) {
+  subhooks.beforeEach(function(assert) {
+    this.clock = sinon.useFakeTimers();
+    this.techPlayCalls = 0;
+    this.playTests = [];
+    this.terminate = false;
+
+    if (middlewareTermination === 'terminates') {
+      this.terminate = true;
+    }
+    this.techPlay = () => {
+      this.techPlayCalls++;
+
+      if (playReturnValue === 'promise') {
+        return window.Promise.resolve('foo');
+      }
+      return 'foo';
+    };
+
+    this.finish = function() {
+      const done = assert.async(this.playTests.length);
+
+      const singleFinish = (playValue, assertName) => {
+        assert.equal(playValue, 'foo', `play call from - ${assertName} - is correct`);
+        done();
+      };
+
+      this.playTests.forEach(function(test) {
+        const playRetval = test.playRetval;
+        const testName = test.assertName;
+
+        if (typeof playRetval === 'string') {
+          singleFinish(playRetval, testName);
+        } else {
+          playRetval.then((v) => {
+            singleFinish(v, testName);
+          });
+        }
+      });
+    };
+
+    this.checkState = (assertName, options = {}) => {
+      const expectedState = videojs.mergeOptions({
+        playCalls: 0,
+        techLoaded: false,
+        techReady: false,
+        playerReady: false,
+        changingSrc: false,
+        playsTerminated: 0
+      }, options);
+
+      if (typeof options.techLoaded === 'undefined' && typeof options.techReady !== 'undefined') {
+        expectedState.techLoaded = options.techReady;
+      }
+
+      const currentState = {
+        playCalls: this.techPlayCalls,
+        techLoaded: Boolean(this.player.tech_),
+        techReady: Boolean((this.player.tech_ || {}).isReady_),
+        playerReady: Boolean(this.player.isReady_),
+        changingSrc: Boolean(this.player.changingSrc_),
+        playsTerminated: Number(this.playsTerminated)
+      };
+
+      assert.deepEqual(currentState, expectedState, assertName);
+    };
+
+    this.playTest = (assertName, options = {}) => {
+      if (this.player && typeof this.playsTerminated !== 'number') {
+        this.playsTerminated = 0;
+        this.player.on('play-terminated', () => this.playsTerminated++);
+      }
+      if (this.player && this.player.tech_ && this.player.tech_.play !== this.techPlay) {
+        this.player.tech_.play = this.techPlay;
+      }
+      this.playTests.push({assertName, playRetval: this.player.play()});
+      this.checkState(assertName, options);
+    };
+
+    middleware.use('*', () => {
+      return {
+        // pass along source
+        setSource(srcObj, next) {
+          next(null, srcObj);
+        },
+        callPlay: () => {
+          if (this.terminate) {
+            return middleware.TERMINATOR;
+          }
+        }
+      };
+    });
+  });
+
+  subhooks.afterEach(function() {
+    // remove added middleware
+    Object.keys(middleware.middlewares).forEach(function(k) {
+      delete middleware.middlewares[k];
+    });
+    if (this.player) {
+      this.player.dispose();
+    }
+    this.clock.restore();
+  });
+
+  QUnit.test('Player#play() resolves correctly with dom sources and async tech ready', function(assert) {
+    // turn of mediaLoader to prevent setting a tech right away
+    // similar to settings sources in the DOM
+    // turn off autoReady to prevent syncronous ready from the tech
+    this.player = TestHelpers.makePlayer({mediaLoader: false, techFaker: {autoReady: false}});
+
+    this.playTest('before anything is ready');
+
+    this.player.src({
+      src: 'http://example.com/video.mp4',
+      type: 'video/mp4'
+    });
+
+    this.playTest('only changingSrc', {
+      changingSrc: true
+    });
+
+    this.clock.tick(1);
+
+    this.playTest('still changingSrc, tech loaded', {
+      techLoaded: true,
+      changingSrc: true
+    });
+
+    this.player.tech_.triggerReady();
+    this.playTest('still changingSrc, tech loaded and ready', {
+      techReady: true,
+      changingSrc: true
+    });
+    this.clock.tick(1);
+
+    this.playTest('done changingSrc, tech/player ready', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.clock.tick(1);
+
+    this.checkState('state stays the same', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.playTest('future calls hit tech#play directly, unless terminated', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 2,
+      playsTerminated: this.terminate ? 2 : 0
+    });
+
+    if (this.terminate) {
+      this.terminate = false;
+
+      this.playTest('play works if not terminated', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 1,
+        playsTerminated: 2
+      });
+
+      this.playTest('future calls hit tech#play directly', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 2,
+        playsTerminated: 2
+      });
+    }
+
+    this.finish(assert);
+  });
+
+  QUnit.test('Player#play() resolves correctly with dom sources', function(assert) {
+    this.player = TestHelpers.makePlayer({mediaLoader: false});
+
+    this.playTest('before anything is ready');
+
+    this.player.src({
+      src: 'http://example.com/video.mp4',
+      type: 'video/mp4'
+    });
+
+    this.playTest('only changingSrc', {
+      changingSrc: true
+    });
+
+    this.clock.tick(1);
+
+    this.playTest('still changingSrc, tech/player ready', {
+      techLoaded: true,
+      changingSrc: true,
+      playerReady: true,
+      techReady: true
+    });
+
+    this.clock.tick(1);
+
+    this.playTest('done changingSrc, tech#play is called', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.clock.tick(1);
+
+    this.checkState('state stays the same', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.playTest('future calls hit tech#play directly', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 2,
+      playsTerminated: this.terminate ? 2 : 0
+    });
+
+    if (this.terminate) {
+      this.terminate = false;
+
+      this.playTest('play works if not terminated', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 1,
+        playsTerminated: 2
+      });
+
+      this.playTest('future calls hit tech#play directly', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 2,
+        playsTerminated: 2
+      });
+    }
+
+    this.finish(assert);
+  });
+
+  QUnit.test('Player#play() resolves correctly with async tech ready', function(assert) {
+    this.player = TestHelpers.makePlayer({techFaker: {autoReady: false}});
+
+    this.playTest('before anything is ready', {
+      techLoaded: true
+    });
+
+    this.player.src({
+      src: 'http://example.com/video.mp4',
+      type: 'video/mp4'
+    });
+
+    this.playTest('tech loaded changingSrc', {
+      techLoaded: true,
+      changingSrc: true
+    });
+
+    this.clock.tick(1);
+
+    this.playTest('still changingSrc, tech loaded', {
+      techLoaded: true,
+      changingSrc: true
+    });
+
+    this.clock.tick(1);
+    this.playTest('still changingSrc, tech loaded again', {
+      techLoaded: true,
+      changingSrc: true
+    });
+
+    this.player.tech_.triggerReady();
+    this.playTest('still changingSrc, tech loaded and ready', {
+      techReady: true,
+      changingSrc: true
+    });
+    this.clock.tick(1);
+
+    this.playTest('still changingSrc tech/player ready', {
+      changingSrc: true,
+      playerReady: true,
+      techReady: true
+    });
+
+    // player ready calls fire now
+    // which sets changingSrc_ to false
+    this.clock.tick(1);
+
+    this.checkState('play was called on ready', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.playTest('future calls hit tech#play directly', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 2,
+      playsTerminated: this.terminate ? 2 : 0
+    });
+
+    if (this.terminate) {
+      this.terminate = false;
+
+      this.playTest('play works if not terminated', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 1,
+        playsTerminated: 2
+      });
+
+      this.playTest('future calls hit tech#play directly', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 2,
+        playsTerminated: 2
+      });
+    }
+
+    this.finish(assert);
+  });
+
+  QUnit.test('Player#play() resolves correctly', function(assert) {
+    this.player = TestHelpers.makePlayer();
+
+    this.playTest('player/tech start out ready', {
+      techReady: true,
+      playerReady: true
+    });
+
+    this.player.src({
+      src: 'http://example.com/video.mp4',
+      type: 'video/mp4'
+    });
+
+    this.playTest('now changingSrc', {
+      techReady: true,
+      playerReady: true,
+      changingSrc: true
+    });
+
+    this.clock.tick(1);
+
+    this.playTest('done changingSrc, play called if not terminated', {
+      techReady: true,
+      playerReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.clock.tick(2);
+
+    this.checkState('state stays the same', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 1,
+      playsTerminated: this.terminate ? 1 : 0
+    });
+
+    this.playTest('future calls hit tech#play directly', {
+      playerReady: true,
+      techReady: true,
+      playCalls: this.terminate ? 0 : 2,
+      playsTerminated: this.terminate ? 2 : 0
+    });
+
+    if (this.terminate) {
+      this.terminate = false;
+
+      this.playTest('play works if not terminated', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 1,
+        playsTerminated: 2
+      });
+
+      this.playTest('future calls hit tech#play directly', {
+        playerReady: true,
+        techReady: true,
+        playCalls: 2,
+        playsTerminated: 2
+      });
+    }
+
+    this.finish(assert);
+  });
+
+  // without enableSourceset this test will fail.
+  QUnit.test('Player#play() resolves correctly on tech el src', function(assert) {
+    this.player = TestHelpers.makePlayer({techOrder: ['html5'], enableSourceset: true}, null, false);
+
+    this.playTest('player/tech start out ready', {
+      techReady: true,
+      playerReady: true
+    });
+
+    this.player.tech_.el_.src = 'http://vjs.zencdn.net/v/oceans.mp4';
+
+    this.player.on('loadstart', () => {
+      this.checkState('play should have been called', {
+        techReady: true,
+        playerReady: true,
+        playCalls: 1
+      });
+    });
+
+    this.finish(assert);
+  });
+};
+
+QUnit.module('Player#play()', (hooks) => {
+  playReturnValues.forEach((playReturnValue) => {
+    middleWareTerminations.forEach((middlewareTermination) => {
+      QUnit.module(`tech#play() => ${playReturnValue}, middleware ${middlewareTermination}`, (subhooks) => {
+        mainModule(playReturnValue, middlewareTermination, subhooks);
+      });
+    });
+  });
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1174,60 +1174,6 @@ QUnit.test('should be scrubbing while seeking', function(assert) {
   player.dispose();
 });
 
-if (window.Promise) {
-  QUnit.test('play promise should resolve to native promise if returned', function(assert) {
-    const player = TestHelpers.makePlayer({});
-    const done = assert.async();
-
-    player.src({
-      src: 'http://example.com/video.mp4',
-      type: 'video/mp4'
-    });
-
-    this.clock.tick(1);
-
-    player.tech_.play = () => window.Promise.resolve('foo');
-    const p = player.play();
-
-    assert.ok(p, 'play returns something');
-    assert.equal(typeof p.then, 'function', 'play returns a promise');
-    p.then(function(val) {
-      assert.equal(val, 'foo', 'should resolve to native promise value');
-
-      player.dispose();
-      done();
-    });
-  });
-}
-
-QUnit.test('play promise should resolve to native value if returned', function(assert) {
-  const done = assert.async();
-  const player = TestHelpers.makePlayer({});
-
-  player.src({
-    src: 'http://example.com/video.mp4',
-    type: 'video/mp4'
-  });
-
-  this.clock.tick(1);
-
-  player.tech_.play = () => 'foo';
-  const p = player.play();
-
-  const finish = (v) => {
-    assert.equal(v, 'foo', 'play returns foo');
-    done();
-  };
-
-  if (typeof p === 'string') {
-    finish(p);
-  } else {
-    p.then((v) => {
-      finish(v);
-    });
-  }
-});
-
 QUnit.test('should throw on startup no techs are specified', function(assert) {
   const techOrder = videojs.options.techOrder;
   const fixture = document.getElementById('qunit-fixture');

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -238,9 +238,9 @@ QUnit.test('middleware mediate allows and can detect cancellation', function(ass
   assert.equal(techPlays, 0, 'the tech should not be called if a middleware terminates');
   assert.equal(playsToPlayer, 2, 'both middleware run after the tech');
 
-  assert.equal(pv1, null, 'null is returned through the middleware if a middleware terminated previously');
-  assert.equal(pv2, null, 'null is returned through the middleware if a middleware terminated previously');
-  assert.equal(pp, null, 'null is returned to the player if a middleware terminated previously');
+  assert.equal(pv1, middleware.TERMINATOR, 'TERMINATOR is returned through the middleware if a middleware terminated previously');
+  assert.equal(pv2, middleware.TERMINATOR, 'TERMINATOR is returned through the middleware if a middleware terminated previously');
+  assert.equal(pp, middleware.TERMINATOR, 'TERMINATOR is returned to the player if a middleware terminated previously');
   assert.equal(pc1, true, 'the play has been cancelled in middleware 1');
   assert.equal(pc2, true, 'the play has been cancelled in middleware 2');
 });

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -238,9 +238,9 @@ QUnit.test('middleware mediate allows and can detect cancellation', function(ass
   assert.equal(techPlays, 0, 'the tech should not be called if a middleware terminates');
   assert.equal(playsToPlayer, 2, 'both middleware run after the tech');
 
-  assert.equal(pv1, middleware.TERMINATOR, 'TERMINATOR is returned through the middleware if a middleware terminated previously');
-  assert.equal(pv2, middleware.TERMINATOR, 'TERMINATOR is returned through the middleware if a middleware terminated previously');
-  assert.equal(pp, middleware.TERMINATOR, 'TERMINATOR is returned to the player if a middleware terminated previously');
+  assert.equal(pv1, null, 'null is returned through the middleware if a middleware terminated previously');
+  assert.equal(pv2, null, 'null is returned through the middleware if a middleware terminated previously');
+  assert.equal(pp, null, 'null is returned to the player if a middleware terminated previously');
   assert.equal(pc1, true, 'the play has been cancelled in middleware 1');
   assert.equal(pc2, true, 'the play has been cancelled in middleware 2');
 });

--- a/test/unit/test-helpers.js
+++ b/test/unit/test-helpers.js
@@ -11,7 +11,7 @@ const TestHelpers = {
     return videoTag;
   },
 
-  makePlayer(playerOptions, videoTag) {
+  makePlayer(playerOptions, videoTag, addTechAsMiddleware = true) {
     videoTag = videoTag || TestHelpers.makeTag();
 
     const fixture = document.getElementById('qunit-fixture');
@@ -23,7 +23,9 @@ const TestHelpers = {
 
     const player = new Player(videoTag, playerOptions);
 
-    player.middleware_ = [player.tech_];
+    if (addTechAsMiddleware) {
+      player.middleware_ = [player.tech_];
+    }
 
     return player;
   },


### PR DESCRIPTION
## Description
Currently when a middleware terminates a call to play, we resolve the promise right away, event though that promise is not resolved. We should instead resolve the promise on the next call to play that works.

Doing this turned out to be a bit tricker than first anticipated. I added detailed tests that make sure that the play `retval` is resolved in a slew different scenarios. I think that we will still need another pull request to handle `play-terminate` events in the `manualAutoplay_` function, but this pull request was getting to big already.