### PR TITLE
Fix/live tracker ie slowdown

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -1,5 +1,6 @@
 import Component from './component.js';
 import mergeOptions from './utils/merge-options.js';
+import document from 'global/document';
 
 /* track when we are at the live edge, and other helpers for live playback */
 class LiveTracker extends Component {
@@ -13,6 +14,25 @@ class LiveTracker extends Component {
     this.reset_();
 
     this.on(this.player_, 'durationchange', this.handleDurationchange);
+
+    // we don't need to track live playback if the document is hidden,
+    // also, tracking when the document is hidden can
+    // cause the CPU to spike and eventually crash the page on IE11.
+    if ('hidden' in document && 'visibilityState' in document) {
+      this.on(document, 'visibilitychange', this.handleVisibilityChange);
+    }
+  }
+
+  handleVisibilityChange() {
+    if (this.player_.duration() !== Infinity) {
+      return;
+    }
+
+    if (document.hidden) {
+      this.stopTracking();
+    } else {
+      this.startTracking();
+    }
   }
 
   isBehind_() {

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -1,6 +1,7 @@
 import Component from './component.js';
 import mergeOptions from './utils/merge-options.js';
 import document from 'global/document';
+import * as browser from './utils/browser.js';
 
 /* track when we are at the live edge, and other helpers for live playback */
 class LiveTracker extends Component {
@@ -18,7 +19,7 @@ class LiveTracker extends Component {
     // we don't need to track live playback if the document is hidden,
     // also, tracking when the document is hidden can
     // cause the CPU to spike and eventually crash the page on IE11.
-    if ('hidden' in document && 'visibilityState' in document) {
+    if (browser.IE_VERSION && 'hidden' in document && 'visibilityState' in document) {
       this.on(document, 'visibilitychange', this.handleVisibilityChange);
     }
   }


### PR DESCRIPTION
## Description
~~We recently had a fix for `setInterval` performance in IE 11 but did not realize that `LiveTracker` has a similar `setInterval`. I added a helper to component that should be used for intervals like this in the future.~~ Originally it seemed like `setInterval` alone was the culprit, but after testing it seems that things in `startTracking` can cause the crash so we have to start and stop when the documents visibility changes.