### PR TITLE
docs: document ModalDialog's pauseOnOpen option

### DIFF
--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -44,6 +44,10 @@ class ModalDialog extends Component {
    * @param {string} [options.label]
    *        A text label for the modal, primarily for accessibility.
    *
+   * @param {boolean} [options.pauseOnOpen=true]
+   *        If `true`, playback will will be paused if playing when
+   *        the modal opens, and resumed when it closes.
+   *
    * @param {boolean} [options.temporary=true]
    *        If `true`, the modal can only be opened once; it will be
    *        disposed as soon as it's closed.


### PR DESCRIPTION
## Description
The ModalDialog's `pauseOnOpen` option is not documented.

## Specific Changes proposed
Adds API docuemntation.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
