### PR TITLE
fix: Always show the mute button by default in responsive mode.

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -42,7 +42,8 @@
     .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
     .vjs-volume-panel.vjs-volume-panel-horizontal:active,
     .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-      width: 4em;
+      width: auto;
+      width: initial;
     }
   }
 

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -68,7 +68,3 @@
     }
   }
 }
-
-.video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
-  .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-}

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -1,56 +1,74 @@
-// When the player is absurdly tiny, display nothing but:
-// - Play button
-// - Volume Mute button
-// - Fullscreen Button
-.video-js.vjs-layout-tiny:not(.vjs-fullscreen) {
-  .vjs-custom-control-spacer {
-    @include flex(auto);
-    display: block;
-  }
-
-  &.vjs-no-flex .vjs-custom-control-spacer { width: auto; }
-
-  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
-  .vjs-playback-rate, .vjs-progress-control,
-  .vjs-volume-control,
-  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-}
-
-// When the player is x-small, display nothing but:
+// When the player is "medium" and higher, display everything by default.
+//
+// When the player is "small", display only:
 // - Play button
 // - Volume Mute button
 // - Progress bar
-// - Fullscreen Button
-.video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
-  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
-  .vjs-playback-rate,
-  .vjs-volume-control,
-  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-}
-
-// When the player is small, display nothing but:
-// - Play button
-// - Volume Mute button
-// - Progress bar
-// - Volume menu button
-// - Subs-Caps Button
+// - Subs-Caps button
 // - Fullscreen button
-.video-js.vjs-layout-small:not(.vjs-fullscreen) {
-  .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
-  .vjs-playback-rate,
-  .vjs-volume-control,
-  .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
-  .vjs-subtitles-button, .vjs-audio-button { display: none; }
-}
-.video-js.vjs-layout-tiny:not(.vjs-fullscreen),
-.video-js.vjs-layout-x-small:not(.vjs-fullscreen),
-.video-js.vjs-layout-small:not(.vjs-fullscreen) {
+//
+// When the player is "small", display only:
+// - Play button
+// - Volume Mute button
+// - Progress bar
+// - Fullscreen button
+//
+// When the player is "tiny", display only:
+// - Play button
+// - Volume Mute button
+// - Fullscreen Button
+//
+.video-js:not(.vjs-fullscreen) {
 
-  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-    width: 4em;
+  &.vjs-layout-small,
+  &.vjs-layout-x-small,
+  &.vjs-layout-tiny {
+    .vjs-current-time,
+    .vjs-time-divider,
+    .vjs-duration,
+    .vjs-remaining-time,
+    .vjs-playback-rate,
+    .vjs-chapters-button,
+    .vjs-descriptions-button,
+    .vjs-captions-button,
+    .vjs-subtitles-button,
+    .vjs-audio-button,
+    .vjs-volume-control {
+      display: none;
+    }
+
+    // Reset the size of the volume panel to the default so we don't see a big
+    // empty space to the right of the mute button.
+    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+      width: 4em;
+    }
   }
+
+  &.vjs-layout-x-small,
+  &.vjs-layout-tiny {
+    .vjs-subs-caps-button {
+      display: none;
+    }
+  }
+
+  &.vjs-layout-tiny {
+    .vjs-custom-control-spacer {
+      @include flex(auto);
+      display: block;
+    }
+
+    &.vjs-no-flex .vjs-custom-control-spacer {
+      width: auto;
+    }
+
+    .vjs-progress-control {
+      display: none;
+    }
+  }
+}
+
+.video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
+  .vjs-subs-caps-button, .vjs-audio-button { display: none; }
 }

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -15,12 +15,6 @@
   .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-
-  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-    width: auto;
-  }
 }
 
 // When the player is x-small, display nothing but:
@@ -34,12 +28,6 @@
   .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-
-  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-    width: auto;
-  }
 }
 
 // When the player is small, display nothing but:
@@ -55,10 +43,14 @@
   .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-audio-button { display: none; }
+}
+.video-js.vjs-layout-tiny:not(.vjs-fullscreen),
+.video-js.vjs-layout-x-small:not(.vjs-fullscreen),
+.video-js.vjs-layout-small:not(.vjs-fullscreen) {
 
   .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
   .vjs-volume-panel.vjs-volume-panel-horizontal:active,
   .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-    width: auto;
+    width: 4em;
   }
 }

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -1,5 +1,6 @@
 // When the player is absurdly tiny, display nothing but:
 // - Play button
+// - Volume Mute button
 // - Fullscreen Button
 .video-js.vjs-layout-tiny:not(.vjs-fullscreen) {
   .vjs-custom-control-spacer {
@@ -11,26 +12,39 @@
 
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate, .vjs-progress-control,
-  .vjs-mute-control, .vjs-volume-control, .vjs-volume-panel,
+  .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
+
+  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+    width: auto;
+  }
 }
 
 // When the player is x-small, display nothing but:
 // - Play button
+// - Volume Mute button
 // - Progress bar
 // - Fullscreen Button
 .video-js.vjs-layout-x-small:not(.vjs-fullscreen) {
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control, .vjs-volume-panel,
+  .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-subs-caps-button, .vjs-audio-button { display: none; }
-}
 
+  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+    width: auto;
+  }
+}
 
 // When the player is small, display nothing but:
 // - Play button
+// - Volume Mute button
 // - Progress bar
 // - Volume menu button
 // - Subs-Caps Button
@@ -38,7 +52,13 @@
 .video-js.vjs-layout-small:not(.vjs-fullscreen) {
   .vjs-current-time, .vjs-time-divider, .vjs-duration, .vjs-remaining-time,
   .vjs-playback-rate,
-  .vjs-mute-control, .vjs-volume-control, .vjs-volume-panel,
+  .vjs-volume-control,
   .vjs-chapters-button, .vjs-descriptions-button, .vjs-captions-button,
   .vjs-subtitles-button, .vjs-audio-button { display: none; }
+
+  .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+    width: auto;
+  }
 }


### PR DESCRIPTION
## Description
We received a report that muted autoplay players using the new responsive breakpoints could not be unmuted at small sizes. This was due to an oversight in the initial implementation of responsive mode.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
