### PR TITLE
fix: Hide the progress control and show the subs-caps button when using Live UI at extra small size.

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -47,14 +47,20 @@
     }
   }
 
-  &.vjs-layout-x-small,
+  // Hide the subs-caps button for non-Live UI "x-small" and for "tiny" players.
+  &.vjs-layout-x-small:not(.vjs-liveui),
   &.vjs-layout-tiny {
     .vjs-subs-caps-button {
       display: none;
     }
   }
 
+  // With the new Live UI, we can have the same treatment as "tiny". At
+  // "x-small", the Live UI makes the progress control very small and almost
+  // useless.
+  &.vjs-layout-x-small.vjs-liveui,
   &.vjs-layout-tiny {
+
     .vjs-custom-control-spacer {
       @include flex(auto);
       display: block;

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -49,6 +49,7 @@
 
   // Hide the subs-caps button for non-Live UI "x-small" and for "tiny" players.
   &.vjs-layout-x-small:not(.vjs-liveui),
+  &.vjs-layout-x-small:not(.vjs-live),
   &.vjs-layout-tiny {
     .vjs-subs-caps-button {
       display: none;


### PR DESCRIPTION
## Description
This follows on from #5914 by hiding the progress control and showing the subs-caps buttons in `x-small` players when the new `liveui` option is used.

No change is necessary for the default `live` treatment because it hides the progress bar already.

**NOTE:** This is currently based on `fix/always-show-mute-button` branch!

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
