### PR TITLE
Fix typo in de translation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -54,7 +54,7 @@
   "Window": "Fenster",
   "Transparent": "Durchsichtig",
   "Semi-Transparent": "Halbdurchsichtig",
-  "Opaque": "Undurchsictig",
+  "Opaque": "Undurchsichtig",
   "Font Size": "Schriftgröße",
   "Text Edge Style": "Textkantenstil",
   "None": "Kein",


### PR DESCRIPTION
## Description

Just a fix for a small typo in German (de) translation.

