### PR TITLE
fix: Explicitly remove all document-level listeners on player dispose.

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -353,8 +353,8 @@ class Player extends Component {
 
     // Create bound methods for document listeners.
     this.boundDocumentFullscreenChange_ = Fn.bind(this, this.documentFullscreenChange_);
-    this.boundFullWindowOnEscKey = Fn.bind(this, this.fullWindowOnEscKey);
-    this.boundHandleKeyPress = Fn.bind(this, this.handleKeyPress);
+    this.boundFullWindowOnEscKey_ = Fn.bind(this, this.fullWindowOnEscKey);
+    this.boundHandleKeyPress_ = Fn.bind(this, this.handleKeyPress);
 
     // create logger
     this.log = createLogger(this.id_);
@@ -561,8 +561,8 @@ class Player extends Component {
 
     // Make sure all player-specific document listeners are unbound. This is
     Events.off(document, FullscreenApi.fullscreenchange, this.boundDocumentFullscreenChange_);
-    Events.off(document, 'keydown', this.boundFullWindowOnEscKey);
-    Events.off(document, 'keydown', this.boundHandleKeyPress);
+    Events.off(document, 'keydown', this.boundFullWindowOnEscKey_);
+    Events.off(document, 'keydown', this.boundHandleKeyPress_);
 
     if (this.styleEl_ && this.styleEl_.parentNode) {
       this.styleEl_.parentNode.removeChild(this.styleEl_);
@@ -2711,7 +2711,7 @@ class Player extends Component {
     this.docOrigOverflow = document.documentElement.style.overflow;
 
     // Add listener for esc key to exit fullscreen
-    Events.on(document, 'keydown', this.boundFullWindowOnEscKey);
+    Events.on(document, 'keydown', this.boundFullWindowOnEscKey_);
 
     // Hide any scroll bars
     document.documentElement.style.overflow = 'hidden';
@@ -2750,7 +2750,7 @@ class Player extends Component {
    */
   exitFullWindow() {
     this.isFullWindow = false;
-    Events.off(document, 'keydown', this.boundFullWindowOnEscKey);
+    Events.off(document, 'keydown', this.boundFullWindowOnEscKey_);
 
     // Unhide scroll bars.
     document.documentElement.style.overflow = this.docOrigOverflow;
@@ -2779,8 +2779,8 @@ class Player extends Component {
    */
   handleFocus(event) {
     // call off first to make sure we don't keep adding keydown handlers
-    Events.off(document, 'keydown', this.boundHandleKeyPress);
-    Events.on(document, 'keydown', this.boundHandleKeyPress);
+    Events.off(document, 'keydown', this.boundHandleKeyPress_);
+    Events.on(document, 'keydown', this.boundHandleKeyPress_);
   }
 
   /**
@@ -2793,7 +2793,7 @@ class Player extends Component {
    * @listens blur
    */
   handleBlur(event) {
-    Events.off(document, 'keydown', this.boundHandleKeyPress);
+    Events.off(document, 'keydown', this.boundHandleKeyPress_);
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -351,6 +351,11 @@ class Player extends Component {
     // Run base component initializing with new options
     super(null, options, ready);
 
+    // Create bound methods for document listeners.
+    this.boundDocumentFullscreenChange_ = Fn.bind(this, this.documentFullscreenChange_);
+    this.boundFullWindowOnEscKey = Fn.bind(this, this.fullWindowOnEscKey);
+    this.boundHandleKeyPress = Fn.bind(this, this.handleKeyPress);
+
     // create logger
     this.log = createLogger(this.id_);
 
@@ -553,6 +558,11 @@ class Player extends Component {
     this.trigger('dispose');
     // prevent dispose from being called twice
     this.off('dispose');
+
+    // Make sure all player-specific document listeners are unbound. This is
+    Events.off(document, FullscreenApi.fullscreenchange, this.boundDocumentFullscreenChange_);
+    Events.off(document, 'keydown', this.boundFullWindowOnEscKey);
+    Events.off(document, 'keydown', this.boundHandleKeyPress);
 
     if (this.styleEl_ && this.styleEl_.parentNode) {
       this.styleEl_.parentNode.removeChild(this.styleEl_);
@@ -1983,7 +1993,7 @@ class Player extends Component {
 
     // If cancelling fullscreen, remove event listener.
     if (this.isFullscreen() === false) {
-      Events.off(document, fsApi.fullscreenchange, Fn.bind(this, this.documentFullscreenChange_));
+      Events.off(document, fsApi.fullscreenchange, this.boundDocumentFullscreenChange_);
     }
 
     if (!prefixedFS) {
@@ -2643,7 +2653,7 @@ class Player extends Component {
       // when canceling fullscreen. Otherwise if there's multiple
       // players on a page, they would all be reacting to the same fullscreen
       // events
-      Events.on(document, fsApi.fullscreenchange, Fn.bind(this, this.documentFullscreenChange_));
+      Events.on(document, fsApi.fullscreenchange, this.boundDocumentFullscreenChange_);
 
       this.el_[fsApi.requestFullscreen]();
 
@@ -2701,7 +2711,7 @@ class Player extends Component {
     this.docOrigOverflow = document.documentElement.style.overflow;
 
     // Add listener for esc key to exit fullscreen
-    Events.on(document, 'keydown', Fn.bind(this, this.fullWindowOnEscKey));
+    Events.on(document, 'keydown', this.boundFullWindowOnEscKey);
 
     // Hide any scroll bars
     document.documentElement.style.overflow = 'hidden';
@@ -2740,7 +2750,7 @@ class Player extends Component {
    */
   exitFullWindow() {
     this.isFullWindow = false;
-    Events.off(document, 'keydown', this.fullWindowOnEscKey);
+    Events.off(document, 'keydown', this.boundFullWindowOnEscKey);
 
     // Unhide scroll bars.
     document.documentElement.style.overflow = this.docOrigOverflow;
@@ -2769,8 +2779,8 @@ class Player extends Component {
    */
   handleFocus(event) {
     // call off first to make sure we don't keep adding keydown handlers
-    Events.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
-    Events.on(document, 'keydown', Fn.bind(this, this.handleKeyPress));
+    Events.off(document, 'keydown', this.boundHandleKeyPress);
+    Events.on(document, 'keydown', this.boundHandleKeyPress);
   }
 
   /**
@@ -2783,7 +2793,7 @@ class Player extends Component {
    * @listens blur
    */
   handleBlur(event) {
-    Events.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
+    Events.off(document, 'keydown', this.boundHandleKeyPress);
   }
 
   /**


### PR DESCRIPTION
We have gotten a report (at Brightcove) of an issue where a disposed player could potentially leave behind the document keydown listener for the new-ish hotkeys feature.

This led me to realize there could be other cases where document-level listeners are left behind. For example, if the player is somehow disposed while in fullscreen, it could leave behind those listeners.

Even though we haven't had reports of any other listeners being left, it seems responsible to make sure they're cleaned up!

## Specific Changes proposed
* Remove all document-level listeners on player dispose.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
