### PR TITLE
Add role='application' to the video element on Chrome on Windows, to work around a JAWS screen reader bug (for v6.x)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -32,7 +32,7 @@ import * as middleware from './tech/middleware.js';
 import {ALL as TRACK_TYPES} from './tracks/track-types';
 import filterSource from './utils/filter-source';
 import {findMimetype} from './utils/mimetypes';
-import {IE_VERSION} from './utils/browser';
+import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
 
 // The following imports are used only to ensure that the corresponding modules
 // are always included in the video.js package. Importing the modules will
@@ -647,11 +647,12 @@ class Player extends Component {
     tag.setAttribute('tabindex', '-1');
     attrs.tabindex = '-1';
 
-    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button)
+    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button), and
+    // for the same issue with Chrome (on Windows) with JAWS.
     // See https://github.com/FreedomScientific/VFO-standards-support/issues/78
     // Note that we can't detect if JAWS is being used, but this ARIA attribute
-    //  doesn't change behavior of IE11 if JAWS is not being used
-    if (IE_VERSION) {
+    //  doesn't change behavior of IE11 or Chrome if JAWS is not being used
+    if (IE_VERSION || (IS_CHROME && IS_WINDOWS)) {
       tag.setAttribute('role', 'application');
       attrs.role = 'application';
     }

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -86,6 +86,22 @@ export const IE_VERSION = (function() {
 export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
 export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;
 
+/**
+ * Whether or not this is a Windows machine.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+export const IS_WINDOWS = (/Windows/i).test(USER_AGENT);
+
+/**
+ * Whether or not this device is touch-enabled.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
 export const TOUCH_ENABLED = Dom.isReal() && (
   'ontouchstart' in window ||
   window.navigator.maxTouchPoints ||


### PR DESCRIPTION
Same as #5863, for v6.x.
