### PR TITLE
fix: change rollup config so that npm run watch works

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -88,8 +88,9 @@ const externals = {
     'mpd-parser',
     'mux.js',
     'mux.js/lib/mp4',
-    'mux.js/lib/tools/ts-inspector.js',
     'mux.js/lib/mp4/probe',
+    'mux.js/lib/tools/ts-inspector.js',
+    'mux.js/lib/tools/mp4-inspector',
     'aes-decrypter',
     'keycode'
   ]),


### PR DESCRIPTION
## Description
Currently, when running `npm run watch`, editing a file will cause a failure in generating the CommonJS and ES outputs:
```
bundles src/js/index.js → dist/video.es.js, dist/video.cjs.js...
[!] Error: Could not load mux.js/lib/tools/mp4-inspector (imported by /tmp/video.js/node_modules/@videojs/http-streaming/dist/videojs-http-streaming.es.js): ENOENT: no such file or directory, open 'mux.js/lib/tools/mp4-inspector'
Error: Could not load mux.js/lib/tools/mp4-inspector (imported by /tmp/video.js/node_modules/@videojs/http-streaming/dist/videojs-http-streaming.es.js): ENOENT: no such file or directory, open 'mux.js/lib/tools/mp4-inspector'
    at /tmp/video.js/node_modules/rollup/dist/rollup.js:17372:19
    at <anonymous>
```

## Specific Changes proposed
Add `mux.js/lib/tools/mp4-inspector` to the list of externals.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
