### PR TITLE
fix: make sure hotkeys are not triggered outside the player or in form fields within the player

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -47,8 +47,6 @@ class BigPlayButton extends Button {
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
       silencePromise(playPromise);
-      // call handleFocus manually to get hotkeys working
-      this.player_.handleFocus({});
       return;
     }
 
@@ -69,10 +67,10 @@ class BigPlayButton extends Button {
     }
   }
 
-  handleKeyPress(event) {
+  handleKeyDown(event) {
     this.mouseused_ = false;
 
-    super.handleKeyPress(event);
+    super.handleKeyDown(event);
   }
 
   handleMouseDown(event) {

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -47,6 +47,7 @@ class BigPlayButton extends Button {
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
       silencePromise(playPromise);
+      this.player_.tech(true).focus();
       return;
     }
 
@@ -54,7 +55,7 @@ class BigPlayButton extends Button {
     const playToggle = cb && cb.getChild('playToggle');
 
     if (!playToggle) {
-      this.player_.focus();
+      this.player_.tech(true).focus();
       return;
     }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -104,13 +104,19 @@ class Button extends ClickableComponent {
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
-    // Ignore Space or Enter key operation, which is handled by the browser for a button.
-    if (!(keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter'))) {
+  handleKeyDown(event) {
 
-      // Pass keypress handling up for unsupported keys
-      super.handleKeyPress(event);
+    // Ignore Space or Enter key operation, which is handled by the browser for
+    // a button - though not for its super class, ClickableComponent. Also,
+    // prevent the event from propagating through the DOM and triggering Player
+    // hotkeys.
+    if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
+      event.stopPropagation();
+      return;
     }
+
+    // Pass keypress handling up for unsupported keys
+    super.handleKeyDown(event);
   }
 }
 

--- a/src/js/button.js
+++ b/src/js/button.js
@@ -109,7 +109,8 @@ class Button extends ClickableComponent {
     // Ignore Space or Enter key operation, which is handled by the browser for
     // a button - though not for its super class, ClickableComponent. Also,
     // prevent the event from propagating through the DOM and triggering Player
-    // hotkeys.
+    // hotkeys. We do not preventDefault here because we _want_ the browser to
+    // handle it.
     if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
       event.stopPropagation();
       return;

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -3,16 +3,13 @@
  */
 import Component from './component';
 import * as Dom from './utils/dom.js';
-import * as Events from './utils/events.js';
-import * as Fn from './utils/fn.js';
 import log from './utils/log.js';
-import document from 'global/document';
 import {assign} from './utils/obj';
 import keycode from 'keycode';
 
 /**
- * Clickable Component which is clickable or keyboard actionable,
- * but is not a native HTML button.
+ * Component which is clickable or keyboard actionable, but is not a
+ * native HTML button.
  *
  * @extends Component
  */
@@ -36,7 +33,7 @@ class ClickableComponent extends Component {
   }
 
   /**
-   * Create the `Component`s DOM element.
+   * Create the `ClickableComponent`s DOM element.
    *
    * @param {string} [tag=div]
    *        The element's node type.
@@ -83,7 +80,7 @@ class ClickableComponent extends Component {
   }
 
   /**
-   * Create a control text element on this `Component`
+   * Create a control text element on this `ClickableComponent`
    *
    * @param {Element} [el]
    *        Parent element for the control text.
@@ -109,7 +106,7 @@ class ClickableComponent extends Component {
   }
 
   /**
-   * Get or set the localize text to use for the controls on the `Component`.
+   * Get or set the localize text to use for the controls on the `ClickableComponent`.
    *
    * @param {string} [text]
    *        Control text for element.
@@ -146,7 +143,7 @@ class ClickableComponent extends Component {
   }
 
   /**
-   * Enable this `Component`s element.
+   * Enable this `ClickableComponent`
    */
   enable() {
     if (!this.enabled_) {
@@ -157,13 +154,12 @@ class ClickableComponent extends Component {
         this.el_.setAttribute('tabIndex', this.tabIndex_);
       }
       this.on(['tap', 'click'], this.handleClick);
-      this.on('focus', this.handleFocus);
-      this.on('blur', this.handleBlur);
+      this.on('keydown', this.handleKeyDown);
     }
   }
 
   /**
-   * Disable this `Component`s element.
+   * Disable this `ClickableComponent`
    */
   disable() {
     this.enabled_ = false;
@@ -173,27 +169,15 @@ class ClickableComponent extends Component {
       this.el_.removeAttribute('tabIndex');
     }
     this.off(['tap', 'click'], this.handleClick);
-    this.off('focus', this.handleFocus);
-    this.off('blur', this.handleBlur);
+    this.off('keydown', this.handleKeyDown);
   }
 
   /**
-   * This gets called when a `ClickableComponent` gets:
-   * - Clicked (via the `click` event, listening starts in the constructor)
-   * - Tapped (via the `tap` event, listening starts in the constructor)
-   * - The following things happen in order:
-   *   1. {@link ClickableComponent#handleFocus} is called via a `focus` event on the
-   *      `ClickableComponent`.
-   *   2. {@link ClickableComponent#handleFocus} adds a listener for `keydown` on using
-   *      {@link ClickableComponent#handleKeyPress}.
-   *   3. `ClickableComponent` has not had a `blur` event (`blur` means that focus was lost). The user presses
-   *      the space or enter key.
-   *   4. {@link ClickableComponent#handleKeyPress} calls this function with the `keydown`
-   *      event as a parameter.
+   * Event handler that is called when a `ClickableComponent` receives a
+   * `click` or `tap` event.
    *
    * @param {EventTarget~Event} event
-   *        The `keydown`, `tap`, or `click` event that caused this function to be
-   *        called.
+   *        The `tap` or `click` event that caused this function to be called.
    *
    * @listens tap
    * @listens click
@@ -202,51 +186,29 @@ class ClickableComponent extends Component {
   handleClick(event) {}
 
   /**
-   * This gets called when a `ClickableComponent` gains focus via a `focus` event.
-   * Turns on listening for `keydown` events. When they happen it
-   * calls `this.handleKeyPress`.
+   * Event handler that is called when a `ClickableComponent` receives a
+   * `keydown` event.
    *
-   * @param {EventTarget~Event} event
-   *        The `focus` event that caused this function to be called.
-   *
-   * @listens focus
-   */
-  handleFocus(event) {
-    Events.on(document, 'keydown', Fn.bind(this, this.handleKeyPress));
-  }
-
-  /**
-   * Called when this ClickableComponent has focus and a key gets pressed down. By
-   * default it will call `this.handleClick` when the key is space or enter.
+   * By default, if the key is Space or Enter, it will trigger a `click` event.
    *
    * @param {EventTarget~Event} event
    *        The `keydown` event that caused this function to be called.
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
-    // Support Space or Enter key operation to fire a click event
+  handleKeyDown(event) {
+
+    // Support Space or Enter key operation to fire a click event. Also,
+    // prevent the event from propagating through the DOM and triggering
+    // Player hotkeys.
     if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.trigger('click');
     } else {
 
       // Pass keypress handling up for unsupported keys
-      super.handleKeyPress(event);
+      super.handleKeyDown(event);
     }
-  }
-
-  /**
-   * Called when a `ClickableComponent` loses focus. Turns off the listener for
-   * `keydown` events. Which Stops `this.handleKeyPress` from getting called.
-   *
-   * @param {EventTarget~Event} event
-   *        The `blur` event that caused this function to be called.
-   *
-   * @listens blur
-   */
-  handleBlur(event) {
-    Events.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
   }
 }
 

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -202,6 +202,7 @@ class ClickableComponent extends Component {
     // prevent the event from propagating through the DOM and triggering
     // Player hotkeys.
     if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
+      event.preventDefault();
       event.stopPropagation();
       this.trigger('click');
     } else {

--- a/src/js/close-button.js
+++ b/src/js/close-button.js
@@ -37,24 +37,9 @@ class CloseButton extends Button {
   }
 
   /**
-   * This gets called when a `CloseButton` has focus and `keydown` is triggered via a key
-   * press.
-   *
-   * @param {EventTarget~Event} event
-   *        The event that caused this function to get called.
-   *
-   * @listens keydown
-   */
-  handleKeyPress(event) {
-    // Override the default `Button` behavior, and don't pass the keypress event
-    //  up to the player because this button is part of a `ModalDialog`, which
-    //  doesn't pass keypresses to the player either.
-  }
-
-  /**
    * This gets called when a `CloseButton` gets clicked. See
-   * {@link ClickableComponent#handleClick} for more information on when this will be
-   * triggered
+   * {@link ClickableComponent#handleClick} for more information on when
+   * this will be triggered
    *
    * @param {EventTarget~Event} event
    *        The `keydown`, `tap`, or `click` event that caused this function to be

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1078,16 +1078,31 @@ class Component {
   }
 
   /**
-   * When this Component receives a keydown event which it does not process,
+   * When this Component receives a `keydown` event which it does not process,
    *  it passes the event to the Player for handling.
    *
    * @param {EventTarget~Event} event
    *        The `keydown` event that caused this function to be called.
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
     if (this.player_) {
-      this.player_.handleKeyPress(event);
+
+      event.stopPropagation();
+      this.player_.handleKeyDown(event);
     }
+  }
+
+  /**
+   * Many components used to have a `handleKeyPress` method, which was poorly
+   * named because it listened to a `keydown` event. This method name now
+   * delegates to `handleKeyDown`. This means anyone calling `handleKeyPress`
+   * will not see their method calls stop working.
+   *
+   * @param {EventTarget~Event} event
+   *        The event that caused this function to be called.
+   */
+  handleKeyPress(event) {
+    this.handleKeyDown(event);
   }
 
   /**

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1087,6 +1087,8 @@ class Component {
   handleKeyDown(event) {
     if (this.player_) {
 
+      // We only stop propagation here because we want unhandled events to fall
+      // back to the browser.
       event.stopPropagation();
       this.player_.handleKeyDown(event);
     }

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -407,30 +407,30 @@ class SeekBar extends Slider {
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
     if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.handleAction(event);
     } else if (keycode.isEventKey(event, 'Home')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.player_.currentTime(0);
     } else if (keycode.isEventKey(event, 'End')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.player_.currentTime(this.player_.duration());
     } else if (/^[0-9]$/.test(keycode(event))) {
-      event.preventDefault();
+      event.stopPropagation();
       const gotoFraction = (keycode.codes[keycode(event)] - keycode.codes['0']) * 10.0 / 100.0;
 
       this.player_.currentTime(this.player_.duration() * gotoFraction);
     } else if (keycode.isEventKey(event, 'PgDn')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.player_.currentTime(this.player_.currentTime() - (STEP_SECONDS * PAGE_KEY_MULTIPLIER));
     } else if (keycode.isEventKey(event, 'PgUp')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.player_.currentTime(this.player_.currentTime() + (STEP_SECONDS * PAGE_KEY_MULTIPLIER));
     } else {
-      // Pass keypress handling up for unsupported keys
-      super.handleKeyPress(event);
+      // Pass keydown handling up for unsupported keys
+      super.handleKeyDown(event);
     }
   }
 }

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -409,23 +409,29 @@ class SeekBar extends Slider {
    */
   handleKeyDown(event) {
     if (keycode.isEventKey(event, 'Space') || keycode.isEventKey(event, 'Enter')) {
+      event.preventDefault();
       event.stopPropagation();
       this.handleAction(event);
     } else if (keycode.isEventKey(event, 'Home')) {
+      event.preventDefault();
       event.stopPropagation();
       this.player_.currentTime(0);
     } else if (keycode.isEventKey(event, 'End')) {
+      event.preventDefault();
       event.stopPropagation();
       this.player_.currentTime(this.player_.duration());
     } else if (/^[0-9]$/.test(keycode(event))) {
+      event.preventDefault();
       event.stopPropagation();
       const gotoFraction = (keycode.codes[keycode(event)] - keycode.codes['0']) * 10.0 / 100.0;
 
       this.player_.currentTime(this.player_.duration() * gotoFraction);
     } else if (keycode.isEventKey(event, 'PgDn')) {
+      event.preventDefault();
       event.stopPropagation();
       this.player_.currentTime(this.player_.currentTime() - (STEP_SECONDS * PAGE_KEY_MULTIPLIER));
     } else if (keycode.isEventKey(event, 'PgUp')) {
+      event.preventDefault();
       event.stopPropagation();
       this.player_.currentTime(this.player_.currentTime() + (STEP_SECONDS * PAGE_KEY_MULTIPLIER));
     } else {

--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -5,11 +5,8 @@ import Button from '../button.js';
 import Component from '../component.js';
 import Menu from './menu.js';
 import * as Dom from '../utils/dom.js';
-import * as Fn from '../utils/fn.js';
-import * as Events from '../utils/events.js';
 import toTitleCase from '../utils/to-title-case.js';
 import { IS_IOS } from '../utils/browser.js';
-import document from 'global/document';
 import keycode from 'keycode';
 
 /**
@@ -50,12 +47,12 @@ class MenuButton extends Component {
 
     this.on(this.menuButton_, 'tap', this.handleClick);
     this.on(this.menuButton_, 'click', this.handleClick);
-    this.on(this.menuButton_, 'focus', this.handleFocus);
-    this.on(this.menuButton_, 'blur', this.handleBlur);
+    this.on(this.menuButton_, 'keydown', this.handleKeyDown);
     this.on(this.menuButton_, 'mouseenter', () => {
       this.menu.show();
     });
-    this.on('keydown', this.handleSubmenuKeyPress);
+
+    this.on('keydown', this.handleSubmenuKeyDown);
   }
 
   /**
@@ -247,47 +244,22 @@ class MenuButton extends Component {
   }
 
   /**
-   * This gets called when a `MenuButton` gains focus via a `focus` event.
-   * Turns on listening for `keydown` events. When they happen it
-   * calls `this.handleKeyPress`.
-   *
-   * @param {EventTarget~Event} event
-   *        The `focus` event that caused this function to be called.
-   *
-   * @listens focus
-   */
-  handleFocus() {
-    Events.on(document, 'keydown', Fn.bind(this, this.handleKeyPress));
-  }
-
-  /**
-   * Called when a `MenuButton` loses focus. Turns off the listener for
-   * `keydown` events. Which Stops `this.handleKeyPress` from getting called.
-   *
-   * @param {EventTarget~Event} event
-   *        The `blur` event that caused this function to be called.
-   *
-   * @listens blur
-   */
-  handleBlur() {
-    Events.off(document, 'keydown', Fn.bind(this, this.handleKeyPress));
-  }
-
-  /**
    * Handle tab, escape, down arrow, and up arrow keys for `MenuButton`. See
-   * {@link ClickableComponent#handleKeyPress} for instances where this is called.
+   * {@link ClickableComponent#handleKeyDown} for instances where this is called.
    *
    * @param {EventTarget~Event} event
    *        The `keydown` event that caused this function to be called.
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
+
     // Escape or Tab unpress the 'button'
     if (keycode.isEventKey(event, 'Esc') || keycode.isEventKey(event, 'Tab')) {
       if (this.buttonPressed_) {
         this.unpressButton();
       }
+
       // Don't preventDefault for Tab key - we still want to lose focus
       if (!keycode.isEventKey(event, 'Tab')) {
         event.preventDefault();
@@ -300,12 +272,19 @@ class MenuButton extends Component {
         event.preventDefault();
         this.pressButton();
       }
-    } else {
-      // NOTE: This is a special case where we don't pass unhandled
-      //  keypress events up to the Component handler, because it is
-      //  just entending the keypress handling of the actual `Button`
-      //  in the `MenuButton` which already passes unused keys up.
     }
+  }
+
+  /**
+   * This method name now delegates to `handleSubmenuKeyDown`. This means
+   * anyone calling `handleSubmenuKeyPress` will not see their method calls
+   * stop working.
+   *
+   * @param {EventTarget~Event} event
+   *        The event that caused this function to be called.
+   */
+  handleSubmenuKeyPress(event) {
+    this.handleSubmenuKeyDown(event);
   }
 
   /**
@@ -317,7 +296,7 @@ class MenuButton extends Component {
    *
    * @listens keydown
    */
-  handleSubmenuKeyPress(event) {
+  handleSubmenuKeyDown(event) {
     // Escape or Tab unpress the 'button'
     if (keycode.isEventKey(event, 'Esc') || keycode.isEventKey(event, 'Tab')) {
       if (this.buttonPressed_) {
@@ -331,8 +310,8 @@ class MenuButton extends Component {
       }
     } else {
       // NOTE: This is a special case where we don't pass unhandled
-      //  keypress events up to the Component handler, because it is
-      //  just entending the keypress handling of the `MenuItem`
+      //  keydown events up to the Component handler, because it is
+      //  just entending the keydown handling of the `MenuItem`
       //  in the `Menu` which already passes unused keys up.
     }
   }

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -72,17 +72,17 @@ class MenuItem extends ClickableComponent {
 
   /**
    * Ignore keys which are used by the menu, but pass any other ones up. See
-   * {@link ClickableComponent#handleKeyPress} for instances where this is called.
+   * {@link ClickableComponent#handleKeyDown} for instances where this is called.
    *
    * @param {EventTarget~Event} event
    *        The `keydown` event that caused this function to be called.
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
     if (!MenuKeys.some((key) => keycode.isEventKey(event, key))) {
-      // Pass keypress handling up for unused keys
-      super.handleKeyPress(event);
+      // Pass keydown handling up for unused keys
+      super.handleKeyDown(event);
     }
   }
 

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -35,7 +35,7 @@ class Menu extends Component {
 
     this.focusedChild_ = -1;
 
-    this.on('keydown', this.handleKeyPress);
+    this.on('keydown', this.handleKeyDown);
 
     // All the menu item instances share the same blur handler provided by the menu container.
     this.boundHandleBlur_ = Fn.bind(this, this.handleBlur);
@@ -211,22 +211,17 @@ class Menu extends Component {
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
+
     // Left and Down Arrows
     if (keycode.isEventKey(event, 'Left') || keycode.isEventKey(event, 'Down')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.stepForward();
 
     // Up and Right Arrows
     } else if (keycode.isEventKey(event, 'Right') || keycode.isEventKey(event, 'Up')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.stepBack();
-    } else {
-      // NOTE: This is a special case where we don't pass unhandled
-      //  keypress events up to the Component handler, because this
-      //  is just adding a keypress handler on top of the MenuItem's
-      //  existing keypress handler, which already handles passing keypress
-      //  events up.
     }
   }
 

--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -215,11 +215,13 @@ class Menu extends Component {
 
     // Left and Down Arrows
     if (keycode.isEventKey(event, 'Left') || keycode.isEventKey(event, 'Down')) {
+      event.preventDefault();
       event.stopPropagation();
       this.stepForward();
 
     // Up and Right Arrows
     } else if (keycode.isEventKey(event, 'Right') || keycode.isEventKey(event, 'Up')) {
+      event.preventDefault();
       event.stopPropagation();
       this.stepBack();
     }

--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -2,7 +2,6 @@
  * @file modal-dialog.js
  */
 import * as Dom from './utils/dom';
-import * as Fn from './utils/fn';
 import Component from './component';
 import window from 'global/window';
 import document from 'global/document';
@@ -120,21 +119,6 @@ class ModalDialog extends Component {
   }
 
   /**
-   * Handles `keydown` events on the document, looking for ESC, which closes
-   * the modal.
-   *
-   * @param {EventTarget~Event} event
-   *        The keypress that triggered this event.
-   *
-   * @listens keydown
-   */
-  handleKeyPress(event) {
-    if (keycode.isEventKey(event, 'Escape') && this.closeable()) {
-      this.close();
-    }
-  }
-
-  /**
    * Returns the label string for this modal. Primarily used for accessibility.
    *
    * @return {string}
@@ -195,9 +179,7 @@ class ModalDialog extends Component {
         player.pause();
       }
 
-      if (this.closeable()) {
-        this.on(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
-      }
+      this.on('keydown', this.handleKeyDown);
 
       // Hide controls and note if they were enabled.
       this.hadControls_ = player.controls();
@@ -260,9 +242,7 @@ class ModalDialog extends Component {
       player.play();
     }
 
-    if (this.closeable()) {
-      this.off(this.el_.ownerDocument, 'keydown', Fn.bind(this, this.handleKeyPress));
-    }
+    this.off('keydown', this.handleKeyDown);
 
     if (this.hadControls_) {
       player.controls(true);
@@ -444,8 +424,6 @@ class ModalDialog extends Component {
       this.previouslyActiveEl_ = activeEl;
 
       this.focus();
-
-      this.on(document, 'keydown', this.handleKeyDown);
     }
   }
 
@@ -459,8 +437,6 @@ class ModalDialog extends Component {
       this.previouslyActiveEl_.focus();
       this.previouslyActiveEl_ = null;
     }
-
-    this.off(document, 'keydown', this.handleKeyDown);
   }
 
   /**
@@ -469,6 +445,15 @@ class ModalDialog extends Component {
    * @listens keydown
    */
   handleKeyDown(event) {
+
+    // Do not allow keydowns to reach out of the modal dialog.
+    event.stopPropagation();
+
+    if (keycode.isEventKey(event, 'Escape') && this.closeable()) {
+      this.close();
+      return;
+    }
+
     // exit early if it isn't a tab key
     if (!keycode.isEventKey(event, 'Tab')) {
       return;

--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -450,6 +450,7 @@ class ModalDialog extends Component {
     event.stopPropagation();
 
     if (keycode.isEventKey(event, 'Escape') && this.closeable()) {
+      event.preventDefault();
       this.close();
       return;
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2825,7 +2825,6 @@ class Player extends Component {
     // Sometimes, people put forms in their player. In general, we do not want
     // to activate hotkey handling when the focus is on one of these elements.
     const hotkeysDisallowed = [
-      'button',
       'datalist',
       'input',
       'optgroup',
@@ -2867,14 +2866,9 @@ class Player extends Component {
       playPauseKey = keydownEvent => (keycode.isEventKey(keydownEvent, 'k') || keycode.isEventKey(keydownEvent, 'Space'))
     } = hotkeys;
 
-    const {keyCode, charCode, code, key} = event;
-
-    log('hotkey', {keyCode, charCode, code, key});
-
-    if (fullscreenKey(event)) {
-      log('fullscreen');
-
+    if (fullscreenKey.call(this, event)) {
       event.preventDefault();
+      event.stopPropagation();
 
       const FSToggle = Component.getComponent('FullscreenToggle');
 
@@ -2882,19 +2876,17 @@ class Player extends Component {
         FSToggle.prototype.handleClick.call(this);
       }
 
-    } else if (muteKey(event)) {
-      log('mute');
-
+    } else if (muteKey.call(this, event)) {
       event.preventDefault();
+      event.stopPropagation();
 
       const MuteToggle = Component.getComponent('MuteToggle');
 
       MuteToggle.prototype.handleClick.call(this);
 
-    } else if (playPauseKey(event)) {
-      log('play/pause');
-
+    } else if (playPauseKey.call(this, event)) {
       event.preventDefault();
+      event.stopPropagation();
 
       const PlayToggle = Component.getComponent('PlayToggle');
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2819,22 +2819,34 @@ class Player extends Component {
       return;
     }
 
-    const activeEl = this.el_.ownerDocument.activeElement;
-    const activeTag = activeEl && activeEl.tagName.toLowerCase();
+    // Function that determines whether or not to exclude an element from
+    // hotkeys handling.
+    const excludeElement = (el) => {
+      const tagName = el.tagName.toLowerCase();
 
-    // Sometimes, people put forms in their player. In general, we do not want
-    // to activate hotkey handling when the focus is on one of these elements.
-    const hotkeysDisallowed = [
-      'datalist',
-      'input',
-      'optgroup',
-      'option',
-      'select',
-      'textarea'
-    ];
+      // These tags will be excluded entirely.
+      const excludedTags = ['textarea'];
+
+      // Inputs matching these types will still trigger hotkey handling as
+      // they are not text inputs.
+      const allowedInputTypes = [
+        'button',
+        'checkbox',
+        'hidden',
+        'radio',
+        'reset',
+        'submit'
+      ];
+
+      if (tagName === 'input') {
+        return allowedInputTypes.indexOf(el.type) === -1;
+      }
+
+      return excludedTags.indexOf(tagName) !== -1;
+    };
 
     // Bail out if the user is focused on an interactive form element.
-    if (activeTag && hotkeysDisallowed.indexOf(activeTag) !== -1) {
+    if (excludeElement(this.el_.ownerDocument.activeElement)) {
       return;
     }
 

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -117,9 +117,6 @@ class PosterImage extends ClickableComponent {
     } else {
       this.player_.pause();
     }
-
-    // call handleFocus manually to get hotkeys working
-    this.player_.handleFocus({});
   }
 
 }

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -112,6 +112,8 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
+    this.player_.tech(true).focus();
+
     if (this.player_.paused()) {
       silencePromise(this.player_.play());
     } else {

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -56,8 +56,7 @@ class Slider extends Component {
 
     this.on('mousedown', this.handleMouseDown);
     this.on('touchstart', this.handleMouseDown);
-    this.on('focus', this.handleFocus);
-    this.on('blur', this.handleBlur);
+    this.on('keydown', this.handleKeyDown);
     this.on('click', this.handleClick);
 
     this.on(this.player_, 'controlsvisible', this.update);
@@ -83,8 +82,7 @@ class Slider extends Component {
 
     this.off('mousedown', this.handleMouseDown);
     this.off('touchstart', this.handleMouseDown);
-    this.off('focus', this.handleFocus);
-    this.off('blur', this.handleBlur);
+    this.off('keydown', this.handleKeyDown);
     this.off('click', this.handleClick);
     this.off(this.player_, 'controlsvisible', this.update);
     this.off(doc, 'mousemove', this.handleMouseMove);
@@ -294,18 +292,6 @@ class Slider extends Component {
   }
 
   /**
-   * Handle a `focus` event on this `Slider`.
-   *
-   * @param {EventTarget~Event} event
-   *        The `focus` event that caused this function to run.
-   *
-   * @listens focus
-   */
-  handleFocus() {
-    this.on(this.bar.el_.ownerDocument, 'keydown', this.handleKeyPress);
-  }
-
-  /**
    * Handle a `keydown` event on the `Slider`. Watches for left, rigth, up, and down
    * arrow keys. This function will only be called when the slider has focus. See
    * {@link Slider#handleFocus} and {@link Slider#handleBlur}.
@@ -315,34 +301,22 @@ class Slider extends Component {
    *
    * @listens keydown
    */
-  handleKeyPress(event) {
+  handleKeyDown(event) {
+
     // Left and Down Arrows
     if (keycode.isEventKey(event, 'Left') || keycode.isEventKey(event, 'Down')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.stepBack();
 
     // Up and Right Arrows
     } else if (keycode.isEventKey(event, 'Right') || keycode.isEventKey(event, 'Up')) {
-      event.preventDefault();
+      event.stopPropagation();
       this.stepForward();
     } else {
 
-      // Pass keypress handling up for unsupported keys
-      super.handleKeyPress(event);
+      // Pass keydown handling up for unsupported keys
+      super.handleKeyDown(event);
     }
-  }
-
-  /**
-   * Handle a `blur` event on this `Slider`.
-   *
-   * @param {EventTarget~Event} event
-   *        The `blur` event that caused this function to run.
-   *
-   * @listens blur
-   */
-
-  handleBlur() {
-    this.off(this.bar.el_.ownerDocument, 'keydown', this.handleKeyPress);
   }
 
   /**
@@ -353,7 +327,7 @@ class Slider extends Component {
    *        Event that caused this object to run
    */
   handleClick(event) {
-    event.stopImmediatePropagation();
+    event.stopPropagation();
     event.preventDefault();
   }
 

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -305,11 +305,13 @@ class Slider extends Component {
 
     // Left and Down Arrows
     if (keycode.isEventKey(event, 'Left') || keycode.isEventKey(event, 'Down')) {
+      event.preventDefault();
       event.stopPropagation();
       this.stepBack();
 
     // Up and Right Arrows
     } else if (keycode.isEventKey(event, 'Right') || keycode.isEventKey(event, 'Up')) {
+      event.preventDefault();
       event.stopPropagation();
       this.stepForward();
     } else {

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -2,7 +2,6 @@
  * @file text-track-settings.js
  */
 import window from 'global/window';
-import document from 'global/document';
 import Component from '../component';
 import ModalDialog from '../modal-dialog';
 import {createEl} from '../utils/dom';
@@ -590,7 +589,6 @@ class TextTrackSettings extends ModalDialog {
    */
   conditionalBlur_() {
     this.previouslyActiveEl_ = null;
-    this.off(document, 'keydown', this.handleKeyDown);
 
     const cb = this.player_.controlBar;
     const subsCapsBtn = cb && cb.subsCapsButton;

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -142,21 +142,21 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
     // `Menu`.`children` will be called when triggering blur event on the menu item.
     const menuChildrenSpy = sinon.spy(watchedMenu, 'children');
 
-    // The number of blur listeners is two because `ClickableComponent`
-    // adds the blur event listener during the construction and
+    assert.strictEqual(eventData.handlers.blur.length, 1, 'the number of blur listeners is one');
+
+    // The number of click listeners is two because `ClickableComponent`
+    // adds the click event listener during the construction and
     // `MenuItem` inherits from `ClickableComponent`.
-    assert.strictEqual(eventData.handlers.blur.length, 2, 'the number of blur listeners is two');
-    // Same reason mentioned above.
     assert.strictEqual(eventData.handlers.click.length, 2, 'the number of click listeners is two');
 
-    const blurListenerAddedByMenu = eventData.handlers.blur[1];
+    // const blurListenerAddedByMenu = eventData.handlers.blur[1];
     const clickListenerAddedByMenu = eventData.handlers.click[1];
 
-    assert.strictEqual(
-      typeof blurListenerAddedByMenu.calledOnce,
-      'undefined',
-      'previous blur listener wrapped in the spy should be removed'
-    );
+    // assert.strictEqual(
+    //   typeof blurListenerAddedByMenu.calledOnce,
+    //   'undefined',
+    //   'previous blur listener wrapped in the spy should be removed'
+    // );
 
     assert.strictEqual(
       typeof clickListenerAddedByMenu.calledOnce,
@@ -164,13 +164,13 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
       'previous click listener wrapped in the spy should be removed'
     );
 
-    const blurListenerSpy = eventData.handlers.blur[1] = sinon.spy(blurListenerAddedByMenu);
+    // const blurListenerSpy = eventData.handlers.blur[1] = sinon.spy(blurListenerAddedByMenu);
     const clickListenerSpy = eventData.handlers.click[1] = sinon.spy(clickListenerAddedByMenu);
 
     TestHelpers.triggerDomEvent(menuItem.el(), 'blur');
 
-    assert.ok(blurListenerSpy.calledOnce, 'blur event listener should be called');
-    assert.strictEqual(blurListenerSpy.getCall(0).args[0].target, menuItem.el(), 'event target should be the `menuItem`');
+    // assert.ok(blurListenerSpy.calledOnce, 'blur event listener should be called');
+    // assert.strictEqual(blurListenerSpy.getCall(0).args[0].target, menuItem.el(), 'event target should be the `menuItem`');
     assert.ok(menuChildrenSpy.calledOnce, '`watchedMenu`.`children` has been called');
 
     TestHelpers.triggerDomEvent(menuItem.el(), 'click');

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -149,14 +149,7 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
     // `MenuItem` inherits from `ClickableComponent`.
     assert.strictEqual(eventData.handlers.click.length, 2, 'the number of click listeners is two');
 
-    // const blurListenerAddedByMenu = eventData.handlers.blur[1];
     const clickListenerAddedByMenu = eventData.handlers.click[1];
-
-    // assert.strictEqual(
-    //   typeof blurListenerAddedByMenu.calledOnce,
-    //   'undefined',
-    //   'previous blur listener wrapped in the spy should be removed'
-    // );
 
     assert.strictEqual(
       typeof clickListenerAddedByMenu.calledOnce,
@@ -164,13 +157,10 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
       'previous click listener wrapped in the spy should be removed'
     );
 
-    // const blurListenerSpy = eventData.handlers.blur[1] = sinon.spy(blurListenerAddedByMenu);
     const clickListenerSpy = eventData.handlers.click[1] = sinon.spy(clickListenerAddedByMenu);
 
     TestHelpers.triggerDomEvent(menuItem.el(), 'blur');
 
-    // assert.ok(blurListenerSpy.calledOnce, 'blur event listener should be called');
-    // assert.strictEqual(blurListenerSpy.getCall(0).args[0].target, menuItem.el(), 'event target should be the `menuItem`');
     assert.ok(menuChildrenSpy.calledOnce, '`watchedMenu`.`children` has been called');
 
     TestHelpers.triggerDomEvent(menuItem.el(), 'click');

--- a/test/unit/modal-dialog.test.js
+++ b/test/unit/modal-dialog.test.js
@@ -233,12 +233,12 @@ QUnit.test('pressing ESC triggers close(), but only when the modal is opened', f
   const spy = sinon.spy();
 
   this.modal.on('modalclose', spy);
-  this.modal.handleKeyPress({which: ESC});
+  this.modal.handleKeyDown({which: ESC});
   assert.expect(2);
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the closed modal');
 
   this.modal.open();
-  this.modal.handleKeyPress({which: ESC});
+  this.modal.handleKeyDown({which: ESC});
   assert.strictEqual(spy.callCount, 1, 'ESC closed the now-opened modal');
 });
 
@@ -417,7 +417,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.getChild('closeButton'), 'the close button is no longer a child of the modal');
   assert.notOk(initialCloseButton.el(), 'the initial close button was disposed');
 
-  this.modal.handleKeyPress({which: ESC});
+  this.modal.handleKeyDown({which: ESC});
   assert.ok(this.modal.opened(), 'the modal was not closed by the ESC key');
 
   this.modal.close();
@@ -431,7 +431,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.opened(), 'the modal was closed by the new close button');
 
   this.modal.open();
-  this.modal.handleKeyPress({which: ESC});
+  this.modal.handleKeyDown({which: ESC});
   assert.notOk(this.modal.opened(), 'the modal was closed by the ESC key');
 });
 
@@ -519,7 +519,7 @@ QUnit.test('"uncloseable" option', function(assert) {
   assert.notOk(modal.getChild('closeButton'), 'the close button is not present');
 
   modal.open();
-  modal.handleKeyPress({which: ESC});
+  modal.handleKeyDown({which: ESC});
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the modal');
   modal.dispose();
 });

--- a/test/unit/modal-dialog.test.js
+++ b/test/unit/modal-dialog.test.js
@@ -80,6 +80,8 @@ const tabTestHelper = function(assert, player) {
       shiftKey: shift,
       preventDefault() {
         prevented = true;
+      },
+      stopPropagation() {
       }
     });
 
@@ -233,12 +235,12 @@ QUnit.test('pressing ESC triggers close(), but only when the modal is opened', f
   const spy = sinon.spy();
 
   this.modal.on('modalclose', spy);
-  this.modal.handleKeyDown({which: ESC});
+  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
   assert.expect(2);
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the closed modal');
 
   this.modal.open();
-  this.modal.handleKeyDown({which: ESC});
+  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
   assert.strictEqual(spy.callCount, 1, 'ESC closed the now-opened modal');
 });
 
@@ -417,7 +419,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.getChild('closeButton'), 'the close button is no longer a child of the modal');
   assert.notOk(initialCloseButton.el(), 'the initial close button was disposed');
 
-  this.modal.handleKeyDown({which: ESC});
+  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
   assert.ok(this.modal.opened(), 'the modal was not closed by the ESC key');
 
   this.modal.close();
@@ -431,7 +433,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.opened(), 'the modal was closed by the new close button');
 
   this.modal.open();
-  this.modal.handleKeyDown({which: ESC});
+  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
   assert.notOk(this.modal.opened(), 'the modal was closed by the ESC key');
 });
 
@@ -519,7 +521,7 @@ QUnit.test('"uncloseable" option', function(assert) {
   assert.notOk(modal.getChild('closeButton'), 'the close button is not present');
 
   modal.open();
-  modal.handleKeyDown({which: ESC});
+  modal.handleKeyDown({which: ESC, stopPropagation() {}});
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the modal');
   modal.dispose();
 });

--- a/test/unit/modal-dialog.test.js
+++ b/test/unit/modal-dialog.test.js
@@ -5,7 +5,11 @@ import ModalDialog from '../../src/js/modal-dialog';
 import * as Dom from '../../src/js/utils/dom';
 import TestHelpers from './test-helpers';
 
-const ESC = 27;
+const getMockEscapeEvent = () => ({
+  which: 27,
+  preventDefault() {},
+  stopPropagation() {}
+});
 
 QUnit.module('ModalDialog', {
 
@@ -235,12 +239,12 @@ QUnit.test('pressing ESC triggers close(), but only when the modal is opened', f
   const spy = sinon.spy();
 
   this.modal.on('modalclose', spy);
-  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
+  this.modal.handleKeyDown(getMockEscapeEvent());
   assert.expect(2);
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the closed modal');
 
   this.modal.open();
-  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
+  this.modal.handleKeyDown(getMockEscapeEvent());
   assert.strictEqual(spy.callCount, 1, 'ESC closed the now-opened modal');
 });
 
@@ -419,7 +423,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.getChild('closeButton'), 'the close button is no longer a child of the modal');
   assert.notOk(initialCloseButton.el(), 'the initial close button was disposed');
 
-  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
+  this.modal.handleKeyDown(getMockEscapeEvent());
   assert.ok(this.modal.opened(), 'the modal was not closed by the ESC key');
 
   this.modal.close();
@@ -433,7 +437,7 @@ QUnit.test('closeable()', function(assert) {
   assert.notOk(this.modal.opened(), 'the modal was closed by the new close button');
 
   this.modal.open();
-  this.modal.handleKeyDown({which: ESC, stopPropagation() {}});
+  this.modal.handleKeyDown(getMockEscapeEvent());
   assert.notOk(this.modal.opened(), 'the modal was closed by the ESC key');
 });
 
@@ -521,7 +525,7 @@ QUnit.test('"uncloseable" option', function(assert) {
   assert.notOk(modal.getChild('closeButton'), 'the close button is not present');
 
   modal.open();
-  modal.handleKeyDown({which: ESC, stopPropagation() {}});
+  modal.handleKeyDown(getMockEscapeEvent());
   assert.strictEqual(spy.callCount, 0, 'ESC did not close the modal');
   modal.dispose();
 });

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -1,24 +1,8 @@
 /* eslint-env qunit */
+import document from 'global/document';
 import keycode from 'keycode';
 import sinon from 'sinon';
 import TestHelpers from './test-helpers';
-
-QUnit.module('Player: User Actions', {
-
-  beforeEach() {
-    this.clock = sinon.useFakeTimers();
-    this.player = TestHelpers.makePlayer({controls: true});
-  },
-
-  afterEach() {
-    this.player.dispose();
-    this.clock.restore();
-  }
-});
-
-QUnit.test('userActions are disabled by default', function(assert) {
-  assert.strictEqual(this.player.options_.userActions, undefined, 'userActions are disabled by default');
-});
 
 QUnit.module('Player: User Actions: Double Click', {
 
@@ -158,7 +142,7 @@ const mockKeyDownEvent = (key) => {
   };
 };
 
-const executeKeyTest = {
+const defaultKeyTests = {
   fullscreen(player, assert, positive) {
     let fullscreen;
 
@@ -271,12 +255,13 @@ const executeKeyTest = {
 
 QUnit.test('by default, hotkeys are disabled', function(assert) {
   assert.expect(14);
-  executeKeyTest.fullscreen(this.player, assert, false);
-  executeKeyTest.mute(this.player, assert, false);
-  executeKeyTest.playPause(this.player, assert, false);
+  defaultKeyTests.fullscreen(this.player, assert, false);
+  defaultKeyTests.mute(this.player, assert, false);
+  defaultKeyTests.playPause(this.player, assert, false);
 });
 
 QUnit.test('when userActions.hotkeys is true, hotkeys are enabled', function(assert) {
+  this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,
     userActions: {
@@ -285,12 +270,13 @@ QUnit.test('when userActions.hotkeys is true, hotkeys are enabled', function(ass
   });
 
   assert.expect(16);
-  executeKeyTest.fullscreen(this.player, assert, true);
-  executeKeyTest.mute(this.player, assert, true);
-  executeKeyTest.playPause(this.player, assert, true);
+  defaultKeyTests.fullscreen(this.player, assert, true);
+  defaultKeyTests.mute(this.player, assert, true);
+  defaultKeyTests.playPause(this.player, assert, true);
 });
 
 QUnit.test('when userActions.hotkeys is an object, hotkeys are enabled', function(assert) {
+  this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,
     userActions: {
@@ -299,12 +285,13 @@ QUnit.test('when userActions.hotkeys is an object, hotkeys are enabled', functio
   });
 
   assert.expect(16);
-  executeKeyTest.fullscreen(this.player, assert, true);
-  executeKeyTest.mute(this.player, assert, true);
-  executeKeyTest.playPause(this.player, assert, true);
+  defaultKeyTests.fullscreen(this.player, assert, true);
+  defaultKeyTests.mute(this.player, assert, true);
+  defaultKeyTests.playPause(this.player, assert, true);
 });
 
 QUnit.test('when userActions.hotkeys.fullscreenKey can be a function', function(assert) {
+  this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,
     userActions: {
@@ -339,6 +326,7 @@ QUnit.test('when userActions.hotkeys.fullscreenKey can be a function', function(
 });
 
 QUnit.test('when userActions.hotkeys.muteKey can be a function', function(assert) {
+  this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,
     userActions: {
@@ -373,6 +361,7 @@ QUnit.test('when userActions.hotkeys.muteKey can be a function', function(assert
 });
 
 QUnit.test('when userActions.hotkeys.playPauseKey can be a function', function(assert) {
+  this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,
     userActions: {
@@ -405,4 +394,86 @@ QUnit.test('when userActions.hotkeys.playPauseKey can be a function', function(a
 
   assert.strictEqual(this.player.pause.callCount, 1, 'has paused');
   assert.strictEqual(this.player.play.callCount, 1, 'has played');
+});
+
+QUnit.test('hotkeys are ignored when focus is in a textarea', function(assert) {
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  const textarea = document.createElement('textarea');
+
+  this.player.el_.appendChild(textarea);
+  textarea.focus();
+
+  assert.expect(14);
+  defaultKeyTests.fullscreen(this.player, assert, false);
+  defaultKeyTests.mute(this.player, assert, false);
+  defaultKeyTests.playPause(this.player, assert, false);
+});
+
+QUnit.test('hotkeys are ignored when focus is in a text input', function(assert) {
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  const input = document.createElement('input');
+
+  input.type = 'text';
+  this.player.el_.appendChild(input);
+  input.focus();
+
+  assert.expect(14);
+  defaultKeyTests.fullscreen(this.player, assert, false);
+  defaultKeyTests.mute(this.player, assert, false);
+  defaultKeyTests.playPause(this.player, assert, false);
+});
+
+QUnit.test('hotkeys are NOT ignored when focus is on a button element', function(assert) {
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  const button = document.createElement('button');
+
+  this.player.el_.appendChild(button);
+  button.focus();
+
+  assert.expect(16);
+  defaultKeyTests.fullscreen(this.player, assert, true);
+  defaultKeyTests.mute(this.player, assert, true);
+  defaultKeyTests.playPause(this.player, assert, true);
+});
+
+QUnit.test('hotkeys are NOT ignored when focus is on a button input', function(assert) {
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  const input = document.createElement('input');
+
+  input.type = 'button';
+  this.player.el_.appendChild(input);
+  input.focus();
+
+  assert.expect(16);
+  defaultKeyTests.fullscreen(this.player, assert, true);
+  defaultKeyTests.mute(this.player, assert, true);
+  defaultKeyTests.playPause(this.player, assert, true);
 });

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -300,6 +300,11 @@ QUnit.test('when userActions.hotkeys is an object, hotkeys are enabled', functio
 });
 
 QUnit.test('when userActions.hotkeys.fullscreenKey can be a function', function(assert) {
+  if (document[FullscreenApi.fullscreenEnabled] === false) {
+    assert.expect(0);
+    return;
+  }
+
   this.player.dispose();
   this.player = TestHelpers.makePlayer({
     controls: true,

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -3,6 +3,7 @@ import document from 'global/document';
 import keycode from 'keycode';
 import sinon from 'sinon';
 import TestHelpers from './test-helpers';
+import FullscreenApi from '../../src/js/fullscreen-api.js';
 
 QUnit.module('Player: User Actions: Double Click', {
 
@@ -123,6 +124,8 @@ QUnit.test('when userActions.doubleClick is a function, that function is called 
 QUnit.module('Player: User Actions: Hotkeys', {
 
   beforeEach() {
+    this.originalFullscreenEnabled = document[FullscreenApi.fullscreenEnabled];
+    document[FullscreenApi.fullscreenEnabled] = true;
     this.clock = sinon.useFakeTimers();
     this.player = TestHelpers.makePlayer();
   },
@@ -130,6 +133,7 @@ QUnit.module('Player: User Actions: Hotkeys', {
   afterEach() {
     this.player.dispose();
     this.clock.restore();
+    document[FullscreenApi.fullscreenEnabled] = this.originalFullscreenEnabled;
   }
 });
 

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -124,8 +124,6 @@ QUnit.test('when userActions.doubleClick is a function, that function is called 
 QUnit.module('Player: User Actions: Hotkeys', {
 
   beforeEach() {
-    this.originalFullscreenEnabled = document[FullscreenApi.fullscreenEnabled];
-    document[FullscreenApi.fullscreenEnabled] = true;
     this.clock = sinon.useFakeTimers();
     this.player = TestHelpers.makePlayer();
   },
@@ -133,7 +131,6 @@ QUnit.module('Player: User Actions: Hotkeys', {
   afterEach() {
     this.player.dispose();
     this.clock.restore();
-    document[FullscreenApi.fullscreenEnabled] = this.originalFullscreenEnabled;
   }
 });
 
@@ -149,6 +146,13 @@ const mockKeyDownEvent = (key) => {
 const defaultKeyTests = {
   fullscreen(player, assert, positive) {
     let fullscreen;
+
+    if (document[FullscreenApi.fullscreenEnabled] === false) {
+      assert.ok(true, 'skipped fullscreen test because not supported');
+      assert.ok(true, 'skipped fullscreen test because not supported');
+      assert.ok(true, 'skipped fullscreen test because not supported');
+      assert.ok(true, 'skipped fullscreen test because not supported');
+    }
 
     player.isFullscreen = () => fullscreen;
     player.requestFullscreen = sinon.spy();

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -1,0 +1,408 @@
+/* eslint-env qunit */
+import keycode from 'keycode';
+import sinon from 'sinon';
+import TestHelpers from './test-helpers';
+
+QUnit.module('Player: User Actions', {
+
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer({controls: true});
+  },
+
+  afterEach() {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+QUnit.test('userActions are disabled by default', function(assert) {
+  assert.strictEqual(this.player.options_.userActions, undefined, 'userActions are disabled by default');
+});
+
+QUnit.module('Player: User Actions: Double Click', {
+
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer({controls: true});
+  },
+
+  afterEach() {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+QUnit.test('by default, double-click opens fullscreen', function(assert) {
+  let fullscreen = false;
+
+  this.player.isFullscreen = () => fullscreen;
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 1, 'has gone fullscreen once');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+
+  fullscreen = true;
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 1, 'has gone fullscreen once');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 1, 'has exited fullscreen');
+});
+
+QUnit.test('when controls are disabled, double-click does nothing', function(assert) {
+  let fullscreen = false;
+
+  this.player.controls(false);
+
+  this.player.isFullscreen = () => fullscreen;
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+
+  fullscreen = true;
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+});
+
+QUnit.test('when userActions.doubleClick is false, double-click does nothing', function(assert) {
+  let fullscreen = false;
+
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      doubleClick: false
+    }
+  });
+
+  this.player.isFullscreen = () => fullscreen;
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+
+  fullscreen = true;
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+});
+
+QUnit.test('when userActions.doubleClick is a function, that function is called instead of going fullscreen', function(assert) {
+  let fullscreen = false;
+
+  const doubleClickSpy = sinon.spy();
+
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      doubleClick: doubleClickSpy
+    }
+  });
+
+  this.player.isFullscreen = () => fullscreen;
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  let event = {target: this.player.tech_.el_};
+
+  this.player.handleTechDoubleClick_(event);
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+  assert.strictEqual(doubleClickSpy.callCount, 1, 'has called the doubleClick handler');
+  assert.strictEqual(doubleClickSpy.getCall(0).args[0], event, 'has passed the event to the handler');
+
+  fullscreen = true;
+  event = {target: this.player.tech_.el_};
+  this.player.handleTechDoubleClick_(event);
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+  assert.strictEqual(doubleClickSpy.callCount, 2, 'has called the doubleClick handler');
+  assert.strictEqual(doubleClickSpy.getCall(1).args[0], event, 'has passed the event to the handler');
+});
+
+QUnit.module('Player: User Actions: Hotkeys', {
+
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer();
+  },
+
+  afterEach() {
+    this.player.dispose();
+    this.clock.restore();
+  }
+});
+
+const mockKeyDownEvent = (key) => {
+  return {
+    preventDefault() {},
+    stopPropagation() {},
+    type: 'keydown',
+    which: keycode.codes[key]
+  };
+};
+
+const executeKeyTest = {
+  fullscreen(player, assert, positive) {
+    let fullscreen;
+
+    player.isFullscreen = () => fullscreen;
+    player.requestFullscreen = sinon.spy();
+    player.exitFullscreen = sinon.spy();
+
+    fullscreen = false;
+    player.handleKeyDown(mockKeyDownEvent('f'));
+
+    if (positive) {
+      assert.strictEqual(player.requestFullscreen.callCount, 1, 'has gone fullscreen');
+      assert.strictEqual(player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+    } else {
+      assert.strictEqual(player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+      assert.strictEqual(player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+    }
+
+    fullscreen = true;
+    player.handleKeyDown(mockKeyDownEvent('f'));
+
+    if (positive) {
+      assert.strictEqual(player.requestFullscreen.callCount, 1, 'has gone fullscreen');
+      assert.strictEqual(player.exitFullscreen.callCount, 1, 'has exited fullscreen');
+    } else {
+      assert.strictEqual(player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+      assert.strictEqual(player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+    }
+  },
+  mute(player, assert, positive) {
+    let muted = false;
+
+    player.muted = sinon.spy((val) => {
+      if (val !== undefined) {
+        muted = val;
+      }
+      return muted;
+    });
+
+    player.handleKeyDown(mockKeyDownEvent('m'));
+
+    if (positive) {
+      assert.strictEqual(player.muted.callCount, 2, 'muted was called twice (get and set)');
+      assert.strictEqual(player.muted.lastCall.args[0], true, 'most recent call was to mute');
+    } else {
+      assert.strictEqual(player.muted.callCount, 0, 'muted was not called');
+    }
+
+    player.handleKeyDown(mockKeyDownEvent('m'));
+
+    if (positive) {
+      assert.strictEqual(player.muted.callCount, 4, 'muted was called twice (get and set)');
+      assert.strictEqual(player.muted.lastCall.args[0], false, 'most recent call was to unmute');
+    } else {
+      assert.strictEqual(player.muted.callCount, 0, 'muted was not called');
+    }
+  },
+  playPause(player, assert, positive) {
+    let paused;
+
+    player.paused = () => paused;
+    player.pause = sinon.spy();
+    player.play = sinon.spy();
+
+    paused = true;
+    player.handleKeyDown(mockKeyDownEvent('k'));
+
+    if (positive) {
+      assert.strictEqual(player.pause.callCount, 0, 'has not paused');
+      assert.strictEqual(player.play.callCount, 1, 'has played');
+    } else {
+      assert.strictEqual(player.pause.callCount, 0, 'has not paused');
+      assert.strictEqual(player.play.callCount, 0, 'has not played');
+    }
+
+    paused = false;
+    player.handleKeyDown(mockKeyDownEvent('k'));
+
+    if (positive) {
+      assert.strictEqual(player.pause.callCount, 1, 'has paused');
+      assert.strictEqual(player.play.callCount, 1, 'has played');
+    } else {
+      assert.strictEqual(player.pause.callCount, 0, 'has not paused');
+      assert.strictEqual(player.play.callCount, 0, 'has not played');
+    }
+
+    paused = true;
+    player.handleKeyDown(mockKeyDownEvent('space'));
+
+    if (positive) {
+      assert.strictEqual(player.pause.callCount, 1, 'has paused');
+      assert.strictEqual(player.play.callCount, 2, 'has played twice');
+    } else {
+      assert.strictEqual(player.pause.callCount, 0, 'has not paused');
+      assert.strictEqual(player.play.callCount, 0, 'has not played');
+    }
+
+    paused = false;
+    player.handleKeyDown(mockKeyDownEvent('space'));
+
+    if (positive) {
+      assert.strictEqual(player.pause.callCount, 2, 'has paused twice');
+      assert.strictEqual(player.play.callCount, 2, 'has played twice');
+    } else {
+      assert.strictEqual(player.pause.callCount, 0, 'has not paused');
+      assert.strictEqual(player.play.callCount, 0, 'has not played');
+    }
+  }
+};
+
+QUnit.test('by default, hotkeys are disabled', function(assert) {
+  assert.expect(14);
+  executeKeyTest.fullscreen(this.player, assert, false);
+  executeKeyTest.mute(this.player, assert, false);
+  executeKeyTest.playPause(this.player, assert, false);
+});
+
+QUnit.test('when userActions.hotkeys is true, hotkeys are enabled', function(assert) {
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  assert.expect(16);
+  executeKeyTest.fullscreen(this.player, assert, true);
+  executeKeyTest.mute(this.player, assert, true);
+  executeKeyTest.playPause(this.player, assert, true);
+});
+
+QUnit.test('when userActions.hotkeys is an object, hotkeys are enabled', function(assert) {
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: {}
+    }
+  });
+
+  assert.expect(16);
+  executeKeyTest.fullscreen(this.player, assert, true);
+  executeKeyTest.mute(this.player, assert, true);
+  executeKeyTest.playPause(this.player, assert, true);
+});
+
+QUnit.test('when userActions.hotkeys.fullscreenKey can be a function', function(assert) {
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: {
+        fullscreenKey: sinon.spy((e) => keycode.isEventKey(e, 'x'))
+      }
+    }
+  });
+
+  let fullscreen;
+
+  this.player.isFullscreen = () => fullscreen;
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  fullscreen = false;
+  this.player.handleKeyDown(mockKeyDownEvent('f'));
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 1, 'has gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+
+  fullscreen = true;
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.requestFullscreen.callCount, 1, 'has gone fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 1, 'has exited fullscreen');
+});
+
+QUnit.test('when userActions.hotkeys.muteKey can be a function', function(assert) {
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: {
+        muteKey: sinon.spy((e) => keycode.isEventKey(e, 'x'))
+      }
+    }
+  });
+
+  let muted = false;
+
+  this.player.muted = sinon.spy((val) => {
+    if (val !== undefined) {
+      muted = val;
+    }
+    return muted;
+  });
+
+  this.player.handleKeyDown(mockKeyDownEvent('m'));
+
+  assert.strictEqual(this.player.muted.callCount, 0, 'muted was not called');
+
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.muted.callCount, 2, 'muted was called twice (get and set)');
+  assert.strictEqual(this.player.muted.lastCall.args[0], true, 'most recent call was to mute');
+
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.muted.callCount, 4, 'muted was called twice (get and set)');
+  assert.strictEqual(this.player.muted.lastCall.args[0], false, 'most recent call was to unmute');
+});
+
+QUnit.test('when userActions.hotkeys.playPauseKey can be a function', function(assert) {
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: {
+        playPauseKey: sinon.spy((e) => keycode.isEventKey(e, 'x'))
+      }
+    }
+  });
+
+  let paused;
+
+  this.player.paused = () => paused;
+  this.player.pause = sinon.spy();
+  this.player.play = sinon.spy();
+
+  paused = true;
+  this.player.handleKeyDown(mockKeyDownEvent('k'));
+  this.player.handleKeyDown(mockKeyDownEvent('space'));
+
+  assert.strictEqual(this.player.pause.callCount, 0, 'has not paused');
+  assert.strictEqual(this.player.play.callCount, 0, 'has not played');
+
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.pause.callCount, 0, 'has not paused');
+  assert.strictEqual(this.player.play.callCount, 1, 'has played');
+
+  paused = false;
+  this.player.handleKeyDown(mockKeyDownEvent('x'));
+
+  assert.strictEqual(this.player.pause.callCount, 1, 'has paused');
+  assert.strictEqual(this.player.play.callCount, 1, 'has played');
+});

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -152,6 +152,7 @@ const defaultKeyTests = {
       assert.ok(true, 'skipped fullscreen test because not supported');
       assert.ok(true, 'skipped fullscreen test because not supported');
       assert.ok(true, 'skipped fullscreen test because not supported');
+      return;
     }
 
     player.isFullscreen = () => fullscreen;


### PR DESCRIPTION
## Description
We saw some issues with the recently-added hotkeys feature.

1. The use of `document`-level `keydown` listeners caused players to respond to events they should not have when focus was not in the player.
1. Those `keydown` events which do reach the player are considered possible hotkey triggers. However, there are sometimes elements added to the player - such as in modals - that _should not_ trigger hotkeys.

## Specific Changes proposed
- Rename any `handleKeyPress` method to `handleKeyDown` because that's more accurate. Define `handleKeyPress` as a `Component` method that delegates to `handleKeyDown` so that any existing uses of it should not break.
- Do not bind/unbind listeners on `focus`/`blur` and stop listening for `keydown` events on the `document`. It's better to just listen for `keydown` events on the components themselves.
- Add exceptions for certain elements by their `tagName`.
- Call `stopPropagation()` in key places to prevent double `keydown` handling.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
