### PR TITLE
feat: any event function

### DIFF
--- a/src/js/event-target.js
+++ b/src/js/event-target.js
@@ -119,6 +119,16 @@ EventTarget.prototype.one = function(type, fn) {
   this.addEventListener = ael;
 };
 
+EventTarget.prototype.race = function(type, fn) {
+  // Remove the addEventListener alialing Events.on
+  // so we don't get into an infinite type loop
+  const ael = this.addEventListener;
+
+  this.addEventListener = () => {};
+  Events.race(this, type, fn);
+  this.addEventListener = ael;
+};
+
 /**
  * This function causes an event to happen. This will then cause any `event listeners`
  * that are waiting for that event, to get called. If there are no `event listeners`

--- a/src/js/event-target.js
+++ b/src/js/event-target.js
@@ -119,13 +119,13 @@ EventTarget.prototype.one = function(type, fn) {
   this.addEventListener = ael;
 };
 
-EventTarget.prototype.race = function(type, fn) {
+EventTarget.prototype.any = function(type, fn) {
   // Remove the addEventListener alialing Events.on
   // so we don't get into an infinite type loop
   const ael = this.addEventListener;
 
   this.addEventListener = () => {};
-  Events.race(this, type, fn);
+  Events.any(this, type, fn);
   this.addEventListener = ael;
 };
 

--- a/src/js/event-target.js
+++ b/src/js/event-target.js
@@ -110,7 +110,7 @@ EventTarget.prototype.removeEventListener = EventTarget.prototype.off;
  *        The function to be called once for each event name.
  */
 EventTarget.prototype.one = function(type, fn) {
-  // Remove the addEventListener alialing Events.on
+  // Remove the addEventListener aliasing Events.on
   // so we don't get into an infinite type loop
   const ael = this.addEventListener;
 
@@ -120,7 +120,7 @@ EventTarget.prototype.one = function(type, fn) {
 };
 
 EventTarget.prototype.any = function(type, fn) {
-  // Remove the addEventListener alialing Events.on
+  // Remove the addEventListener aliasing Events.on
   // so we don't get into an infinite type loop
   const ael = this.addEventListener;
 

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -312,12 +312,12 @@ const EventedMixin = {
    *         If the first argument was another evented object, this will be
    *         the listener function.
    */
-  race(...args) {
+  any(...args) {
     const {isTargetingSelf, target, type, listener} = normalizeListenArgs(this, args);
 
     // Targeting this evented object.
     if (isTargetingSelf) {
-      listen(target, 'race', type, listener);
+      listen(target, 'any', type, listener);
 
     // Targeting another evented object.
     } else {
@@ -329,7 +329,7 @@ const EventedMixin = {
       // Use the same function ID as the listener so we can remove it later
       // it using the ID of the original listener.
       wrapper.guid = listener.guid;
-      listen(target, 'race', type, wrapper);
+      listen(target, 'any', type, wrapper);
     }
   },
 

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -476,3 +476,29 @@ export function one(elem, type, fn) {
   func.guid = fn.guid = fn.guid || Guid.newGUID();
   on(elem, type, func);
 }
+
+/**
+ * Trigger a listener only once and then turn if off for all
+ * configured events
+ *
+ * @param {Element|Object} elem
+ *        Element or object to bind to.
+ *
+ * @param {string|string[]} type
+ *        Name/type of event
+ *
+ * @param {Event~EventListener} fn
+ *        Event listener function
+ */
+export function race(elem, type, fn) {
+  const func = function() {
+    off(elem, type, func);
+    fn.apply(this, arguments);
+  };
+
+  // copy the guid to the new function so it can removed using the original function's ID
+  func.guid = fn.guid = fn.guid || Guid.newGUID();
+
+  // multiple ons, but one off for everything
+  on(elem, type, func);
+}

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -490,7 +490,7 @@ export function one(elem, type, fn) {
  * @param {Event~EventListener} fn
  *        Event listener function
  */
-export function race(elem, type, fn) {
+export function any(elem, type, fn) {
   const func = function() {
     off(elem, type, func);
     fn.apply(this, arguments);

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -347,3 +347,39 @@ QUnit.test('retrigger with an object should use the old element as target', func
   Events.off(el1, 'click');
   Events.off(el2, 'click');
 });
+
+QUnit.test('should listen only once for race', function(assert) {
+  const el = document.createElement('div');
+  let triggered = 0;
+  const listener = () => triggered++;
+
+  Events.race(el, 'click', listener);
+  assert.equal(triggered, 0, 'listener was not yet triggered');
+  // 1 click
+  Events.trigger(el, 'click');
+
+  assert.equal(triggered, 1, 'listener was triggered');
+  // No click should happen.
+  Events.trigger(el, 'click');
+  assert.equal(triggered, 1, 'listener was not triggered again');
+});
+
+QUnit.test('only the first event should call listener via race', function(assert) {
+  const el = document.createElement('div');
+  let triggered = 0;
+  const listener = () => triggered++;
+
+  Events.race(el, ['click', 'event1', 'event2'], listener);
+  assert.equal(triggered, 0, 'listener was not yet triggered');
+
+  // 1 click
+  Events.trigger(el, 'click');
+  assert.equal(triggered, 1, 'listener was triggered');
+  // nothing below here should trigger the Callback
+  Events.trigger(el, 'click');
+  Events.trigger(el, 'event1');
+  Events.trigger(el, 'event1');
+  Events.trigger(el, 'event2');
+  Events.trigger(el, 'event2');
+  assert.equal(triggered, 1, 'listener was not triggered again');
+});

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -348,12 +348,12 @@ QUnit.test('retrigger with an object should use the old element as target', func
   Events.off(el2, 'click');
 });
 
-QUnit.test('should listen only once for race', function(assert) {
+QUnit.test('should listen only once for any', function(assert) {
   const el = document.createElement('div');
   let triggered = 0;
   const listener = () => triggered++;
 
-  Events.race(el, 'click', listener);
+  Events.any(el, 'click', listener);
   assert.equal(triggered, 0, 'listener was not yet triggered');
   // 1 click
   Events.trigger(el, 'click');
@@ -364,12 +364,12 @@ QUnit.test('should listen only once for race', function(assert) {
   assert.equal(triggered, 1, 'listener was not triggered again');
 });
 
-QUnit.test('only the first event should call listener via race', function(assert) {
+QUnit.test('only the first event should call listener via any', function(assert) {
   const el = document.createElement('div');
   let triggered = 0;
   const listener = () => triggered++;
 
-  Events.race(el, ['click', 'event1', 'event2'], listener);
+  Events.any(el, ['click', 'event1', 'event2'], listener);
   assert.equal(triggered, 0, 'listener was not yet triggered');
 
   // 1 click

--- a/test/unit/mixins/evented.test.js
+++ b/test/unit/mixins/evented.test.js
@@ -61,11 +61,11 @@ QUnit.test('evented() with custom element', function(assert) {
   );
 });
 
-QUnit.test('on(), one(), and race() errors', function(assert) {
+QUnit.test('on(), one(), and any() errors', function(assert) {
   const targeta = this.targets.a = evented({});
   const targetb = this.targets.b = evented({});
 
-  ['on', 'one', 'race'].forEach(method => {
+  ['on', 'one', 'any'].forEach(method => {
     assert.throws(() => targeta[method](), errors.type, 'the expected error is thrown');
     assert.throws(() => targeta[method]('   '), errors.type, 'the expected error is thrown');
     assert.throws(() => targeta[method]([]), errors.type, 'the expected error is thrown');
@@ -188,11 +188,11 @@ QUnit.test('one() can add a listener to an array of event types on this object',
   });
 });
 
-QUnit.test('race() can add a listener to one event type on this object', function(assert) {
+QUnit.test('any() can add a listener to one event type on this object', function(assert) {
   const a = this.targets.a = evented({});
   const spy = sinon.spy();
 
-  a.race('x', spy);
+  a.any('x', spy);
   a.trigger('x');
   a.trigger('x');
 
@@ -204,11 +204,11 @@ QUnit.test('race() can add a listener to one event type on this object', functio
   });
 });
 
-QUnit.test('race() can add a listener to an array of event types on this object', function(assert) {
+QUnit.test('any() can add a listener to an array of event types on this object', function(assert) {
   const a = this.targets.a = evented({});
   const spy = sinon.spy();
 
-  a.race(['x', 'y'], spy);
+  a.any(['x', 'y'], spy);
   a.trigger('x');
   a.trigger('y');
   a.trigger('x');
@@ -312,12 +312,12 @@ QUnit.test('one() can add a listener to an array of event types on a different t
   });
 });
 
-QUnit.test('race() can add a listener to one event type on a different target object', function(assert) {
+QUnit.test('any() can add a listener to one event type on a different target object', function(assert) {
   const a = this.targets.a = evented({});
   const b = this.targets.b = evented({});
   const spy = sinon.spy();
 
-  a.race(b, 'x', spy);
+  a.any(b, 'x', spy);
   b.trigger('x');
 
   // Make sure we aren't magically binding a listener to "a".
@@ -331,12 +331,12 @@ QUnit.test('race() can add a listener to one event type on a different target ob
   });
 });
 
-QUnit.test('race() can add a listener to an array of event types on a different target object', function(assert) {
+QUnit.test('any() can add a listener to an array of event types on a different target object', function(assert) {
   const a = this.targets.a = evented({});
   const b = this.targets.b = evented({});
   const spy = sinon.spy();
 
-  a.race(b, ['x', 'y'], spy);
+  a.any(b, ['x', 'y'], spy);
   b.trigger('x');
   b.trigger('y');
   b.trigger('x');


### PR DESCRIPTION
There are a lot of times in Video.js code and plugin code where we want a function to trigger a single time for an array of events, then remove itself after the first event. I have implemented such a function via `any`.

Here are some examples:

Single event
```js
const player = videojs('some-player-id');

player.any('a', (e) => console.log(e.type + ' triggered');

player.trigger('a');
// logs 'a triggered'

player.trigger('a');
// logs nothing as the listener has been removed.
```

Multiple Events
```js
const player = videojs('some-player-id');

player.any(['a', 'b', 'c', 'd'], (e) => console.log(e.type + ' triggered');

player.trigger('d');
// logs 'd triggered'

player.trigger('a');
player.trigger('b');
player.trigger('c');
player.trigger('d');
// all triggers above log nothing as the listener is removed after the first 'd' trigger.
```

I also added some comments to the code about videojs/video.js#5962 

EDIT: updated from `race` to `any`