### PR TITLE
fix(fs): fix isFullscreen check for spec-api

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2661,6 +2661,21 @@ class Player extends Component {
       this.toggleFullscreenClass_();
       return;
     }
+
+    if (prefixedFS) {
+      const fsApi = FullscreenApi;
+      const el = this.el();
+      let isFs = document[fsApi.fullscreenElement] === el;
+
+      if (!isFs && el.matches) {
+        isFs = el.matches(':' + fsApi.fullscreen);
+      } else if (!isFs && el.msMatchesSelector) {
+        isFs = el.msMatchesSelector(':' + fsApi.fullscreen);
+      }
+
+      return isFs;
+    }
+
     return !!this.isFullscreen_;
   }
 

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -158,14 +158,26 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
   const fullscreentoggle = new FullscreenToggle(player);
   const oldfsel = document[FullscreenApi.fullscreenElement];
 
+  // because we now check against the fullscreen element in the non-prefixed case (which if(prefixedFS) checks for)
+  // we override isFullscreen to ignore that check for this test
   if (prefixedFS) {
-    document[FullscreenApi.fullscreenElement] = player.el();
+    const originalIsFS = player.isFullscreen;
+    let currentFS;
+    
+    player.isFullscreen = function(isFS) {
+      if (isFS !== undefined) {
+        currentFS = isFS;
+        originalIsFS.call(player, isFS);
+        return;
+      }
+      
+      return currentFS;
+    };
   }
   player.isFullscreen(true);
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Non-Fullscreen', 'Control Text is correct while switching to fullscreen mode');
 
-  document[FullscreenApi.fullscreenElement] = oldfsel;
   player.isFullscreen(false);
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Fullscreen', 'Control Text is correct while switching back to normal mode');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -164,7 +164,7 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
   player.isFullscreen(true);
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Non-Fullscreen', 'Control Text is correct while switching to fullscreen mode');
-  
+
   document[FullscreenApi.fullscreenElement] = oldfsel;
   player.isFullscreen(false);
   player.trigger('fullscreenchange');

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -158,20 +158,20 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
   const fullscreentoggle = new FullscreenToggle(player);
   const oldfsel = document[FullscreenApi.fullscreenElement];
 
-  player.isFullscreen(true);
   if (prefixedFS) {
     document[FullscreenApi.fullscreenElement] = player.el();
   }
+  player.isFullscreen(true);
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Non-Fullscreen', 'Control Text is correct while switching to fullscreen mode');
-
+  
+  document[FullscreenApi.fullscreenElement] = oldfsel;
   player.isFullscreen(false);
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Fullscreen', 'Control Text is correct while switching back to normal mode');
 
   player.dispose();
   fullscreentoggle.dispose();
-  document[FullscreenApi.fullscreenElement] = oldfsel;
 });
 
 QUnit.test('Clicking MuteToggle when volume is above 0 should toggle muted property and not change volume', function(assert) {

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -171,7 +171,7 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
 
   player.dispose();
   fullscreentoggle.dispose();
-  document[FullscreenApi.fullscreenElement] = odlfsel;
+  document[FullscreenApi.fullscreenElement] = oldfsel;
 });
 
 QUnit.test('Clicking MuteToggle when volume is above 0 should toggle muted property and not change volume', function(assert) {

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -7,6 +7,7 @@ import PlaybackRateMenuButton from '../../src/js/control-bar/playback-rate-menu/
 import Slider from '../../src/js/slider/slider.js';
 import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
 import ControlBar from '../../src/js/control-bar/control-bar.js';
+import FullscreenApi, {prefixedAPI as prefixedFS} from '../../src/js/fullscreen-api.js'
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 import sinon from 'sinon';
@@ -155,8 +156,12 @@ QUnit.test('should hide playback rate control if it\'s not supported', function(
 QUnit.test('Fullscreen control text should be correct when fullscreenchange is triggered', function(assert) {
   const player = TestHelpers.makePlayer();
   const fullscreentoggle = new FullscreenToggle(player);
+  const oldfsel = document[FullscreenApi.fullscreenElement];
 
   player.isFullscreen(true);
+  if (prefixedFS) {
+    document[FullscreenApi.fullscreenElement] = player.el();
+  }
   player.trigger('fullscreenchange');
   assert.equal(fullscreentoggle.controlText(), 'Non-Fullscreen', 'Control Text is correct while switching to fullscreen mode');
 
@@ -166,6 +171,7 @@ QUnit.test('Fullscreen control text should be correct when fullscreenchange is t
 
   player.dispose();
   fullscreentoggle.dispose();
+  document[FullscreenApi.fullscreenElement] = odlfsel;
 });
 
 QUnit.test('Clicking MuteToggle when volume is above 0 should toggle muted property and not change volume', function(assert) {

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -7,7 +7,7 @@ import PlaybackRateMenuButton from '../../src/js/control-bar/playback-rate-menu/
 import Slider from '../../src/js/slider/slider.js';
 import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
 import ControlBar from '../../src/js/control-bar/control-bar.js';
-import FullscreenApi, {prefixedAPI as prefixedFS} from '../../src/js/fullscreen-api.js'
+import FullscreenApi, {prefixedAPI as prefixedFS} from '../../src/js/fullscreen-api.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 import sinon from 'sinon';

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -7,7 +7,7 @@ import PlaybackRateMenuButton from '../../src/js/control-bar/playback-rate-menu/
 import Slider from '../../src/js/slider/slider.js';
 import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
 import ControlBar from '../../src/js/control-bar/control-bar.js';
-import FullscreenApi, {prefixedAPI as prefixedFS} from '../../src/js/fullscreen-api.js';
+import {prefixedAPI as prefixedFS} from '../../src/js/fullscreen-api.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 import sinon from 'sinon';

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -156,21 +156,20 @@ QUnit.test('should hide playback rate control if it\'s not supported', function(
 QUnit.test('Fullscreen control text should be correct when fullscreenchange is triggered', function(assert) {
   const player = TestHelpers.makePlayer();
   const fullscreentoggle = new FullscreenToggle(player);
-  const oldfsel = document[FullscreenApi.fullscreenElement];
 
   // because we now check against the fullscreen element in the non-prefixed case (which if(prefixedFS) checks for)
   // we override isFullscreen to ignore that check for this test
   if (prefixedFS) {
     const originalIsFS = player.isFullscreen;
     let currentFS;
-    
+
     player.isFullscreen = function(isFS) {
       if (isFS !== undefined) {
         currentFS = isFS;
         originalIsFS.call(player, isFS);
         return;
       }
-      
+
       return currentFS;
     };
   }


### PR DESCRIPTION
For non-prefixed APIs, check directly against the fullscreen element
rather than using the cached value.

Fixes #5814.