### PR TITLE
Introduce write method to handle value output

### DIFF
--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -82,6 +82,16 @@ class TimeTooltip extends Component {
     }
 
     this.el_.style.right = `-${pullTooltipBy}px`;
+    this.write(content);
+  }
+
+  /**
+   * Write the time to the tooltip DOM element.
+   *
+   * @param {String} content
+   *        The formatted time for the tooltip.
+   */
+  write(content) {
     Dom.textContent(this.el_, content);
   }
 


### PR DESCRIPTION
## Description
I found myself needing to access the value that was being written to the time tooltip and the only way to do this was to overwrite the entire `update` method just to set the `time` content to the TimeTooltip state. This method would allow for overriding a single line of code if the DOM mutations aren't preferred.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
