### PR TITLE
fix: fix an error thrown in IE11 when exiting fullscreen

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1994,11 +1994,22 @@ class Player extends Component {
    */
   documentFullscreenChange_(e) {
     const fsApi = FullscreenApi;
+    const el = this.el();
 
-    this.isFullscreen(document[fsApi.fullscreenElement] === this.el() || this.el().matches(':' + fsApi.fullscreen));
+    let isFullscreen = false;
+
+    if (document[fsApi.fullscreenElement] === this.el()) {
+      isFullscreen = true;
+    } else {
+      const matches = typeof el.msMatchesSelector === 'function' ? 'msMatchesSelector' : 'matches';
+
+      isFullscreen = el[matches](':' + fsApi.fullscreen);
+    }
+
+    this.isFullscreen(isFullscreen);
 
     // If cancelling fullscreen, remove event listener.
-    if (this.isFullscreen() === false) {
+    if (!isFullscreen) {
       Events.off(document, fsApi.fullscreenchange, this.boundDocumentFullscreenChange_);
     }
 


### PR DESCRIPTION
## Description
When exiting fullscreen in IE11, an error is thrown: `Object doesn't support property or method 'matches'`

## Specific Changes proposed
Use the non-standard `msMatchesSelector` if available.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
