### PR TITLE
Load text tracks on demand

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -58,6 +58,7 @@
     * [nativeAudioTracks](#nativeaudiotracks)
     * [nativeTextTracks](#nativetexttracks)
     * [nativeVideoTracks](#nativevideotracks)
+    * [preloadTextTracks](#preloadtexttracks)
 
 ## Standard `<video>` Element Options
 
@@ -606,6 +607,14 @@ Can be set to `false` to force emulation of text tracks instead of native suppor
 > Type: `boolean`
 
 Can be set to `false` to disable native video track support. Most commonly used with [videojs-contrib-hls][videojs-contrib-hls].
+
+#### `preloadTextTracks`
+
+> Type: `boolean`
+
+Can be set to `false` to delay loading of non-active text tracks until use. This can cause a short delay when switching captions during which there may be missing captions.
+
+The default behavior is to preload all text tracks.
 
 [plugins]: /docs/guides/plugins.md
 

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -141,6 +141,8 @@ class Tech extends Component {
       this.emulateTextTracks();
     }
 
+    this.preloadTextTracks = options.preloadTextTracks !== false;
+
     this.autoRemoteTextTracks_ = new TRACK_TYPES.ALL.text.ListClass();
 
     this.initTrackListeners();


### PR DESCRIPTION
## Description

Reimplementation of https://github.com/videojs/video.js/pull/2192
on current code. Seems to work but has not been carefully tested,
especially on conditions such as slow networks or default tracks.
Would appreciate testing and any advice on ways this may go
wrong and need additional work.

For https://github.com/videojs/video.js/issues/5252

This delays loading of the VTT cue files until they are selected.
For sites like Wikipedia that tend to have large numbers of
crowdsourced subtitles and can show many files together on one
page, this saves a lot of unnecessary network transfer and API
hits.

## Specific Changes proposed

* does not load text tracks immediately unless they are default or non-subtitles
* does load them on demand

## Requirements Checklist
- [X] Feature implemented / Bug fixed (seems to work!)
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE) (tested in Firefox)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
