### PR TITLE
feat: Add option to suppress initial error for non-playable sources

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -35,6 +35,7 @@
   * [plugins](#plugins)
   * [responsive](#responsive)
   * [sources](#sources)
+  * [suppressNotSupportedMessage](#suppressNotSupportedMessage)
   * [techCanOverridePoster](#techcanoverrideposter)
   * [techOrder](#techorder)
   * [userActions](#useractions)
@@ -373,6 +374,12 @@ Using `<source>` elements will have the same effect:
   <source src="//path/to/video.webm" type="video/webm">
 </video>
 ```
+
+### `suppressNotSupportedMessage`
+
+> Type: `boolean`
+
+If set to true, then the no compatible source error will not be triggered immediately and instead will occur on the first user interaction. This is useful for Google's "mobile friendly" test tool, which can't play video but where you might not want to see an error displayed.
 
 ### `techCanOverridePoster`
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -35,7 +35,7 @@
   * [plugins](#plugins)
   * [responsive](#responsive)
   * [sources](#sources)
-  * [suppressNotSupportedMessage](#suppressNotSupportedMessage)
+  * [suppressNotSupportedError](#suppressNotSupportedError)
   * [techCanOverridePoster](#techcanoverrideposter)
   * [techOrder](#techorder)
   * [userActions](#useractions)
@@ -375,7 +375,7 @@ Using `<source>` elements will have the same effect:
 </video>
 ```
 
-### `suppressNotSupportedMessage`
+### `suppressNotSupportedError`
 
 > Type: `boolean`
 

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -47,7 +47,9 @@ class BigPlayButton extends Button {
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
       silencePromise(playPromise);
-      this.player_.tech(true).focus();
+      if (this.player_.tech(true)) {
+        this.player_.tech(true).focus();
+      }
       return;
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3712,7 +3712,7 @@ class Player extends Component {
     // Suppress the first error message for no compatible source until
     // user interaction
     if (this.options_.suppressNotSupportedMessage &&
-        err & err.message &&
+        err && err.message &&
         err.message === this.localize(this.options_.notSupportedMessage)
     ) {
       const triggerSuppressedError = function() {
@@ -3720,7 +3720,7 @@ class Player extends Component {
       };
 
       this.options_.suppressNotSupportedMessage = false;
-      this.one(['click', 'touchstart'], triggerSuppressedError);
+      this.any(['click', 'touchstart'], triggerSuppressedError);
       this.one('loadstart', function() {
         this.off(['click', 'touchstart'], triggerSuppressedError);
       });

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3709,6 +3709,24 @@ class Player extends Component {
       return this.error_ || null;
     }
 
+    // Suppress the first error message for no compatible source until
+    // user interaction
+    if (this.options_.suppressNotSupportedMessage &&
+        err & err.message &&
+        err.message === this.localize(this.options_.notSupportedMessage)
+    ) {
+      const triggerSuppressedError = function() {
+        this.error(err);
+      };
+
+      this.options_.suppressNotSupportedMessage = false;
+      this.one(['click', 'touchstart'], triggerSuppressedError);
+      this.one('loadstart', function() {
+        this.off(['click', 'touchstart'], triggerSuppressedError);
+      });
+      return;
+    }
+
     // restoring to default
     if (err === null) {
       this.error_ = err;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3711,7 +3711,7 @@ class Player extends Component {
 
     // Suppress the first error message for no compatible source until
     // user interaction
-    if (this.options_.suppressNotSupportedMessage &&
+    if (this.options_.suppressNotSupportedError &&
         err && err.message &&
         err.message === this.localize(this.options_.notSupportedMessage)
     ) {
@@ -3719,7 +3719,7 @@ class Player extends Component {
         this.error(err);
       };
 
-      this.options_.suppressNotSupportedMessage = false;
+      this.options_.suppressNotSupportedError = false;
       this.any(['click', 'touchstart'], triggerSuppressedError);
       this.one('loadstart', function() {
         this.off(['click', 'touchstart'], triggerSuppressedError);

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -112,7 +112,9 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
-    this.player_.tech(true).focus();
+    if (this.player_.tech(true)) {
+      this.player_.tech(true).focus();
+    }
 
     if (this.player_.paused()) {
       silencePromise(this.player_.play());

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -336,6 +336,68 @@ QUnit.test('should asynchronously fire error events during source selection', fu
   log.error.restore();
 });
 
+QUnit.test('should suppress source error messages', function(assert) {
+  const clock = sinon.useFakeTimers();
+
+  const player = TestHelpers.makePlayer({
+    suppressNotSupportedMessage: true
+  });
+
+  let errors = 0;
+
+  player.on('error', function(e) {
+    errors++;
+  });
+
+  player.loadTech_('Html5');
+
+  player.src({src: 'http://example.com', type: 'video/null'});
+
+  clock.tick(1);
+
+  assert.ok(errors === 0, 'no error on bad source load');
+
+  player.trigger('click');
+
+  clock.tick(1);
+
+  assert.ok(errors === 1, 'error after click');
+
+  player.dispose();
+});
+
+QUnit.test('should cancel a suppressed error message on loadstart', function(assert) {
+  const clock = sinon.useFakeTimers();
+
+  const player = TestHelpers.makePlayer({
+    suppressNotSupportedMessage: true
+  });
+
+  let errors = 0;
+
+  player.on('error', function(e) {
+    errors++;
+  });
+
+  player.src({src: 'http://example.com', type: 'video/null'});
+
+  clock.tick(1);
+
+  assert.ok(errors === 0, 'no error on bad source load');
+
+  player.trigger('loadstart');
+
+  clock.tick(1);
+
+  player.trigger('click');
+
+  clock.tick(1);
+
+  assert.ok(errors === 0, 'no error after click after loadstart');
+
+  player.dispose();
+});
+
 QUnit.test('should set the width, height, and aspect ratio via a css class', function(assert) {
   const player = TestHelpers.makePlayer();
   const getStyleText = function(styleEl) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -340,7 +340,8 @@ QUnit.test('should suppress source error messages', function(assert) {
   const clock = sinon.useFakeTimers();
 
   const player = TestHelpers.makePlayer({
-    suppressNotSupportedMessage: true
+    techOrder: ['foo'],
+    suppressNotSupportedError: true
   });
 
   let errors = 0;
@@ -349,19 +350,17 @@ QUnit.test('should suppress source error messages', function(assert) {
     errors++;
   });
 
-  player.loadTech_('Html5');
+  player.src({src: 'http://example.com', type: 'video/mp4'});
 
-  player.src({src: 'http://example.com', type: 'video/null'});
+  clock.tick(10);
 
-  clock.tick(1);
-
-  assert.ok(errors === 0, 'no error on bad source load');
+  assert.strictEqual(errors, 0, 'no error on bad source load');
 
   player.trigger('click');
 
-  clock.tick(1);
+  clock.tick(10);
 
-  assert.ok(errors === 1, 'error after click');
+  assert.strictEqual(errors, 1, 'error after click');
 
   player.dispose();
 });
@@ -370,7 +369,8 @@ QUnit.test('should cancel a suppressed error message on loadstart', function(ass
   const clock = sinon.useFakeTimers();
 
   const player = TestHelpers.makePlayer({
-    suppressNotSupportedMessage: true
+    techOrder: ['foo'],
+    suppressNotSupportedError: true
   });
 
   let errors = 0;
@@ -379,21 +379,26 @@ QUnit.test('should cancel a suppressed error message on loadstart', function(ass
     errors++;
   });
 
-  player.src({src: 'http://example.com', type: 'video/null'});
+  player.src({src: 'http://example.com', type: 'video/mp4'});
 
-  clock.tick(1);
+  clock.tick(10);
 
-  assert.ok(errors === 0, 'no error on bad source load');
+  assert.strictEqual(errors, 0, 'no error on bad source load');
+  assert.strictEqual(
+    player.options_.suppressNotSupportedError,
+    false,
+    'option was unset when error was suppressed'
+  );
 
   player.trigger('loadstart');
 
-  clock.tick(1);
+  clock.tick(10);
 
   player.trigger('click');
 
-  clock.tick(1);
+  clock.tick(10);
 
-  assert.ok(errors === 0, 'no error after click after loadstart');
+  assert.strictEqual(errors, 0, 'no error after click after loadstart');
 
   player.dispose();
 });


### PR DESCRIPTION
## Description
Video.js checks whether sources are playable and both displays a message to the user and logs an error to the console. In Google's [mobile friendly test](https://search.google.com/test/mobile-friendly) and related tools, this message and error is triggered because their test browser's video element does not support any video formats. Some Video.js users are concerned about the æsthetics of the rendered preview within the tools and whether this might have an SEO impact.

## Specific Changes proposed
Adds a `suppressNotSupportedError` option, defaulting to `false`. If set to `true`, if no sources are playable the error is deferred to the first human interaction (click or touchstart) but cleared if a loadstart occurs.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
