### PR TITLE
fix: do not seek to live on first manual seek when autoplaying a live stream

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -110,16 +110,23 @@ class LiveTracker extends Component {
       return;
     }
 
+    // If we haven't seen a timeupdate, we need to check whether playback
+    // began before this component started tracking. This can happen commonly
+    // when using autoplay.
+    if (!this.timeupdateSeen_) {
+      this.timeupdateSeen_ = this.player_.hasStarted();
+    }
+
     this.trackingInterval_ = this.setInterval(this.trackLive_, 30);
     this.trackLive_();
 
     this.on(this.player_, 'play', this.trackLive_);
     this.on(this.player_, 'pause', this.trackLive_);
-    this.one(this.player_, 'play', this.handlePlay);
 
     // this is to prevent showing that we are not live
     // before a video starts to play
     if (!this.timeupdateSeen_) {
+      this.one(this.player_, 'play', this.handlePlay);
       this.handleTimeupdate = () => {
         this.timeupdateSeen_ = true;
         this.handleTimeupdate = null;

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -153,6 +153,44 @@ QUnit.module('LiveTracker', () => {
     assert.equal(playCalls, 0, 'should not have called play');
   });
 
+  QUnit.test('seeks to live edge on the first timeupdate after playback is requested', function(assert) {
+    sinon.spy(this.liveTracker, 'seekToLiveEdge');
+
+    // Begin live tracking.
+    this.player.duration(Infinity);
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called yet');
+
+    this.player.trigger('play');
+    this.player.trigger('playing');
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called yet');
+
+    this.player.trigger('timeupdate');
+    assert.ok(this.liveTracker.seekToLiveEdge.calledOnce, 'seekToLiveEdge was called');
+
+    this.player.trigger('timeupdate');
+    assert.ok(this.liveTracker.seekToLiveEdge.calledOnce, 'seekToLiveEdge was not called on subsequent timeupdate');
+  });
+
+  QUnit.test('does not seek to live edge on the first timeupdate after playback is requested if playback already began', function(assert) {
+    sinon.spy(this.liveTracker, 'seekToLiveEdge');
+
+    // Begin live tracking.
+    this.liveTracker.stopTracking();
+    this.player.hasStarted = () => true;
+    this.liveTracker.startTracking();
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called');
+
+    this.player.trigger('play');
+    this.player.trigger('playing');
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called');
+
+    this.player.trigger('timeupdate');
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called');
+
+    this.player.trigger('timeupdate');
+    assert.ok(this.liveTracker.seekToLiveEdge.notCalled, 'seekToLiveEdge was not called');
+  });
+
   QUnit.test('single seekable, helpers should be correct', function(assert) {
     // simple
     this.player.seekable = () => createTimeRanges(10, 50);


### PR DESCRIPTION
## Description
This addresses an issue where autoplay players playing live streams would seek to the live edge after the first seek a user initiated (via UI or API).

## Specific Changes proposed
Before listening for the `play`/`timeupdate` combination when starting the `LiveTracker`, check if the player has already started playback.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
editors=1000#0))
- [ ] Reviewed by Two Core Contributors
