### PR TITLE
Silenced `play()` promise

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2254,8 +2254,11 @@ class Player extends Component {
     const PromiseClass = this.options_.Promise || window.Promise;
 
     if (PromiseClass) {
-      return new PromiseClass((resolve) => {
-        this.play_(resolve);
+      return new PromiseClass(resolve => {
+        this.play_(promise => {
+          silencePromise(promise);
+          resolve();
+        });
       });
     }
 


### PR DESCRIPTION
## Description
It seems like the method `Player.play()` tries to silence the tech promises only when the promises are not supported.

i.e. If we run the following code in Chrome 75:
```js
var player = window.player = videojs('video-element');
player.ready(function () {
  player.play();
  player.pause();
});
```
the browser will show the error message `Uncaught (in promise) DOMException: The play() request was interrupted`.

I don't think this is the expected behaviour because by default the private method `play_()` wraps the promises returned by the tech method with `silencePromise()`. (https://github.com/videojs/video.js/blob/master/src/js/player.js#L2274)

The method `Player.play()`, however, overrides that argument with the `resolve` of the new promise.

## Related issues
- https://github.com/videojs/video.js/issues/3474
- https://github.com/videojs/video.js/pull/3518
