### PR TITLE
lang: clone zh-CN to zh-Hans and zh-TW to zh-Hant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ es5/*
 .idea/
 
 core.js
+
+# Ignore Chinese clones for now.
+lang/zh-Han*.json

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "build:css:default": "sass --no-source-map src/css/vjs.scss dist/video-js.css",
     "postbuild:css:default": "postcss --verbose --config postcss.config.js -d dist/ dist/video-js.css",
     "build:lang": "npm-run-all build:lang:*",
+    "build:lang:chinese-s": "shx cp lang/zh-CN.json lang/zh-Hans.json",
+    "build:lang:chinese-t": "shx cp lang/zh-TW.json lang/zh-Hant.json",
     "build:lang:js": "vjslang --dir dist/lang",
     "build:lang:copy": "shx cp -R lang/* dist/lang/",
     "minify": "npm-run-all minify:*",


### PR DESCRIPTION
## Description
Currently, `zh-CN` and `zh-TW` are used as shorthands for Simplified and Traditional Chinese character sets, respectively. However, they carry with them a built-in assumption about the geographic locale which may not be appropriate in all cases.

The codes `zh-Hans` and `zh-Hant` are more correct in that they refer only to the character set and not the geographic locale. Further specificity is available via codes like `zh-Hans-CN`.

## Specific Changes proposed
* Clone `zh-CN` to `zh-Hans` and `zh-TW` to `zh-Hant` during the build process.
* For the time being, do not check these copied files into source control. In v8.0, Video.js can switch to the new codes.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
