### PR TITLE
feat: add isDisposed method to components

### DIFF
--- a/docs/guides/player-workflows.md
+++ b/docs/guides/player-workflows.md
@@ -54,6 +54,10 @@ Additionally, these actions are recursively applied to _all_ the player's child 
 
 > **Note**: Do _not_ remove players via standard DOM removal methods: this will leave listeners and other objects in memory that you might not be able to clean up!
 
+### Checking if a Player is Disposed
+
+At times, it is useful to know whether or not a player reference in your code is stale. The `isDisposed()` method is available on all components (including players) for this purpose.
+
 ### Signs of an Undisposed Player
 
 Seeing an error such as:

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -131,10 +131,12 @@ class Component {
      * @type {EventTarget~Event}
      *
      * @property {boolean} [bubbles=false]
-     *           set to false so that the close event does not
+     *           set to false so that the dispose event does not
      *           bubble up
      */
     this.trigger({type: 'dispose', bubbles: false});
+
+    this.isDisposed_ = true;
 
     // Dispose all children.
     if (this.children_) {
@@ -166,6 +168,16 @@ class Component {
 
     // remove reference to the player after disposing of the element
     this.player_ = null;
+  }
+
+  /**
+   * Determine whether or not this component has been disposed.
+   *
+   * @return {boolean}
+   *         If the component has been disposed, will be `true`. Otherwise, `false`.
+   */
+  isDisposed() {
+    return Boolean(this.isDisposed_);
   }
 
   /**

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -124,6 +124,11 @@ class Component {
    */
   dispose() {
 
+    // Bail out if the component has already been disposed.
+    if (this.isDisposed_) {
+      return;
+    }
+
     /**
      * Triggered when a `Component` is disposed.
      *

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -58,6 +58,8 @@ class Component {
       this.player_ = player;
     }
 
+    this.isDisposed_ = false;
+
     // Hold the reference to the parent component via `addChild` method
     this.parentComponent_ = null;
 

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -340,6 +340,7 @@ QUnit.test('should dispose of component and children', function(assert) {
   const child = comp.addChild('Component');
 
   assert.ok(comp.children().length === 1);
+  assert.notOk(comp.isDisposed(), 'the component reports that it is not disposed');
 
   // Add a listener
   comp.on('click', function() {
@@ -370,6 +371,7 @@ QUnit.test('should dispose of component and children', function(assert) {
     !Object.getOwnPropertyNames(data).length,
     'original listener data object was emptied'
   );
+  assert.ok(comp.isDisposed(), 'the component reports that it is disposed');
 });
 
 QUnit.test('should add and remove event listeners to element', function(assert) {


### PR DESCRIPTION
## Description
Usually, when we need to check if a component (or player) has been disposed, we check if its element exists:

```js
if (player.el()) {
  // Do something...
}
```

It would be clearer if we had a method for that:

```js
if (!player.isDisposed()) {
  // Do something...
}
```

## Specific Changes proposed
* Add `isDisposed` method to the base component.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
