### PR TITLE
revert: "fix(play-toggle): call event.stopPropagation in the click ha…

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -61,7 +61,6 @@ class PlayToggle extends Button {
     } else {
       this.player_.pause();
     }
-    event.stopPropagation();
   }
 
   /**


### PR DESCRIPTION
…ndler (#5803)"

PR #5083 introduces a fix to #5624, an issue with click events when
Polymer's tap gesture is being used. However, this causes an issue where
`player.on('click')` no longer triggers from the play toggle. Thus, we
revert the change. In addition, looking at Polymer 2 and 3, they
recommend against using the tap gesture.

Fixes #6092