### PR TITLE
fix(pip): hide PiP button in browsers not support the WICG spec

### DIFF
--- a/src/js/control-bar/control-bar.js
+++ b/src/js/control-bar/control-bar.js
@@ -2,6 +2,7 @@
  * @file control-bar.js
  */
 import Component from '../component.js';
+import document from 'global/document';
 
 // Required children
 import './play-toggle.js';
@@ -68,10 +69,17 @@ ControlBar.prototype.options_ = {
     'descriptionsButton',
     'subsCapsButton',
     'audioTrackButton',
-    'pictureInPictureToggle',
     'fullscreenToggle'
   ]
 };
+
+if ('exitPictureInPicture' in document) {
+  ControlBar.prototype.options_.children.splice(
+    ControlBar.prototype.options_.children.length - 1,
+    0,
+    'pictureInPictureToggle'
+  );
+}
 
 Component.registerComponent('ControlBar', ControlBar);
 export default ControlBar;


### PR DESCRIPTION
This came up in #5824. We do currently disable the button if PiP isn't available or isn't allowed, but we should just not show it if the APIs aren't available in the browser to keep the control bar cleaner.
When Safari support is added, this should be augmented to check for Safari PiP support.