### PR TITLE
perf: Do not add/remove listeners for each timer

### DIFF
--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -981,11 +981,11 @@ QUnit.test('setTimeout should remove dispose handler on trigger', function(asser
 
   comp.setTimeout(() => {}, 1);
 
-  assert.equal(comp.setTimeoutIds_.length, 1, 'we removed our dispose handle');
+  assert.equal(comp.setTimeoutIds_.size, 1, 'we removed our dispose handle');
 
   this.clock.tick(1);
 
-  assert.equal(comp.setTimeoutIds_.length, 0, 'we removed our dispose handle');
+  assert.equal(comp.setTimeoutIds_.size, 0, 'we removed our dispose handle');
 
   comp.dispose();
 });
@@ -1007,11 +1007,11 @@ QUnit.test('requestAnimationFrame should remove dispose handler on trigger', fun
 
   comp.requestAnimationFrame(spyRAF);
 
-  assert.equal(comp.rafIds_.length, 1, 'we got a new dispose handler');
+  assert.equal(comp.rafIds_.size, 1, 'we got a new dispose handler');
 
   this.clock.tick(1);
 
-  assert.equal(comp.rafIds_.length, 0, 'we removed our dispose handle');
+  assert.equal(comp.rafIds_.size, 0, 'we removed our dispose handle');
 
   comp.dispose();
 

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -978,25 +978,20 @@ QUnit.test('*AnimationFrame methods fall back to timers if rAF not supported', f
 
 QUnit.test('setTimeout should remove dispose handler on trigger', function(assert) {
   const comp = new Component(getFakePlayer());
-  const el = comp.el();
-  const data = DomData.get(el);
 
   comp.setTimeout(() => {}, 1);
 
-  assert.equal(data.handlers.dispose.length, 2, 'we got a new dispose handler');
-  assert.ok(/vjs-timeout-\d/.test(data.handlers.dispose[1].guid), 'we got a new dispose handler');
+  assert.equal(comp.setTimeoutIds_.length, 1, 'we removed our dispose handle');
 
   this.clock.tick(1);
 
-  assert.equal(data.handlers.dispose.length, 1, 'we removed our dispose handle');
+  assert.equal(comp.setTimeoutIds_.length, 0, 'we removed our dispose handle');
 
   comp.dispose();
 });
 
 QUnit.test('requestAnimationFrame should remove dispose handler on trigger', function(assert) {
   const comp = new Component(getFakePlayer());
-  const el = comp.el();
-  const data = DomData.get(el);
   const oldRAF = window.requestAnimationFrame;
   const oldCAF = window.cancelAnimationFrame;
 
@@ -1012,12 +1007,11 @@ QUnit.test('requestAnimationFrame should remove dispose handler on trigger', fun
 
   comp.requestAnimationFrame(spyRAF);
 
-  assert.equal(data.handlers.dispose.length, 2, 'we got a new dispose handler');
-  assert.ok(/vjs-raf-\d/.test(data.handlers.dispose[1].guid), 'we got a new dispose handler');
+  assert.equal(comp.rafIds_.length, 1, 'we got a new dispose handler');
 
   this.clock.tick(1);
 
-  assert.equal(data.handlers.dispose.length, 1, 'we removed our dispose handle');
+  assert.equal(comp.rafIds_.length, 0, 'we removed our dispose handle');
 
   comp.dispose();
 


### PR DESCRIPTION
## Description
Saves about 1ms per `setTimeout`/`requestAnimationFrame`. Since we have several long running intervals that use these this is a fairly significant performance improvement.

