### PR TITLE
chore: fix lang watch loop caused by zh-* copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "minify:css:cdn": "cleancss dist/alt/video-js-cdn.css -o dist/alt/video-js-cdn.min.css",
     "minify:css:default": "cleancss dist/video-js.css -o dist/video-js.min.css",
     "watch": "npm-run-all -p watch:*",
-    "watch:lang": "chokidar --initial 'lang/**/*.json' -c 'npm run build:lang'",
+    "watch:lang": "chokidar --initial 'lang/**/!(zh-Hans|zh-Hant)*.json' -c 'npm run build:lang'",
     "watch:rollup": "rollup -c -w --no-progress",
     "watch:css": "npm-run-all -p build:css:default build:css:cdn watch:css:*",
     "watch:css:default": "npm run build:css:default -- --watch",


### PR DESCRIPTION
## Description
Currently running `npm run start` or `npm run watch` causes a loop since chokidar watches for all `.json` changes and during `build:lang` we copy to `.json` files. This causes chokidar to `build:lang` forever.
