### PR TITLE
perf: Throttle ProgressControl ui updates, add document.hidden check to time-displays

### DIFF
--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -38,7 +38,6 @@ class LoadProgressBar extends Component {
     this.partEls_ = [];
     this.update = bind(this, this.update);
     activeElement(this, {
-      update: this.update,
       startUpdate: () => {
         this.on(player, 'progress', this.update);
         this.update();

--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -13,7 +13,8 @@ const percentify = function(time, end) {
 
   percent = (percent >= 1 ? 1 : percent) * 100;
 
-  return percent;
+  // round to two digits
+  return percent.toFixed(2) + '%';
 };
 
 /**
@@ -88,11 +89,11 @@ class LoadProgressBar extends Component {
 
       if (this.el_.style.width !== percent) {
         // update the width of the progress bar
-        this.el_.style.width = percent + '%';
+        this.el_.style.width = percent;
       }
 
       // update the control-text
-      Dom.textContent(controlTextPercentage, percent.toFixed(2) + '%');
+      Dom.textContent(controlTextPercentage, percent);
 
       // add child elements to represent the individual buffered time ranges
       for (let i = 0; i < buffered.length; i++) {
@@ -106,8 +107,8 @@ class LoadProgressBar extends Component {
         }
 
         // set the percent based on the width of the progress bar (bufferedEnd)
-        const leftPercent = percentify(start, bufferedEnd) + '%';
-        const widthPercent = percentify(end - start, bufferedEnd) + '%';
+        const leftPercent = percentify(start, bufferedEnd);
+        const widthPercent = percentify(end - start, bufferedEnd);
 
         if (part.style.left !== leftPercent) {
           part.style.left = leftPercent;

--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -38,6 +38,7 @@ class LoadProgressBar extends Component {
     this.partEls_ = [];
     this.update = bind(this, this.update);
     activeElement(this, {
+      update: this.update,
       startUpdate: () => {
         this.on(player, 'progress', this.update);
         this.update();

--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -38,8 +38,6 @@ class LoadProgressBar extends Component {
     this.partEls_ = [];
     this.update = bind(this, this.update);
     activeElement(this, {
-      liveUpdates: false,
-      update: this.update,
       startUpdate: () => {
         this.on(player, 'progress', this.update);
         this.update();

--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -93,7 +93,9 @@ class LoadProgressBar extends Component {
       }
 
       // update the control-text
-      Dom.textContent(controlTextPercentage, percent);
+      if (controlTextPercentage.textContent !== percent) {
+        Dom.textContent(controlTextPercentage, percent);
+      }
 
       // add child elements to represent the individual buffered time ranges
       for (let i = 0; i < buffered.length; i++) {

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -35,6 +35,7 @@ class ProgressControl extends Component {
       extraComponents: [this.getChild('seekBar')],
       startUpdate: () => {
         this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);
+        this.throttledUpdate();
       },
       stopUpdate: () => {
         this.clearInterval(this.updateInterval_);

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -32,6 +32,7 @@ class ProgressControl extends Component {
     this.throttledUpdate = throttle(bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, {
+      update: this.throttledUpdate,
       extraComponents: [this.getChild('seekBar')],
       startUpdate: () => {
         this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -32,8 +32,7 @@ class ProgressControl extends Component {
     this.throttledUpdate = throttle(bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, {
-      update: this.throttledUpdate,
-      extraComponents: [this.getChild('seekBar')],
+      update: this.update,
       startUpdate: () => {
         this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);
         this.throttledUpdate();

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -32,7 +32,6 @@ class ProgressControl extends Component {
     this.throttledUpdate = throttle(bind(this, this.update), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, {
-      update: this.update,
       startUpdate: () => {
         this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);
         this.throttledUpdate();

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -4,6 +4,7 @@
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import {bind, throttle, UPDATE_REFRESH_INTERVAL} from '../../utils/fn.js';
+import activeElement from '../../mixins/active-element.js';
 
 import './seek-bar.js';
 
@@ -28,8 +29,32 @@ class ProgressControl extends Component {
     super(player, options);
     this.handleMouseMove = throttle(bind(this, this.handleMouseMove), UPDATE_REFRESH_INTERVAL);
     this.throttledHandleMouseSeek = throttle(bind(this, this.handleMouseSeek), UPDATE_REFRESH_INTERVAL);
+    this.throttledUpdate = throttle(bind(this, this.update), UPDATE_REFRESH_INTERVAL);
+    this.update = bind(this, this.update);
+
+    activeElement(this, {
+      extraComponents: [this.getChild('seekBar')],
+      update: this.throttledUpdate,
+      startUpdate: () => {
+        this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);
+      },
+      stopUpdate: () => {
+        this.clearInterval(this.updateInterval_);
+        this.updateInterval_ = null;
+      }
+    });
 
     this.enable();
+  }
+
+  update() {
+    const seekBar = this.getChild('seekBar');
+
+    if (!seekBar) {
+      return;
+    }
+
+    seekBar.update();
   }
 
   /**

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -30,11 +30,9 @@ class ProgressControl extends Component {
     this.handleMouseMove = throttle(bind(this, this.handleMouseMove), UPDATE_REFRESH_INTERVAL);
     this.throttledHandleMouseSeek = throttle(bind(this, this.handleMouseSeek), UPDATE_REFRESH_INTERVAL);
     this.throttledUpdate = throttle(bind(this, this.update), UPDATE_REFRESH_INTERVAL);
-    this.update = bind(this, this.update);
 
     activeElement(this, {
       extraComponents: [this.getChild('seekBar')],
-      update: this.throttledUpdate,
       startUpdate: () => {
         this.updateInterval_ = this.setInterval(this.throttledUpdate, UPDATE_REFRESH_INTERVAL);
       },

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -29,6 +29,7 @@ class TimeDisplay extends Component {
     this.throttledUpdateContent = throttle(bind(this, this.updateContent), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, Object.assign({
+      update: this.throttledUpdateContent,
       startUpdate: () => {
         this.on(player, 'timeupdate', this.throttledUpdateContent);
         // update as soon as we are visible again

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -29,7 +29,6 @@ class TimeDisplay extends Component {
     this.throttledUpdateContent = throttle(bind(this, this.updateContent), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, Object.assign({
-      update: this.throttledUpdateContent,
       startUpdate: () => {
         this.on(player, 'timeupdate', this.throttledUpdateContent);
         // update as soon as we are visible again

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -29,11 +29,10 @@ class TimeDisplay extends Component {
     this.throttledUpdateContent = throttle(bind(this, this.updateContent), UPDATE_REFRESH_INTERVAL);
 
     activeElement(this, Object.assign({
-      update: this.throttledUpdateContent,
       startUpdate: () => {
         this.on(player, 'timeupdate', this.throttledUpdateContent);
         // update as soon as we are visible again
-        this.throttledUpdateContent();
+        this.updateContent();
       },
       stopUpdate: () => {
         this.off(player, 'timeupdate', this.throttledUpdateContent);

--- a/src/js/mixins/active-element.js
+++ b/src/js/mixins/active-element.js
@@ -1,0 +1,69 @@
+import document from 'global/document';
+import {bind} from '../utils/fn.js';
+
+const defaults = {
+  liveUpdates: true,
+  extraComponents: []
+};
+
+const activeElement = function(target, options = {}) {
+  const settings = Object.assign({}, defaults, options);
+
+  if (!options.update || !options.startUpdate || !options.stopUpdate) {
+    throw new Error('activeElement mixin requires update, startUpdate, and stopUpdate functions');
+  }
+
+  const els = [target.el_].concat(settings.extraComponents.map((c) => c.el_));
+  const player = target.player_;
+
+  target.mouseFocus_ = false;
+  target.keyFocus_ = false;
+
+  let started = false;
+
+  const shouldUpdate = bind(target, function() {
+    const isActive = target.keyFocus_ || target.mouseFocus_ || player.userActive() ||
+      els.some((el) => document.activeElement === el);
+
+    return !player.paused() && isActive && !document.hidden;
+  });
+
+  const startOrStopUpdate = bind(target, function() {
+    const _shouldUpdate = shouldUpdate();
+
+    if (!started && _shouldUpdate) {
+      settings.startUpdate();
+      started = true;
+    } else if (started && !_shouldUpdate) {
+      settings.stopUpdate();
+      started = false;
+    }
+  });
+
+  if ('hidden' in document && 'visibilityState' in document) {
+    target.on(document, 'visibilitychange', startOrStopUpdate);
+    target.on('dispose', function() {
+      target.off(document, 'visibilitychange', startOrStopUpdate);
+    });
+  }
+  target.on(player, ['playing', 'pause'], startOrStopUpdate);
+
+  target.on(['mouseenter', 'mouseleave', 'focus', 'blur'], function(e) {
+    if ((/^mouse/).test(e.type)) {
+      target.mouseFocus_ = e.type === 'mouseenter' ? true : false;
+    } else {
+      target.keyFocus_ = e.type === 'focus' ? true : false;
+    }
+  });
+
+  // do not start updaing the ui until playback starts
+  target.one(player, 'playing', function() {
+    target.on(player, ['useractive', 'userinactive'], startOrStopUpdate);
+    target.on(['mouseenter', 'mouseleave', 'focus', 'blur'], startOrStopUpdate);
+    if (settings.liveUpdates && player.liveTracker) {
+      target.on(player.liveTracker, 'liveedgechange', settings.update);
+    }
+  });
+};
+
+export default activeElement;

--- a/src/js/mixins/active-element.js
+++ b/src/js/mixins/active-element.js
@@ -47,7 +47,7 @@ const activeElement = function(target, options = {}) {
     return Boolean((!player.paused() || isLive) && isActive && !settings.doc.hidden);
   });
 
-  target.startOrStopUpdate = bind(target, function() {
+  target.startOrStopUpdate = bind(target, function(e) {
     const _shouldUpdate = target.shouldUpdate();
 
     if (!target.activeElementStarted_ && _shouldUpdate) {
@@ -59,9 +59,11 @@ const activeElement = function(target, options = {}) {
     }
   });
 
-  // we must call update on ended or pause, as the controls come back up
+  // startUpdate right away on pause, then toggle it off if neccessary in
+  // startOrStopUpdate. This prevents cases were pause happens, the controls come up
+  // and the ui is out of date and not going to update.
+  target.on(player, ['pause'], settings.startUpdate);
   target.on(player, ['playing', 'pause'], target.startOrStopUpdate);
-  target.on(player, ['pause'], settings.update);
 
   target.on(['mouseenter', 'mouseleave', 'focusin', 'focusout'], function(e) {
     if (e.type.indexOf('mouse') !== -1) {

--- a/src/js/mixins/active-element.js
+++ b/src/js/mixins/active-element.js
@@ -22,6 +22,8 @@ const defaults = {
  *        The Function to run when updates should be started
  * @param {Function} options.stopUpdate
  *        The function to run when updates should be stopped
+ * @param {Function} options.update
+ *        The actual update function that is being started and stopped.
  * @param {Array} options.extraComponents
  *        Extra components to watch for keyboard focus.
  * @param {Object} options.doc
@@ -30,8 +32,8 @@ const defaults = {
 const activeElement = function(target, options = {}) {
   const settings = Object.assign({}, defaults, options);
 
-  if (!options.startUpdate || !options.stopUpdate) {
-    throw new Error('activeElement mixin requires startUpdate and stopUpdate functions');
+  if (!options.update || !options.startUpdate || !options.stopUpdate) {
+    throw new Error('activeElement mixin requires startUpdate, stopUpdate, and update functions');
   }
 
   const els = [target.el_].concat(settings.extraComponents.map((c) => c.el_));
@@ -61,7 +63,9 @@ const activeElement = function(target, options = {}) {
     }
   });
 
+  // we must call update on ended or pause, as the controls come back up
   target.on(player, ['playing', 'pause'], target.startOrStopUpdate);
+  target.on(player, ['pause'], settings.update);
 
   target.on(['mouseenter', 'mouseleave', 'focus', 'blur'], function(e) {
     if ((/^mouse/).test(e.type)) {

--- a/src/js/mixins/active-element.js
+++ b/src/js/mixins/active-element.js
@@ -29,8 +29,8 @@ const defaults = {
 const activeElement = function(target, options = {}) {
   const settings = Object.assign({}, defaults, options);
 
-  if (!options.update || !options.startUpdate || !options.stopUpdate) {
-    throw new Error('activeElement mixin requires startUpdate, stopUpdate, and update functions');
+  if (!options.startUpdate || !options.stopUpdate) {
+    throw new Error('activeElement mixin requires startUpdate and stopUpdate functions');
   }
 
   const player = target.player_;
@@ -82,7 +82,7 @@ const activeElement = function(target, options = {}) {
       });
     }
     target.on(player, ['useractive', 'userinactive'], target.startOrStopUpdate);
-    target.on(['mouseenter', 'mouseleave', 'focus', 'blur'], target.startOrStopUpdate);
+    target.on(['mouseenter', 'mouseleave', 'focusin', 'focusout'], target.startOrStopUpdate);
     if (player.liveTracker) {
       target.on(player.liveTracker, 'liveedgechange', target.startOrStopUpdate);
     }

--- a/test/unit/mixins/active-element.test.js
+++ b/test/unit/mixins/active-element.test.js
@@ -61,6 +61,7 @@ QUnit.module('mixins: activeElement', {
     activeElement(this.comp, {
       startUpdate: () => this.startUpdates++,
       stopUpdate: () => this.stopUpdates++,
+      update: noop,
       doc: this.doc
     });
   },
@@ -74,11 +75,14 @@ QUnit.module('mixins: activeElement', {
 });
 
 QUnit.test('throws an error without startUpdate/stopUpdate functions', function(assert) {
-  const error = new Error('activeElement mixin requires startUpdate and stopUpdate functions');
+  const error = new Error('activeElement mixin requires startUpdate, stopUpdate, and update functions');
 
   assert.throws(() => activeElement(this.comp, {}), error, 'throws an error');
   assert.throws(() => activeElement(this.comp, {startUpdate: noop}), error, 'throws an error');
   assert.throws(() => activeElement(this.comp, {stopUpdate: noop}), error, 'throws an error');
+  assert.throws(() => activeElement(this.comp, {update: noop}), error, 'throws an error');
+  assert.throws(() => activeElement(this.comp, {startUpdate: noop, update: noop}), error, 'throws an error');
+  assert.throws(() => activeElement(this.comp, {stopUpdate: noop, update: noop}), error, 'throws an error');
 });
 
 QUnit.test('shouldUpdate is correct by default', function(assert) {

--- a/test/unit/mixins/active-element.test.js
+++ b/test/unit/mixins/active-element.test.js
@@ -1,0 +1,240 @@
+/* eslint-env qunit */
+import activeElement from '../../../src/js/mixins/active-element.js';
+import Component from '../../../src/js/component.js';
+
+const noop = () => {};
+
+QUnit.module('mixins: activeElement', {
+  beforeEach(done) {
+    this.userActive = false;
+    this.live = false;
+    this.paused = true;
+    this.keyFocus = false;
+    this.mouseFocus = false;
+    this.hidden = false;
+    this.activeElement = null;
+
+    this.liveTracker = Object.assign(new Component({}), {
+      isLive: () => this.live
+    });
+
+    this.player = Object.assign(new Component({}), {
+      paused: () => this.paused,
+      userActive: () => this.userActive,
+      liveTracker: this.liveTracker
+    });
+
+    this.doc = Object.assign(new Component({}), {visibilityState: true});
+
+    Object.defineProperty(this.doc, 'hidden', {
+      get: () => this.hidden,
+      set: (v) => {
+        this.hidden = v;
+      }
+    });
+
+    Object.defineProperty(this.doc, 'activeElement', {
+      get: () => this.activeElement,
+      set: (v) => {
+        this.activeElement = v;
+      }
+    });
+
+    this.comp = new Component(this.player);
+    Object.defineProperty(this.comp, 'mouseFocus_', {
+      get: () => this.mouseFocus,
+      set: (v) => {
+        this.mouseFocus = v;
+      }
+    });
+
+    Object.defineProperty(this.comp, 'keyFocus_', {
+      get: () => this.keyFocus,
+      set: (v) => {
+        this.keyFocus = v;
+      }
+    });
+
+    this.startUpdates = 0;
+    this.stopUpdates = 0;
+
+    activeElement(this.comp, {
+      startUpdate: () => this.startUpdates++,
+      stopUpdate: () => this.stopUpdates++,
+      doc: this.doc
+    });
+  },
+
+  afterEach() {
+    this.comp.dispose();
+    this.doc.dispose();
+    this.player.dispose();
+    this.liveTracker.dispose();
+  }
+});
+
+QUnit.test('throws an error without startUpdate/stopUpdate functions', function(assert) {
+  const error = new Error('activeElement mixin requires startUpdate and stopUpdate functions');
+
+  assert.throws(() => activeElement(this.comp, {}), error, 'throws an error');
+  assert.throws(() => activeElement(this.comp, {startUpdate: noop}), error, 'throws an error');
+  assert.throws(() => activeElement(this.comp, {stopUpdate: noop}), error, 'throws an error');
+});
+
+QUnit.test('shouldUpdate is correct by default', function(assert) {
+
+  assert.strictEqual(this.comp.shouldUpdate(), false, 'false by default');
+
+  const setters = {
+    userActive: () => true,
+    mouseFocus: () => true,
+    keyFocus: () => true,
+    activeElement: () => this.comp.el_
+  };
+
+  const runTest = (state, trueOrFalse) => {
+    let runActiveTests = false;
+
+    if (state.active) {
+      runActiveTests = true;
+    }
+
+    delete state.active;
+    Object.assign(this, state);
+    if (runActiveTests) {
+      Object.keys(setters).forEach((k) => {
+        const oldValue = this[k];
+
+        this[k] = setters[k]();
+        assert.strictEqual(this.comp.shouldUpdate(), trueOrFalse, `${trueOrFalse} when ${k} is set and ${JSON.stringify(state)}`);
+        this[k] = oldValue;
+      });
+    } else {
+      assert.strictEqual(this.comp.shouldUpdate(), trueOrFalse, `${trueOrFalse} when ${JSON.stringify(state)}`);
+    }
+
+    this.live = false;
+    this.hidden = false;
+    this.paused = false;
+  };
+
+  // active permutations
+  runTest({active: true, paused: false, live: false, hidden: false}, true);
+  runTest({active: true, paused: true, live: false, hidden: false}, false);
+  runTest({active: true, paused: true, live: true, hidden: false}, true);
+  runTest({active: true, paused: true, live: true, hidden: true}, false);
+  runTest({active: true, paused: false, live: true, hidden: true}, false);
+  runTest({active: true, paused: false, live: false, hidden: true}, false);
+  runTest({active: true, paused: false, live: true, hidden: false}, true);
+
+  // paused permutations
+  runTest({paused: true, active: false, live: false, hidden: false}, false);
+  runTest({paused: true, active: true, live: false, hidden: false}, false);
+  runTest({paused: true, active: true, live: true, hidden: false}, true);
+  runTest({paused: true, active: true, live: true, hidden: true}, false);
+  runTest({paused: true, active: false, live: true, hidden: true}, false);
+  runTest({paused: true, active: false, live: false, hidden: true}, false);
+  runTest({paused: true, active: false, live: true, hidden: false}, false);
+
+  // live permutations
+  runTest({live: true, active: false, paused: false, hidden: false}, false);
+  runTest({live: true, active: true, paused: false, hidden: false}, true);
+  runTest({live: true, active: true, paused: true, hidden: false}, true);
+  runTest({live: true, active: true, paused: true, hidden: true}, false);
+  runTest({live: true, active: false, paused: true, hidden: true}, false);
+  runTest({live: true, active: false, paused: false, hidden: true}, false);
+  runTest({live: true, active: false, paused: true, hidden: false}, false);
+
+  // live permutations
+  runTest({hidden: true, active: false, paused: false, live: false}, false);
+  runTest({hidden: true, active: true, paused: false, live: false}, false);
+  runTest({hidden: true, active: true, paused: true, live: false}, false);
+  runTest({hidden: true, active: true, paused: true, live: true}, false);
+  runTest({hidden: true, active: false, paused: true, live: true}, false);
+  runTest({hidden: true, active: false, paused: false, live: true}, false);
+  runTest({hidden: true, active: false, paused: true, live: false}, false);
+});
+
+QUnit.test('startUpdate and stopUpdate run correctly run for events', function(assert) {
+
+  ['mouseenter', 'mouseleave', 'focus', 'blur'].forEach((event) => {
+    this.comp.trigger(event);
+  });
+  ['useractive', 'userinactive'].forEach((event) => {
+    this.userActive = event === 'useractive' ? true : false;
+    this.player.trigger(event);
+  });
+  this.hidden = true;
+  this.doc.trigger('visibilitychange');
+
+  this.hidden = false;
+  this.doc.trigger('visibilitychange');
+
+  this.live = true;
+  this.liveTracker.trigger('liveedgechange');
+
+  assert.equal(this.startUpdates, 0, 'no start updates for events before playing');
+  assert.equal(this.stopUpdates, 0, 'no stop updates for events before playing');
+
+  // reset everything
+  this.live = false;
+  this.userActive = false;
+  this.keyFocus = false;
+  this.mouseFocus = false;
+  this.paused = true;
+  this.hidden = false;
+
+  // set into an active state
+  this.paused = false;
+  this.userActive = true;
+
+  this.player.trigger('playing');
+  assert.equal(this.startUpdates, 1, 'playing runs startUpdate');
+
+  this.paused = true;
+  this.player.trigger('pause');
+  assert.equal(this.stopUpdates, 1, 'pause runs stopUpdate');
+
+  // reset paused
+  this.paused = false;
+
+  this.doc.trigger('visibilitychange');
+  assert.equal(this.startUpdates, 2, 'visibilitychange without hidden runs startUpdate');
+
+  this.hidden = true;
+  this.doc.trigger('visibilitychange');
+  assert.equal(this.stopUpdates, 2, 'visibilitychange with hidden runs stopUpdate');
+
+  // reset hidden
+  this.hidden = false;
+
+  this.userActive = true;
+  this.player.trigger('useractive');
+  assert.equal(this.startUpdates, 3, 'useractive runs startUpdate');
+
+  this.userActive = false;
+  this.player.trigger('userinactive');
+  assert.equal(this.stopUpdates, 3, 'userinactive runs stopUpdate');
+
+  this.comp.trigger('mouseenter');
+  assert.equal(this.startUpdates, 4, 'mouseenter runs startUpdate');
+
+  this.comp.trigger('mouseleave');
+  assert.equal(this.stopUpdates, 4, 'mouseleave runs stopUpdate');
+
+  this.comp.trigger('focus');
+  assert.equal(this.startUpdates, 5, 'focus runs startUpdate');
+
+  this.comp.trigger('blur');
+  assert.equal(this.stopUpdates, 5, 'blur runs stopUpdate');
+
+  this.userActive = true;
+  this.paused = false;
+  this.live = true;
+  this.liveTracker.trigger('liveedgechange');
+  assert.equal(this.startUpdates, 6, 'liveedgechange runs startUpdate');
+});
+
+QUnit.test('some events before first playing do nothing', function(assert) {
+
+});

--- a/test/unit/mixins/active-element.test.js
+++ b/test/unit/mixins/active-element.test.js
@@ -234,7 +234,3 @@ QUnit.test('startUpdate and stopUpdate run correctly run for events', function(a
   this.liveTracker.trigger('liveedgechange');
   assert.equal(this.startUpdates, 6, 'liveedgechange runs startUpdate');
 });
-
-QUnit.test('some events before first playing do nothing', function(assert) {
-
-});


### PR DESCRIPTION
So the activeElement mixin does the following:

1. Manages starting and stoping an update function when:
  a. The player is/is not paused
  b. The component gains or loses Keyboard/mouse focus or `player.userActive` changes
  c.  The tabs visibility (wether it is in the background or not) changes.
2. Does not start anything until the player has started playback.