### PR TITLE
fix: make vhs external rather than its dependencies

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,11 +82,7 @@ const moduleExternals = [
   'tsml',
   'safe-json-parse',
   'videojs-vtt.js',
-  'url-toolkit',
-  'm3u8-parser',
-  'mpd-parser',
-  'mux.js',
-  'aes-decrypter',
+  '@videojs/http-streaming',
   'keycode',
   '@babel/runtime'
 ];


### PR DESCRIPTION
## Description
Noticed this in #6166, we don't have a good way for users to exclude vhs from there own builds because we embed it in our `cjs` and `es` files, and only external its dependencies. We should instead make vhs external so that it can be done.
