### PR TITLE
fix: do not handle hotkeys in contenteditable elements

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2941,8 +2941,10 @@ class Player extends Component {
     const excludeElement = (el) => {
       const tagName = el.tagName.toLowerCase();
 
-      // These tags will be excluded entirely.
-      const excludedTags = ['textarea'];
+      // The first and easiest test is for `contenteditable` elements.
+      if (el.isContentEditable) {
+        return true;
+      }
 
       // Inputs matching these types will still trigger hotkey handling as
       // they are not text inputs.
@@ -2958,6 +2960,9 @@ class Player extends Component {
       if (tagName === 'input') {
         return allowedInputTypes.indexOf(el.type) === -1;
       }
+
+      // The final test is by tag name. These tags will be excluded entirely.
+      const excludedTags = ['textarea'];
 
       return excludedTags.indexOf(tagName) !== -1;
     };

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -410,6 +410,27 @@ QUnit.test('when userActions.hotkeys.playPauseKey can be a function', function(a
   assert.strictEqual(this.player.play.callCount, 1, 'has played');
 });
 
+QUnit.test('hotkeys are ignored when focus is in a contenteditable element', function(assert) {
+  this.player.dispose();
+  this.player = TestHelpers.makePlayer({
+    controls: true,
+    userActions: {
+      hotkeys: true
+    }
+  });
+
+  const div = document.createElement('div');
+
+  div.contentEditable = 'true';
+  this.player.el_.appendChild(div);
+  div.focus();
+
+  assert.expect(14);
+  defaultKeyTests.fullscreen(this.player, assert, false);
+  defaultKeyTests.mute(this.player, assert, false);
+  defaultKeyTests.playPause(this.player, assert, false);
+});
+
 QUnit.test('hotkeys are ignored when focus is in a textarea', function(assert) {
   this.player.dispose();
   this.player = TestHelpers.makePlayer({


### PR DESCRIPTION
## Description
We got a bug report at Brightcove about hotkeys still firing when the user was focused in an element with `contenteditable`. This should fix that.

## Specific Changes proposed
Exclude elements where `el.isContentEditable == true;`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
