### PR TITLE
feat: allow player dimension method to accept 'auto'

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -817,7 +817,7 @@ class Player extends Component {
       return this[privDimension] || 0;
     }
 
-    if (value === '') {
+    if (value === '' || value === 'auto') {
       // If an empty string is given, reset the dimension to be automatic
       this[privDimension] = undefined;
       this.updateStyleEl_();


### PR DESCRIPTION
## Description
Allow the dimension method of the Player module to accept 'auto' as an explicit value.

## Specific Changes proposed
Check if dimension value in src/js/player.js's dimension function is 'auto' or '' when deciding to set the dimension to be automatic and return early in the function.

## Requirements Checklist
- [*] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
