### PR TITLE
fix: cap log history at 1000 items

### DIFF
--- a/src/js/utils/create-logger.js
+++ b/src/js/utils/create-logger.js
@@ -35,7 +35,9 @@ const LogByTypeFactory = (name, log) => (type, level, args) => {
     history.push([].concat(args));
 
     // only store 1000 history entries
-    history = history.length > 1000 ? history : history.slice(-1000);
+    const splice = history.length - 1000;
+
+    history.splice(0, splice > 0 ? splice : 0);
   }
 
   // If there's no console then don't try to output messages, but they will

--- a/src/js/utils/create-logger.js
+++ b/src/js/utils/create-logger.js
@@ -34,10 +34,8 @@ const LogByTypeFactory = (name, log) => (type, level, args) => {
   if (history) {
     history.push([].concat(args));
 
-    // remove old history
-    while (history.length > 1000) {
-      history.shift();
-    }
+    // only store 1000 history entries
+    history = history.length > 1000 ? history : history.slice(-1000);
   }
 
   // If there's no console then don't try to output messages, but they will

--- a/src/js/utils/create-logger.js
+++ b/src/js/utils/create-logger.js
@@ -33,6 +33,11 @@ const LogByTypeFactory = (name, log) => (type, level, args) => {
   // Add a clone of the args at this point to history.
   if (history) {
     history.push([].concat(args));
+
+    // remove old history
+    while (history.length > 1000) {
+      history.shift();
+    }
   }
 
   // If there's no console then don't try to output messages, but they will

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -228,3 +228,18 @@ QUnit.test('falls back to info and log when debug is not supported', function(as
   assert.notOk(window.console.warn.called, 'warn was not called');
   assert.notOk(window.console.error.called, 'error was not called');
 });
+
+QUnit.test('history only retains 1000 items', function(assert) {
+  // Need to reset history here because there are extra messages logged
+  // when running via Karma.
+  log.history.clear();
+
+  for (let i = 1; i <= 1005; i++) {
+    log(i);
+  }
+
+  const hist = log.history();
+
+  assert.equal(hist.length, 1000, 'only 1000 items in history');
+  assert.deepEqual([hist[0], hist[hist.length - 1 ]], [['VIDEOJS:', 6], ['VIDEOJS:', 1005]], 'keeps most recent items');
+});


### PR DESCRIPTION
## Description
Cap log history at 1000 items to prevent running out of memory on long videos.