### PR TITLE
fix: validation for stalled and suspended event in iOS when headphones disconnect

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -215,6 +215,7 @@ class Html5 extends Tech {
   handleIOSHeadphonesDisconnection_() {
     // Fudge factor to account for TimeRanges rounding
     const TIME_FUDGE_FACTOR = 1 / 30;
+
     // Comparisons between time values such as current time and the end of the buffered range
     // can be misleading because of precision differences or when the current media has poorly
     // aligned audio and video, which can cause values to be slightly off from what you would
@@ -225,9 +226,16 @@ class Html5 extends Tech {
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
     this.on(['stalled', 'suspend'], (e) => {
-      if ((!this.el_.paused && window.navigator.onLine) &&
-          (this.el_.buffered.end(this.el_.buffered.length - 1) + SAFE_TIME_DELTA >= this.el_.currentTime)) {
-        this.el_.pause();
+      const buffered = this.buffered();
+
+      if (buffered.length > 0) {
+        const end = buffered.end(buffered.length - 1);
+
+        // if tech is not paused, browser has internet connection & end + safe delta >= current time
+        if ((!this.paused() && window.navigator.onLine) &&
+            (end + SAFE_TIME_DELTA >= this.currentTime())) {
+          this.pause();
+        }
       }
     });
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -233,8 +233,9 @@ class Html5 extends Tech {
 
         // Establish if we have an extra buffer in the current time range playing.
         for (let i = 0; i < buffered.length; i++) {
-          if (buffered.start(i) <= this.currentTime() <= buffered.end(i) + SAFE_TIME_DELTA) {
+          if (buffered.start(i) <= this.currentTime() < buffered.end(i) + SAFE_TIME_DELTA) {
             extraBuffer = true;
+            break;
           }
         }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -230,17 +230,19 @@ class Html5 extends Tech {
 
       if (buffered.length > 0) {
         let extraBuffer = false;
+        const currentTime = this.currentTime();
 
         // Establish if we have an extra buffer in the current time range playing.
         for (let i = 0; i < buffered.length; i++) {
-          if (buffered.start(i) <= this.currentTime() < buffered.end(i) + SAFE_TIME_DELTA) {
+          if (buffered.start(i) <= currentTime &&
+              currentTime < buffered.end(i) + SAFE_TIME_DELTA) {
             extraBuffer = true;
             break;
           }
         }
 
         // if tech is not paused, browser has internet connection & player has extraBuffer inside the timeRange
-        if ((!this.paused() && window.navigator.onLine) && extraBuffer) {
+        if (extraBuffer && !this.paused() && window.navigator.onLine) {
           this.pause();
         }
       }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -213,22 +213,22 @@ class Html5 extends Tech {
    * @private
   */
   handleIOSHeadphonesDisconnection_() {
-
+    // Fudge factor to account for TimeRanges rounding
     const TIME_FUDGE_FACTOR = 1 / 30;
-
+    // Comparisons between time values such as current time and the end of the buffered range
+    // can be misleading because of precision differences or when the current media has poorly
+    // aligned audio and video, which can cause values to be slightly off from what you would
+    // expect. This value is what we consider to be safe to use in such comparisons to account
+    // for these scenarios.
     const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
-
-    const disconnectionIOSListener = () => {
-      if ((!this.el_.paused && window.navigator.onLine) &&
-          (this.el_.buffered.end(this.el_.buffered.length - 1) + SAFE_TIME_DELTA >= this.el_.currentTime)) {
-        this.el_.pause();
-      }
-    };
 
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
     this.on(['stalled', 'suspend'], (e) => {
-      disconnectionIOSListener();
+      if ((!this.el_.paused && window.navigator.onLine) &&
+          (this.el_.buffered.end(this.el_.buffered.length - 1) + SAFE_TIME_DELTA >= this.el_.currentTime)) {
+        this.el_.pause();
+      }
     });
   }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -229,11 +229,17 @@ class Html5 extends Tech {
       const buffered = this.buffered();
 
       if (buffered.length > 0) {
-        const end = buffered.end(buffered.length - 1);
+        let extraBuffer = false;
 
-        // if tech is not paused, browser has internet connection & end + safe delta >= current time
-        if ((!this.paused() && window.navigator.onLine) &&
-            (end + SAFE_TIME_DELTA >= this.currentTime())) {
+        // Establish if we have an extra buffer in the current time range playing.
+        for (let i = 0; i < buffered.length; i++) {
+          if (buffered.start(i) <= this.currentTime() <= buffered.end(i) + SAFE_TIME_DELTA) {
+            extraBuffer = true;
+          }
+        }
+
+        // if tech is not paused, browser has internet connection & player has extraBuffer inside the timeRange
+        if ((!this.paused() && window.navigator.onLine) && extraBuffer) {
           this.pause();
         }
       }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -228,23 +228,25 @@ class Html5 extends Tech {
     this.on(['stalled', 'suspend'], (e) => {
       const buffered = this.buffered();
 
-      if (buffered.length > 0) {
-        let extraBuffer = false;
-        const currentTime = this.currentTime();
+      if (!buffered.length) {
+        return;
+      }
 
-        // Establish if we have an extra buffer in the current time range playing.
-        for (let i = 0; i < buffered.length; i++) {
-          if (buffered.start(i) <= currentTime &&
-              currentTime < buffered.end(i) + SAFE_TIME_DELTA) {
-            extraBuffer = true;
-            break;
-          }
-        }
+      let extraBuffer = false;
+      const currentTime = this.currentTime();
 
-        // if tech is not paused, browser has internet connection & player has extraBuffer inside the timeRange
-        if (extraBuffer && !this.paused() && window.navigator.onLine) {
-          this.pause();
+      // Establish if we have an extra buffer in the current time range playing.
+      for (let i = 0; i < buffered.length; i++) {
+        if (buffered.start(i) <= currentTime &&
+          currentTime < buffered.end(i) + SAFE_TIME_DELTA) {
+          extraBuffer = true;
+          break;
         }
+      }
+
+      // if tech is not paused, browser has internet connection & player has extraBuffer inside the timeRange
+      if (extraBuffer && !this.paused() && window.navigator.onLine) {
+        this.pause();
       }
     });
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -110,6 +110,10 @@ class Html5 extends Tech {
     // into a `fullscreenchange` event
     this.proxyWebkitFullscreen_();
 
+    if (browser.IS_IOS) {
+      this.handleIOSHeadphonesDisconnection_();
+    }
+
     this.triggerReady();
   }
 
@@ -200,6 +204,31 @@ class Html5 extends Tech {
 
       // remove the restoreTrackMode handler in case it wasn't triggered during fullscreen playback
       textTracks.removeEventListener('change', restoreTrackMode);
+    });
+  }
+
+  /**
+   * Handle IOS Headphone disconnection during playback
+   *
+   * @private
+  */
+  handleIOSHeadphonesDisconnection_() {
+
+    const TIME_FUDGE_FACTOR = 1 / 30;
+
+    const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
+
+    const disconnectionIOSListener = () => {
+      if ((!this.el_.paused && window.navigator.onLine) &&
+          (this.el_.buffered.end(this.el_.buffered.length - 1) + SAFE_TIME_DELTA >= this.el_.currentTime)) {
+        this.el_.pause();
+      }
+    };
+
+    // If iOS check if we have a real stalled or supend event or
+    // we got stalled/suspend due headphones where disconnected during playback
+    this.on(['stalled', 'suspend'], (e) => {
+      disconnectionIOSListener();
     });
   }
 


### PR DESCRIPTION
Description of the problem: 
When playback is ongoing in iOS + Safari and the user disconnect headphones (wired or Bluetooth) the player will throw 'suspend' or 'stalled' after a couple of seconds and 'progress' events. 

Solution: Validation for stalled and suspended event for iOS browser when headphones are disconnected
