### PR TITLE
chore: ignore sandbox during linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "ignore": [
       "dist",
       "docs",
+      "sandbox",
       "test/dist",
       "test/api",
       "core.js"


### PR DESCRIPTION
I put a lot of random files into the sandbox, so, we shouldn't be linting it.