### PR TITLE
fix: ensure the default ID of the first player is 'vjs_video_3' as some people have relied on this

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -5,7 +5,6 @@
  * @module setup
  */
 import * as Dom from './utils/dom';
-import * as Events from './utils/events.js';
 import document from 'global/document';
 import window from 'global/window';
 
@@ -79,21 +78,32 @@ function autoSetupTimeout(wait, vjs) {
   window.setTimeout(autoSetup, wait);
 }
 
-if (Dom.isReal() && document.readyState === 'complete') {
+/**
+ * Used to set the internal tracking of window loaded state to true.
+ *
+ * @private
+ */
+function setWindowLoaded() {
   _windowLoaded = true;
+  window.removeEventListener('load', setWindowLoaded);
+}
+
+if (Dom.isReal() && document.readyState === 'complete') {
+  setWindowLoaded();
 } else {
   /**
    * Listen for the load event on window, and set _windowLoaded to true.
    *
+   * We use a standard event listener here to avoid incrementing the GUID
+   * before any players are created.
+   *
    * @listens load
    */
-  Events.one(window, 'load', function() {
-    _windowLoaded = true;
-  });
+  window.addEventListener('load', setWindowLoaded);
 }
 
 /**
- * check if the document has been loaded
+ * check if the window has been loaded
  */
 const hasLoaded = function() {
   return _windowLoaded;

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -88,18 +88,20 @@ function setWindowLoaded() {
   window.removeEventListener('load', setWindowLoaded);
 }
 
-if (Dom.isReal() && document.readyState === 'complete') {
-  setWindowLoaded();
-} else {
-  /**
-   * Listen for the load event on window, and set _windowLoaded to true.
-   *
-   * We use a standard event listener here to avoid incrementing the GUID
-   * before any players are created.
-   *
-   * @listens load
-   */
-  window.addEventListener('load', setWindowLoaded);
+if (Dom.isReal()) {
+  if (document.readyState === 'complete') {
+    setWindowLoaded();
+  } else {
+    /**
+     * Listen for the load event on window, and set _windowLoaded to true.
+     *
+     * We use a standard event listener here to avoid incrementing the GUID
+     * before any players are created.
+     *
+     * @listens load
+     */
+    window.addEventListener('load', setWindowLoaded);
+  }
 }
 
 /**

--- a/src/js/utils/guid.js
+++ b/src/js/utils/guid.js
@@ -3,11 +3,14 @@
  * @module guid
  */
 
+// Default value for GUIDs. This allows us to reset the GUID counter in tests.
+const _guidStart = 2;
+
 /**
  * Unique ID for an element or function
  * @type {Number}
  */
-let _guid = 1;
+let _guid = _guidStart;
 
 /**
  * Get a unique auto-incrementing ID by number that has not been returned before.
@@ -17,4 +20,13 @@ let _guid = 1;
  */
 export function newGUID() {
   return _guid++;
+}
+
+/**
+ * Reset the unique auto-incrementing ID.
+ *
+ * FOR TESTS ONLY!
+ */
+export function resetGuidInTestsOnly() {
+  _guid = _guidStart;
 }

--- a/src/js/utils/guid.js
+++ b/src/js/utils/guid.js
@@ -4,13 +4,13 @@
  */
 
 // Default value for GUIDs. This allows us to reset the GUID counter in tests.
-const _guidStart = 2;
+const _initialGuid = 3;
 
 /**
  * Unique ID for an element or function
  * @type {Number}
  */
-let _guid = _guidStart;
+let _guid = _initialGuid;
 
 /**
  * Get a unique auto-incrementing ID by number that has not been returned before.
@@ -23,10 +23,8 @@ export function newGUID() {
 }
 
 /**
- * Reset the unique auto-incrementing ID.
- *
- * FOR TESTS ONLY!
+ * Reset the unique auto-incrementing ID for testing only.
  */
 export function resetGuidInTestsOnly() {
-  _guid = _guidStart;
+  _guid = _initialGuid;
 }

--- a/src/js/utils/guid.js
+++ b/src/js/utils/guid.js
@@ -4,10 +4,16 @@
  */
 
 // Default value for GUIDs. This allows us to reset the GUID counter in tests.
+//
+// The initial GUID is 3 because some users have come to rely on the first
+// default player ID ending up as `vjs_video_3`.
+//
+// See: https://github.com/videojs/video.js/pull/6216
 const _initialGuid = 3;
 
 /**
  * Unique ID for an element or function
+ *
  * @type {Number}
  */
 let _guid = _initialGuid;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -34,12 +34,6 @@ QUnit.module('Player', {
 
 QUnit.test('the default ID of the first player remains "vjs_video_3"', function(assert) {
   Guid.resetGuidInTestsOnly();
-
-  // When Video.js loads, the GUID is incremented once:
-  // https://github.com/videojs/video.js/blob/de2daead6526683ba2ff441ccb4d7dfd9ccf8a98/src/js/setup.js#L90
-  // To simulate that situation here, increment the Guid once.
-  Guid.newGUID();
-
   const tag = document.createElement('video');
 
   tag.className = 'video-js';

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -14,6 +14,7 @@ import sinon from 'sinon';
 import window from 'global/window';
 import * as middleware from '../../src/js/tech/middleware.js';
 import * as Events from '../../src/js/utils/events.js';
+import * as Guid from '../../src/js/utils/guid.js';
 
 QUnit.module('Player', {
   beforeEach() {
@@ -29,6 +30,23 @@ QUnit.module('Player', {
   afterEach() {
     this.clock.restore();
   }
+});
+
+QUnit.test('the default ID of the first player remains "vjs_video_3"', function(assert) {
+  Guid.resetGuidInTestsOnly();
+
+  // When Video.js loads, the GUID is incremented once:
+  // https://github.com/videojs/video.js/blob/de2daead6526683ba2ff441ccb4d7dfd9ccf8a98/src/js/setup.js#L90
+  // To simulate that situation here, increment the Guid once.
+  Guid.newGUID();
+
+  const tag = document.createElement('video');
+
+  tag.className = 'video-js';
+
+  const player = TestHelpers.makePlayer({}, tag);
+
+  assert.strictEqual(player.id(), 'vjs_video_3', 'id is correct');
 });
 
 QUnit.test('should create player instance that inherits from component and dispose it', function(assert) {


### PR DESCRIPTION
## Description
When a player is created without an `id` on the embed code, Video.js automatically assigns it one based on an auto-incrementing number (a.k.a. a GUID). For the longest time, this has happened to result in the default `id` of the first player being `vjs_video_3`.

It was never intended for users to rely on this value being consistent, but users do strange and inadvisable things.

PR #6103 had an unintended side effect in that it changed the default `id` to `vjs_video_2`, which we worry could affect some users of Video.js.

## Specific Changes proposed
* Increment the internal starting point of the GUID from 1 to 3.
* Avoid doing anything that increments the GUID simply by including Video.js on the page.
* Add a test that simulates the initial player creation by resetting the GUID to its initial value to verify that the first player created has its `id` assigned as `vjs_video_3`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] ~Docs/guides updated~
  - [ ] ~Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))~
- [ ] Reviewed by Two Core Contributors
