### PR TITLE
fix: Make suppressing no source error compatible with videojs-errors

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3708,8 +3708,7 @@ class Player extends Component {
     // Suppress the first error message for no compatible source until
     // user interaction
     if (this.options_.suppressNotSupportedError &&
-        err && err.message &&
-        err.message === this.localize(this.options_.notSupportedMessage)
+        err && err.code === 4
     ) {
       const triggerSuppressedError = function() {
         this.error(err);


### PR DESCRIPTION
## Description
When suppressing the incompatible source error the error message is checked. This makes it incompatible with videojs-errors, which changes the error text.

## Specific Changes proposed
Check the error code instead of message

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
