### PR TITLE
fix: update the progress-bar correctly when pausing the video and cli…

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -78,7 +78,9 @@ class SeekBar extends Slider {
     if (document.hidden) {
       this.disableInterval_(e);
     } else {
-      this.enableInterval_();
+      if (!this.player_.paused() && !this.player_.hasClass('vjs-waiting')) {
+        this.enableInterval_();
+      }
 
       // we just switched back to the page and someone may be looking, so, update ASAP
       this.update();
@@ -133,9 +135,8 @@ class SeekBar extends Slider {
    *          The current percent at a number from 0-1
    */
   update(event) {
-    const percent = super.update();
-
     this.requestAnimationFrame(() => {
+      const percent = super.update();
       const currentTime = this.player_.ended() ?
         this.player_.duration() : this.getCurrentTime_();
       const liveTracker = this.player_.liveTracker;
@@ -167,8 +168,6 @@ class SeekBar extends Slider {
         this.duration_ = duration;
       }
     });
-
-    return percent;
   }
 
   /**


### PR DESCRIPTION
## Description

First, when handle `mouse down` event of the `seek-bar`, we set player's `scrubbing_` to true, and at the same tick, the `update` function called and we call `super.update()`. However, it returns `undefined` because the progress equals to the previous progress, the root cause is that we get cached `currentTime`. So we call `super.update()` in the next tick to make sure we can get the correct progress.

Second, when toggle visibility of the document, we should not call `this.enableInterval_()` when the player is paused or waiting.

Fixed https://github.com/videojs/video.js/issues/6232

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
