### PR TITLE
fix: IE11 and Edge focus on fullscreen toggle

### DIFF
--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -54,6 +54,15 @@ class FullscreenToggle extends Button {
     } else {
       this.controlText('Fullscreen');
     }
+    /**
+     * On IE11 and Edge, focus is moved to the window when fullscreen is
+     * enabled. This ensures screen readers keep focus on the FullscreenToggle
+     * element after activating the button.
+     */
+    if (this._clickElement === this.el()) {
+      this.el().focus();
+      this._clickElement = null;
+    }
   }
 
   /**
@@ -68,6 +77,7 @@ class FullscreenToggle extends Button {
    * @listens click
    */
   handleClick(event) {
+    this._clickElement = event.currentTarget;
     if (!this.player_.isFullscreen()) {
       this.player_.requestFullscreen();
     } else {

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -11,7 +11,6 @@ import document from 'global/document';
  * @extends Button
  */
 class FullscreenToggle extends Button {
-
   /**
    * Creates an instance of this class.
    *
@@ -74,8 +73,13 @@ class FullscreenToggle extends Button {
     } else {
       this.player_.exitFullscreen();
     }
+    /**
+     * On IE11 and Edge, focus is moved to the window when fullscreen is
+     * enabled. This ensures screen readers keep focus on the FullscreenToggle
+     * element after activating the button.
+     */
+    this.el().focus();
   }
-
 }
 
 /**


### PR DESCRIPTION
On IE11 and Edge, focus is moved to the window when fullscreen is toggled. This ensures screen readers keep focus on the FullscreenToggle element after activating the button.

Fixes #6242

## Description
See #6242

## Specific Changes proposed
-Added this.el().focus() to the FullscreenToggle component whenever "handleClick" is invoked.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (IE, Edge)
- [ ] Reviewed by Two Core Contributors
