### PR TITLE
feat: resets pastSeekEnd_ variable.

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -88,7 +88,13 @@ class LiveTracker extends Component {
       this.trigger('seekableendchange');
     }
 
-    this.pastSeekEnd_ = this.pastSeekEnd() + 0.03;
+    // we should reset pastSeekEnd when the value
+    // is much higher than seeking increment.
+    if (this.pastSeekEnd() > this.seekableIncrement_ * 1.5) {
+      this.pastSeekEnd_ = 0;
+    } else {
+      this.pastSeekEnd_ = this.pastSeekEnd() + 0.03;
+    }
 
     if (this.isBehind_() !== this.behindLiveEdge()) {
       this.behindLiveEdge_ = this.isBehind_();

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -68,9 +68,12 @@ QUnit.module('LiveTracker', () => {
   QUnit.test('Triggers liveedgechange when we fall behind and catch up', function(assert) {
 
     this.liveTracker.seekableIncrement_ = 6;
+    this.player.seekable = () => createTimeRanges(0, 20);
     this.player.trigger('timeupdate');
-    this.player.currentTime = () => 0;
-    this.clock.tick(20000);
+    this.player.currentTime = () => 14;
+    this.clock.tick(6000);
+    this.player.seekable = () => createTimeRanges(0, 26);
+    this.clock.tick(1000);
 
     assert.equal(this.liveEdgeChanges, 1, 'should have one live edge change');
     assert.ok(this.liveTracker.behindLiveEdge(), 'behind live edge');
@@ -99,6 +102,7 @@ QUnit.module('LiveTracker', () => {
   QUnit.test('seeks to live edge on seekableendchange', function(assert) {
     this.player.trigger('timeupdate');
 
+    this.player.seekable = () => createTimeRanges(0, 6);
     this.liveTracker.seekableIncrement_ = 2;
     let currentTime = 0;
 


### PR DESCRIPTION

## Description
It resets pastSeekEnd_ value to 0 when its value is higher than seeking increment value.
In rare cases, for example when we stop ingesting the live stream. The playlist duration doesn't change at all but we are constantly increasing the value of the pastSeekEnd_ variable which forces the DVR progress forward and increases the size of the gap on the progress bar.

## Specific Changes proposed
If the pastSeekEnd_ value is higher than 1.5 x seeking increment value then set pastSeekEnd_ variable value to 0.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
