### PR TITLE
Minor update to components.md

### DIFF
--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -317,7 +317,7 @@ Player
 │ ├── DescriptionsButton (hidden, unless there are relevant tracks)
 │ ├── SubtitlesButton (hidden, unless there are relevant tracks)
 │ ├── CaptionsButton (hidden, unless there are relevant tracks)
-│ ├── SubsCapsButton
+│ ├── SubsCapsButton (hidden, unless there are relevant tracks)
 │ ├── AudioTrackButton (hidden, unless there are relevant tracks)
 │ ├── PictureInPictureToggle
 │ └── FullscreenToggle


### PR DESCRIPTION
Wondering if the recent update to components.md shouldn't also have the note "_(hidden, unless there are relevant tracks)_" next to the `SubsCapsButton` (like all other text track buttons)? Sure, in this case "_relevant_" is two different `kind`s of text tracks, but it still holds, doesn't it?

If I'm wrong about this, feel free to dismiss this PR! I just wanted to add it as I didn't see/review the #6253 before it was merged.