### PR TITLE
fix: Subtitles gets hidden behind the control bar.

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -116,10 +116,26 @@ class TextTrackDisplay extends Component {
       }
 
       player.on('fullscreenchange', updateDisplayHandler);
-      player.on('playerresize', updateDisplayHandler);
+
+      if (this.player_.resizeManager) {
+        this.ResizeObserver = this.player_.resizeManager.ResizeObserver || window.ResizeObserver;
+      }
+      if (this.ResizeObserver) {
+        this.resizeObserver_ = new this.ResizeObserver(Fn.debounce(() => {
+          updateDisplayHandler();
+        }, 100, false, this));
+        this.resizeObserver_.observe(this.el_);
+      } else {
+        player.on('playerresize', updateDisplayHandler);
+      }
 
       window.addEventListener('orientationchange', updateDisplayHandler);
-      player.on('dispose', () => window.removeEventListener('orientationchange', updateDisplayHandler));
+      player.on('dispose', () => {
+        window.removeEventListener('orientationchange', updateDisplayHandler);
+        if (this.resizeObserver_) {
+          this.resizeObserver_.disconnect();
+        }
+      });
 
       const tracks = this.options_.playerOptions.tracks || [];
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -117,11 +117,12 @@ class TextTrackDisplay extends Component {
 
       player.on('fullscreenchange', updateDisplayHandler);
 
-      if (this.player_.resizeManager) {
-        this.ResizeObserver = this.player_.resizeManager.ResizeObserver || window.ResizeObserver;
-      }
-      if (this.ResizeObserver) {
-        this.resizeObserver_ = new this.ResizeObserver(Fn.debounce(() => {
+      const {
+        ResizeObserver = this.player_.resizeManager ? this.player_.resizeManager.ResizeObserver : null
+      } = window;
+
+      if (ResizeObserver) {
+        this.resizeObserver_ = new ResizeObserver(Fn.debounce(() => {
           updateDisplayHandler();
         }, 100, false, this));
         this.resizeObserver_.observe(this.el_);

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -116,27 +116,10 @@ class TextTrackDisplay extends Component {
       }
 
       player.on('fullscreenchange', updateDisplayHandler);
-
-      const {
-        ResizeObserver = this.player_.resizeManager ? this.player_.resizeManager.ResizeObserver : null
-      } = window;
-
-      if (ResizeObserver) {
-        this.resizeObserver_ = new ResizeObserver(Fn.debounce(() => {
-          updateDisplayHandler();
-        }, 100, false, this));
-        this.resizeObserver_.observe(this.el_);
-      } else {
-        player.on('playerresize', updateDisplayHandler);
-      }
+      player.on('playerresize', updateDisplayHandler);
 
       window.addEventListener('orientationchange', updateDisplayHandler);
-      player.on('dispose', () => {
-        window.removeEventListener('orientationchange', updateDisplayHandler);
-        if (this.resizeObserver_) {
-          this.resizeObserver_.disconnect();
-        }
-      });
+      player.on('dispose', () => window.removeEventListener('orientationchange', updateDisplayHandler));
 
       const tracks = this.options_.playerOptions.tracks || [];
 
@@ -331,6 +314,7 @@ class TextTrackDisplay extends Component {
 
       const cueDiv = cue.displayState;
 
+      cueDiv.style.top = 'auto';
       if (overrides.color) {
         cueDiv.firstChild.style.color = overrides.color;
       }


### PR DESCRIPTION
## Description
This PR fixes subtitles issue described in PR #6207 .
The Demo with this fix is available here: https://codepen.io/grbla/pen/xxxZPQm?editors=1010
## Specific Changes proposed
Add resize observer for the "vjs-text-track-display" div element.
The fix should work on the latest Firefox, Chrome, Safari and Opera.
However, you will need to use resizeObserver polyfill for IE11 or Edge browser to make things work.
 
## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [X] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
