### PR TITLE
Chore: introduces core ES module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ es5/*
 .idea/
 
 core.js
+core.es.js
 
 # Ignore Chinese clones for now.
 lang/zh-Han*.json

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ dist/video-js-*.zip
 !es5/**
 !src/css/**
 !core.js
+!core.es.js

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
       "sandbox",
       "test/dist",
       "test/api",
-      "core.js"
+      "core.js",
+      "core.es.js"
     ]
   },
   "greenkeeper": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -192,7 +192,7 @@ export default cliargs => [
     output: [
       {
         format: 'es',
-        file: 'dist/alt/video.core.es.js',
+        file: 'core.es.js',
         strict: false,
         banner,
         globals: globals.module

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -186,16 +186,24 @@ export default cliargs => [
     onwarn,
     watch
   },
-  // core
+  // core cjs, es
   {
     input: 'src/js/video.js',
-    output: {
-      format: 'cjs',
-      file: 'core.js',
-      strict: false,
-      banner,
-      globals: globals.module
-    },
+    output: [
+      {
+        format: 'es',
+        file: 'dist/alt/video.core.es.js',
+        strict: false,
+        banner,
+        globals: globals.module
+      }, {
+        format: 'cjs',
+        file: 'core.js',
+        strict: false,
+        banner,
+        globals: globals.module
+      }
+    ],
     external: externals.module,
     plugins: [
       json(),


### PR DESCRIPTION
## Description
The PR introduces an alternative ES module file for videojs core build.
I created this PR because I would like to use videojs core directly from the browser like this:

`<script type="module">
import videojs from 'video.js/dist/alt/video.core.es.js';
</script>`

For now, main videojs build supports umd, cjs and es module. Not sure why core build supports only cjs and umd.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
