### PR TITLE
fix: bring back Android 4.x support

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -98,9 +98,33 @@ class Component {
     this.childIndex_ = {};
     this.childNameIndex_ = {};
 
-    this.setTimeoutIds_ = new Set();
-    this.setIntervalIds_ = new Set();
-    this.rafIds_ = new Set();
+    let SetSham;
+
+    if (!window.Set) {
+      SetSham = class {
+        constructor() {
+          this.set_ = {};
+        }
+        has(key) {
+          return key in this.set_;
+        }
+        delete(key) {
+          const has = this.has(key);
+
+          delete this.set_[key];
+
+          return has;
+        }
+        add(key) {
+          this.set_[key] = 1;
+          return this;
+        }
+      };
+    }
+
+    this.setTimeoutIds_ = window.Set ? new Set() : new SetSham();
+    this.setIntervalIds_ = window.Set ? new Set() : new SetSham();
+    this.rafIds_ = window.Set ? new Set() : new SetSham();
     this.clearingTimersOnDispose_ = false;
 
     // Add any child components in options

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -119,6 +119,11 @@ class Component {
           this.set_[key] = 1;
           return this;
         }
+        forEach(callback, thisArg) {
+          for (const key in this.set_) {
+            callback.call(thisArg, key, key, this);
+          }
+        }
       };
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -655,7 +655,11 @@ class Player extends Component {
       // `src` or `controls` that were set via js before the player
       // was initialized.
       Object.keys(el).forEach((k) => {
-        tag[k] = el[k];
+        try {
+          tag[k] = el[k];
+        } catch (e) {
+          // we got a a property like outerHTML which we can't actually copy, ignore it
+        }
       });
     }
 

--- a/src/js/utils/dom-data.js
+++ b/src/js/utils/dom-data.js
@@ -3,6 +3,62 @@
  * @module dom-data
  */
 
+import log from './log.js';
+import * as Guid from './guid.js';
+import window from 'global/window';
+
+let FakeWeakMap;
+
+if (!WeakMap) {
+  FakeWeakMap = class {
+    constructor() {
+      this.vdata = 'vdata' + Math.floor(window.performance && window.performance.now() || Date.now());
+      this.data = {};
+    }
+
+    set(key, value) {
+      const access = key[this.vdata] || Guid.newGUID();
+
+      if (!key[this.vdata]) {
+        key[this.vdata] = access;
+      }
+
+      this.data[access] = value;
+
+      return this;
+    }
+
+    get(key) {
+      const access = key[this.vdata];
+
+      // we have data, return it
+      if (access) {
+        return this.data[access];
+      }
+
+      // we don't have data, return nothing.
+      // return undefined explicitly as that's the contract for this method
+      log('We have no data for this element', key);
+      return undefined;
+    }
+
+    has(key) {
+      const access = key[this.vdata];
+
+      return access in this.data;
+    }
+
+    delete(key) {
+      const access = key[this.vdata];
+
+      if (access) {
+        delete this.data[access];
+        delete key[this.vdata];
+      }
+    }
+  };
+}
+
 /**
  * Element Data Store.
  *
@@ -13,4 +69,4 @@
  * @type {Object}
  * @private
  */
-export default new WeakMap();
+export default WeakMap ? new WeakMap() : new FakeWeakMap();

--- a/src/js/utils/dom-data.js
+++ b/src/js/utils/dom-data.js
@@ -9,7 +9,7 @@ import window from 'global/window';
 
 let FakeWeakMap;
 
-if (!WeakMap) {
+if (!window.WeakMap) {
   FakeWeakMap = class {
     constructor() {
       this.vdata = 'vdata' + Math.floor(window.performance && window.performance.now() || Date.now());
@@ -69,4 +69,4 @@ if (!WeakMap) {
  * @type {Object}
  * @private
  */
-export default WeakMap ? new WeakMap() : new FakeWeakMap();
+export default window.WeakMap ? new WeakMap() : new FakeWeakMap();


### PR DESCRIPTION
If we are running on a browser that doesn't support WeakMap, use a
simple WeakMap sham as a fallback.
Also, add a tiny Set sham.

We received a request (in https://github.com/videojs/video.js/pull/6103) that we broke Android 4.x due to lack to WeakMap. This creates a WeakMap sham to use as a fallback when WeakMap isn't available.

To test locally, I change the file to always create the FakeWeakMap and use that as the default export.