### PR TITLE
Fix SASS import

### DIFF
--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -2,7 +2,7 @@
 @import "private-variables";
 @import "utilities";
 
-@import "../../node_modules/videojs-font/scss/icons";
+@import "./node_modules/videojs-font/scss/icons";
 
 @import "components/layout";
 @import "components/big-play";


### PR DESCRIPTION
Fixes https://github.com/videojs/video.js/issues/6195

## Description
When compiling .scss with **node-sass in an angular project**. the compiler can not use the import. 

So i would like to remove the relative import. 

This issue appears since https://github.com/videojs/video.js/pull/6055
As an alternative couldn't we use this one? 
 
`@import "node_modules/videojs-font/scss/icons";`


## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
