### PR TITLE
fix: ensure components added with an index are added in the correct location

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -463,8 +463,12 @@ class Component {
     // Add the UI object's element to the container div (box)
     // Having an element is not required
     if (typeof component.el === 'function' && component.el()) {
-      const childNodes = this.contentEl().children;
-      const refNode = childNodes[index] || null;
+      // If inserting before a compoennt, insert before that component's element
+      let refNode = null;
+
+      if (this.children_[index + 1] && this.children_[index + 1].el_) {
+        refNode = this.children_[index + 1].el_;
+      }
 
       this.contentEl().insertBefore(component.el(), refNode);
     }

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -463,7 +463,7 @@ class Component {
     // Add the UI object's element to the container div (box)
     // Having an element is not required
     if (typeof component.el === 'function' && component.el()) {
-      // If inserting before a compoennt, insert before that component's element
+      // If inserting before a component, insert before that component's element
       let refNode = null;
 
       if (this.children_[index + 1] && this.children_[index + 1].el_) {

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -146,6 +146,24 @@ QUnit.test('should add a child component to an index', function(assert) {
   comp.dispose();
 });
 
+QUnit.test('should insert element relative to the element of the component to insert before', function(assert) {
+
+  // for legibility of the test itself:
+  /* eslint-disable no-unused-vars */
+
+  const comp = new Component(getFakePlayer());
+
+  const child0 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c0'})});
+  const child1 = comp.addChild('component', {createEl: false});
+  const child2 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c2'})});
+  const child3 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c3'})});
+  const child4 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c4'})}, comp.children_.indexOf(child2));
+
+  assert.ok(child2.el_.previousSibling === child4.el_, 'addChild should insert el before its next sibling\'s element');
+
+  /* eslint-enable no-unused-vars */
+});
+
 QUnit.test('addChild should throw if the child does not exist', function(assert) {
   const comp = new Component(getFakePlayer());
 


### PR DESCRIPTION
## Description
When an index is specified with `Component.addChild()` then the new component's element is added at the given index. This isn't necessarily correct, as not all of a component's children have DOM elements. Adding a component at the index of the control bar in the player's children will insert its el after the control bar el, because of the MediaLoader and LiveTracker.

## Specific Changes proposed
When inserting the elelment, refer to the `el_` of the sibling component this is to be inserted before.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
