### PR TITLE
fix: encrypted content goes black in IE/Edge when video element focused

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
   },
   "vjsstandard": {
     "ignore": [
+      "build",
       "dist",
       "docs",
       "sandbox",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
   },
   "vjsstandard": {
     "ignore": [
-      "build",
       "dist",
       "docs",
       "sandbox",

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -48,8 +48,8 @@ class BigPlayButton extends Button {
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
       const sourceIsEncrypted = this.player_.usingPlugin('eme') &&
-                          this.player_.eme.sessions &&
-                          this.player_.eme.sessions.length > 0;
+                                this.player_.eme.sessions &&
+                                this.player_.eme.sessions.length > 0;
 
       silencePromise(playPromise);
       if (this.player_.tech(true) &&

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -47,11 +47,16 @@ class BigPlayButton extends Button {
 
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
+      const sourceIsEncrypted = this.player_.usingPlugin('eme') &&
+                          this.player_.eme.sessions &&
+                          this.player_.eme.sessions.length > 0;
+
       silencePromise(playPromise);
       if (this.player_.tech(true) &&
          // We've observed a bug in IE and Edge when playing back DRM content where
-         // calling .focus() on the video element causes the video to go black
-         ((browser.IE_VERSION || browser.IS_EDGE) && this.player_.usingPlugin('eme'))) {
+         // calling .focus() on the video element causes the video to go black,
+         // so we avoid it in that specific case
+         !((browser.IE_VERSION || browser.IS_EDGE) && sourceIsEncrypted)) {
         this.player_.tech(true).focus();
       }
       return;

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -4,6 +4,7 @@
 import Button from './button.js';
 import Component from './component.js';
 import {isPromise, silencePromise} from './utils/promise';
+import * as browser from './utils/browser.js';
 
 /**
  * The initial play button that shows before the video has played. The hiding of the
@@ -47,7 +48,10 @@ class BigPlayButton extends Button {
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
       silencePromise(playPromise);
-      if (this.player_.tech(true)) {
+      if (this.player_.tech(true) &&
+         // We've observed a bug in IE and Edge when playing back DRM content where
+         // calling .focus() on the video element causes the video to go black
+         ((browser.IE_VERSION || browser.IS_EDGE) && this.player_.usingPlugin('eme'))) {
         this.player_.tech(true).focus();
       }
       return;


### PR DESCRIPTION
## Description
Fixes #6270. This appears to be caused by an unreported browser bug. It also reproduces with shaka player if you call `document.querySelector('video').focus()` while playing back DRM content. For now, the only solution is simply to avoid calling `videoEl.focus()` in IE/Edge for DRM. This unfortunately may prevent hotkeys from working correctly in IE/Edge.

## Specific Changes proposed
Modify the conditions under which we call `this.player_.tech(true).focus()` when the big play button is clicked.
