### PR TITLE
Fix: Add detection to for iPadOS in IS_IPAD const

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -181,8 +181,7 @@ export const TOUCH_ENABLED = Dom.isReal() && (
  * @const
  * @type {Boolean}
  */
-export const IS_IPAD = (/iPad/i).test(USER_AGENT) ||
-(IS_SAFARI && TOUCH_ENABLED);
+export const IS_IPAD = (/iPad/i).test(USER_AGENT) || (IS_SAFARI && TOUCH_ENABLED);
 
 /**
  * Whether or not this device is an iPhone.

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -10,27 +10,6 @@ const webkitVersionMap = (/AppleWebKit\/([\d.]+)/i).exec(USER_AGENT);
 const appleWebkitVersion = webkitVersionMap ? parseFloat(webkitVersionMap.pop()) : null;
 
 /**
- * Whether or not this device is an iPad.
- *
- * @static
- * @const
- * @type {Boolean}
- */
-export const IS_IPAD = (/iPad/i).test(USER_AGENT);
-
-/**
- * Whether or not this device is an iPhone.
- *
- * @static
- * @const
- * @type {Boolean}
- */
-// The Facebook app's UIWebView identifies as both an iPhone and iPad, so
-// to identify iPhones, we need to exclude iPads.
-// http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
-export const IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
-
-/**
  * Whether or not this device is an iPod.
  *
  * @static
@@ -38,15 +17,6 @@ export const IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
  * @type {Boolean}
  */
 export const IS_IPOD = (/iPod/i).test(USER_AGENT);
-
-/**
- * Whether or not this is an iOS device.
- *
- * @static
- * @const
- * @type {Boolean}
- */
-export const IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
 
 /**
  * The detected iOS version - or `null`.
@@ -184,15 +154,6 @@ export const IE_VERSION = (function() {
 export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
 
 /**
- * Whether or not this is any flavor of Safari - including iOS.
- *
- * @static
- * @const
- * @type {Boolean}
- */
-export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;
-
-/**
  * Whether or not this is a Windows machine.
  *
  * @static
@@ -212,3 +173,43 @@ export const TOUCH_ENABLED = Dom.isReal() && (
   'ontouchstart' in window ||
   window.navigator.maxTouchPoints ||
   window.DocumentTouch && window.document instanceof window.DocumentTouch);
+
+/**
+ * Whether or not this device is an iPad.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+export const IS_IPAD = (/iPad/i).test(USER_AGENT) ||
+(IS_SAFARI && TOUCH_ENABLED);
+
+/**
+ * Whether or not this device is an iPhone.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+// The Facebook app's UIWebView identifies as both an iPhone and iPad, so
+// to identify iPhones, we need to exclude iPads.
+// http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
+export const IS_IPHONE = (/iPhone/i).test(USER_AGENT) && !IS_IPAD;
+
+/**
+ * Whether or not this is an iOS device.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+export const IS_IOS = IS_IPHONE || IS_IPAD || IS_IPOD;
+
+/**
+ * Whether or not this is any flavor of Safari - including iOS.
+ *
+ * @static
+ * @const
+ * @type {Boolean}
+ */
+export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;


### PR DESCRIPTION
## Description
New iPadOS User-agent does not contain "iPad" string in order to detect the device 

## Specific Changes proposed
Detect  IS_SAFARI && TOUCH_ENABLED we can conclude is and iPad Device. 
