### PR TITLE
fix: turn on strict mode again

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -111,7 +111,6 @@ export default cliargs => [
       format: 'umd',
       file: 'dist/video.js',
       name: 'videojs',
-      strict: false,
       banner,
       globals: globals.browser
     },
@@ -136,13 +135,11 @@ export default cliargs => [
       {
         format: 'es',
         file: 'dist/video.es.js',
-        strict: false,
         banner,
         globals: globals.module
       }, {
         format: 'cjs',
         file: 'dist/video.cjs.js',
-        strict: false,
         banner,
         globals: globals.module
       }
@@ -167,7 +164,6 @@ export default cliargs => [
       format: 'umd',
       file: 'dist/alt/video.novtt.js',
       name: 'videojs',
-      strict: false,
       banner: compiledLicense(Object.assign({includesVtt: true}, bannerData)),
       globals: globals.browser
     },
@@ -193,13 +189,11 @@ export default cliargs => [
       {
         format: 'es',
         file: 'core.es.js',
-        strict: false,
         banner,
         globals: globals.module
       }, {
         format: 'cjs',
         file: 'core.js',
-        strict: false,
         banner,
         globals: globals.module
       }
@@ -220,7 +214,6 @@ export default cliargs => [
       format: 'umd',
       name: 'videojs',
       file: 'dist/alt/video.core.js',
-      strict: false,
       banner,
       globals: globals.browser
     },
@@ -242,7 +235,6 @@ export default cliargs => [
       format: 'umd',
       name: 'videojs',
       file: 'dist/alt/video.core.novtt.js',
-      strict: false,
       banner: compiledLicense(Object.assign({includesVtt: true}, bannerData)),
       globals: globals.browser
     },

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1218,7 +1218,7 @@ Html5.Events = [
   ['featuresNativeVideoTracks', 'supportsNativeVideoTracks'],
   ['featuresNativeAudioTracks', 'supportsNativeAudioTracks']
 ].forEach(function([key, fn]) {
-  defineLazyProperty(Html5.prototype, key, () => Html5[fn](), false);
+  defineLazyProperty(Html5.prototype, key, () => Html5[fn](), true);
 });
 
 /**


### PR DESCRIPTION
We had to turn off strict mode (https://github.com/videojs/video.js/pull/4551) in Video.js due to a change in vtt.js. That has now been fixed in videojs/vtt.js#40 and released as part of 0.15.2 which will be available via https://github.com/videojs/video.js/pull/6333.

Fixes videojs/vtt.js#15
