### PR TITLE
fix broken logo link in README and docs

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -19,7 +19,7 @@
       }
     },
     "logo": {
-      "url": "https://videojs.com/img/logo.png",
+      "url": "https://videojs.com/logo-white.png",
       "height": "30px",
       "width": "214px"
     },

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 
 [license]: LICENSE
 
-[logo]: https://videojs.com/img/logo.png
+[logo]: https://videojs.com/logo-white.png
 
 [npm-icon]: https://nodei.co/npm/video.js.png?downloads=true&downloadRank=true
 


### PR DESCRIPTION
depends on https://github.com/videojs/videojs.com/pull/112

closes https://github.com/videojs/video.js/issues/6340

## Description

video.js logo is broken in this README and on the docs site (#6340 )

## Specific Changes proposed

Update the link to point to a valid image url (waiting for https://github.com/videojs/videojs.com/pull/112 to be merged)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
