### PR TITLE
Apply the IOS headphone disconnect patch only after successful playback

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -225,16 +225,20 @@ class Html5 extends Tech {
     const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
 
     // try to determine whether a successful playback occurred
-    const SUCCESSFUL_PLAYBACK_TIME = 1; // second
-    const timeupdateAfterOneSecond = false;
+    const SUCCESSFUL_PLAYBACK_TIME = 1;
+
+    let timeupdateAfterOneSecond = false;
+
+    const timeUpdateListener = function() {
+      if (this.currentTime() > SUCCESSFUL_PLAYBACK_TIME) {
+        this.off('timeupdate', timeUpdateListener);
+        timeupdateAfterOneSecond = true;
+      }
+    };
+
     this.on('loadedmetadata', function() {
       timeupdateAfterOneSecond = false;
-      const timeUpdateListener = function() {
-        if (this.currentTime() > SUCCESSFUL_PLAYBACK_TIME) {
-          this.off('timeupdate', timeUpdateListener);
-          timeupdateAfterOneSecond = true;
-        }
-      };
+
       // disconnect previous listener
       this.off('timeupdate', timeUpdateListener);
       this.on('timeupdate', timeUpdateListener);
@@ -243,7 +247,9 @@ class Html5 extends Tech {
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
     this.on(['stalled', 'suspend'], (e) => {
-      if (!timeupdateAfterOneSecond) return;
+      if (!timeupdateAfterOneSecond) {
+        return;
+      }
       const buffered = this.buffered();
 
       if (!buffered.length) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -224,9 +224,26 @@ class Html5 extends Tech {
     // for these scenarios.
     const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
 
+    // try to determine whether a successful playback occurred
+    const SUCCESFULL_PLAYBACK_TIME = 1; // second
+    const timeupdateAfterOneSecond = false;
+    this.on('loadedmetadata', function() {
+      timeupdateAfterOneSecond = false;
+      const timeUpdateListener = function() {
+        if (this.currentTime() > SUCCESFULL_PLAYBACK_TIME) {
+          this.off('timeupdate', timeUpdateListener);
+          timeupdateAfterOneSecond = true;
+        }
+      };
+      // disconnect previous listener
+      this.off('timeupdate', timeUpdateListener);
+      this.on('timeupdate', timeUpdateListener);
+    });
+
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
     this.on(['stalled', 'suspend'], (e) => {
+      if (!timeupdateAfterOneSecond) return;
       const buffered = this.buffered();
 
       if (!buffered.length) {

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -227,17 +227,17 @@ class Html5 extends Tech {
     // try to determine whether a successful playback occurred
     const SUCCESSFUL_PLAYBACK_TIME = 1;
 
-    let timeupdateAfterOneSecond = false;
+    let successfulPlayback = false;
 
     const timeUpdateListener = function() {
       if (this.currentTime() > SUCCESSFUL_PLAYBACK_TIME) {
         this.off('timeupdate', timeUpdateListener);
-        timeupdateAfterOneSecond = true;
+        successfulPlayback = true;
       }
     };
 
     this.on('loadedmetadata', function() {
-      timeupdateAfterOneSecond = false;
+      successfulPlayback = false;
 
       // disconnect previous listener
       this.off('timeupdate', timeUpdateListener);
@@ -247,7 +247,7 @@ class Html5 extends Tech {
     // If iOS check if we have a real stalled or supend event or
     // we got stalled/suspend due headphones where disconnected during playback
     this.on(['stalled', 'suspend'], (e) => {
-      if (!timeupdateAfterOneSecond) {
+      if (!successfulPlayback) {
         return;
       }
       const buffered = this.buffered();

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -226,8 +226,7 @@ class Html5 extends Tech {
 
         // If iOS check if we have a real stalled or supend event or
         // we got stalled/suspend due headphones where disconnected during playback
-        this.on('stalled', boundStalledAndSuspendHandler);
-        this.on('suspend', boundStalledAndSuspendHandler);
+        this.on(['stalled', 'suspend'], boundStalledAndSuspendHandler);
       }
     };
 
@@ -235,8 +234,7 @@ class Html5 extends Tech {
     this.on('loadedmetadata', function() {
       // disconnect previous listeners
       this.off('timeupdate', timeUpdateListener);
-      this.off('stalled', boundStalledAndSuspendHandler);
-      this.off('suspend', boundStalledAndSuspendHandler);
+      this.on(['stalled', 'suspend'], boundStalledAndSuspendHandler);
       // wait until we reached a succesful playback
       this.on('timeupdate', timeUpdateListener);
     });

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -225,12 +225,12 @@ class Html5 extends Tech {
     const SAFE_TIME_DELTA = TIME_FUDGE_FACTOR * 3;
 
     // try to determine whether a successful playback occurred
-    const SUCCESFULL_PLAYBACK_TIME = 1; // second
+    const SUCCESSFUL_PLAYBACK_TIME = 1; // second
     const timeupdateAfterOneSecond = false;
     this.on('loadedmetadata', function() {
       timeupdateAfterOneSecond = false;
       const timeUpdateListener = function() {
-        if (this.currentTime() > SUCCESFULL_PLAYBACK_TIME) {
+        if (this.currentTime() > SUCCESSFUL_PLAYBACK_TIME) {
           this.off('timeupdate', timeUpdateListener);
           timeupdateAfterOneSecond = true;
         }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -231,6 +231,7 @@ class Html5 extends Tech {
       }
     };
 
+    // a new source got loaded
     this.on('loadedmetadata', function() {
       // disconnect previous listeners
       this.off('timeupdate', timeUpdateListener);


### PR DESCRIPTION
## Description

Since using the version which includes https://github.com/videojs/video.js/pull/6199 we saw issues when using videojs in combination with videojs+ima. Because Google IMA uses the same video-tag on iOS to display video ads it happens that a `suspend` event is occurring when video sources get switched (in my case a preroll in a muted autoplay scenario). And calling `pause()` in this switching phase could lead to a state within IMA that the player gets stalled.

A fix could either be to enable / disable this headphone-disconnect patch or this pull request, which only does stalled/suspend checks after a video-source was played for at least 1s.

## Requirements Checklist
- [X] Bug fixed
- [ ] Reviewed by Two Core Contributors
