### PR TITLE
fix: IS_IPAD should be false on iPhone

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -181,7 +181,8 @@ export const TOUCH_ENABLED = Dom.isReal() && (
  * @const
  * @type {Boolean}
  */
-export const IS_IPAD = (/iPad/i).test(USER_AGENT) || (IS_SAFARI && TOUCH_ENABLED);
+export const IS_IPAD = (/iPad/i).test(USER_AGENT) ||
+  (IS_SAFARI && TOUCH_ENABLED && !(/iPhone/i).test(USER_AGENT));
 
 /**
  * Whether or not this device is an iPhone.


### PR DESCRIPTION
Safari user agent. However, the new check also returns true for iPhones.
Therefore, we should exclude iPhones from the check.

Unfortunately, this means that the iPhone user agent detection on
iPhones inside the Facebook app may break again as previously
(https://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/) we
excluded iPads from the iPhone check but that won't work anymore.