### PR TITLE
fix: updates seekbar position after mouse up event is triggered.

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -326,6 +326,14 @@ class SeekBar extends Slider {
     }
     this.player_.scrubbing(false);
 
+    /**
+     * Trigger timeupdate because we're done seeking and the time has changed.
+     * This is particularly useful for if the player is paused to time the time displays.
+     *
+     * @event Tech#timeupdate
+     * @type {EventTarget~Event}
+     */
+    this.player_.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
     if (this.videoWasPlaying) {
       silencePromise(this.player_.play());
     } else {

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -52,7 +52,8 @@ class SeekBar extends Slider {
    * @private
    */
   setEventHandlers_() {
-    this.update = Fn.throttle(Fn.bind(this, this.update), UPDATE_REFRESH_INTERVAL);
+    this.update_ = Fn.bind(this, this.update);
+    this.update = Fn.throttle(this.update_, UPDATE_REFRESH_INTERVAL);
 
     this.on(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
     if (this.player_.liveTracker) {
@@ -325,16 +326,12 @@ class SeekBar extends Slider {
     }
     this.player_.scrubbing(false);
 
-    /**
-     * Trigger timeupdate because we're done seeking and the time has changed.
-     * This is particularly useful for if the player is paused to time the time displays.
-     *
-     * @event Tech#timeupdate
-     * @type {EventTarget~Event}
-     */
-    this.player_.trigger({ type: 'timeupdate', target: this, manuallyTriggered: true });
     if (this.videoWasPlaying) {
       silencePromise(this.player_.play());
+    } else {
+      // We're done seeking and the time has changed.
+      // If the player is paused, make sure we display the correct time on the seek bar.
+      this.update_();
     }
   }
 


### PR DESCRIPTION
## Description
A proposed fix for #6370
Progress control is not updating as expected when the video is paused and the user would like to seek a point in time by clicking the progress bar.

## Specific Changes proposed
Improves handle for `mouseup` event inside the seekbar component. When the player is in pause mode and the `mouseup` event is triggered we want to call the update method without `throttling` to be sure that the progress bar position is up to date.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
