### PR TITLE
feat(cors): add cors options to enable cookies on requests

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4,35 +4,35 @@
 // Subclasses Component
 import Component from './component.js';
 
-import {version} from '../../package.json';
+import { version } from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import evented from './mixins/evented';
-import {isEvented, addEventedCallback} from './mixins/evented';
+import { isEvented, addEventedCallback } from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
+import { IE_VERSION, IS_CHROME, IS_WINDOWS } from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
-import {toTitleCase, titleCaseEquals} from './utils/string-cases.js';
+import { toTitleCase, titleCaseEquals } from './utils/string-cases.js';
 import { createTimeRange } from './utils/time-ranges.js';
 import { bufferedPercent } from './utils/buffer.js';
 import * as stylesheet from './utils/stylesheet.js';
 import FullscreenApi from './fullscreen-api.js';
 import MediaError from './media-error.js';
 import safeParseTuple from 'safe-json-parse/tuple';
-import {assign} from './utils/obj';
+import { assign } from './utils/obj';
 import mergeOptions from './utils/merge-options.js';
-import {silencePromise, isPromise} from './utils/promise';
+import { silencePromise, isPromise } from './utils/promise';
 import textTrackConverter from './tracks/text-track-list-converter.js';
 import ModalDialog from './modal-dialog';
 import Tech from './tech/tech.js';
 import * as middleware from './tech/middleware.js';
-import {ALL as TRACK_TYPES} from './tracks/track-types';
+import { ALL as TRACK_TYPES } from './tracks/track-types';
 import filterSource from './utils/filter-source';
-import {getMimetype, findMimetype} from './utils/mimetypes';
+import { getMimetype, findMimetype } from './utils/mimetypes';
 import keycode from 'keycode';
 
 // The following imports are used only to ensure that the corresponding modules
@@ -379,11 +379,11 @@ class Player extends Component {
     // if the global option object was accidentally blown away by
     // someone, bail early with an informative error
     if (!this.options_ ||
-        !this.options_.techOrder ||
-        !this.options_.techOrder.length) {
+      !this.options_.techOrder ||
+      !this.options_.techOrder.length) {
       throw new Error('No techOrder specified. Did you overwrite ' +
-                      'videojs.options instead of just changing the ' +
-                      'properties you want to override?');
+        'videojs.options instead of just changing the ' +
+        'properties you want to override?');
     }
 
     // Store the original tag used to set options
@@ -455,7 +455,7 @@ class Player extends Component {
     this.el_ = this.createEl();
 
     // Make this an evented object and use `el_` as its event bus.
-    evented(this, {eventBusKey: 'el_'});
+    evented(this, { eventBusKey: 'el_' });
 
     if (this.fluid_) {
       this.on('playerreset', this.updateStyleEl_);
@@ -733,6 +733,7 @@ class Player extends Component {
     this.fill(this.options_.fill);
     this.fluid(this.options_.fluid);
     this.aspectRatio(this.options_.aspectRatio);
+    this.crossOrigin(this.options_.crossOrigin);
 
     // Hide any links within the video/audio tag,
     // because IE doesn't hide them completely from screen readers.
@@ -769,6 +770,32 @@ class Player extends Component {
     this.el_ = el;
 
     return el;
+  }
+
+  /**
+   * A getter/setter for the `Player`'s crossOrigin. Returns the player's configured value.
+   *
+   * @param {string} [value]
+   *        The value to set the `Player`'s crossorigin to.
+   *
+   * @return {string}
+   *         The current crossorigin value of the `Player`.
+   */
+  crossOrigin(value) {
+    if (!value) {
+      return this.techGet_('crossorigin');
+    }
+
+    const validCorsValues = ['anonymous', 'use-credentials'];
+
+    if (validCorsValues.indexOf(value) < 0) {
+      log.error(`Improper value "${value}" supplied for crossorigin`);
+      return;
+    }
+
+    this.techCall_('setCrossorigin', value);
+
+    return this.techGet_('crossorigin');
   }
 
   /**
@@ -1400,9 +1427,9 @@ class Player extends Component {
     }
 
     return promise.then(() => {
-      this.trigger({type: 'autoplay-success', autoplay: type});
+      this.trigger({ type: 'autoplay-success', autoplay: type });
     }).catch((e) => {
-      this.trigger({type: 'autoplay-failure', autoplay: type});
+      this.trigger({ type: 'autoplay-failure', autoplay: type });
     });
   }
 
@@ -1438,7 +1465,7 @@ class Player extends Component {
     }
 
     // update `currentSource` cache always
-    this.cache_.source = mergeOptions({}, srcObj, {src, type});
+    this.cache_.source = mergeOptions({}, srcObj, { src, type });
 
     const matchingSources = this.cache_.sources.filter((s) => s.src && s.src === src);
     const sourceElSources = [];
@@ -1459,8 +1486,8 @@ class Player extends Component {
     // the current source cache is not up to date
     if (matchingSourceEls.length && !matchingSources.length) {
       this.cache_.sources = sourceElSources;
-    // if we don't have matching source or source els set the
-    // sources cache to the `currentSource` cache
+      // if we don't have matching source or source els set the
+      // sources cache to the `currentSource` cache
     } else if (!matchingSources.length) {
       this.cache_.sources = [this.cache_.source];
     }
@@ -1518,7 +1545,7 @@ class Player extends Component {
         // if both the tech source and the player source were updated we assume
         // something like @videojs/http-streaming did the sourceset and skip updating the source cache.
         if (!this.lastSource_ || (this.lastSource_.tech !== eventSrc && this.lastSource_.player !== playerSrc)) {
-          updateSourceCaches = () => {};
+          updateSourceCaches = () => { };
         }
       }
 
@@ -1545,7 +1572,7 @@ class Player extends Component {
         });
       }
     }
-    this.lastSource_ = {player: this.currentSource().src, tech: event.src};
+    this.lastSource_ = { player: this.currentSource().src, tech: event.src };
 
     this.trigger({
       src: event.src,
@@ -2930,7 +2957,7 @@ class Player extends Component {
    * @listens keydown
    */
   handleKeyDown(event) {
-    const {userActions} = this.options_;
+    const { userActions } = this.options_;
 
     // Bail out if hotkeys are not configured.
     if (!userActions || !userActions.hotkeys) {
@@ -3126,7 +3153,7 @@ class Player extends Component {
     const flip = (fn) => (a, b) => fn(b, a);
     const finder = ([techName, tech], source) => {
       if (tech.canPlaySource(source, this.options_[techName.toLowerCase()])) {
-        return {source, tech: techName};
+        return { source, tech: techName };
       }
     };
 
@@ -3448,12 +3475,12 @@ class Player extends Component {
       this.manualAutoplay_(value);
       techAutoplay = false;
 
-    // any falsy value sets autoplay to false in the browser,
-    // lets do the same
+      // any falsy value sets autoplay to false in the browser,
+      // lets do the same
     } else if (!value) {
       this.options_.autoplay = false;
 
-    // any other value (ie truthy) sets autoplay to true
+      // any other value (ie truthy) sets autoplay to true
     } else {
       this.options_.autoplay = true;
     }
@@ -3712,7 +3739,7 @@ class Player extends Component {
     // Suppress the first error message for no compatible source until
     // user interaction
     if (this.options_.suppressNotSupportedError &&
-        err && err.code === 4
+      err && err.code === 4
     ) {
       const triggerSuppressedError = function() {
         this.error(err);
@@ -4070,7 +4097,7 @@ class Player extends Component {
    *         does not return anything
    */
   removeRemoteTextTrack(obj = {}) {
-    let {track} = obj;
+    let { track } = obj;
 
     if (!track) {
       track = obj;
@@ -4347,7 +4374,7 @@ class Player extends Component {
       this.on('playerresize', this.updateCurrentBreakpoint_);
       this.updateCurrentBreakpoint_();
 
-    // Stop listening for breakpoints if the player is no longer responsive.
+      // Stop listening for breakpoints if the player is no longer responsive.
     } else {
       this.off('playerresize', this.updateCurrentBreakpoint_);
       this.removeCurrentBreakpoint_();
@@ -4443,7 +4470,7 @@ class Player extends Component {
     // Clone the media object so it cannot be mutated from outside.
     this.cache_.media = mergeOptions(media);
 
-    const {artwork, poster, src, textTracks} = this.cache_.media;
+    const { artwork, poster, src, textTracks } = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
@@ -4487,7 +4514,7 @@ class Player extends Component {
         src: tt.src
       }));
 
-      const media = {src, textTracks};
+      const media = { src, textTracks };
 
       if (poster) {
         media.poster = poster;
@@ -4576,11 +4603,11 @@ class Player extends Component {
     // Note: We don't actually use flexBasis (or flexOrder), but it's one of the more
     // common flex features that we can rely on when checking for flex support.
     return !('flexBasis' in elem.style ||
-            'webkitFlexBasis' in elem.style ||
-            'mozFlexBasis' in elem.style ||
-            'msFlexBasis' in elem.style ||
-            // IE10-specific (2012 flex spec), available for completeness
-            'msFlexOrder' in elem.style);
+      'webkitFlexBasis' in elem.style ||
+      'mozFlexBasis' in elem.style ||
+      'msFlexBasis' in elem.style ||
+      // IE10-specific (2012 flex spec), available for completeness
+      'msFlexOrder' in elem.style);
   }
 }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -8,10 +8,10 @@ import log from '../utils/log.js';
 import * as browser from '../utils/browser.js';
 import document from 'global/document';
 import window from 'global/window';
-import {assign} from '../utils/obj';
+import { assign } from '../utils/obj';
 import mergeOptions from '../utils/merge-options.js';
-import {toTitleCase} from '../utils/string-cases.js';
-import {NORMAL as TRACK_TYPES} from '../tracks/track-types';
+import { toTitleCase } from '../utils/string-cases.js';
+import { NORMAL as TRACK_TYPES } from '../tracks/track-types';
 import setupSourceset from './setup-sourceset';
 import defineLazyProperty from '../utils/define-lazy-property.js';
 
@@ -76,8 +76,8 @@ class Html5 extends Tech {
             this.remoteTextTracks().addTrack(node.track);
             this.textTracks().addTrack(node.track);
             if (!crossoriginTracks &&
-                !this.el_.hasAttribute('crossorigin') &&
-                Url.isCrossOrigin(node.src)) {
+              !this.el_.hasAttribute('crossorigin') &&
+              Url.isCrossOrigin(node.src)) {
               crossoriginTracks = true;
             }
           }
@@ -92,7 +92,7 @@ class Html5 extends Tech {
     this.proxyNativeTracks_();
     if (this.featuresNativeTextTracks && crossoriginTracks) {
       log.warn('Text Tracks are being loaded from another origin but the crossorigin attribute isn\'t used.\n' +
-            'This may prevent text tracks from loading.');
+        'This may prevent text tracks from loading.');
     }
 
     // prevent iOS Safari from disabling metadata text tracks during native playback
@@ -103,7 +103,7 @@ class Html5 extends Tech {
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
     if ((browser.TOUCH_ENABLED || browser.IS_IPHONE ||
-        browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
+      browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
       this.setControls(true);
     }
 
@@ -268,8 +268,8 @@ class Html5 extends Tech {
     const techTracks = this[props.getterName]();
 
     if (!this[`featuresNative${props.capitalName}Tracks`] ||
-        !elTracks ||
-        !elTracks.addEventListener) {
+      !elTracks ||
+      !elTracks.addEventListener) {
       return;
     }
     const listeners = {
@@ -351,8 +351,8 @@ class Html5 extends Tech {
     // So we have to create a brand new element.
     // If we ingested the player div, we do not need to move the media element.
     if (!el ||
-        !(this.options_.playerElIngest ||
-          this.movingMediaElementInDOM)) {
+      !(this.options_.playerElIngest ||
+        this.movingMediaElementInDOM)) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {
@@ -868,7 +868,7 @@ class Html5 extends Tech {
     const videoPlaybackQuality = {};
 
     if (typeof this.el().webkitDroppedFrameCount !== 'undefined' &&
-        typeof this.el().webkitDecodedFrameCount !== 'undefined') {
+      typeof this.el().webkitDecodedFrameCount !== 'undefined') {
       videoPlaybackQuality.droppedVideoFrames = this.el().webkitDroppedFrameCount;
       videoPlaybackQuality.totalVideoFrames = this.el().webkitDecodedFrameCount;
     }
@@ -876,8 +876,8 @@ class Html5 extends Tech {
     if (window.performance && typeof window.performance.now === 'function') {
       videoPlaybackQuality.creationTime = window.performance.now();
     } else if (window.performance &&
-               window.performance.timing &&
-               typeof window.performance.timing.navigationStart === 'number') {
+      window.performance.timing &&
+      typeof window.performance.timing.navigationStart === 'number') {
       videoPlaybackQuality.creationTime =
         window.Date.now() - window.performance.timing.navigationStart;
     }
@@ -1036,12 +1036,12 @@ Html5.canOverrideAttributes = function() {
   // if we cannot overwrite the src/innerHTML property, there is no support
   // iOS 7 safari for instance cannot do this.
   try {
-    const noop = () => {};
+    const noop = () => { };
 
-    Object.defineProperty(document.createElement('video'), 'src', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('audio'), 'src', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('video'), 'innerHTML', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('audio'), 'innerHTML', {get: noop, set: noop});
+    Object.defineProperty(document.createElement('video'), 'src', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('audio'), 'src', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('video'), 'innerHTML', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('audio'), 'innerHTML', { get: noop, set: noop });
   } catch (e) {
     return false;
   }
@@ -1737,7 +1737,20 @@ Html5.resetMediaElement = function(el) {
    *
    * @see [Spec] {@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-video-videowidth}
    */
-  'videoHeight'
+  'videoHeight',
+  /**
+   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * to the browser that should sent the cookies along with the requests for the
+   * different assets/playlists
+   *
+   * @method Html5#setCrossorigin
+   * @param {string} crossorigin
+   *         - anonymous indicates that the media should not sent cookies.
+   *         - use-credentials indicates that the media should sent cookies along the requests.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
+   */
+  'crossorigin'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
     return this.el_[prop];
@@ -1747,7 +1760,7 @@ Html5.resetMediaElement = function(el) {
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 // The list is as follows:
-// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate
+// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate, setCrossorigin
 [
   /**
    * Set the value of `volume` on the media element. `volume` indicates the current
@@ -1837,7 +1850,20 @@ Html5.resetMediaElement = function(el) {
    *
    * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-defaultplaybackrate}
    */
-  'defaultPlaybackRate'
+  'defaultPlaybackRate',
+  /**
+   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * to the browser that should sent the cookies along with the requests for the
+   * different assets/playlists
+   *
+   * @method Html5#setCrossorigin
+   * @param {string} crossorigin
+   *         - anonymous indicates that the media should not sent cookies.
+   *         - use-credentials indicates that the media should sent cookies along the requests.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
+   */
+  'crossorigin'
 
 ].forEach(function(prop) {
   Html5.prototype['set' + toTitleCase(prop)] = function(v) {
@@ -1930,7 +1956,7 @@ Html5.nativeSourceHandler.canHandleSource = function(source, options) {
   if (source.type) {
     return Html5.nativeSourceHandler.canPlayType(source.type);
 
-  // If no type, fall back to checking 'video/[EXTENSION]'
+    // If no type, fall back to checking 'video/[EXTENSION]'
   } else if (source.src) {
     const ext = Url.getFileExtension(source.src);
 
@@ -1959,7 +1985,7 @@ Html5.nativeSourceHandler.handleSource = function(source, tech, options) {
 /**
  * A noop for the native dispose function, as cleanup is not needed.
  */
-Html5.nativeSourceHandler.dispose = function() {};
+Html5.nativeSourceHandler.dispose = function() { };
 
 // Register the native source handler
 Html5.registerSourceHandler(Html5.nativeSourceHandler);


### PR DESCRIPTION
fixes #5438, #4851

## Description

Adds ability to send credentials in the XHR requests.

If the video the user needs to play is in a different domain and it is protected with a session, we need to configure the player so it will forward cookies along with the request, otherwise, the user will receive a 403.

This happens, for example, when playing videos from Akamai:

https://community.akamai.com/customers/s/question/0D50f00005Rtq3sCAB/media-services-on-demand-hls-manifests-are-different-for-firefox?language=en_US

## Specific Changes proposed

- Add crossorigin to the options object

## Requirements Checklist

- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
