### PR TITLE
fix: slider screenreader value returning as NaN

### DIFF
--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -244,7 +244,7 @@ class Slider extends Component {
     const progress = this.getProgress();
 
     if (progress === this.progress_) {
-      return;
+      return progress;
     }
 
     this.progress_ = progress;
@@ -268,7 +268,7 @@ class Slider extends Component {
    *         percentage filled that the slider is
    */
   getProgress() {
-    return clamp(this.getPercent(), 0, 1).toFixed(4);
+    return Number(clamp(this.getPercent(), 0, 1).toFixed(4));
   }
 
   /**


### PR DESCRIPTION
## Description
Without these changes `area-valuenow` for the seek bar often reports `NaN`
