### PR TITLE
refactor: use Fn.UPDATE_REFRESH_INTERVAL in seekBar & liveTracker

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -21,9 +21,6 @@ const STEP_SECONDS = 5;
 // The multiplier of STEP_SECONDS that PgUp/PgDown move the timeline.
 const PAGE_KEY_MULTIPLIER = 12;
 
-// The interval at which the bar should update as it progresses.
-const UPDATE_REFRESH_INTERVAL = 30;
-
 /**
  * Seek bar and container for the progress bars. Uses {@link PlayProgressBar}
  * as its `bar`.
@@ -53,7 +50,7 @@ class SeekBar extends Slider {
    */
   setEventHandlers_() {
     this.update_ = Fn.bind(this, this.update);
-    this.update = Fn.throttle(this.update_, UPDATE_REFRESH_INTERVAL);
+    this.update = Fn.throttle(this.update_, Fn.UPDATE_REFRESH_INTERVAL);
 
     this.on(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
     if (this.player_.liveTracker) {
@@ -91,7 +88,7 @@ class SeekBar extends Slider {
       return;
 
     }
-    this.updateInterval = this.setInterval(this.update, UPDATE_REFRESH_INTERVAL);
+    this.updateInterval = this.setInterval(this.update, Fn.UPDATE_REFRESH_INTERVAL);
   }
 
   disableInterval_(e) {

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -3,6 +3,7 @@ import median from './utils/median.js';
 import mergeOptions from './utils/merge-options.js';
 import document from 'global/document';
 import * as browser from './utils/browser.js';
+import * as Fn from './utils/fn.js';
 
 /* track when we are at the live edge, and other helpers for live playback */
 class LiveTracker extends Component {
@@ -129,7 +130,7 @@ class LiveTracker extends Component {
       this.timeupdateSeen_ = this.player_.hasStarted();
     }
 
-    this.trackingInterval_ = this.setInterval(this.trackLive_, 30);
+    this.trackingInterval_ = this.setInterval(this.trackLive_, Fn.UPDATE_REFRESH_INTERVAL);
     this.trackLive_();
 
     this.on(this.player_, 'play', this.trackLive_);


### PR DESCRIPTION
## Description

In #6142 I updated a lot of our code that used a hard coded 30ms `UPDATE_REFRESH_INTERVAL` so that it used a shared value in `Fn`.  Seems like I missed two in `seek-bar` and `live-tracker`