### PR TITLE
fix: add a threshold of 30s for the liveui to show

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -113,7 +113,7 @@ class LiveTracker extends Component {
    * and start/stop tracking accordingly.
    */
   handleDurationchange() {
-    if (this.player_.duration() === Infinity && this.liveWindow() > this.options_.trackingThreshold) {
+    if (this.player_.duration() === Infinity && this.liveWindow() >= this.options_.trackingThreshold) {
       if (this.player_.options_.liveui) {
         this.player_.addClass('vjs-liveui');
       }

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -4,12 +4,18 @@ import mergeOptions from './utils/merge-options.js';
 import document from 'global/document';
 import * as browser from './utils/browser.js';
 
+const defaults = {
+  // Number of seconds of live window (seekableEnd - seekableStart) that
+  // a video needs to have before the liveui will be shown.
+  trackingThreshold: 30
+};
+
 /* track when we are at the live edge, and other helpers for live playback */
 class LiveTracker extends Component {
 
   constructor(player, options) {
     // LiveTracker does not need an element
-    const options_ = mergeOptions({createEl: false}, options);
+    const options_ = mergeOptions(defaults, options, {createEl: false});
 
     super(player, options_);
 
@@ -107,9 +113,13 @@ class LiveTracker extends Component {
    * and start/stop tracking accordingly.
    */
   handleDurationchange() {
-    if (this.player_.duration() === Infinity) {
+    if (this.player_.duration() === Infinity && this.liveWindow() > this.options_.trackingThreshold) {
+      if (this.player_.options_.liveui) {
+        this.player_.addClass('vjs-liveui');
+      }
       this.startTracking();
     } else {
+      this.player_.removeClass('vjs-liveui');
       this.stopTracking();
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2467,12 +2467,8 @@ class Player extends Component {
 
       if (seconds === Infinity) {
         this.addClass('vjs-live');
-        if (this.options_.liveui && this.player_.liveTracker) {
-          this.addClass('vjs-liveui');
-        }
       } else {
         this.removeClass('vjs-live');
-        this.removeClass('vjs-liveui');
       }
       if (!isNaN(seconds)) {
         // Do not fire durationchange unless the duration value is known.

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -18,7 +18,7 @@ QUnit.module('LiveTracker', () => {
     this.player = TestHelpers.makePlayer({liveui: true});
     this.player.seekable = () => createTimeRanges(0, 30);
 
-    this.player.duration('Infinity');
+    this.player.duration(Infinity);
 
     assert.ok(this.player.hasClass('vjs-liveui'), 'has vjs-liveui');
     assert.ok(this.player.liveTracker.isTracking(), 'is tracking');
@@ -28,7 +28,7 @@ QUnit.module('LiveTracker', () => {
     this.player = TestHelpers.makePlayer({liveui: true, liveTracker: {trackingThreshold: 31}});
     this.player.seekable = () => createTimeRanges(0, 30);
 
-    this.player.duration('Infinity');
+    this.player.duration(Infinity);
 
     assert.notOk(this.player.hasClass('vjs-liveui'), 'does not have vjs-iveui');
     assert.notOk(this.player.liveTracker.isTracking(), 'is not tracking');
@@ -38,7 +38,7 @@ QUnit.module('LiveTracker', () => {
     this.player = TestHelpers.makePlayer({liveui: false});
     this.player.seekable = () => createTimeRanges(0, 30);
 
-    this.player.duration('Infinity');
+    this.player.duration(Infinity);
 
     assert.notOk(this.player.hasClass('vjs-liveui'), 'does not have vjs-liveui');
     assert.ok(this.player.liveTracker.isTracking(), 'is tracking');
@@ -48,7 +48,7 @@ QUnit.module('LiveTracker', () => {
     this.player = TestHelpers.makePlayer({liveui: false, liveTracker: {trackingThreshold: 31}});
     this.player.seekable = () => createTimeRanges(0, 30);
 
-    this.player.duration('Infinity');
+    this.player.duration(Infinity);
 
     assert.notOk(this.player.hasClass('vjs-liveui'), 'does not have vjs-liveui');
     assert.notOk(this.player.liveTracker.isTracking(), 'is not tracking');

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -10,6 +10,7 @@ QUnit.module('LiveTracker', () => {
       this.clock = sinon.useFakeTimers();
 
       this.player = TestHelpers.makePlayer({liveui: true});
+      this.player.seekable = () => createTimeRanges(0, 31);
 
       this.liveTracker = this.player.liveTracker;
     },
@@ -46,6 +47,7 @@ QUnit.module('LiveTracker', () => {
       this.player = TestHelpers.makePlayer();
 
       this.liveTracker = this.player.liveTracker;
+      this.player.seekable = () => createTimeRanges(0, 31);
       this.player.duration(Infinity);
 
       this.liveEdgeChanges = 0;
@@ -63,6 +65,15 @@ QUnit.module('LiveTracker', () => {
       this.player.dispose();
       this.clock.restore();
     }
+  });
+  QUnit.test('trackingThreshold works', function(assert) {
+    assert.ok(this.liveTracker.isTracking(), 'starts off tracking');
+
+    // live window is now too low, stop tracking
+    this.player.seekable = () => createTimeRanges(0, 29);
+    this.player.trigger('durationchange');
+
+    assert.ok(!this.liveTracker.isTracking(), 'stops tracking on duration change');
   });
 
   QUnit.test('Triggers liveedgechange when we fall behind and catch up', function(assert) {
@@ -86,17 +97,16 @@ QUnit.module('LiveTracker', () => {
   });
 
   QUnit.test('pastSeekEnd should update when seekable changes', function(assert) {
-    assert.strictEqual(this.liveTracker.liveCurrentTime(), 0.03, 'liveCurrentTime is now 0.03');
-    this.clock.tick(2000);
+    assert.strictEqual(this.liveTracker.liveCurrentTime(), 31.03, 'liveCurrentTime is now 31');
+    this.clock.tick(2010);
 
     assert.ok(this.liveTracker.pastSeekEnd() > 2, 'pastSeekEnd should be over 2s');
 
-    this.player.seekable = () => createTimeRanges(0, 2);
+    this.player.seekable = () => createTimeRanges(31, 62);
 
     this.clock.tick(30);
     assert.strictEqual(this.liveTracker.pastSeekEnd(), 0.03, 'pastSeekEnd start at 0.03 again');
-    assert.strictEqual(this.liveTracker.liveCurrentTime(), 2.03, 'liveCurrentTime is now 2.03');
-    assert.equal(this.seekableEndChanges, 1, 'should be one seek end change');
+    assert.strictEqual(this.liveTracker.liveCurrentTime(), 62.03, 'liveCurrentTime is now 2.03');
   });
 
   QUnit.test('seeks to live edge on seekableendchange', function(assert) {

--- a/test/unit/seek-to-live.test.js
+++ b/test/unit/seek-to-live.test.js
@@ -2,6 +2,7 @@
 import TestHelpers from './test-helpers.js';
 import sinon from 'sinon';
 import computedStyle from '../../src/js/utils/computed-style.js';
+import { createTimeRange } from '../../src/js/utils/time-ranges.js';
 
 QUnit.module('SeekToLive', () => {
   QUnit.module('live with liveui', {
@@ -10,6 +11,7 @@ QUnit.module('SeekToLive', () => {
 
       this.player = TestHelpers.makePlayer({liveui: true});
       this.seekToLive = this.player.controlBar.seekToLive;
+      this.player.seekable = () => createTimeRange(0, 45);
 
       this.getComputedDisplay = () => {
         return computedStyle(this.seekToLive.el(), 'display');
@@ -50,6 +52,7 @@ QUnit.module('SeekToLive', () => {
 
       this.player = TestHelpers.makePlayer();
       this.seekToLive = this.player.controlBar.seekToLive;
+      this.player.seekable = () => createTimeRange(0, 45);
 
       this.getComputedDisplay = () => {
         return computedStyle(this.seekToLive.el(), 'display');
@@ -89,6 +92,7 @@ QUnit.module('SeekToLive', () => {
   QUnit.test('switch to live', function(assert) {
     assert.equal(this.getComputedDisplay(), 'none', 'is hidden');
 
+    this.player.seekable = () => createTimeRange(0, 45);
     this.player.duration(Infinity);
     this.player.trigger('durationchange');
 


### PR DESCRIPTION
## Description

## Specific Changes proposed
Use the old liveui for live videos where `seekableEnd - seekableStart` is less than `30s`. This is configurable with an option.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
