### PR TITLE
fix: trigger change events on remoteTextTrack when nativeTextTrack is set to true

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -11,7 +11,7 @@ import window from 'global/window';
 import {assign} from '../utils/obj';
 import mergeOptions from '../utils/merge-options.js';
 import {toTitleCase} from '../utils/string-cases.js';
-import {NORMAL as TRACK_TYPES} from '../tracks/track-types';
+import {NORMAL as TRACK_TYPES, REMOTE} from '../tracks/track-types';
 import setupSourceset from './setup-sourceset';
 import defineLazyProperty from '../utils/define-lazy-property.js';
 
@@ -273,13 +273,26 @@ class Html5 extends Tech {
       return;
     }
     const listeners = {
-      change(e) {
-        techTracks.trigger({
+      change: (e) => {
+        const event = {
           type: 'change',
           target: techTracks,
           currentTarget: techTracks,
           srcElement: techTracks
-        });
+        };
+
+        techTracks.trigger(event);
+
+        // if we are a text track change event, we should also notify the
+        // remote text track list. This can potentially cause a false positive
+        // if we were to get a change event on a non-remote track and
+        // we triggered the event on the remote text track list which doesn't
+        // contain that track. However, best practices mean looping through the
+        // list of tracks and searching for the appropriate mode value, so,
+        // this shouldn't pose an issue
+        if (name === 'text') {
+          this[REMOTE.remoteText.getterName]().trigger(event);
+        }
       },
       addtrack(e) {
         techTracks.addTrack(e.track);

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -476,30 +476,32 @@ QUnit.test('should uniformly create html track element when adding text track', 
   player.dispose();
 });
 
-QUnit.test('remote text tracks change event should fire when using native text tracks', function(assert) {
-  const done = assert.async();
+if (!browser.IS_FIREFOX && !browser.IE_VERSION === 11) {
+  QUnit.test('remote text tracks change event should fire when using native text tracks', function(assert) {
+    const done = assert.async();
 
-  const player = TestHelpers.makePlayer({
-    techOrder: ['html5'],
-    html5: { nativeTextTracks: true }
+    const player = TestHelpers.makePlayer({
+      techOrder: ['html5'],
+      html5: { nativeTextTracks: true }
+    });
+
+    player.remoteTextTracks().on('change', function(e) {
+      assert.ok(true, 'change event triggered');
+      player.dispose();
+      done();
+    });
+
+    const track = {
+      kind: 'kind',
+      src: 'src',
+      language: 'language',
+      label: 'label',
+      default: 'default'
+    };
+
+    player.addRemoteTextTrack(track, true);
   });
-
-  player.remoteTextTracks().on('change', function(e) {
-    assert.ok(true, 'change event triggered');
-    player.dispose();
-    done();
-  });
-
-  const track = {
-    kind: 'kind',
-    src: 'src',
-    language: 'language',
-    label: 'label',
-    default: 'default'
-  };
-
-  player.addRemoteTextTrack(track, true);
-});
+}
 
 QUnit.test('default text tracks should show by default', function(assert) {
   const tag = TestHelpers.makeTag();

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -476,6 +476,31 @@ QUnit.test('should uniformly create html track element when adding text track', 
   player.dispose();
 });
 
+QUnit.test('remote text tracks change event should fire when using native text tracks', function(assert) {
+  const done = assert.async();
+
+  const player = TestHelpers.makePlayer({
+    techOrder: ['html5'],
+    html5: { nativeTextTracks: true }
+  });
+
+  player.remoteTextTracks().on('change', function(e) {
+    assert.ok(true, 'change event triggered');
+    player.dispose();
+    done();
+  });
+
+  const track = {
+    kind: 'kind',
+    src: 'src',
+    language: 'language',
+    label: 'label',
+    default: 'default'
+  };
+
+  player.addRemoteTextTrack(track, true);
+});
+
 QUnit.test('default text tracks should show by default', function(assert) {
   const tag = TestHelpers.makeTag();
   const capt = document.createElement('track');

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -476,6 +476,9 @@ QUnit.test('should uniformly create html track element when adding text track', 
   player.dispose();
 });
 
+// disable in Firefox and IE because while the code works in practice,
+// during the tests, somehow the text track object isn't ready and thus it won't
+// allow us to change the mode of the track rendering the test non-functional.
 if (!browser.IS_FIREFOX && !browser.IE_VERSION === 11) {
   QUnit.test('remote text tracks change event should fire when using native text tracks', function(assert) {
     const done = assert.async();


### PR DESCRIPTION
It seems we have never triggered `change` events on `remoteTextTrack` when we were using native text tracks. This was a problem for VHS, which exclusively uses text tracks.
This makes it so we do trigger the event. Main issue with this change is that it creates a potential for a false positive where a change event was triggered from a non-remote text track but the remoteTextTrack list still received a change event. This issue is mitigated by best practices of looping through the list looking for the modes that you care about.