### PR TITLE
fix: Only update seekBar during pause when live

### DIFF
--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -2,8 +2,6 @@
  * @file progress-control.js
  */
 import Component from '../../component.js';
-import * as Dom from '../../utils/dom.js';
-import clamp from '../../utils/clamp.js';
 import {bind, throttle, UPDATE_REFRESH_INTERVAL} from '../../utils/fn.js';
 
 import './seek-bar.js';
@@ -61,30 +59,7 @@ class ProgressControl extends Component {
       return;
     }
 
-    const playProgressBar = seekBar.getChild('playProgressBar');
-    const mouseTimeDisplay = seekBar.getChild('mouseTimeDisplay');
-
-    if (!playProgressBar && !mouseTimeDisplay) {
-      return;
-    }
-
-    const seekBarEl = seekBar.el();
-    const seekBarRect = Dom.findPosition(seekBarEl);
-    let seekBarPoint = Dom.getPointerPosition(seekBarEl, event).x;
-
-    // The default skin has a gap on either side of the `SeekBar`. This means
-    // that it's possible to trigger this behavior outside the boundaries of
-    // the `SeekBar`. This ensures we stay within it at all times.
-    seekBarPoint = clamp(seekBarPoint, 0, 1);
-
-    if (mouseTimeDisplay) {
-      mouseTimeDisplay.update(seekBarRect, seekBarPoint);
-    }
-
-    if (playProgressBar) {
-      playProgressBar.update(seekBarRect, seekBar.getProgress());
-    }
-
+    seekBar.update(event);
   }
 
   /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -10,6 +10,7 @@ import formatTime from '../../utils/format-time.js';
 import {silencePromise} from '../../utils/promise';
 import keycode from 'keycode';
 import document from 'global/document';
+import clamp from '../../utils/clamp.js';
 
 import './load-progress-bar.js';
 import './play-progress-bar.js';
@@ -156,7 +157,7 @@ class SeekBar extends Slider {
    * attributes to whatever is passed in.
    *
    * @param {EventTarget~Event} [event]
-   *        The `timeupdate` or `ended` event that caused this to run.
+   *        The event that caused this to run.
    *
    * @listens Player#timeupdate
    *
@@ -198,9 +199,26 @@ class SeekBar extends Slider {
         this.duration_ = duration;
       }
 
+      if (!this.bar && !this.mouseTimeDisplay) {
+        return;
+      }
+
+      const rect = Dom.findPosition(this.el());
+
       // update the progress bar time tooltip with the current time
       if (this.bar) {
-        this.bar.update(Dom.getBoundingClientRect(this.el()), this.getProgress());
+        this.bar.update(rect, this.getProgress());
+      }
+
+      if (this.mouseTimeDisplay && event && event.type === 'mousemove') {
+        let point = Dom.getPointerPosition(this.el_, event).x;
+
+        // The default skin has a gap on either side of the `SeekBar`. This means
+        // that it's possible to trigger this behavior outside the boundaries of
+        // the `SeekBar`. This ensures we stay within it at all times.
+        point = clamp(point, 0, 1);
+
+        this.mouseTimeDisplay.update(rect, point);
       }
     });
 

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -96,6 +96,12 @@ class TimeTooltip extends Component {
       pullTooltipBy = tooltipRect.width;
     }
 
+    // prevent small width fluctuations within 0.4px from
+    // changing the value below.
+    // This really helps for live to prevent the play
+    // progress time tooltip from jittering
+    pullTooltipBy = Math.round(pullTooltipBy);
+
     this.el_.style.right = `-${pullTooltipBy}px`;
     this.write(content);
   }


### PR DESCRIPTION
## Description
During live playback the seek bar only has to be updated when the player is paused, because we will always be the same period away from live while playing. 

## Specific Changes proposed
* Start updating the seekbar for the first time on duration change.
* If the duration is Infinity only update when paused otherwise update how we do now.
* Make sure visibility change only enables the interval if it was enabled before losing focus.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
