### PR TITLE
fix: current time tooltip does not update

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -166,10 +166,9 @@ class SeekBar extends Slider {
       }
 
       // update the progress bar time tooltip with the current time
-      const playProgressBar = this.getChild('playProgressBar');
-      const barRect = Dom.getBoundingClientRect(this.el());
-
-      playProgressBar.update(barRect, this.getProgress());
+      if (this.bar) {
+        this.bar.update(Dom.getBoundingClientRect(this.el()), this.getProgress());
+      }
     });
 
     return percent;

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -164,6 +164,12 @@ class SeekBar extends Slider {
         this.currentTime_ = currentTime;
         this.duration_ = duration;
       }
+
+      // update the progress bar time tooltip with the current time
+      const playProgressBar = this.getChild('playProgressBar');
+      const barRect = Dom.getBoundingClientRect(this.el());
+
+      playProgressBar.update(barRect, this.getProgress());
     });
 
     return percent;


### PR DESCRIPTION
## Description
The progress bar tooltip get stuck and don't update the time as the video plays. It only respond to mouse movements and reflects the time in the current time tool tip.

## Specific Changes proposed
Add a reference for the playProgressBar component at seekBar to trigger the update action on every playing and timeupdate event
