### PR TITLE
FIX | 6436 | focus trap in fullscreen mode

### DIFF
--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -68,12 +68,15 @@ class FullscreenToggle extends Button {
    * @listens keydown
    */
   handleKeyDown(event) {
-    // If not Fullscreen mode and Tab press the 'button'
-    if (!(this.player_.isFullscreen() && keycode.isEventKey(event, 'Tab'))) {
+    const isTabKey = !event.shiftKey && keycode.isEventKey(event, 'Tab');
+
+    if (!(this.player_.isFullscreen() && isTabKey)) {
       return;
     }
+
     event.preventDefault();
 
+    // If not Fullscreen mode and Tab press the 'button'
     // Trap the keyboard focus by rewinding back to the play toggle button in the player
     const cb = this.player_.getChild('controlBar');
     const playToggle = cb && cb.getChild('playToggle');

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -4,6 +4,7 @@
 import Button from '../button.js';
 import Component from '../component.js';
 import document from 'global/document';
+import keycode from 'keycode';
 
 /**
  * Toggle fullscreen video
@@ -55,6 +56,34 @@ class FullscreenToggle extends Button {
     } else {
       this.controlText('Fullscreen');
     }
+  }
+
+  /**
+   * Handle tab key for `FullscreenToggle`. See
+   * {@link ClickableComponent#handleKeyDown} for instances where this is called.
+   *
+   * @param {EventTarget~Event} event
+   *        The `keydown` event that caused this function to be called.
+   *
+   * @listens keydown
+   */
+  handleKeyDown(event) {
+    // If not Fullscreen mode and Tab press the 'button'
+    if (!(this.player_.isFullscreen() && keycode.isEventKey(event, 'Tab'))) {
+      return;
+    }
+    event.preventDefault();
+
+    // Trap the keyboard focus by rewinding back to the play toggle button in the player
+    const cb = this.player_.getChild('controlBar');
+    const playToggle = cb && cb.getChild('playToggle');
+
+    if (!playToggle) {
+      this.player_.tech(true).focus();
+      return;
+    }
+
+    return playToggle.focus();
   }
 
   /**

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -3,6 +3,7 @@
  */
 import Button from '../button.js';
 import Component from '../component.js';
+import keycode from 'keycode';
 
 /**
  * Button to toggle between play and pause.
@@ -61,6 +62,37 @@ class PlayToggle extends Button {
     } else {
       this.player_.pause();
     }
+  }
+
+  /**
+   * Handle tab key for `PlayToggle`. See
+   * {@link ClickableComponent#handleKeyDown} for instances where this is called.
+   *
+   * @param {EventTarget~Event} event
+   *        The `keydown` event that caused this function to be called.
+   *
+   * @listens keydown
+   */
+  handleKeyDown(event) {
+    const isShiftTab = event.shiftKey && keycode.isEventKey(event, 'Tab');
+
+    if (!(this.player_.isFullscreen() && isShiftTab)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    // If Fullscreen mode and Shift-Tab press the 'button'
+    // Trap the keyboard focus by rewinding back to the fullscreen toggle button in the player
+    const cb = this.player_.getChild('controlBar');
+    const fullscreenToggle = cb && cb.getChild('fullscreenToggle');
+
+    if (!fullscreenToggle) {
+      this.player_.tech(true).focus();
+      return;
+    }
+
+    return fullscreenToggle.focus();
   }
 
   /**

--- a/test/unit/player-fullscreen.test.js
+++ b/test/unit/player-fullscreen.test.js
@@ -237,6 +237,7 @@ QUnit.test('fullscreen mode should trap focus within the player', function(asser
   player.isFullscreen(true);
   fullscreenToggle.handleKeyDown({
     which: 9,
+    shiftKey: false,
     preventDefault() {
       prevented = true;
     }
@@ -252,6 +253,22 @@ QUnit.test('fullscreen mode should trap focus within the player', function(asser
 
   fullscreenToggle.handleKeyDown({
     which: 9,
+    shiftKey: false,
+    preventDefault() {
+      prevented = true;
+    }
+  });
+
+  assert.notOk(prevented, 'event.preventDefault should have be called');
+  assert.equal(focusSpy.callCount, 1, 'PlayToggle should not be focused');
+
+  // When pressing shift-tab
+  prevented = false;
+  player.isFullscreen(true);
+
+  fullscreenToggle.handleKeyDown({
+    which: 9,
+    shiftKey: true,
     preventDefault() {
       prevented = true;
     }


### PR DESCRIPTION
## Description
This is an attempt to fix the focus trap issue (https://github.com/videojs/video.js/issues/6436)
When the fullscreen toggle is in focus in fullscreen mode, pressing `Tab` key on the keyboard will focus element outside the element, i.e. there was no `focus-trap`.

## Specific Changes proposed
* When the player is in fullscreen mode and focus is currently on the fullscreen toggle and the user presses the `Tab` key
  * Programmatically focus on the PlayToggle in the ControlBar
* When the player is in fullscreen mode and focus is currently on the play toggle and the user presses the `Shift+Tab` key
  * Programmatically focus on the FullscreenToggle in the ControlBar

## Requirements Checklist
- [x] Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors


## Manual test
> Added an extra element next to the player to test if pressing the tab key will focus on that element

| Mode | Demo |
| --- | --- |
| Normal mode | ![2020-02-23 22 59 22](https://user-images.githubusercontent.com/6264004/75133688-88493580-5690-11ea-9b4b-578f9a32472f.gif) <br />`Tab` on the fullscreen toggle moves focus to the next element |
| Fullscreen mode | ![fullscreenmode](https://media.giphy.com/media/XcjH1tWYOBlcjAFJxO/giphy.gif)  <br />`Tab` on the fullscreen toggle moves focus to the PlayToggle|