### PR TITLE
fix: detect chromium-based Edge

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -95,7 +95,7 @@ export const IS_FIREFOX = (/Firefox/i).test(USER_AGENT);
  * @const
  * @type {Boolean}
  */
-export const IS_EDGE = (/Edge/i).test(USER_AGENT);
+export const IS_EDGE = (/Edg/i).test(USER_AGENT);
 
 /**
  * Whether or not this is Google Chrome.


### PR DESCRIPTION
This loosens the regex used for Edge. Still detects legacy Edge but now
also detects the new Edge.

IS_CHROME still returns true for Edgium but I think that it's worth
keeping that as the behavior should be pretty close. If there is a need
to differentiate, can check IS_EDGE and also whether IS_EDGE &&
IS_CHROME is present. Combining with IS_WINDOWS could also be useful as
some capabilities of Edge are only available in Windows.