### PR TITLE
Fix: solves a typo in en translation file

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -46,7 +46,7 @@
   ", opens descriptions settings dialog": ", opens descriptions settings dialog",
   ", selected": ", selected",
   "captions settings": "captions settings",
-  "subtitles settings": "subititles settings",
+  "subtitles settings": "subtitles settings",
   "descriptions settings": "descriptions settings",
   "Text": "Text",
   "White": "White",


### PR DESCRIPTION
## Description
Change from "subititles" to "subtitles"

## Specific Changes proposed
"subititles settings" -> "subtitles settings"

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
