### PR TITLE
feat: Improve currentTime to allow be used before player is ready to play

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2417,13 +2417,14 @@ class Player extends Component {
       if (seconds < 0) {
         seconds = 0;
       }
-      if (!this.isReady_ || this.changingSrc_ || !this.tech_ || !this.tech_.isReady_ && seconds > 0) {
+      if (!this.isReady_ || this.changingSrc_ || !this.tech_ || !this.tech_.isReady_) {
         this.cache_.initTime = seconds;
         this.off('canplay', this.applyInitTime_);
         this.one('canplay', this.applyInitTime_);
         return;
       }
       this.techCall_('setCurrentTime', seconds);
+      this.cache_.initTime = 0;
       return;
     }
 
@@ -2443,7 +2444,7 @@ class Player extends Component {
    * @private
    */
   applyInitTime_() {
-    this.techCall_('setCurrentTime', this.cache_.initTime);
+    this.currentTime(this.cache_.initTime);
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2145,6 +2145,7 @@ class Player extends Component {
       // we set it to zero here to ensure that if we do start actually caching
       // it, we reset it along with everything else.
       currentTime: 0,
+      initTime: 0,
       inactivityTimeout: this.options_.inactivityTimeout,
       duration: NaN,
       lastVolume: 1,
@@ -2416,6 +2417,12 @@ class Player extends Component {
       if (seconds < 0) {
         seconds = 0;
       }
+      if (!this.isReady_ || this.changingSrc_ || !this.tech_ || !this.tech_.isReady_ && seconds > 0) {
+        this.cache_.initTime = seconds;
+        this.off('canplay', this.applyInitTime_);
+        this.one('canplay', this.applyInitTime_);
+        return;
+      }
       this.techCall_('setCurrentTime', seconds);
       return;
     }
@@ -2428,6 +2435,15 @@ class Player extends Component {
     // never get updated.
     this.cache_.currentTime = (this.techGet_('currentTime') || 0);
     return this.cache_.currentTime;
+  }
+
+  /**
+   * Apply the value of initTime stored in cache as currentTime.
+   *
+   * @private
+   */
+  applyInitTime_() {
+    this.techCall_('setCurrentTime', this.cache_.initTime);
   }
 
   /**

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -104,26 +104,3 @@ QUnit.test('tech ready + has source + changing source = wait for loadstart', fun
   this.player.trigger('loadstart');
   assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
-
-QUnit.test('tech not ready +  currentTime =  wait until canplay event to apply currentTime value', function(assert) {
-  this.player.src('xyz.mp4');
-  this.player.currentTime(500);
-  assert.strictEqual(this.techCurrentTimeCallCount, 0);
-  this.clock.tick(100);
-  this.player.trigger('canplay');
-  assert.strictEqual(this.techCurrentTimeCallCount, 1);
-  assert.strictEqual(this.initTime, 500);
-});
-
-QUnit.test('tech not ready +  currentTime multiple times =  wait until canplay event to apply the last currentTime value', function(assert) {
-  this.player.src('xyz.mp4');
-  this.player.currentTime(500);
-  this.player.currentTime(600);
-  this.player.currentTime(700);
-  this.player.currentTime(800);
-  assert.strictEqual(this.techCurrentTimeCallCount, 0);
-  this.clock.tick(100);
-  this.player.trigger('canplay');
-  assert.strictEqual(this.techCurrentTimeCallCount, 1);
-  assert.strictEqual(this.initTime, 800);
-});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2213,3 +2213,31 @@ QUnit.test('controlBar behaviour with mouseenter and mouseleave events', functio
 
   player.dispose();
 });
+
+QUnit.test('Should be able to set a currentTime after player initialization as soon the canplay event is fired', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
+  player.src('xyz.mp4');
+  player.currentTime(500);
+  assert.strictEqual(player.currentTime(), 0, 'currentTime value was not changed');
+  this.clock.tick(100);
+  player.trigger('canplay');
+  assert.strictEqual(player.currentTime(), 500, 'currentTime value is the one passed after initialization');
+});
+
+QUnit.test('Should accept multiple calls to currentTime after player initialization and apply the last value as soon the canplay event is fired', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const spyInitTime = sinon.spy(player, 'applyInitTime_');
+  const spyCurrentTime = sinon.spy(player, 'currentTime');
+
+  player.src('xyz.mp4');
+  player.currentTime(500);
+  player.currentTime(600);
+  player.currentTime(700);
+  player.currentTime(800);
+  this.clock.tick(100);
+  player.trigger('canplay');
+  assert.equal(spyInitTime.callCount, 1, 'After multiple calls to currentTime just apply the last one');
+  assert.ok(spyCurrentTime.calledAfter(spyInitTime), 'currentTime was called on canplay event listener');
+  assert.equal(player.currentTime(), 800, 'The last value passed is stored as the currentTime value');
+});


### PR DESCRIPTION
## Description
This change allow the player to seek into a specific time before the player starts to play on all the browsers.

## Specific Changes proposed
Add some checks to detect whenever the player is changing the source or is not ready yet to process the seek attempt and stores in cache the given value in seconds to be applied once the player is able to perform a seek
