### PR TITLE
fix: DRM content goes black in IE/Edge when playback is started by clicking on poster image

### DIFF
--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -6,6 +6,7 @@ import Component from './component.js';
 import * as Fn from './utils/fn.js';
 import * as Dom from './utils/dom.js';
 import {silencePromise} from './utils/promise';
+import * as browser from './utils/browser.js';
 
 /**
  * A `ClickableComponent` that handles showing the poster image for the player.
@@ -112,7 +113,15 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
-    if (this.player_.tech(true)) {
+    const sourceIsEncrypted = this.player_.usingPlugin('eme') &&
+                                this.player_.eme.sessions &&
+                                this.player_.eme.sessions.length > 0;
+
+    if (this.player_.tech(true) &&
+    // We've observed a bug in IE and Edge when playing back DRM content where
+    // calling .focus() on the video element causes the video to go black,
+    // so we avoid it in that specific case
+    !((browser.IE_VERSION || browser.IS_EDGE) && sourceIsEncrypted)) {
       this.player_.tech(true).focus();
     }
 


### PR DESCRIPTION
## Description
This is continuation of #6318. The original fix addresses the issue with DRM content going black in IE11/Edge only if playback is started by clicking directly on the big play button. The issue is still present when you initiate playback by clicking anywhere on the poster element.

## Specific Changes proposed
Implement the same solution in PosterImage click handler as in the original fix.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
