### PR TITLE
fix: ensure once we fall back to * middlewares, they are all called in sequence

### DIFF
--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -311,11 +311,12 @@ function setSourceHelper(src = {}, middleware = [], next, player, acc = [], last
       // we've succeeded, now we need to go deeper
       acc.push(mw);
 
-      // if it's the same type, continue down the current chain
+      // if it's the same type or we are working through the * middlewares,
+      // continue down the current chain
       // otherwise, we want to go down the new chain
       setSourceHelper(
         _src,
-        src.type === _src.type ? mwrest : middlewares[_src.type],
+        src.type === _src.type || lastRun ? mwrest : middlewares[_src.type],
         next,
         player,
         acc,

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -537,6 +537,67 @@ QUnit.test('a middleware without a setSource gets chosen implicitly', function(a
   middleware.getMiddleware('video/foo').pop();
 });
 
+QUnit.test('a * middleware is called after type-specific middleware', function(assert) {
+  let src;
+  let acc;
+  let callCount = 0;
+
+  const mw1 = {
+    setSource(_src, next) {
+      next(null, {
+        src: 'foo',
+        type: 'video/foo'
+      });
+    }
+  };
+
+  const mw2 = {
+    setSource(_src, next) {
+      next(null, {
+        src: 'http://example.com/video.mp4',
+        type: 'video/mp4'
+      });
+    }
+  };
+
+  const factory1 = () => {
+    callCount++;
+    return mw1;
+  };
+
+  const factory2 = () => {
+    callCount++;
+    return mw2;
+  };
+
+  middleware.use('video/bar', factory1);
+  middleware.use('*', factory2);
+
+  middleware.setSource({
+    id() {
+      return 'vid1';
+    },
+    setTimeout: window.setTimeout
+  }, {src: 'bar', type: 'video/bar'}, function(_src, _acc) {
+    src = _src;
+    acc = _acc;
+  });
+
+  this.clock.tick(1);
+
+  assert.equal(src.type, 'video/mp4', 'we selected a new type of video/mp4');
+  assert.equal(src.src, 'http://example.com/video.mp4', 'we selected a new src of video.mp4');
+  assert.equal(acc.length, 2, 'we got two middleware');
+
+  assert.equal(acc[0], mw1, 'mw1 is the first middleware');
+  assert.equal(acc[1], mw2, 'mw2 is the second middleware');
+
+  assert.equal(callCount, 2, 'we saw two middleware setSource calls');
+
+  middleware.getMiddleware('video/bar').pop();
+  middleware.getMiddleware('*').pop();
+});
+
 QUnit.test('a * middleware will be called even if the source type changes', function(assert) {
   let src;
   let acc;


### PR DESCRIPTION
## Description
Middleware's `setSource` process will automatically fall back to `*` if no middlewares are available that match the source `type`. This is correct and expected!

However, if one of the `*` middlewares _changes_ the `type`, we drop the rest of the `*` chain.

## Specific Changes proposed
TBD

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
