### PR TITLE
 feat(cors): add cors options to enable cookies on requests

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -962,7 +962,7 @@ class Player extends Component {
    * A getter/setter for the `Player`'s aspect ratio.
    *
    * @param {string} [ratio]
-   *        The value to set the `Player's aspect ratio to.
+   *        The value to set the `Player`'s aspect ratio to.
    *
    * @return {string|undefined}
    *         - The current aspect ratio of the `Player` when getting.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -784,10 +784,16 @@ class Player extends Component {
   }
 
   /**
-   * A getter/setter for the `Player`'s crossOrigin. Returns the player's configured value.
+   * Get or set the `Player`'s crossOrigin option. For the HTML5 player, this
+   * sets the `crossorigin` attribute on the `<video>` tag to control the CORS
+   * behavior.
+   *
+   * @see [Video Element Attributes]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin}
    *
    * @param {string} [value]
-   *        The value to set the `Player`'s crossorigin to.
+   *        The value to set the `Player`'s crossorigin to. If an argument is
+   *        given, must be one of `anonymous` or `use-credentials`.
+   *
    *
    * @return {string}
    *         The current crossorigin value of the `Player`.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4,35 +4,35 @@
 // Subclasses Component
 import Component from './component.js';
 
-import {version} from '../../package.json';
+import { version } from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import evented from './mixins/evented';
-import {isEvented, addEventedCallback} from './mixins/evented';
+import { isEvented, addEventedCallback } from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
+import { IE_VERSION, IS_CHROME, IS_WINDOWS } from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
-import {toTitleCase, titleCaseEquals} from './utils/string-cases.js';
+import { toTitleCase, titleCaseEquals } from './utils/string-cases.js';
 import { createTimeRange } from './utils/time-ranges.js';
 import { bufferedPercent } from './utils/buffer.js';
 import * as stylesheet from './utils/stylesheet.js';
 import FullscreenApi from './fullscreen-api.js';
 import MediaError from './media-error.js';
 import safeParseTuple from 'safe-json-parse/tuple';
-import {assign} from './utils/obj';
+import { assign } from './utils/obj';
 import mergeOptions from './utils/merge-options.js';
-import {silencePromise, isPromise} from './utils/promise';
+import { silencePromise, isPromise } from './utils/promise';
 import textTrackConverter from './tracks/text-track-list-converter.js';
 import ModalDialog from './modal-dialog';
 import Tech from './tech/tech.js';
 import * as middleware from './tech/middleware.js';
-import {ALL as TRACK_TYPES} from './tracks/track-types';
+import { ALL as TRACK_TYPES } from './tracks/track-types';
 import filterSource from './utils/filter-source';
-import {getMimetype, findMimetype} from './utils/mimetypes';
+import { getMimetype, findMimetype } from './utils/mimetypes';
 import keycode from 'keycode';
 
 // The following imports are used only to ensure that the corresponding modules
@@ -382,11 +382,11 @@ class Player extends Component {
     // if the global option object was accidentally blown away by
     // someone, bail early with an informative error
     if (!this.options_ ||
-        !this.options_.techOrder ||
-        !this.options_.techOrder.length) {
+      !this.options_.techOrder ||
+      !this.options_.techOrder.length) {
       throw new Error('No techOrder specified. Did you overwrite ' +
-                      'videojs.options instead of just changing the ' +
-                      'properties you want to override?');
+        'videojs.options instead of just changing the ' +
+        'properties you want to override?');
     }
 
     // Store the original tag used to set options
@@ -458,7 +458,7 @@ class Player extends Component {
     this.el_ = this.createEl();
 
     // Make this an evented object and use `el_` as its event bus.
-    evented(this, {eventBusKey: 'el_'});
+    evented(this, { eventBusKey: 'el_' });
 
     // listen to document and player fullscreenchange handlers so we receive those events
     // before a user can receive them so we can update isFullscreen appropriately.
@@ -744,6 +744,7 @@ class Player extends Component {
     this.fill(this.options_.fill);
     this.fluid(this.options_.fluid);
     this.aspectRatio(this.options_.aspectRatio);
+    this.crossOrigin(this.options_.crossOrigin);
 
     // Hide any links within the video/audio tag,
     // because IE doesn't hide them completely from screen readers.
@@ -780,6 +781,32 @@ class Player extends Component {
     this.el_ = el;
 
     return el;
+  }
+
+  /**
+   * A getter/setter for the `Player`'s crossOrigin. Returns the player's configured value.
+   *
+   * @param {string} [value]
+   *        The value to set the `Player`'s crossorigin to.
+   *
+   * @return {string}
+   *         The current crossorigin value of the `Player`.
+   */
+  crossOrigin(value) {
+    if (!value) {
+      return this.techGet_('crossorigin');
+    }
+
+    const validCorsValues = ['anonymous', 'use-credentials'];
+
+    if (validCorsValues.indexOf(value) < 0) {
+      log.error(`Improper value "${value}" supplied for crossorigin`);
+      return;
+    }
+
+    this.techCall_('setCrossorigin', value);
+
+    return this.techGet_('crossorigin');
   }
 
   /**
@@ -1412,9 +1439,9 @@ class Player extends Component {
     }
 
     return promise.then(() => {
-      this.trigger({type: 'autoplay-success', autoplay: type});
+      this.trigger({ type: 'autoplay-success', autoplay: type });
     }).catch((e) => {
-      this.trigger({type: 'autoplay-failure', autoplay: type});
+      this.trigger({ type: 'autoplay-failure', autoplay: type });
     });
   }
 
@@ -1450,7 +1477,7 @@ class Player extends Component {
     }
 
     // update `currentSource` cache always
-    this.cache_.source = mergeOptions({}, srcObj, {src, type});
+    this.cache_.source = mergeOptions({}, srcObj, { src, type });
 
     const matchingSources = this.cache_.sources.filter((s) => s.src && s.src === src);
     const sourceElSources = [];
@@ -1471,8 +1498,8 @@ class Player extends Component {
     // the current source cache is not up to date
     if (matchingSourceEls.length && !matchingSources.length) {
       this.cache_.sources = sourceElSources;
-    // if we don't have matching source or source els set the
-    // sources cache to the `currentSource` cache
+      // if we don't have matching source or source els set the
+      // sources cache to the `currentSource` cache
     } else if (!matchingSources.length) {
       this.cache_.sources = [this.cache_.source];
     }
@@ -1530,7 +1557,7 @@ class Player extends Component {
         // if both the tech source and the player source were updated we assume
         // something like @videojs/http-streaming did the sourceset and skip updating the source cache.
         if (!this.lastSource_ || (this.lastSource_.tech !== eventSrc && this.lastSource_.player !== playerSrc)) {
-          updateSourceCaches = () => {};
+          updateSourceCaches = () => { };
         }
       }
 
@@ -1557,7 +1584,7 @@ class Player extends Component {
         });
       }
     }
-    this.lastSource_ = {player: this.currentSource().src, tech: event.src};
+    this.lastSource_ = { player: this.currentSource().src, tech: event.src };
 
     this.trigger({
       src: event.src,
@@ -3027,7 +3054,7 @@ class Player extends Component {
    * @listens keydown
    */
   handleKeyDown(event) {
-    const {userActions} = this.options_;
+    const { userActions } = this.options_;
 
     // Bail out if hotkeys are not configured.
     if (!userActions || !userActions.hotkeys) {
@@ -3223,7 +3250,7 @@ class Player extends Component {
     const flip = (fn) => (a, b) => fn(b, a);
     const finder = ([techName, tech], source) => {
       if (tech.canPlaySource(source, this.options_[techName.toLowerCase()])) {
-        return {source, tech: techName};
+        return { source, tech: techName };
       }
     };
 
@@ -3545,12 +3572,12 @@ class Player extends Component {
       this.manualAutoplay_(value);
       techAutoplay = false;
 
-    // any falsy value sets autoplay to false in the browser,
-    // lets do the same
+      // any falsy value sets autoplay to false in the browser,
+      // lets do the same
     } else if (!value) {
       this.options_.autoplay = false;
 
-    // any other value (ie truthy) sets autoplay to true
+      // any other value (ie truthy) sets autoplay to true
     } else {
       this.options_.autoplay = true;
     }
@@ -3809,7 +3836,7 @@ class Player extends Component {
     // Suppress the first error message for no compatible source until
     // user interaction
     if (this.options_.suppressNotSupportedError &&
-        err && err.code === 4
+      err && err.code === 4
     ) {
       const triggerSuppressedError = function() {
         this.error(err);
@@ -4169,7 +4196,7 @@ class Player extends Component {
    *         does not return anything
    */
   removeRemoteTextTrack(obj = {}) {
-    let {track} = obj;
+    let { track } = obj;
 
     if (!track) {
       track = obj;
@@ -4446,7 +4473,7 @@ class Player extends Component {
       this.on('playerresize', this.updateCurrentBreakpoint_);
       this.updateCurrentBreakpoint_();
 
-    // Stop listening for breakpoints if the player is no longer responsive.
+      // Stop listening for breakpoints if the player is no longer responsive.
     } else {
       this.off('playerresize', this.updateCurrentBreakpoint_);
       this.removeCurrentBreakpoint_();
@@ -4542,7 +4569,7 @@ class Player extends Component {
     // Clone the media object so it cannot be mutated from outside.
     this.cache_.media = mergeOptions(media);
 
-    const {artwork, poster, src, textTracks} = this.cache_.media;
+    const { artwork, poster, src, textTracks } = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
@@ -4586,7 +4613,7 @@ class Player extends Component {
         src: tt.src
       }));
 
-      const media = {src, textTracks};
+      const media = { src, textTracks };
 
       if (poster) {
         media.poster = poster;
@@ -4675,11 +4702,11 @@ class Player extends Component {
     // Note: We don't actually use flexBasis (or flexOrder), but it's one of the more
     // common flex features that we can rely on when checking for flex support.
     return !('flexBasis' in elem.style ||
-            'webkitFlexBasis' in elem.style ||
-            'mozFlexBasis' in elem.style ||
-            'msFlexBasis' in elem.style ||
-            // IE10-specific (2012 flex spec), available for completeness
-            'msFlexOrder' in elem.style);
+      'webkitFlexBasis' in elem.style ||
+      'mozFlexBasis' in elem.style ||
+      'msFlexBasis' in elem.style ||
+      // IE10-specific (2012 flex spec), available for completeness
+      'msFlexOrder' in elem.style);
   }
 }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -785,34 +785,32 @@ class Player extends Component {
 
   /**
    * Get or set the `Player`'s crossOrigin option. For the HTML5 player, this
-   * sets the `crossorigin` attribute on the `<video>` tag to control the CORS
+   * sets the `crossOrigin` property on the `<video>` tag to control the CORS
    * behavior.
    *
    * @see [Video Element Attributes]{@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin}
    *
    * @param {string} [value]
-   *        The value to set the `Player`'s crossorigin to. If an argument is
+   *        The value to set the `Player`'s crossOrigin to. If an argument is
    *        given, must be one of `anonymous` or `use-credentials`.
    *
-   *
-   * @return {string}
-   *         The current crossorigin value of the `Player`.
+   * @return {string|undefined}
+   *         - The current crossOrigin value of the `Player` when getting.
+   *         - undefined when setting
    */
   crossOrigin(value) {
     if (!value) {
-      return this.techGet_('crossorigin');
+      return this.techGet_('crossOrigin');
     }
 
-    const validCorsValues = ['anonymous', 'use-credentials'];
-
-    if (validCorsValues.indexOf(value) < 0) {
-      log.error(`Improper value "${value}" supplied for crossorigin`);
+    if (value != 'anonymous' || value != 'use-credentials') {
+      log.warn(`crossOrigin must be "anonymous" or "use-credentials", given "${value}"`);
       return;
     }
 
-    this.techCall_('setCrossorigin', value);
+    this.techCall_('setCrossOrigin', value);
 
-    return this.techGet_('crossorigin');
+    return;
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -803,7 +803,7 @@ class Player extends Component {
       return this.techGet_('crossOrigin');
     }
 
-    if (value != 'anonymous' || value != 'use-credentials') {
+    if (value !== 'anonymous' || value !== 'use-credentials') {
       log.warn(`crossOrigin must be "anonymous" or "use-credentials", given "${value}"`);
       return;
     }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4,35 +4,35 @@
 // Subclasses Component
 import Component from './component.js';
 
-import { version } from '../../package.json';
+import {version} from '../../package.json';
 import document from 'global/document';
 import window from 'global/window';
 import evented from './mixins/evented';
-import { isEvented, addEventedCallback } from './mixins/evented';
+import {isEvented, addEventedCallback} from './mixins/evented';
 import * as Events from './utils/events.js';
 import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import { IE_VERSION, IS_CHROME, IS_WINDOWS } from './utils/browser.js';
+import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
-import { toTitleCase, titleCaseEquals } from './utils/string-cases.js';
+import {toTitleCase, titleCaseEquals} from './utils/string-cases.js';
 import { createTimeRange } from './utils/time-ranges.js';
 import { bufferedPercent } from './utils/buffer.js';
 import * as stylesheet from './utils/stylesheet.js';
 import FullscreenApi from './fullscreen-api.js';
 import MediaError from './media-error.js';
 import safeParseTuple from 'safe-json-parse/tuple';
-import { assign } from './utils/obj';
+import {assign} from './utils/obj';
 import mergeOptions from './utils/merge-options.js';
-import { silencePromise, isPromise } from './utils/promise';
+import {silencePromise, isPromise} from './utils/promise';
 import textTrackConverter from './tracks/text-track-list-converter.js';
 import ModalDialog from './modal-dialog';
 import Tech from './tech/tech.js';
 import * as middleware from './tech/middleware.js';
-import { ALL as TRACK_TYPES } from './tracks/track-types';
+import {ALL as TRACK_TYPES} from './tracks/track-types';
 import filterSource from './utils/filter-source';
-import { getMimetype, findMimetype } from './utils/mimetypes';
+import {getMimetype, findMimetype} from './utils/mimetypes';
 import keycode from 'keycode';
 
 // The following imports are used only to ensure that the corresponding modules
@@ -382,11 +382,11 @@ class Player extends Component {
     // if the global option object was accidentally blown away by
     // someone, bail early with an informative error
     if (!this.options_ ||
-      !this.options_.techOrder ||
-      !this.options_.techOrder.length) {
+        !this.options_.techOrder ||
+        !this.options_.techOrder.length) {
       throw new Error('No techOrder specified. Did you overwrite ' +
-        'videojs.options instead of just changing the ' +
-        'properties you want to override?');
+                      'videojs.options instead of just changing the ' +
+                      'properties you want to override?');
     }
 
     // Store the original tag used to set options
@@ -458,7 +458,7 @@ class Player extends Component {
     this.el_ = this.createEl();
 
     // Make this an evented object and use `el_` as its event bus.
-    evented(this, { eventBusKey: 'el_' });
+    evented(this, {eventBusKey: 'el_'});
 
     // listen to document and player fullscreenchange handlers so we receive those events
     // before a user can receive them so we can update isFullscreen appropriately.
@@ -1439,9 +1439,9 @@ class Player extends Component {
     }
 
     return promise.then(() => {
-      this.trigger({ type: 'autoplay-success', autoplay: type });
+      this.trigger({type: 'autoplay-success', autoplay: type});
     }).catch((e) => {
-      this.trigger({ type: 'autoplay-failure', autoplay: type });
+      this.trigger({type: 'autoplay-failure', autoplay: type});
     });
   }
 
@@ -1477,7 +1477,7 @@ class Player extends Component {
     }
 
     // update `currentSource` cache always
-    this.cache_.source = mergeOptions({}, srcObj, { src, type });
+    this.cache_.source = mergeOptions({}, srcObj, {src, type});
 
     const matchingSources = this.cache_.sources.filter((s) => s.src && s.src === src);
     const sourceElSources = [];
@@ -1498,8 +1498,8 @@ class Player extends Component {
     // the current source cache is not up to date
     if (matchingSourceEls.length && !matchingSources.length) {
       this.cache_.sources = sourceElSources;
-      // if we don't have matching source or source els set the
-      // sources cache to the `currentSource` cache
+    // if we don't have matching source or source els set the
+    // sources cache to the `currentSource` cache
     } else if (!matchingSources.length) {
       this.cache_.sources = [this.cache_.source];
     }
@@ -1557,7 +1557,7 @@ class Player extends Component {
         // if both the tech source and the player source were updated we assume
         // something like @videojs/http-streaming did the sourceset and skip updating the source cache.
         if (!this.lastSource_ || (this.lastSource_.tech !== eventSrc && this.lastSource_.player !== playerSrc)) {
-          updateSourceCaches = () => { };
+          updateSourceCaches = () => {};
         }
       }
 
@@ -1584,7 +1584,7 @@ class Player extends Component {
         });
       }
     }
-    this.lastSource_ = { player: this.currentSource().src, tech: event.src };
+    this.lastSource_ = {player: this.currentSource().src, tech: event.src};
 
     this.trigger({
       src: event.src,
@@ -3054,7 +3054,7 @@ class Player extends Component {
    * @listens keydown
    */
   handleKeyDown(event) {
-    const { userActions } = this.options_;
+    const {userActions} = this.options_;
 
     // Bail out if hotkeys are not configured.
     if (!userActions || !userActions.hotkeys) {
@@ -3250,7 +3250,7 @@ class Player extends Component {
     const flip = (fn) => (a, b) => fn(b, a);
     const finder = ([techName, tech], source) => {
       if (tech.canPlaySource(source, this.options_[techName.toLowerCase()])) {
-        return { source, tech: techName };
+        return {source, tech: techName};
       }
     };
 
@@ -3572,12 +3572,12 @@ class Player extends Component {
       this.manualAutoplay_(value);
       techAutoplay = false;
 
-      // any falsy value sets autoplay to false in the browser,
-      // lets do the same
+    // any falsy value sets autoplay to false in the browser,
+    // lets do the same
     } else if (!value) {
       this.options_.autoplay = false;
 
-      // any other value (ie truthy) sets autoplay to true
+    // any other value (ie truthy) sets autoplay to true
     } else {
       this.options_.autoplay = true;
     }
@@ -3836,7 +3836,7 @@ class Player extends Component {
     // Suppress the first error message for no compatible source until
     // user interaction
     if (this.options_.suppressNotSupportedError &&
-      err && err.code === 4
+        err && err.code === 4
     ) {
       const triggerSuppressedError = function() {
         this.error(err);
@@ -4196,7 +4196,7 @@ class Player extends Component {
    *         does not return anything
    */
   removeRemoteTextTrack(obj = {}) {
-    let { track } = obj;
+    let {track} = obj;
 
     if (!track) {
       track = obj;
@@ -4473,7 +4473,7 @@ class Player extends Component {
       this.on('playerresize', this.updateCurrentBreakpoint_);
       this.updateCurrentBreakpoint_();
 
-      // Stop listening for breakpoints if the player is no longer responsive.
+    // Stop listening for breakpoints if the player is no longer responsive.
     } else {
       this.off('playerresize', this.updateCurrentBreakpoint_);
       this.removeCurrentBreakpoint_();
@@ -4569,7 +4569,7 @@ class Player extends Component {
     // Clone the media object so it cannot be mutated from outside.
     this.cache_.media = mergeOptions(media);
 
-    const { artwork, poster, src, textTracks } = this.cache_.media;
+    const {artwork, poster, src, textTracks} = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
@@ -4613,7 +4613,7 @@ class Player extends Component {
         src: tt.src
       }));
 
-      const media = { src, textTracks };
+      const media = {src, textTracks};
 
       if (poster) {
         media.poster = poster;
@@ -4702,11 +4702,11 @@ class Player extends Component {
     // Note: We don't actually use flexBasis (or flexOrder), but it's one of the more
     // common flex features that we can rely on when checking for flex support.
     return !('flexBasis' in elem.style ||
-      'webkitFlexBasis' in elem.style ||
-      'mozFlexBasis' in elem.style ||
-      'msFlexBasis' in elem.style ||
-      // IE10-specific (2012 flex spec), available for completeness
-      'msFlexOrder' in elem.style);
+            'webkitFlexBasis' in elem.style ||
+            'mozFlexBasis' in elem.style ||
+            'msFlexBasis' in elem.style ||
+            // IE10-specific (2012 flex spec), available for completeness
+            'msFlexOrder' in elem.style);
   }
 }
 

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -77,8 +77,8 @@ class Html5 extends Tech {
             this.remoteTextTracks().addTrack(node.track);
             this.textTracks().addTrack(node.track);
             if (!crossoriginTracks &&
-                !this.el_.hasAttribute('crossorigin') &&
-                Url.isCrossOrigin(node.src)) {
+              !this.el_.hasAttribute('crossorigin') &&
+              Url.isCrossOrigin(node.src)) {
               crossoriginTracks = true;
             }
           }
@@ -93,7 +93,7 @@ class Html5 extends Tech {
     this.proxyNativeTracks_();
     if (this.featuresNativeTextTracks && crossoriginTracks) {
       log.warn('Text Tracks are being loaded from another origin but the crossorigin attribute isn\'t used.\n' +
-            'This may prevent text tracks from loading.');
+        'This may prevent text tracks from loading.');
     }
 
     // prevent iOS Safari from disabling metadata text tracks during native playback
@@ -104,7 +104,7 @@ class Html5 extends Tech {
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
     if ((browser.TOUCH_ENABLED || browser.IS_IPHONE ||
-        browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
+      browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
       this.setControls(true);
     }
 
@@ -269,8 +269,8 @@ class Html5 extends Tech {
     const techTracks = this[props.getterName]();
 
     if (!this[`featuresNative${props.capitalName}Tracks`] ||
-        !elTracks ||
-        !elTracks.addEventListener) {
+      !elTracks ||
+      !elTracks.addEventListener) {
       return;
     }
     const listeners = {
@@ -365,8 +365,8 @@ class Html5 extends Tech {
     // So we have to create a brand new element.
     // If we ingested the player div, we do not need to move the media element.
     if (!el ||
-        !(this.options_.playerElIngest ||
-          this.movingMediaElementInDOM)) {
+      !(this.options_.playerElIngest ||
+        this.movingMediaElementInDOM)) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {
@@ -895,7 +895,7 @@ class Html5 extends Tech {
     const videoPlaybackQuality = {};
 
     if (typeof this.el().webkitDroppedFrameCount !== 'undefined' &&
-        typeof this.el().webkitDecodedFrameCount !== 'undefined') {
+      typeof this.el().webkitDecodedFrameCount !== 'undefined') {
       videoPlaybackQuality.droppedVideoFrames = this.el().webkitDroppedFrameCount;
       videoPlaybackQuality.totalVideoFrames = this.el().webkitDecodedFrameCount;
     }
@@ -903,8 +903,8 @@ class Html5 extends Tech {
     if (window.performance && typeof window.performance.now === 'function') {
       videoPlaybackQuality.creationTime = window.performance.now();
     } else if (window.performance &&
-               window.performance.timing &&
-               typeof window.performance.timing.navigationStart === 'number') {
+      window.performance.timing &&
+      typeof window.performance.timing.navigationStart === 'number') {
       videoPlaybackQuality.creationTime =
         window.Date.now() - window.performance.timing.navigationStart;
     }
@@ -1063,12 +1063,12 @@ Html5.canOverrideAttributes = function() {
   // if we cannot overwrite the src/innerHTML property, there is no support
   // iOS 7 safari for instance cannot do this.
   try {
-    const noop = () => {};
+    const noop = () => { };
 
-    Object.defineProperty(document.createElement('video'), 'src', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('audio'), 'src', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('video'), 'innerHTML', {get: noop, set: noop});
-    Object.defineProperty(document.createElement('audio'), 'innerHTML', {get: noop, set: noop});
+    Object.defineProperty(document.createElement('video'), 'src', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('audio'), 'src', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('video'), 'innerHTML', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('audio'), 'innerHTML', { get: noop, set: noop });
   } catch (e) {
     return false;
   }
@@ -1764,7 +1764,20 @@ Html5.resetMediaElement = function(el) {
    *
    * @see [Spec] {@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-video-videowidth}
    */
-  'videoHeight'
+  'videoHeight',
+  /**
+   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * to the browser that should sent the cookies along with the requests for the
+   * different assets/playlists
+   *
+   * @method Html5#setCrossorigin
+   * @param {string} crossorigin
+   *         - anonymous indicates that the media should not sent cookies.
+   *         - use-credentials indicates that the media should sent cookies along the requests.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
+   */
+  'crossorigin'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
     return this.el_[prop];
@@ -1774,7 +1787,7 @@ Html5.resetMediaElement = function(el) {
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 // The list is as follows:
-// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate
+// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate, setCrossorigin
 [
   /**
    * Set the value of `volume` on the media element. `volume` indicates the current
@@ -1864,7 +1877,20 @@ Html5.resetMediaElement = function(el) {
    *
    * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-defaultplaybackrate}
    */
-  'defaultPlaybackRate'
+  'defaultPlaybackRate',
+  /**
+   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * to the browser that should sent the cookies along with the requests for the
+   * different assets/playlists
+   *
+   * @method Html5#setCrossorigin
+   * @param {string} crossorigin
+   *         - anonymous indicates that the media should not sent cookies.
+   *         - use-credentials indicates that the media should sent cookies along the requests.
+   *
+   * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
+   */
+  'crossorigin'
 
 ].forEach(function(prop) {
   Html5.prototype['set' + toTitleCase(prop)] = function(v) {
@@ -1957,7 +1983,7 @@ Html5.nativeSourceHandler.canHandleSource = function(source, options) {
   if (source.type) {
     return Html5.nativeSourceHandler.canPlayType(source.type);
 
-  // If no type, fall back to checking 'video/[EXTENSION]'
+    // If no type, fall back to checking 'video/[EXTENSION]'
   } else if (source.src) {
     const ext = Url.getFileExtension(source.src);
 
@@ -1986,7 +2012,7 @@ Html5.nativeSourceHandler.handleSource = function(source, tech, options) {
 /**
  * A noop for the native dispose function, as cleanup is not needed.
  */
-Html5.nativeSourceHandler.dispose = function() {};
+Html5.nativeSourceHandler.dispose = function() { };
 
 // Register the native source handler
 Html5.registerSourceHandler(Html5.nativeSourceHandler);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1519,7 +1519,7 @@ Html5.resetMediaElement = function(el) {
 // The list is as followed
 // paused, currentTime, buffered, volume, poster, preload, error, seeking
 // seekable, ended, playbackRate, defaultPlaybackRate, played, networkState
-// readyState, videoWidth, videoHeight
+// readyState, videoWidth, videoHeight, crossOrigin
 [
   /**
    * Get the value of `paused` from the media element. `paused` indicates whether the media element
@@ -1788,7 +1788,7 @@ Html5.resetMediaElement = function(el) {
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 // The list is as follows:
-// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate
+// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate, setCrossOrigin
 [
   /**
    * Set the value of `volume` on the media element. `volume` indicates the current
@@ -1893,7 +1893,6 @@ Html5.resetMediaElement = function(el) {
    * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
    */
   'crossOrigin'
-
 ].forEach(function(prop) {
   Html5.prototype['set' + toTitleCase(prop)] = function(v) {
     this.el_[prop] = v;

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -77,8 +77,8 @@ class Html5 extends Tech {
             this.remoteTextTracks().addTrack(node.track);
             this.textTracks().addTrack(node.track);
             if (!crossoriginTracks &&
-              !this.el_.hasAttribute('crossorigin') &&
-              Url.isCrossOrigin(node.src)) {
+                !this.el_.hasAttribute('crossorigin') &&
+                Url.isCrossOrigin(node.src)) {
               crossoriginTracks = true;
             }
           }
@@ -93,7 +93,7 @@ class Html5 extends Tech {
     this.proxyNativeTracks_();
     if (this.featuresNativeTextTracks && crossoriginTracks) {
       log.warn('Text Tracks are being loaded from another origin but the crossorigin attribute isn\'t used.\n' +
-        'This may prevent text tracks from loading.');
+            'This may prevent text tracks from loading.');
     }
 
     // prevent iOS Safari from disabling metadata text tracks during native playback
@@ -104,7 +104,7 @@ class Html5 extends Tech {
     // so we can remove this all together. Right now this will block custom
     // controls on touch enabled laptops like the Chrome Pixel
     if ((browser.TOUCH_ENABLED || browser.IS_IPHONE ||
-      browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
+        browser.IS_NATIVE_ANDROID) && options.nativeControlsForTouch === true) {
       this.setControls(true);
     }
 
@@ -269,8 +269,8 @@ class Html5 extends Tech {
     const techTracks = this[props.getterName]();
 
     if (!this[`featuresNative${props.capitalName}Tracks`] ||
-      !elTracks ||
-      !elTracks.addEventListener) {
+        !elTracks ||
+        !elTracks.addEventListener) {
       return;
     }
     const listeners = {
@@ -365,8 +365,8 @@ class Html5 extends Tech {
     // So we have to create a brand new element.
     // If we ingested the player div, we do not need to move the media element.
     if (!el ||
-      !(this.options_.playerElIngest ||
-        this.movingMediaElementInDOM)) {
+        !(this.options_.playerElIngest ||
+          this.movingMediaElementInDOM)) {
 
       // If the original tag is still there, clone and remove it.
       if (el) {
@@ -895,7 +895,7 @@ class Html5 extends Tech {
     const videoPlaybackQuality = {};
 
     if (typeof this.el().webkitDroppedFrameCount !== 'undefined' &&
-      typeof this.el().webkitDecodedFrameCount !== 'undefined') {
+        typeof this.el().webkitDecodedFrameCount !== 'undefined') {
       videoPlaybackQuality.droppedVideoFrames = this.el().webkitDroppedFrameCount;
       videoPlaybackQuality.totalVideoFrames = this.el().webkitDecodedFrameCount;
     }
@@ -903,8 +903,8 @@ class Html5 extends Tech {
     if (window.performance && typeof window.performance.now === 'function') {
       videoPlaybackQuality.creationTime = window.performance.now();
     } else if (window.performance &&
-      window.performance.timing &&
-      typeof window.performance.timing.navigationStart === 'number') {
+               window.performance.timing &&
+               typeof window.performance.timing.navigationStart === 'number') {
       videoPlaybackQuality.creationTime =
         window.Date.now() - window.performance.timing.navigationStart;
     }
@@ -1063,12 +1063,12 @@ Html5.canOverrideAttributes = function() {
   // if we cannot overwrite the src/innerHTML property, there is no support
   // iOS 7 safari for instance cannot do this.
   try {
-    const noop = () => { };
+    const noop = () => {};
 
-    Object.defineProperty(document.createElement('video'), 'src', { get: noop, set: noop });
-    Object.defineProperty(document.createElement('audio'), 'src', { get: noop, set: noop });
-    Object.defineProperty(document.createElement('video'), 'innerHTML', { get: noop, set: noop });
-    Object.defineProperty(document.createElement('audio'), 'innerHTML', { get: noop, set: noop });
+    Object.defineProperty(document.createElement('video'), 'src', {get: noop, set: noop});
+    Object.defineProperty(document.createElement('audio'), 'src', {get: noop, set: noop});
+    Object.defineProperty(document.createElement('video'), 'innerHTML', {get: noop, set: noop});
+    Object.defineProperty(document.createElement('audio'), 'innerHTML', {get: noop, set: noop});
   } catch (e) {
     return false;
   }
@@ -1765,6 +1765,7 @@ Html5.resetMediaElement = function(el) {
    * @see [Spec] {@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-video-videowidth}
    */
   'videoHeight',
+
   /**
    * Set the value of `crossorigin` from the media element. `crossorigin` indicates
    * to the browser that should sent the cookies along with the requests for the
@@ -1787,7 +1788,7 @@ Html5.resetMediaElement = function(el) {
 // Wrap native properties with a setter in this format:
 // set + toTitleCase(name)
 // The list is as follows:
-// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate, setCrossorigin
+// setVolume, setSrc, setPoster, setPreload, setPlaybackRate, setDefaultPlaybackRate
 [
   /**
    * Set the value of `volume` on the media element. `volume` indicates the current
@@ -1878,6 +1879,7 @@ Html5.resetMediaElement = function(el) {
    * @see [Spec]{@link https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-defaultplaybackrate}
    */
   'defaultPlaybackRate',
+
   /**
    * Set the value of `crossorigin` from the media element. `crossorigin` indicates
    * to the browser that should sent the cookies along with the requests for the
@@ -1983,7 +1985,7 @@ Html5.nativeSourceHandler.canHandleSource = function(source, options) {
   if (source.type) {
     return Html5.nativeSourceHandler.canPlayType(source.type);
 
-    // If no type, fall back to checking 'video/[EXTENSION]'
+  // If no type, fall back to checking 'video/[EXTENSION]'
   } else if (source.src) {
     const ext = Url.getFileExtension(source.src);
 
@@ -2012,7 +2014,7 @@ Html5.nativeSourceHandler.handleSource = function(source, tech, options) {
 /**
  * A noop for the native dispose function, as cleanup is not needed.
  */
-Html5.nativeSourceHandler.dispose = function() { };
+Html5.nativeSourceHandler.dispose = function() {};
 
 // Register the native source handler
 Html5.registerSourceHandler(Html5.nativeSourceHandler);

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1767,18 +1767,18 @@ Html5.resetMediaElement = function(el) {
   'videoHeight',
 
   /**
-   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * Get the value of `crossOrigin` from the media element. `crossOrigin` indicates
    * to the browser that should sent the cookies along with the requests for the
    * different assets/playlists
    *
-   * @method Html5#setCrossorigin
-   * @param {string} crossorigin
+   * @method Html5#crossOrigin
+   * @return {string}
    *         - anonymous indicates that the media should not sent cookies.
    *         - use-credentials indicates that the media should sent cookies along the requests.
    *
    * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
    */
-  'crossorigin'
+  'crossOrigin'
 ].forEach(function(prop) {
   Html5.prototype[prop] = function() {
     return this.el_[prop];
@@ -1881,18 +1881,18 @@ Html5.resetMediaElement = function(el) {
   'defaultPlaybackRate',
 
   /**
-   * Set the value of `crossorigin` from the media element. `crossorigin` indicates
+   * Set the value of `crossOrigin` from the media element. `crossOrigin` indicates
    * to the browser that should sent the cookies along with the requests for the
    * different assets/playlists
    *
-   * @method Html5#setCrossorigin
-   * @param {string} crossorigin
+   * @method Html5#setCrossOrigin
+   * @param {string} crossOrigin
    *         - anonymous indicates that the media should not sent cookies.
    *         - use-credentials indicates that the media should sent cookies along the requests.
    *
    * @see [Spec]{@link https://html.spec.whatwg.org/#attr-media-crossorigin}
    */
-  'crossorigin'
+  'crossOrigin'
 
 ].forEach(function(prop) {
   Html5.prototype['set' + toTitleCase(prop)] = function(v) {


### PR DESCRIPTION
## Description

This is a rebase of #6376 with whitespace changes removed. All credit due to @citosid, whose original committer information is retained.

## Specific Changes proposed

Expose getter/setter for the player's `crossOrigin` property, and add `crossorigin` to the list of internal properties that are copied into the HTML5 video elements. This enables resources like subtitles to include cookies in their XHR requests for sites that require authorization to fetch.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
