### PR TITLE
fix: update being called on seekbar during dispose

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -92,7 +92,7 @@ class SeekBar extends Slider {
   }
 
   disableInterval_(e) {
-    if (this.player_.liveTracker && this.player_.liveTracker.isLive() && e.type !== 'ended') {
+    if (this.player_.liveTracker && this.player_.liveTracker.isLive() && e && e.type !== 'ended') {
       return;
     }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -428,6 +428,14 @@ class SeekBar extends Slider {
       super.handleKeyDown(event);
     }
   }
+
+  dispose() {
+    if (this.player_.liveTracker) {
+      this.off(this.player_.liveTracker, 'liveedgechange', this.update);
+    }
+
+    super.dispose();
+  }
 }
 
 /**

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -430,8 +430,20 @@ class SeekBar extends Slider {
   }
 
   dispose() {
+    this.disableInterval_();
+
+    this.off(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
     if (this.player_.liveTracker) {
-      this.off(this.player_.liveTracker, 'liveedgechange', this.update);
+      this.on(this.player_.liveTracker, 'liveedgechange', this.update);
+    }
+
+    this.off(this.player_, ['playing'], this.enableInterval_);
+    this.off(this.player_, ['ended', 'pause', 'waiting'], this.disableInterval_);
+
+    // we don't need to update the play progress if the document is hidden,
+    // also, this causes the CPU to spike and eventually crash the page on IE11.
+    if ('hidden' in document && 'visibilityState' in document) {
+      this.off(document, 'visibilitychange', this.toggleVisibility_);
     }
 
     super.dispose();


### PR DESCRIPTION
Right now `seekBar.update()` is getting called on after it is disposed by `liveedgechange` causing  and error to be thrown about `player` not existing and us trying to call `ended` on it [here](https://github.com/videojs/video.js/blob/master/src/js/control-bar/progress-control/seek-bar.js#L138)