### PR TITLE
docs: let the demo work correctly in angular v8+.

### DIFF
--- a/docs/guides/angular.md
+++ b/docs/guides/angular.md
@@ -20,7 +20,7 @@ import videojs from 'video.js';
   encapsulation: ViewEncapsulation.None,
 })
 export class VjsPlayerComponent implements OnInit, OnDestroy {
-  @ViewChild('target') target: ElementRef;
+  @ViewChild('target', {static: true}) target: ElementRef;
   // see options: https://github.com/videojs/video.js/blob/master/docs/guides/options.md
   @Input() options: {
       fluid: boolean,


### PR DESCRIPTION

## Description
Updated the demo to make it run correctly in angular v8.0.0 and later.
Without the `static: true` property, an `not defined ReferenceError` will be thrown since the target is null on init.

## Specific Changes proposed


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
