### PR TITLE
WIP: Expose a flaw in our current evented dispose handling

### DIFF
--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -91,6 +91,43 @@ QUnit.test('registerComponent() throws with bad arguments', function(assert) {
   );
 });
 
+QUnit.test('Component event handlers do not interfere with one another', function(assert) {
+  class Foo extends Component {
+    constructor(player, options) {
+      super(player, options);
+
+      this.count = 0;
+
+      this.on(this.player_, 'test', this.listener);
+    }
+
+    listener(e) {
+      this.count++;
+
+      if (this.count === this.options_.max) {
+        this.off(this.player_, 'test', this.listener);
+      }
+    }
+  }
+
+  const player = TestHelpers.makePlayer();
+  const comp1 = new Foo(player, {max: 10});
+  const comp2 = new Foo(player, {max: 20});
+
+  let i = 30;
+
+  while (i--) {
+    player.trigger('test');
+  }
+
+  assert.strictEqual(comp1.count, 10, 'should have 10');
+  assert.strictEqual(comp2.count, 20, 'should have 20');
+
+  player.dispose();
+  comp1.dispose();
+  comp2.dispose();
+});
+
 QUnit.test('should create an element', function(assert) {
   const comp = new Component(getFakePlayer(), {});
 

--- a/test/unit/mixins/evented.test.js
+++ b/test/unit/mixins/evented.test.js
@@ -504,3 +504,40 @@ QUnit.test('off() can remove a listener from an array of events on a different t
     target: b.eventBusEl_
   });
 });
+
+QUnit.test('on() with the same function on two different targets should be disposed correctly', function(assert) {
+  const a = this.targets.a = evented({});
+  const b = this.targets.b = evented({});
+  const c = this.targets.c = evented({});
+  let i = 0;
+  const update = () => {
+    i++;
+  };
+
+  a.on(b, 'foo', update);
+  a.on(c, 'bar', update);
+
+  // sanity test with b trigger
+  b.trigger('foo');
+  assert.strictEqual(i, 1, 'b trigger works');
+
+  // sanity test with c trigger
+  c.trigger('bar');
+  assert.strictEqual(i, 2, 'c trigger works');
+
+  b.trigger('dispose');
+  b.trigger('foo');
+  assert.strictEqual(i, 2, 'b trigger after b dispose, does nothing');
+
+  c.trigger('bar');
+  assert.strictEqual(i, 3, 'c trigger after b dispose works');
+
+  a.trigger('dispose');
+
+  c.trigger('bar');
+  assert.strictEqual(i, 3, 'c trigger after a dispose does nothing');
+
+  b.trigger('bar');
+  assert.strictEqual(i, 3, 'b trigger after a dispose does nothing');
+});
+


### PR DESCRIPTION
## Description
When one target is disposed that an object is listening to, all target dispose handlers will be removed. See the unit test. 