### PR TITLE
Update description of video.js in the package.json file, and add 'hls' keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "description": "An HTML5 and Flash video player with a common API and skin for both.",
+  "description": "An HTML5 and HLS video player (with optional Flash support) with a common API and skin.",
   "version": "7.8.1",
   "main": "./dist/video.cjs.js",
   "module": "./dist/video.es.js",
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "keywords": [
     "flash",
+    "hls",
     "html5",
     "player",
     "video",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "description": "An HTML5 and HLS video player (with optional Flash support) with a common API and skin.",
+  "description": "An HTML5 video player that supports HLS and DASH with a common API and skin.",
   "version": "7.8.1",
   "main": "./dist/video.cjs.js",
   "module": "./dist/video.es.js",


### PR DESCRIPTION
## Description
Just a suggestion; update the description of video.js to better reflect what it is now, rather than what it was. It seems like this change should have happened when v7 was first released, but maybe it makes sense to do it now?