### PR TITLE
fix: checks if body has a 'zoom' set and uses it to calculate pointer…

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -592,7 +592,7 @@ export function findPosition(el) {
  */
 export function getElementZoomLevel(el) {
   try {
-    return window.getComputedStyle(el).getPropertyValue('zoom') * 1.0 || 1;
+    return parseFloat(computedStyle(el, 'zoom')) || 1;
   } catch (ignore) {
     log.warn('Can not detect zoom level', el);
     return 1;

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -583,6 +583,23 @@ export function findPosition(el) {
 }
 
 /**
+ * Gets element zoom level (reads it from computed style)
+ *
+ * @param  {Element} el
+ *         Element we get the zoom value from
+ *
+ * @return {number} zoom value
+ */
+export function getElementZoomLevel(el) {
+  try {
+    return window.getComputedStyle(el).getPropertyValue('zoom') * 1.0 || 1;
+  } catch (ignore) {
+    log.warn('Can not detect zoom level', el);
+    return 1;
+  }
+}
+
+/**
  * Represents x and y coordinates for a DOM element or mouse pointer.
  *
  * @typedef  {Object} module:dom~Coordinates
@@ -609,7 +626,13 @@ export function findPosition(el) {
  *         A coordinates object corresponding to the mouse position.
  *
  */
+let zoomLevel;
+
 export function getPointerPosition(el, event) {
+  if (!zoomLevel) {
+    zoomLevel = getElementZoomLevel(document.body);
+  }
+
   const position = {};
   const box = findPosition(el);
   const boxW = el.offsetWidth;
@@ -624,6 +647,9 @@ export function getPointerPosition(el, event) {
     pageX = event.changedTouches[0].pageX;
     pageY = event.changedTouches[0].pageY;
   }
+
+  pageY = pageY / zoomLevel;
+  pageX = pageX / zoomLevel;
 
   position.y = Math.max(0, Math.min(1, ((boxY - pageY) + boxH) / boxH));
   position.x = Math.max(0, Math.min(1, (pageX - boxX) / boxW));


### PR DESCRIPTION
… position correctly

## Description
If document `body` has set a `zoom` style set, src/utils/dom.js `getPointerPosition` is incorrectly calculating the position, causing improper behaviour of eg. volume control slider.

## Specific Changes proposed
dom.js `getPointerPosition` gets now zoom value and uses it for calculation.
As the `getComputedStyle` used to read the `zoom` style "costs" some cycles - it stores the zoom value for future use.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
