### PR TITLE
fix regression: prevent requestAnimationFrame calls from repeatedly being callled when tab is in background

### DIFF
--- a/src/js/control-bar/progress-control/load-progress-bar.js
+++ b/src/js/control-bar/progress-control/load-progress-bar.js
@@ -28,6 +28,7 @@ class LoadProgressBar extends Component {
   constructor(player, options) {
     super(player, options);
     this.partEls_ = [];
+    this.needsRequestAnimationFrame = true;
     this.on(player, 'progress', this.update);
   }
 
@@ -72,6 +73,11 @@ class LoadProgressBar extends Component {
    * @listens Player#progress
    */
   update(event) {
+    // Prevent multiple RAF's from being called when tab is in background since setInterval runs in background, but RAF does not.
+    if (!this.needsRequestAnimationFrame) {
+      return;
+    }
+
     this.requestAnimationFrame(() => {
       const liveTracker = this.player_.liveTracker;
       const buffered = this.player_.buffered();
@@ -117,7 +123,13 @@ class LoadProgressBar extends Component {
         this.el_.removeChild(children[i - 1]);
       }
       children.length = buffered.length;
+
+      // Allow additional RAF's after update has completed
+      this.needsRequestAnimationFrame = true;
     });
+
+    // Prevent additional RAF's from being called
+    this.needsRequestAnimationFrame = false;
   }
 }
 

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -41,6 +41,7 @@ class SeekBar extends Slider {
   constructor(player, options) {
     super(player, options);
     this.setEventHandlers_();
+    this.needsRequestAnimationFrame = true;
   }
 
   /**
@@ -133,6 +134,11 @@ class SeekBar extends Slider {
   update(event) {
     const percent = super.update();
 
+    // Prevent multiple RAF's from being called when tab is in background since setInterval runs in background, but RAF does not.
+    if (!this.needsRequestAnimationFrame) {
+      return;
+    }
+
     this.requestAnimationFrame(() => {
       const currentTime = this.player_.ended() ?
         this.player_.duration() : this.getCurrentTime_();
@@ -169,7 +175,13 @@ class SeekBar extends Slider {
       if (this.bar) {
         this.bar.update(Dom.getBoundingClientRect(this.el()), this.getProgress());
       }
+
+      // Allow additional RAF's after update has completed
+      this.needsRequestAnimationFrame = true;
     });
+
+    // Prevent additional RAF's from being called
+    this.needsRequestAnimationFrame = false;
 
     return percent;
   }

--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -31,6 +31,8 @@ class Slider extends Component {
     // Set property names to bar to match with the child Slider class is looking for
     this.bar = this.getChild(this.options_.barName);
 
+    this.needsRequestAnimationFrame = true;
+
     // Set a horizontal or vertical class on the slider depending on the slider type
     this.vertical(!!this.options_.vertical);
 
@@ -249,13 +251,24 @@ class Slider extends Component {
 
     this.progress_ = progress;
 
+    // Prevent multiple RAF's from being called when tab is in background since setInterval runs in background, but RAF does not.
+    if (!this.needsRequestAnimationFrame) {
+      return;
+    }
+
     this.requestAnimationFrame(() => {
       // Set the new bar width or height
       const sizeKey = this.vertical() ? 'height' : 'width';
 
       // Convert to a percentage for css value
       this.bar.el().style[sizeKey] = (progress * 100).toFixed(2) + '%';
+
+      // Allow additional RAF's after update has completed
+      this.needsRequestAnimationFrame = true;
     });
+
+    // Prevent additional RAF's from being called
+    this.needsRequestAnimationFrame = false;
 
     return progress;
   }


### PR DESCRIPTION
## Description
Fixes: https://github.com/videojs/video.js/issues/5937
Issue originally found and explained by @meikidd, see: https://github.com/videojs/video.js/issues/5937#issuecomment-539442030

This PR fixes a regression introduced in 7.7.0 by this PR: https://github.com/videojs/video.js/pull/6155
This issue had been previously fixed and working in v7.6.6, but was reintroduced when wrapping the component's update call in a `requestAnimationFrame`.

## Specific Changes proposed
Adds requestAnimationFrame (RAF) flag to prevent RAF calls from stacking in background
This component's `update` method is called via a `setInterval` which runs when a tab is in the background.
Since `update` is continuously called, RAF calls are made each tick, but RAF does not fire in the background.
RAF calls stack while tab is in the background and will fire immediately when tab regains focus.
This causes a potentially huge number of RAF calls to attempt to immediately execute when tab regains focus, which can potentially lock up a tab entirely until all queued RAF's finish firing.
To prevent this issue, we can use a variable to track when an RAF call is made, and prevent additional calls from being made until the last queued RAF function executes.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] ~~Unit Tests updated or fixed~~
  - [ ] ~~Docs/guides updated~~
  - [ ] ~~Example created~~
- [ ] Reviewed by Two Core Contributors

All tests passing.
I have also pulled this code into my project and tested against v7.6.6, v7.7.0, and v7.8.1 and confirmed:
1) bug does *not* exist in v.7.6.6
2) bug *does* exist in v7.7.0 *and* v7.8.1
3) bug does *not* exist in build produced by this PR
4) behavior of PR is nearly identical to performance of v7.6.6 when returning to a background tab.