### PR TITLE
fix: Use clamp correctly in progress control

### DIFF
--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -75,7 +75,7 @@ class ProgressControl extends Component {
     // The default skin has a gap on either side of the `SeekBar`. This means
     // that it's possible to trigger this behavior outside the boundaries of
     // the `SeekBar`. This ensures we stay within it at all times.
-    seekBarPoint = clamp(0, 1, seekBarPoint);
+    seekBarPoint = clamp(seekBarPoint, 0, 1);
 
     if (mouseTimeDisplay) {
       mouseTimeDisplay.update(seekBarRect, seekBarPoint);


### PR DESCRIPTION
## Description
This was brought to our attention by a comment on #6155 https://github.com/videojs/video.js/pull/6155/files#r416763642

It seems that I used clamp wrong in that pull request. and this is the fix for it.