### PR TITLE
fix(live-tracker): continously check liveWindow

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -47,6 +47,7 @@ class LiveTracker extends Component {
     this.reset_();
 
     this.on(this.player_, 'durationchange', this.handleDurationchange);
+    this.on(this.player_, 'timeupdate', this.handleDurationchange);
 
     // we don't need to track live playback if the document is hidden,
     // also, tracking when the document is hidden can


### PR DESCRIPTION

## Description
Checks if liveui should be enabled (thus showing the progress control bar) on every timeupdate event, fixes #6646

## Specific Changes proposed

* Add a timeupdate listener that triggers the same handler as the durationchange event, makes it so the progress control bar is displayed as soon as enough time has passed

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
