### PR TITLE
Fix on demand load of default text track

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -71,6 +71,12 @@ const parseCues = function(srcContent, track) {
  * @private
  */
 const loadTrack = function(src, track) {
+  if (track._loading === true) {
+    return;
+  }
+
+  track._loading = true;
+
   const opts = {
     uri: src
   };
@@ -87,6 +93,8 @@ const loadTrack = function(src, track) {
   }
 
   XHR(opts, Fn.bind(this, function(err, response, responseBody) {
+    track._loading = false;
+
     if (err) {
       return log.error(err, response);
     }


### PR DESCRIPTION
Hi, and thanks for the *load on demand* text track feature.

Just noticed a bug: when you use `addRemoteTextTrack` and set `default` to `true` before/while the player is being initialized, then videojs displays duplicate captions.

That's because https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track.js#L73 is called twice at the same time:
 * In https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track.js#L345 when we use `addRemoteTextTrack`
 * In https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track.js#L242 (called by https://github.com/videojs/video.js/blob/master/src/js/tracks/text-track-display.js#L143 on player initialization)

This PR adds a guard in `loadTrack` to avoid parallel loading of the same track
