### PR TITLE
feat: adding core debug mode

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -379,6 +379,9 @@ class Player extends Component {
     // Init state userActive_
     this.userActive_ = false;
 
+    // Init debugEnabled_
+    this.debugEnabled_ = false;
+
     // if the global option object was accidentally blown away by
     // someone, bail early with an informative error
     if (!this.options_ ||
@@ -4748,13 +4751,19 @@ class Player extends Component {
    * @fires Player#debugoff
    */
   debug(enabled) {
+    if (enabled === undefined) {
+      return this.debugEnabled_;
+    }
     if (enabled) {
       this.trigger('debugon');
       this.previousLogLevel_ = this.log.level;
-      this.log.level('info');
+      this.log.level('debug');
+      this.debugEnabled_ = true;
     } else {
       this.trigger('debugoff');
       this.log.level(this.previousLogLevel_);
+      this.previousLogLevel_ = undefined;
+      this.debugEnabled_ = false;
     }
   }
 }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -485,6 +485,11 @@ class Player extends Component {
       });
     }
 
+    // Enable debug mode to fire debugon event for all plugins.
+    if (options.debug) {
+      this.debug(true);
+    }
+
     this.options_.playerOptions = playerOptionsCopy;
 
     this.middleware_ = [];
@@ -4733,6 +4738,24 @@ class Player extends Component {
             'msFlexBasis' in elem.style ||
             // IE10-specific (2012 flex spec), available for completeness
             'msFlexOrder' in elem.style);
+  }
+
+  /**
+   * Set debug mode to enable/disable logs at info level.
+   *
+   * @param {boolean} enabled
+   * @fires Player#debugon
+   * @fires Player#debugoff
+   */
+  debug(enabled) {
+    if (enabled) {
+      this.trigger('debugon');
+      this.previousLogLevel_ = this.log.level;
+      this.log.level('info');
+    } else {
+      this.trigger('debugoff');
+      this.log.level(this.previousLogLevel_);
+    }
   }
 }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2258,3 +2258,10 @@ QUnit.test('Should accept multiple calls to currentTime after player initializat
   assert.ok(spyCurrentTime.calledAfter(spyInitTime), 'currentTime was called on canplay event listener');
   assert.equal(player.currentTime(), 800, 'The last value passed is stored as the currentTime value');
 });
+
+QUnit.test('Should enable debug mode and store log level when calling options', function(assert) {
+  const player = TestHelpers.makePlayer({debug: true});
+
+  assert.ok(player.previousLogLevel_, 'info', 'previous log level is stored when enabling debug');
+});
+

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2259,9 +2259,40 @@ QUnit.test('Should accept multiple calls to currentTime after player initializat
   assert.equal(player.currentTime(), 800, 'The last value passed is stored as the currentTime value');
 });
 
+QUnit.test('Should fire debugon event when debug mode is enabled', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const debugOnSpy = sinon.spy();
+
+  player.on('debugon', debugOnSpy);
+  player.debug(true);
+
+  assert.ok(debugOnSpy.calledOnce, 'debugon event was fired');
+});
+
+QUnit.test('Should fire debugoff event when debug mode is disabled', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const debugOffSpy = sinon.spy();
+
+  player.on('debugoff', debugOffSpy);
+  player.debug(false);
+
+  assert.ok(debugOffSpy.calledOnce, 'debugoff event was fired');
+});
+
 QUnit.test('Should enable debug mode and store log level when calling options', function(assert) {
   const player = TestHelpers.makePlayer({debug: true});
 
   assert.ok(player.previousLogLevel_, 'info', 'previous log level is stored when enabling debug');
+});
+
+QUnit.test('Should restore previous log level when disabling debug mode', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  player.log.level('error');
+  player.debug(true);
+  assert.ok(player.previousLogLevel_, 'info', 'log level is info when debug is enabled');
+
+  player.debug(false);
+  assert.ok(player.previousLogLevel_, 'error', 'previous log level was restored');
 });
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2267,6 +2267,7 @@ QUnit.test('Should fire debugon event when debug mode is enabled', function(asse
   player.debug(true);
 
   assert.ok(debugOnSpy.calledOnce, 'debugon event was fired');
+  player.dispose();
 });
 
 QUnit.test('Should fire debugoff event when debug mode is disabled', function(assert) {
@@ -2277,12 +2278,14 @@ QUnit.test('Should fire debugoff event when debug mode is disabled', function(as
   player.debug(false);
 
   assert.ok(debugOffSpy.calledOnce, 'debugoff event was fired');
+  player.dispose();
 });
 
 QUnit.test('Should enable debug mode and store log level when calling options', function(assert) {
   const player = TestHelpers.makePlayer({debug: true});
 
-  assert.ok(player.previousLogLevel_, 'info', 'previous log level is stored when enabling debug');
+  assert.ok(player.previousLogLevel_, 'debug', 'previous log level is stored when enabling debug');
+  player.dispose();
 });
 
 QUnit.test('Should restore previous log level when disabling debug mode', function(assert) {
@@ -2290,9 +2293,24 @@ QUnit.test('Should restore previous log level when disabling debug mode', functi
 
   player.log.level('error');
   player.debug(true);
-  assert.ok(player.previousLogLevel_, 'info', 'log level is info when debug is enabled');
+  assert.ok(player.log.level(), 'debug', 'log level is debug when debug is enabled');
 
   player.debug(false);
-  assert.ok(player.previousLogLevel_, 'error', 'previous log level was restored');
+  assert.ok(player.log.level(), 'error', 'previous log level was restored');
+  player.dispose();
 });
 
+QUnit.test('Should return if debug is enabled or disabled', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  player.debug(true);
+  const enabled = player.debug();
+
+  assert.ok(enabled);
+
+  player.debug(false);
+  const disabled = player.debug();
+
+  assert.notOk(disabled);
+  player.dispose();
+});


### PR DESCRIPTION
This introduces a debug mode which can be used to enable logs. Debug mode can be enabled via options, which will fire `debugon` and `debugoff` events.