### PR TITLE
Remove "flash" and add "dash" in keywords about video.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "copyright": "Copyright Brightcove, Inc. <https://www.brightcove.com/>",
   "license": "Apache-2.0",
   "keywords": [
-    "flash",
+    "dash",
     "hls",
     "html5",
     "player",


### PR DESCRIPTION
Following on from #6603, change the keywords to match the updated description in `package.json`.