### PR TITLE
fix: change time-display to not crash after dispose

### DIFF
--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -94,7 +94,7 @@ class TimeDisplay extends Component {
         return;
       }
 
-      if (oldNode) {
+      if (oldNode && this.contentEl_.contains(oldNode)) {
         this.contentEl_.replaceChild(this.textNode_, oldNode);
       } else {
         this.contentEl_.appendChild(this.textNode_);


### PR DESCRIPTION
## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.
https://github.com/videojs/video.js/issues/6699


## Specific Changes proposed
Check the view hierarchy before replacing to avoid the crash

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
