### PR TITLE
fix: Fullscreen broken in iOS

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2872,8 +2872,8 @@ class Player extends Component {
 
       return new PromiseClass((resolve, reject) => {
         function offHandler() {
-          self.off(self.fsApi_.fullscreenerror, errorHandler);
-          self.off(self.fsApi_.fullscreenchange, changeHandler);
+          self.off('fullscreenerror', errorHandler);
+          self.off('fullscreenchange', changeHandler);
         }
         function changeHandler() {
           offHandler();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2794,8 +2794,8 @@ class Player extends Component {
 
       return new PromiseClass((resolve, reject) => {
         function offHandler() {
-          self.off(self.fsApi_.fullscreenerror, errorHandler);
-          self.off(self.fsApi_.fullscreenchange, changeHandler);
+          self.off('fullscreenerror', errorHandler);
+          self.off('fullscreenchange', changeHandler);
         }
         function changeHandler() {
           offHandler();


### PR DESCRIPTION
## Description
Fixes #6707. The Fullscreen API is unsupported in iOS, so `self.fsApi_.fullscreenerror` and `self.fsApi_.fullscreenchange` are undefined, which was breaking the player after entering fullscreen by [removing all bound player events](https://github.com/videojs/video.js/blob/main/src/js/utils/events.js#L369-L377).

## Specific Additions
Both `requestFullscreen()` and `exitFullscreen()` add handlers for `'fullscreenchange'` and `'fullscreenerror'` events, but remove those handlers for `self.fsApi_.fullscreenchange` and `self.fsApi_.fullscreenerror` events. There may be a reason for this inconsistency, but it seems to me that if `.one()` uses the event string, `.off()` should as well (especially considering the latter two are not always defined).

Another option might be to check for Fullscreen API support as well as Promise support in `requestFullscreen()` and `exitFullscreen()`
