### PR TITLE
fix(tech): add abstract crossOrigin method on Tech

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -431,6 +431,25 @@ class Tech extends Component {
   reset() {}
 
   /**
+   * Get the value of `crossOrigin` from the tech.
+   *
+   * @abstract
+   *
+   * @see {Html5#crossOrigin}
+   */
+  crossOrigin() {}
+
+  /**
+   * Set the value of `crossOrigin` on the tech.
+   *
+   * @abstract
+   *
+   * @param {string} crossOrigin the crossOrigin value
+   * @see {Html5#setCrossOrigin}
+   */
+  setCrossOrigin() {}
+
+  /**
    * Get or set an error on the Tech.
    *
    * @param {MediaError} [err]


### PR DESCRIPTION
As part of #6588, we started using the crossOrigin method. However, it's
possible that a tech doesn't support this. Notably, the Flash tech. We
should instead have an abstract method on Tech that returns nothing so
we don't fail on those browsers.