### PR TITLE
fix: autoprefixer warning for missing grid-template-rows

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -48,6 +48,7 @@
   .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
   .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
     grid-template-columns: 1fr;
+    grid-template-rows: auto;
   }
 
 }


### PR DESCRIPTION
## Description
Added a line to prevent Autoprefixer 9.4.0 from displaying a warning. Warning was due to missing `grid-template-rows` property missing.

Fix:
`grid-template-rows: auto;` added on line `51`

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
