### PR TITLE
[#6436] - Create a helper to get focusable elements and trap focus in fullscreen mode to fix an a11y bug

### DIFF
--- a/src/js/modal-dialog.js
+++ b/src/js/modal-dialog.js
@@ -3,7 +3,6 @@
  */
 import * as Dom from './utils/dom';
 import Component from './component';
-import window from 'global/window';
 import document from 'global/document';
 import keycode from 'keycode';
 
@@ -493,17 +492,7 @@ class ModalDialog extends Component {
     const allChildren = this.el_.querySelectorAll('*');
 
     return Array.prototype.filter.call(allChildren, (child) => {
-      return ((child instanceof window.HTMLAnchorElement ||
-               child instanceof window.HTMLAreaElement) && child.hasAttribute('href')) ||
-             ((child instanceof window.HTMLInputElement ||
-               child instanceof window.HTMLSelectElement ||
-               child instanceof window.HTMLTextAreaElement ||
-               child instanceof window.HTMLButtonElement) && !child.hasAttribute('disabled')) ||
-             (child instanceof window.HTMLIFrameElement ||
-               child instanceof window.HTMLObjectElement ||
-               child instanceof window.HTMLEmbedElement) ||
-             (child.hasAttribute('tabindex') && child.getAttribute('tabindex') !== -1) ||
-             (child.hasAttribute('contenteditable'));
+      return Dom.isFocusable(child);
     });
   }
 }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2229,6 +2229,10 @@ class Player extends Component {
   }
 
   trapFullscreenTab_(event) {
+    if (!Array.isArray(this._focusableControls) || !this._focusableControls.length) {
+      return;
+    }
+
     // We'll use this to figure out if the user just tabbed on the first or last focusable control
     const focusIndex = this._focusableControls.indexOf(event.target);
     let indexToFocus;

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -181,6 +181,23 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
   return el;
 }
 
+export function isFocusable(control) {
+  return (
+    ((control instanceof window.HTMLAnchorElement || control instanceof window.HTMLAreaElement) &&
+      control.hasAttribute('href')) ||
+    ((control instanceof window.HTMLInputElement ||
+      control instanceof window.HTMLSelectElement ||
+      control instanceof window.HTMLTextAreaElement ||
+      control instanceof window.HTMLButtonElement) &&
+      !control.hasAttribute('disabled')) ||
+    control instanceof window.HTMLIFrameElement ||
+    control instanceof window.HTMLObjectElement ||
+    control instanceof window.HTMLEmbedElement ||
+    (control.hasAttribute('tabindex') && control.getAttribute('tabindex') !== -1) ||
+    control.hasAttribute('contenteditable')
+  );
+}
+
 /**
  * Injects text into an element, replacing any existing contents entirely.
  *

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -181,10 +181,35 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
   return el;
 }
 
+/**
+ * Determines if a control is visible to the user
+ *
+ * @param {HTMLElement} control - The control whose visibility is being checked
+ * @return {boolean} - True if the control is visible
+ */
+export function isVisible(control) {
+  if (!control) {
+    return false;
+  }
+
+  // Using `includes` below to catch cases where `!important` is used in the style
+  return !computedStyle(control, 'display').includes('none') && !computedStyle(control, 'visibility').includes('hidden');
+}
+
+/**
+ * Determines if a control can receive focus
+ *
+ * @param {HTMLElement} control - The control that may be focusable
+ * @return {boolean} - True if the control can receive focus
+ */
 export function isFocusable(control) {
+  if (!control || control.getAttribute('tabindex') === '-1' || !isVisible(control)) {
+    return false;
+  }
+
   return (
     ((control instanceof window.HTMLAnchorElement || control instanceof window.HTMLAreaElement) &&
-      control.hasAttribute('href')) ||
+      (control.hasAttribute('href') && !control.hasAttribute('hidden'))) ||
     ((control instanceof window.HTMLInputElement ||
       control instanceof window.HTMLSelectElement ||
       control instanceof window.HTMLTextAreaElement ||
@@ -193,7 +218,7 @@ export function isFocusable(control) {
     control instanceof window.HTMLIFrameElement ||
     control instanceof window.HTMLObjectElement ||
     control instanceof window.HTMLEmbedElement ||
-    (control.hasAttribute('tabindex') && control.getAttribute('tabindex') !== -1) ||
+    control.hasAttribute('tabindex') ||
     control.hasAttribute('contenteditable')
   );
 }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2263,9 +2263,11 @@ QUnit.test('Tabbing through the control bar is trapped correctly', function(asse
   const player = TestHelpers.makePlayer({
     controls: true
   });
-  // Need hasStarted to be true so that the controlBar is visible and focusable
 
   player.tech_.trigger('play');
+
+  // Focusable controls are calculated when fullscreen is requested
+  player.requestFullscreen();
 
   const fullscreenStub = sinon.stub(player, 'isFullscreen').returns(true);
   const children = player.controlBar.children();

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -475,9 +475,32 @@ QUnit.test('Dom.normalizeContent: functions returning arrays', function(assert) 
   );
 });
 
-QUnit.test('Dom.isFocusable', function(assert) {
-  assert.expect(12);
+QUnit.test('Dom.isVisible', function(assert) {
+  assert.expect(4);
 
+  const fixture = document.getElementById('qunit-fixture');
+
+  assert.equal(Dom.isVisible(), false, 'Returns false if control is non existent');
+
+  const visibleEl = Dom.createEl('div');
+
+  assert.equal(Dom.isVisible(visibleEl), true, 'Returns true if the control is visible');
+
+  const invisibleEl = Dom.createEl('div', {}, { style: 'visibility: hidden'});
+
+  fixture.appendChild(invisibleEl);
+  assert.equal(Dom.isVisible(invisibleEl), false, 'Returns false if the control is invisible');
+
+  const hiddenEl = Dom.createEl('div', {}, { style: 'display: none'});
+
+  fixture.appendChild(hiddenEl);
+  assert.equal(Dom.isVisible(hiddenEl), false, 'Returns false if the control is hidden via display: none');
+});
+
+QUnit.test('Dom.isFocusable', function(assert) {
+  assert.expect(15);
+
+  const fixture = document.getElementById('qunit-fixture');
   const anchorNoHref = Dom.createEl('a');
 
   assert.equal(Dom.isFocusable(anchorNoHref), false, 'An anchor with no href is not focusable');
@@ -489,6 +512,20 @@ QUnit.test('Dom.isFocusable', function(assert) {
   const inputEl = Dom.createEl('input');
 
   assert.equal(Dom.isFocusable(inputEl), true, 'An input is focusable');
+
+  const focusableNegativeTabindex = Dom.createEl('input', {}, { tabIndex: -1 });
+
+  assert.equal(Dom.isFocusable(focusableNegativeTabindex), false, 'A focusable control with a negative tabindex is not focusable');
+
+  const focusableNotVisible = Dom.createEl('input', {}, { style: 'display: none' });
+
+  fixture.appendChild(focusableNotVisible);
+  assert.equal(Dom.isFocusable(focusableNotVisible), false, 'Non visible controls are not focusable');
+
+  const focusableNotVisibleWithImportant = Dom.createEl('input', {}, { style: 'display: none !important' });
+
+  fixture.appendChild(focusableNotVisibleWithImportant);
+  assert.equal(Dom.isFocusable(focusableNotVisibleWithImportant), false, 'The important tag does not interfere with the visibility check');
 
   const selectEl = Dom.createEl('select');
 

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -475,6 +475,58 @@ QUnit.test('Dom.normalizeContent: functions returning arrays', function(assert) 
   );
 });
 
+QUnit.test('Dom.isFocusable', function(assert) {
+  assert.expect(12);
+
+  const anchorNoHref = Dom.createEl('a');
+
+  assert.equal(Dom.isFocusable(anchorNoHref), false, 'An anchor with no href is not focusable');
+
+  const anchorWithHref = Dom.createEl('a', {}, { href: '#blah' });
+
+  assert.equal(Dom.isFocusable(anchorWithHref), true, 'An anchor with an href is focusable');
+
+  const inputEl = Dom.createEl('input');
+
+  assert.equal(Dom.isFocusable(inputEl), true, 'An input is focusable');
+
+  const selectEl = Dom.createEl('select');
+
+  assert.equal(Dom.isFocusable(selectEl), true, 'An select el is focusable');
+
+  const textareaEl = Dom.createEl('textarea');
+
+  assert.equal(Dom.isFocusable(textareaEl), true, 'An textarea is focusable');
+
+  const buttonEl = Dom.createEl('button');
+
+  assert.equal(Dom.isFocusable(buttonEl), true, 'An button is focusable');
+
+  const buttonDisabledEl = Dom.createEl('button', {}, { disabled: true });
+
+  assert.equal(Dom.isFocusable(buttonDisabledEl), false, 'A disabled button is not focusable');
+
+  const iframeEl = Dom.createEl('iframe');
+
+  assert.equal(Dom.isFocusable(iframeEl), true, 'An iframe is focusable');
+
+  const embedEl = Dom.createEl('embed');
+
+  assert.equal(Dom.isFocusable(embedEl), true, 'An embed is focusable');
+
+  const divEl = Dom.createEl('div');
+
+  assert.equal(Dom.isFocusable(divEl), false, 'A div is not focusable');
+
+  const focusableDivEl = Dom.createEl('div', {}, { tabIndex: 0 });
+
+  assert.equal(Dom.isFocusable(focusableDivEl), true, 'A non-focusable control with a tabIndex >= 0 is focusable');
+
+  const contentEditableDivEl = Dom.createEl('div', {}, { contenteditable: true });
+
+  assert.equal(Dom.isFocusable(contentEditableDivEl), true, 'A non-focusable control with a contenteditable=true is focusable');
+});
+
 QUnit.test('Dom.insertContent', function(assert) {
   const p = Dom.createEl('p');
   const text = document.createTextNode('hello');


### PR DESCRIPTION
## Description
Addresses issue #6436 

## Specific Changes proposed
- Get focusable controlBar elements on first `play`
- When a user tabs on the last focusable controlBar el, set the focus back to the first focusable El in the control bar
- When a user presses Shift + tab on the first focusable controlBar el, set the focus back to the last focusable El in the control bar

## Requirements Checklist
- [x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
