### PR TITLE
docs: Fix simple typo, intial -> initial

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1575,7 +1575,7 @@ class Player extends Component {
         }
       }
 
-      // update the source to the intial source right away
+      // update the source to the initial source right away
       // in some cases this will be empty string
       updateSourceCaches(eventSrc);
 
@@ -3335,7 +3335,7 @@ class Player extends Component {
       return;
     }
 
-    // intial sources
+    // initial sources
     this.changingSrc_ = true;
 
     this.cache_.sources = sources;

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1475,7 +1475,7 @@ Html5.resetMediaElement = function(el) {
 
   /**
    * Set the value of `defaultMuted` on the media element. `defaultMuted` indicates that the current
-   * audio level should be silent, but will only effect the muted level on intial playback..
+   * audio level should be silent, but will only effect the muted level on initial playback..
    *
    * @method Html5.prototype.setDefaultMuted
    * @param {boolean} defaultMuted

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -746,7 +746,7 @@ QUnit[qunitFn]('sourceset', function(hooks) {
           this.mediaEl = this.player.tech_.el();
         });
 
-        // intial sourceset should happen on player.ready
+        // initial sourceset should happen on player.ready
         this.player.one('sourceset', (e) => {
           validateSource(this.player, [testSrc], e);
           done();


### PR DESCRIPTION
There is a small typo in src/js/player.js, src/js/tech/html5.js, test/unit/sourceset.test.js.

Should read `initial` rather than `intial`.

