### PR TITLE
fix(dom): vertical getPointerPosition value

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -620,7 +620,7 @@ export function getPointerPosition(el, event) {
     offsetY = event.changedTouches[0].pageY + box.top;
   }
 
-  position.y = Math.max(0, Math.min(1, (offsetY + boxH) / boxH));
+  position.y = (1 - Math.max(0, Math.min(1, offsetY / boxH)));
   position.x = Math.max(0, Math.min(1, offsetX / boxW));
   return position;
 }


### PR DESCRIPTION
From my understand, in the changes #5773, the Y position of all the
boxes is already calculated and accounted for in the offsetY value we
get. However, because the HTML coordinate system has Y=0 at the top,
when we do offsetY/boxH, we get a position relative to the top of the
element. However, we expect that position relative to the "start" of the
slider, or the bottom of it. Therefore, we want to get the inverse
value, which is '1 - clamp(offsetY/boxH)'.

Fixes #6863