### PR TITLE
fix: always set tabIndex to restore keydown a11y

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -165,7 +165,7 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
     // method for it.
     } else if (propName === 'textContent') {
       textContent(el, val);
-    } else if (el[propName] !== val) {
+    } else if (el[propName] !== val || propName === 'tabIndex') {
       el[propName] = val;
     }
   });


### PR DESCRIPTION
Fixes #6870

## Description
Skipping the `tabIndex` property on created elements due to #6145 optimizations blocks them from receiving keyboard events, due to not
being focus-able; for example this breaks closing `ModalDialog` elements by pressing Escape.
Fix this by always setting `tabIndex`, as the element may return the same value even though the property has not been explicitly set.

Fixes #6870

## Specific Changes proposed
* Always set a `tabIndex` property passed to `Dom.createEl()`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
