### PR TITLE
fix(text-track): don't overlap captions when font-size changes

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -368,7 +368,6 @@ class TextTrackDisplay extends Component {
         cueDiv.style.fontSize = (fontSize * overrides.fontPercent) + 'px';
         cueDiv.style.height = 'auto';
         cueDiv.style.top = 'auto';
-        cueDiv.style.bottom = '2px';
       }
       if (overrides.fontFamily && overrides.fontFamily !== 'default') {
         if (overrides.fontFamily === 'small-caps') {


### PR DESCRIPTION
For whatever reason, when the font size for text tracks is changed in
the text track settings dialog, we set a bottom of 2px on the cue.
This was added as part of the initial vtt work for Video.js in
https://github.com/videojs/video.js/commit/4e5c28cc561487ff29394d19dce3a420675e4f9d#diff-8169d53aa7eee6cab5f85b6641ef3117R176.
However, this doesn't seem to be doing anything right now and having it
means that when font-size is changed, multiple cues end up with a button
value of 2px causing them to overlap and obscure each other.

This works fine if the cues are positioned away from each other,
however, if multiple cues are positioned by default and a large font
size is used, while they will now stay on their lines, they may
partially obscure each other. This does not fix that issue and may
require modification (addition of overrides) to vtt.js to properly
support.