### PR TITLE
docs(fixup): change blog links to most recent blog version, fix typo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Please list the specific changes involved in this pull request.
 ## Requirements Checklist
 - [ ] Feature implemented / Bug fixed
 - [ ] If necessary, more likely in a feature request than a bug fix
-  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
+  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
   - [ ] Unit Tests updated or fixed
   - [ ] Docs/guides updated
   - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -144,7 +144,7 @@ on the `video` element. It's still supported by Video.js but, many browsers, inc
 Instead we recommend using the `autoplay` option rather than the `autoplay` attribute, for more information on using that.
 see the [autoplay option][autoplay-option] in the Video.js options guide.
 
-For more information on the autoplay changes see our blog post: <https://blog.videojs.com/autoplay-best-practices-with-video-js/>
+For more information on the autoplay changes see our blog post: <https://videojs.com/blog/autoplay-best-practices-with-video-js/>
 
 ### Q: How can I autoplay a video on a mobile device?
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,6 +1,6 @@
 # Middleware
 
-Middleware is a Video.js feature that allows interaction with and modification of how the `Player` and `Tech` talk to each other. For more in-depth information, check out our [feature spotlight](https://blog.videojs.com/feature-spotlight-middleware/).
+Middleware is a Video.js feature that allows interaction with and modification of how the `Player` and `Tech` talk to each other. For more in-depth information, check out our [feature spotlight](https://videojs.com/blog/feature-spotlight-middleware/).
 
 ## Table of Contents
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -94,7 +94,7 @@ player.autoplay('muted');
 
 #### More info on autoplay support and changes:
 
-* See our blog post: <https://blog.videojs.com/autoplay-best-practices-with-video-js/>
+* See our blog post: <https://videojs.com/blog/autoplay-best-practices-with-video-js/>
 
 ### `controls`
 


### PR DESCRIPTION
## Description
The FAQ lists the following as the autoplay blog link: https://blog.videojs.com/autoplay-best-practices-with-video-js/
The current blog link is: https://videojs.com/blog/autoplay-best-practices-with-video-js/

I made similar updates to other files as well. 

## Specific Changes proposed
- URL changes from previous to new blog version
- Update pull request template to say "Chrome" instead of "Chome"

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
