### PR TITLE
fix(menu): focus correct MenuItem on keyboard open

### DIFF
--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -259,8 +259,7 @@ class Menu extends Component {
    */
   focus(item = 0) {
     const children = this.children().slice();
-    const haveTitle = children.length && children[0].className &&
-      (/vjs-menu-title/).test(children[0].className);
+    const haveTitle = children.length && children[0].hasClass('vjs-menu-title');
 
     if (haveTitle) {
       children.shift();


### PR DESCRIPTION
Closes #6912

## Description
Updates the `focus()` method of the Menu component to fix a bug with a CSS `className` comparison that expected the title element to be a standard DOM element instead of a Video.js Component.

## Specific Changes proposed
When `focus()` is called on a Menu, use `Component.hasClass()` to determine if the first child is the title.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
