### PR TITLE
feat(track): make label property mutable and fire a labelchange event when the label is changed

### DIFF
--- a/src/js/control-bar/track-button.js
+++ b/src/js/control-bar/track-button.js
@@ -38,11 +38,13 @@ class TrackButton extends MenuButton {
 
     tracks.addEventListener('removetrack', updateHandler);
     tracks.addEventListener('addtrack', updateHandler);
+    tracks.addEventListener('labelchange', updateHandler);
     this.player_.on('ready', updateHandler);
 
     this.player_.on('dispose', function() {
       tracks.removeEventListener('removetrack', updateHandler);
       tracks.removeEventListener('addtrack', updateHandler);
+      tracks.removeEventListener('labelchange', updateHandler);
     });
   }
 

--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -2,6 +2,7 @@
  * @file track-list.js
  */
 import EventTarget from '../event-target';
+import {isEvented} from '../mixins/evented';
 
 /**
  * Common functionaliy between {@link TextTrackList}, {@link AudioTrackList}, and
@@ -93,7 +94,9 @@ class TrackList extends EventTarget {
       });
     };
 
-    track.addEventListener('labelchange', track.labelchange_);
+    if (isEvented(track)) {
+      track.addEventListener('labelchange', track.labelchange_);
+    }
   }
 
   /**

--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -76,6 +76,24 @@ class TrackList extends EventTarget {
         target: this
       });
     }
+
+    /**
+     * Triggered when a track label is changed.
+     *
+     * @event TrackList#addtrack
+     * @type {EventTarget~Event}
+     * @property {Track} track
+     *           A reference to track that was added.
+     */
+    track.labelchange_ = () => {
+      this.trigger({
+        track,
+        type: 'labelchange',
+        target: this
+      });
+    };
+
+    track.addEventListener('labelchange', track.labelchange_);
   }
 
   /**
@@ -161,7 +179,8 @@ class TrackList extends EventTarget {
 TrackList.prototype.allowedEvents_ = {
   change: 'change',
   addtrack: 'addtrack',
-  removetrack: 'removetrack'
+  removetrack: 'removetrack',
+  labelchange: 'labelchange'
 };
 
 // emulate attribute EventHandler support to allow for feature detection

--- a/src/js/tracks/track.js
+++ b/src/js/tracks/track.js
@@ -42,9 +42,10 @@ class Track extends EventTarget {
     const trackProps = {
       id: options.id || 'vjs_track_' + Guid.newGUID(),
       kind: options.kind || '',
-      label: options.label || '',
       language: options.language || ''
     };
+
+    let label = options.label || '';
 
     /**
      * @memberof Track
@@ -59,15 +60,6 @@ class Track extends EventTarget {
      * @memberof Track
      * @member {string} kind
      *         The kind of track that this is. Cannot be changed after creation.
-     * @instance
-     *
-     * @readonly
-     */
-
-    /**
-     * @memberof Track
-     * @member {string} label
-     *         The label of this track. Cannot be changed after creation.
      * @instance
      *
      * @readonly
@@ -91,6 +83,33 @@ class Track extends EventTarget {
         set() {}
       });
     }
+
+    /**
+     * @memberof Track
+     * @member {string} label
+     *         The label of this track. Cannot be changed after creation.
+     * @instance
+     *
+     * @fires Track#labelchange
+     */
+    Object.defineProperty(this, 'label', {
+      get() {
+        return label;
+      },
+      set(newLabel) {
+        label = newLabel;
+
+        /**
+         * An event that fires when label changes on this track.
+         *
+         * > Note: This is not part of the spec!
+         *
+         * @event Track#labelchange
+         * @type {EventTarget~Event}
+         */
+        this.trigger('labelchange');
+      }
+    });
   }
 }
 

--- a/src/js/tracks/track.js
+++ b/src/js/tracks/track.js
@@ -97,17 +97,19 @@ class Track extends EventTarget {
         return label;
       },
       set(newLabel) {
-        label = newLabel;
+        if (newLabel !== label) {
+          label = newLabel;
 
-        /**
-         * An event that fires when label changes on this track.
-         *
-         * > Note: This is not part of the spec!
-         *
-         * @event Track#labelchange
-         * @type {EventTarget~Event}
-         */
-        this.trigger('labelchange');
+          /**
+           * An event that fires when label changes on this track.
+           *
+           * > Note: This is not part of the spec!
+           *
+           * @event Track#labelchange
+           * @type {EventTarget~Event}
+           */
+          this.trigger('labelchange');
+        }
       }
     });
   }

--- a/test/unit/tracks/track-baseline.js
+++ b/test/unit/tracks/track-baseline.js
@@ -21,17 +21,15 @@ const TrackBaseline = function(TrackClass, options) {
     tech.dispose();
   });
 
-  QUnit.test('kind, label, language, id, are read only', function(assert) {
+  QUnit.test('kind, language, id, are read only', function(assert) {
     const tech = new TechFaker();
     const track = new TrackClass(Object.assign({tech}, options));
 
     track.kind = 'subtitles';
-    track.label = 'Spanish';
     track.language = 'es';
     track.id = '2';
 
     assert.equal(track.kind, options.kind, 'we have a kind');
-    assert.equal(track.label, options.label, 'we have a label');
     assert.equal(track.language, options.language, 'we have a language');
     assert.equal(track.id, options.id, 'we have an id');
 

--- a/test/unit/tracks/track-list.test.js
+++ b/test/unit/tracks/track-list.test.js
@@ -1,5 +1,6 @@
 /* eslint-env qunit */
 import TrackList from '../../../src/js/tracks/track-list.js';
+import EventTarget from '../../../src/js/event-target.js';
 
 const newTrack = function(id) {
   return {
@@ -161,3 +162,16 @@ QUnit.test('a "removetrack" event is triggered when tracks are removed', functio
   assert.equal(rms, 3, 'we got ' + rms + ' "removetrack" events');
   assert.equal(tracks, 3, 'we got a track with every event');
 });
+
+QUnit.test('labelchange event is fired for the list when a child track fires labelchange', function(assert) {
+  const trackList = new TrackList([new EventTarget()]);
+  let labelchanges = 0;
+  const labelchangeHandler = (e) => {
+    labelchanges++;
+  };
+
+  trackList.on('labelchange', labelchangeHandler);
+  trackList[0].trigger('labelchange');
+  assert.equal(labelchanges, '1', 'labelchange event is fired on tracklist');
+});
+

--- a/test/unit/tracks/track.test.js
+++ b/test/unit/tracks/track.test.js
@@ -35,3 +35,22 @@ QUnit.test('defaults when items not provided', function(assert) {
   assert.equal(track.language, '', 'language defaults to empty string');
   assert.ok(track.id.match(/vjs_track_\d+/), 'id defaults to vjs_track_GUID');
 });
+
+QUnit.test('label is updated and labelchange event is fired when label is changed', function(assert) {
+  const track = new Track({
+    tech: defaultTech
+  });
+  let eventsTriggered = 0;
+
+  track.addEventListener('labelchange', () => {
+    eventsTriggered++;
+  });
+
+  // two events
+  track.label = 'English (auto)';
+  assert.equal(eventsTriggered, 1, 'one label change');
+
+  assert.equal(track.label, 'English (auto)');
+
+  track.off();
+});

--- a/test/unit/tracks/track.test.js
+++ b/test/unit/tracks/track.test.js
@@ -46,10 +46,12 @@ QUnit.test('label is updated and labelchange event is fired when label is change
     eventsTriggered++;
   });
 
-  // two events
   track.label = 'English (auto)';
   assert.equal(eventsTriggered, 1, 'one label change');
+  assert.equal(track.label, 'English (auto)');
 
+  track.label = 'English (auto)';
+  assert.equal(eventsTriggered, 1, 'additional label change not fired when new label is the same as old');
   assert.equal(track.label, 'English (auto)');
 
   track.off();


### PR DESCRIPTION
## Description
Allows the editing of a track's label after it's creation. Track buttons will listen for the labelchange event and update their content accordingly. This aligns videojs behavior with the [HTML label spec](https://html.spec.whatwg.org/multipage/media.html#text-track-label) linked in the docs, which says that "The label of a track can change dynamically".

## Specific Changes proposed
- Add a setter for label property of the Track & fire labelchange event when the label is changed
- When tracks are added to TrackList, add a listener for a labelchange event on the track to trigger a labelchange event on the parent TrackList
- TrackButton listens for labelchange event on the TrackList, and will call the existing update handler to update the menu when the event is triggered.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
