### PR TITLE
fix: cast TOUCH_ENABLED to boolean

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -169,10 +169,10 @@ export const IS_WINDOWS = (/Windows/i).test(USER_AGENT);
  * @const
  * @type {Boolean}
  */
-export const TOUCH_ENABLED = Dom.isReal() && (
+export const TOUCH_ENABLED = Boolean(Dom.isReal() && (
   'ontouchstart' in window ||
   window.navigator.maxTouchPoints ||
-  window.DocumentTouch && window.document instanceof window.DocumentTouch);
+  window.DocumentTouch && window.document instanceof window.DocumentTouch));
 
 /**
  * Whether or not this device is an iPad.


### PR DESCRIPTION
## Description
Ran into an issue where we were using a configuration that looks something like:

```
{
  nativeControlsForTouch: true,
  html5: {
    nativeTextTracks: browser.TOUCH_ENABLED
  }
}
```

and we were not seeing captions appear in the native controls in Chrome on Microsoft Surface devices. After some digging, we found that with that browser/device combination, `TOUCH_ENABLED` is a number, not a boolean. And [the `nativeTextTracks` logic specifically does strict equality checks against `true` and `false` values](https://github.com/videojs/video.js/blob/694fe0f787f6b9b4edb06e6c87b91c50a8429237/src/js/tech/tech.js#L134-L138).

## Specific Changes proposed
`TOUCH_ENABLED` should ALWAYS be a boolean. This PR casts the expression.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
