### PR TITLE
easier contributions.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install && npm build
+    command: npm start
+ports:
+  - port: 9999
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ So you want to help out? Great! There's a number of ways you can get involved.
     * [Installing local dependencies](#installing-local-dependencies)
     * [Running tests](#running-tests)
     * [Building videojs](#building-videojs)
+  * [Online one-click setup](#online-one-click-setup)
     * [Testing Locally](#testing-locally)
     * [Sandbox test directory](#sandbox-test-directory)
     * [Running a local web server](#running-a-local-web-server)
@@ -164,6 +165,17 @@ npm run build
 ```
 
 This outputs an `es5/` and `dist/` folder. The `es5/` folder is used by bundling tools like browserify and webpack to package video.js into projects. The `dist/` folder has pre-compiled versions of video.js, including a minified version and the CSS file. This file can be included in page via a `<script></script>` tag.
+
+### Online one-click setup
+
+You can use Gitpod(an online IDE which is free for Open Source) for contributing, with a single click it will launch a workspace and automatically:
+
+* clone the `video.js` repo.
+* install the dependencies.
+* run `yarn build`.
+* run `yarn start`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 #### Testing Locally
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coverage Status][coveralls-icon]][coveralls-link]
 [![Greenkeeper badge](https://badges.greenkeeper.io/videojs/video.js.svg)](https://greenkeeper.io/)
 [![Slack Status][slack-icon]][slack-link]
+[![Gitpod Ready-to-Code](gitpod-icon)](gitpod-link)
 
 [![NPM][npm-icon]][npm-link]
 
@@ -154,6 +155,10 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 [travis-icon]: https://travis-ci.org/videojs/video.js.svg?branch=main
 
 [travis-link]: https://travis-ci.org/videojs/video.js
+
+[gitpod-icon]: https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod
+
+[gitpod-link]: https://gitpod.io/from-referrer/
 
 [vjs]: https://videojs.com
 


### PR DESCRIPTION
## Description

Hi.

I work for Gitpod. This PR adds gitpod config to the repo to make contributions easier for newcomers i.e with a single click it will launch a workspace and automatically:

* clone the `video.js` repo.
* install the dependencies.
* run `yarn build`.
* run `yarn start`.

This can be helpful for beginners i.e they can start coding instantly without setting anything up.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/video.js

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/99421445-33390800-2920-11eb-8e9c-2f4d16876bb3.png)

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
