### PR TITLE
chore: move unit test build right below main for faster watch

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -130,6 +130,30 @@ export default cliargs => [
     onwarn,
     watch
   },
+  {
+    input: 'test/unit/**/*.test.js',
+    output: {
+      format: 'iife',
+      name: 'videojsTests',
+      file: 'test/dist/bundle.js',
+      globals: globals.test
+    },
+    external: externals.test,
+    plugins: [
+      multiEntry({exports: false}),
+      alias({
+        'video.js': path.resolve(__dirname, './src/js/video.js')
+      }),
+      primedResolve,
+      json(),
+      stub(),
+      primedCjs,
+      primedBabel,
+      cliargs.progress !== false ? progress() : {}
+    ],
+    onwarn,
+    watch
+  },
   // es, cjs
   {
     input: 'src/js/index.js',
@@ -251,30 +275,5 @@ export default cliargs => [
     ],
     onwarn,
     watch
-  },
-  {
-    input: 'test/unit/**/*.test.js',
-    output: {
-      format: 'iife',
-      name: 'videojsTests',
-      file: 'test/dist/bundle.js',
-      globals: globals.test
-    },
-    external: externals.test,
-    plugins: [
-      multiEntry({exports: false}),
-      alias({
-        'video.js': path.resolve(__dirname, './src/js/video.js')
-      }),
-      primedResolve,
-      json(),
-      stub(),
-      primedCjs,
-      primedBabel,
-      cliargs.progress !== false ? progress() : {}
-    ],
-    onwarn,
-    watch
   }
-
 ];


### PR DESCRIPTION
## Description
Makes changes tests in watch take a bit less time to finish building (~5-10s) so that test iteration can be faster. 
