### PR TITLE
fix(rollup): browser globals shouldn't be external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,8 +94,7 @@ const moduleExternals = [
   '@babel/runtime'
 ];
 const externals = {
-  browser: Object.keys(globals.browser).concat([
-  ]),
+  browser: [],
   module(id) {
     const result = moduleExternals.some((ext) => id.indexOf(ext) !== -1);
 


### PR DESCRIPTION
This fixes an issue with requirejs where global/window and
global/document were being marked as dependencies. Instead, this makes
sure that the module gets inlines properly and not worked as a dep for
requirejs.

Fixes #6443, fixes #6272, fixes #6212, fixes #5680.