### PR TITLE
fix: play progress time tooltip from jittering during live

### DIFF
--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -96,6 +96,12 @@ class TimeTooltip extends Component {
       pullTooltipBy = tooltipRect.width;
     }
 
+    // prevent small width fluctuations within 0.4px from
+    // changing the value below.
+    // This really helps for live to prevent the play
+    // progress time tooltip from jittering
+    pullTooltipBy = Math.round(pullTooltipBy);
+
     this.el_.style.right = `-${pullTooltipBy}px`;
     this.write(content);
   }


### PR DESCRIPTION
Currently during live playback with the new liveui if the progress control is all the way to the right of the seek bar the time tooltip changes in very small increments rapidly which looks really strange. 

Before:
![before](https://user-images.githubusercontent.com/2381475/100783519-e2bfb100-33db-11eb-8e87-2dc31f22584e.gif)

After:
![after](https://user-images.githubusercontent.com/2381475/100783531-e5baa180-33db-11eb-9f1f-4c27fe23b06e.gif)

This happened when we introduced https://github.com/videojs/video.js/pull/5773