### PR TITLE
fix: fix set method to use map property

### DIFF
--- a/src/js/utils/map.js
+++ b/src/js/utils/map.js
@@ -15,7 +15,7 @@ class MapSham {
     return has;
   }
   set(key, value) {
-    this.set_[key] = value;
+    this.map_[key] = value;
     return this;
   }
   forEach(callback, thisArg) {


### PR DESCRIPTION
## Description
Bug was produced on an Android device using Chrome 34, which `window.Map` is not available. Error message `Cannot set property 'TimeDisplay#updateTextNode_' of undefined` was logged to console.
the `set` method in `MapSham` was using `set_` property, which is not defined within MapSham class. `map_` must be used instead.

## Specific Changes proposed
Just changed `src/js/utils/map.js` file updating set method to use `map_` instead of `set_`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
