### PR TITLE
fix: do not preload default text track if preloadTextTracks is false

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -341,7 +341,7 @@ class TextTrack extends Track {
         // Act like we're loaded for other purposes.
         this.loaded_ = true;
       }
-      if (this.preload_ || default_ || (settings.kind !== 'subtitles' && settings.kind !== 'captions')) {
+      if (this.preload_ || (settings.kind !== 'subtitles' && settings.kind !== 'captions')) {
         loadTrack(this.src, this);
       }
     } else {


### PR DESCRIPTION
When preloadTextTracks option is set to false, it still preloads the default text track. This leads to duplicate tracks once the mode changes to showing and the track is loaded a second time. This includes the default text track in the behavior defined by the preloadTextTracks option.

Fixes #7019

## Description
#7019

## Specific Changes proposed
Removes default text tracks from exclusion of behavior defined by `preloadTextTracks` option

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
