### PR TITLE
fix: set liveWindow to 0 liveCurrentTime is Infinity

### DIFF
--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -103,7 +103,7 @@ class LiveTracker extends Component {
 
     // we cannot be behind if
     // 1. until we have not seen a timeupdate yet
-    // 2. liveCurrentTime is Infinity, which happens on Android
+    // 2. liveCurrentTime is Infinity, which happens on Android and Native Safari
     if (!this.timeupdateSeen_ || liveCurrentTime === Infinity) {
       isBehind = false;
     }
@@ -275,8 +275,9 @@ class LiveTracker extends Component {
   liveWindow() {
     const liveCurrentTime = this.liveCurrentTime();
 
+    // if liveCurrenTime is Infinity then we don't have a liveWindow at all
     if (liveCurrentTime === Infinity) {
-      return Infinity;
+      return 0;
     }
 
     return liveCurrentTime - this.seekableStart();

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -290,7 +290,7 @@ QUnit.module('LiveTracker', () => {
   QUnit.test('single seekable with Infinity, helpers should be correct', function(assert) {
     // single with Infinity
     this.player.seekable = () => createTimeRanges(0, Infinity);
-    assert.strictEqual(this.liveTracker.liveWindow(), Infinity, 'liveWindow is Infinity');
+    assert.strictEqual(this.liveTracker.liveWindow(), 0, 'liveWindow is Infinity');
     assert.strictEqual(this.liveTracker.seekableStart(), 0, 'seekableStart is 0s');
     assert.strictEqual(this.liveTracker.seekableEnd(), Infinity, 'seekableEnd is Infinity');
   });
@@ -298,7 +298,7 @@ QUnit.module('LiveTracker', () => {
   QUnit.test('multiple seekables with Infinity, helpers should be correct', function(assert) {
     // multiple with Infinity
     this.player.seekable = () => createTimeRanges([[0, Infinity], [1, Infinity]]);
-    assert.strictEqual(this.liveTracker.liveWindow(), Infinity, 'liveWindow is Infinity');
+    assert.strictEqual(this.liveTracker.liveWindow(), 0, 'liveWindow is Infinity');
     assert.strictEqual(this.liveTracker.seekableStart(), 0, 'seekableStart is 0s');
     assert.strictEqual(this.liveTracker.seekableEnd(), Infinity, 'seekableEnd is Infinity');
   });
@@ -307,7 +307,7 @@ QUnit.module('LiveTracker', () => {
     // defaults
     this.player.seekable = () => createTimeRanges();
 
-    assert.strictEqual(this.liveTracker.liveWindow(), Infinity, 'liveWindow is Infinity');
+    assert.strictEqual(this.liveTracker.liveWindow(), 0, 'liveWindow is Infinity');
     assert.strictEqual(this.liveTracker.seekableStart(), 0, 'seekableStart is 0s');
     assert.strictEqual(this.liveTracker.seekableEnd(), Infinity, 'seekableEnd is Infinity');
   });


### PR DESCRIPTION
## Fixes
* Prevents the live UI from showing when we don't have a seekable range
* Prevents the live ui control bar and tooltips from looking invalid when the trackingThreshold is turned off. (everything will display 0 now).

## Description
Fixes an issue in native Safari and Android HLS playback where liveCurrentTime returns Infinity (as we don't have a seekableEnd or seekableEnd is actually Infinity). Which causes the new live ui to show up when we don't really have a live window. 

Instead of returning Infinity when liveCurrentTime is Infinity, return 0. So that everything knows that we do not have a seekable window of live playback.