### PR TITLE
fix(fs): make sure handlers are unique per player

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -351,8 +351,8 @@ class Player extends Component {
     super(null, options, ready);
 
     // Create bound methods for document listeners.
-    this.boundDocumentFullscreenChange_ = Fn.bind(this, this.documentFullscreenChange_);
-    this.boundFullWindowOnEscKey_ = Fn.bind(this, this.fullWindowOnEscKey);
+    this.boundDocumentFullscreenChange_ = (e) => this.documentFullscreenChange_(e);
+    this.boundFullWindowOnEscKey_ = (e) => this.fullWindowOnEscKey(e);
 
     // default isFullscreen_ to false
     this.isFullscreen_ = false;


### PR DESCRIPTION
Using Video.js's .bind still makes us attach prototype methods as
handlers. Then when one is removed, all handlers are removed.

Instead, use arrow methods to make these methods unique.

Fixes #7013.