### PR TITLE
feat: Retry on error

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3343,7 +3343,12 @@ class Player extends Component {
     // initial sources
     this.changingSrc_ = true;
 
-    this.cache_.sources = sources;
+    // Only update the cached source list if we haven't initiated a retry on error,
+    // since in that case we want to include the failed source(s) in the cache
+    if (!this.retrying_) {
+      this.cache_.sources = sources;
+    }
+
     this.updateSourceCaches_(sources[0]);
 
     // middlewareSource is the source after it has been changed by middleware
@@ -3352,7 +3357,10 @@ class Player extends Component {
 
       // since sourceSet is async we have to update the cache again after we select a source since
       // the source that is selected could be out of order from the cache update above this callback.
-      this.cache_.sources = sources;
+      if (!this.retrying_) {
+        this.cache_.sources = sources;
+      }
+
       this.updateSourceCaches_(middlewareSource);
 
       const err = this.src_(middlewareSource);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3410,7 +3410,7 @@ class Player extends Component {
         this.one('playing', stopListeningForErrors);
       }
 
-      this.resetRetryOnError = () => {
+      this.resetRetryOnError_ = () => {
         this.off('error', retry);
         this.off('playing', stopListeningForErrors);
       };

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3433,7 +3433,7 @@ class Player extends Component {
    *         URL. Otherwise, returns nothing/undefined.
    */
   src(source) {
-    return this.handleSrc_(source);
+    return this.handleSrc_(source, false);
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -429,7 +429,6 @@ class Player extends Component {
     tag.removeAttribute('controls');
 
     this.changingSrc_ = false;
-    this.retrying_ = false;
     this.playCallbacks_ = [];
     this.playTerminatedQueue_ = [];
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3350,8 +3350,8 @@ class Player extends Component {
       this.cache_.sources = sources;
 
       // If a retry was previously started, reset it
-      if (this.resetRetryOnError) {
-        this.resetRetryOnError();
+      if (this.resetRetryOnError_) {
+        this.resetRetryOnError_();
       }
     }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -349,6 +349,89 @@ QUnit.test('should asynchronously fire error events during source selection', fu
   log.error.restore();
 });
 
+QUnit.test('should retry setting source if error occurs and retryOnError: true', function(assert) {
+  const player = TestHelpers.makePlayer({
+    techOrder: ['html5'],
+    retryOnError: true,
+    sources: [
+      { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' }
+    ]
+  });
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+    'first source set'
+  );
+
+  player.trigger('error');
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+    'second source set'
+  );
+
+  player.trigger('error');
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' },
+    'last source set'
+  );
+
+  // No more sources to try so the previous source should remain
+  player.trigger('error');
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' },
+    'last source remains'
+  );
+
+  player.dispose();
+});
+
+QUnit.test('should not retry setting source if retryOnError: true and error occurs during playback', function(assert) {
+  const player = TestHelpers.makePlayer({
+    techOrder: ['html5'],
+    retryOnError: true,
+    sources: [
+      { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' }
+    ]
+  });
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+    'first source set'
+  );
+
+  player.trigger('error');
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+    'second source set'
+  );
+
+  // Playback starts then error occurs
+  player.trigger('playing');
+  player.trigger('error');
+
+  assert.deepEqual(
+    player.currentSource(),
+    { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' },
+    'second source remains'
+  );
+
+  player.dispose();
+});
+
 QUnit.test('should suppress source error messages', function(assert) {
   sinon.stub(log, 'error');
   const clock = sinon.useFakeTimers();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -435,7 +435,7 @@ QUnit.test('should not retry setting source if retryOnError: true and error occu
 
   assert.deepEqual(
     player.currentSource(),
-    { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' },
+    { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
     'second source remains'
   );
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -391,6 +391,16 @@ QUnit.test('should retry setting source if error occurs and retryOnError: true',
     'last source remains'
   );
 
+  assert.deepEqual(
+    player.currentSources(),
+    [
+      { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' }
+    ],
+    'currentSources() correctly returns the full source list'
+  );
+
   player.dispose();
 });
 
@@ -427,6 +437,16 @@ QUnit.test('should not retry setting source if retryOnError: true and error occu
     player.currentSource(),
     { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' },
     'second source remains'
+  );
+
+  assert.deepEqual(
+    player.currentSources(),
+    [
+      { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
+      { src: 'http://vjs.zencdn.net/v/oceans3.mp4', type: 'video/mp4' }
+    ],
+    'currentSources() correctly returns the full source list'
   );
 
   player.dispose();


### PR DESCRIPTION
## Description
This adds support for a `retryOnError` option that will have the player select a new source from the source list when the selected one fails prior to playback. If a source fails during playback, no retry will be attempted.