### PR TITLE
test: update ci workflow to prevent install failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,62 +3,75 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  should-skip:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should-skip-job: ${{steps.skip-check.outputs.should_skip}}
+    steps:
+      - id: skip-check
+        uses: fkirc/skip-duplicate-actions@v2.1.0
+        with:
+          github_token: ${{github.token}}
+
   ci:
-    env:
-      BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
-      BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
-    runs-on: ${{ matrix.os }}
+    needs: should-skip
+    if: ${{needs.should-skip.outputs.should-skip-job != 'true'}}
     strategy:
-      # TODO: test IE 11, Legacy Edge, and New Edge on windows-latest
-      #       test Safari on macos-latest
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
-
+    env:
+      BROWSER_STACK_USERNAME: ${{secrets.BROWSER_STACK_USERNAME}}
+      BROWSER_STACK_ACCESS_KEY: ${{secrets.BROWSER_STACK_ACCESS_KEY}}
+    runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - name: checkout code
+      uses: actions/checkout@v2
+
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
         path: |
           ~/.npm
           **/node_modules
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        key: ${{runner.os}}-npm-${{hashFiles('**/package-lock.json')}}
         restore-keys: |
-          ${{ runner.os }}-npm-
-          ${{ runner.os }}-
+          ${{runner.os}}-npm-
+          ${{runner.os}}-
 
-    - name: Read .nvmrc
+    - name: read node version from .nvmrc
       run: echo ::set-output name=NVMRC::$(cat .nvmrc)
       shell: bash
       id: nvm
 
-    - name: Install ffmpeg/pulseaudio for firefox on linux w/o browserstack
+    - name: update apt cache on linux w/o browserstack
+      run: sudo apt-get update
+      if: ${{startsWith(matrix.os, 'ubuntu') && !env.BROWSER_STACK_USERNAME}}
+
+    - name: install ffmpeg/pulseaudio for firefox on linux w/o browserstack
       run: sudo apt-get install ffmpeg pulseaudio
-      if: ${{ startsWith(matrix.os, 'ubuntu') && !env.BROWSER_STACK_USERNAME }}
+      if: ${{startsWith(matrix.os, 'ubuntu') && !env.BROWSER_STACK_USERNAME}}
 
     - name: start pulseaudio for firefox on linux w/o browserstack
       run: pulseaudio -D
-      if: ${{ startsWith(matrix.os, 'ubuntu') && !env.BROWSER_STACK_USERNAME }}
+      if: ${{startsWith(matrix.os, 'ubuntu') && !env.BROWSER_STACK_USERNAME}}
 
-    - name: Setup node
+    - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: '${{ steps.nvm.outputs.NVMRC }}'
-    - run: npm i --prefer-offline --no-audit
+        node-version: '${{steps.nvm.outputs.NVMRC}}'
 
-    # run safari on macos
-    - name: Run Mac test
-      run: npm run test -- --browsers Safari
-      if: ${{ startsWith(matrix.os, 'macos') }}
+    # turn off the default setup-node problem watchers...
+    - run: echo "::remove-matcher owner=eslint-compact::"
+    - run: echo "::remove-matcher owner=eslint-stylish::"
+    - run: echo "::remove-matcher owner=tsc::"
 
-    # only run ie 11 on windows
-    - name: Run Windows test
-      run: npm run test -- --browsers IE
-      if: ${{ startsWith(matrix.os, 'windows') }}
+    - name: npm install
+      run: npm i --prefer-offline --no-audit
 
-    # run chrome/firefox or browserstack in linux
-    - name: Run linux test
+    - name: run npm test
       uses: GabrielBB/xvfb-action@v1
       with:
-        run: npm test
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: npm run test


### PR DESCRIPTION
Fixes the issue seen in the tests that causes dependency installs to fail. Such as in this pull request: https://github.com/videojs/video.js/pull/7038 

This is just taking the updates from https://github.com/videojs/.github/blob/main/workflow-templates/ci.yml that were implemented in @videojs/http-streaming