### PR TITLE
docs: change master to main

### DIFF
--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -10,9 +10,9 @@
   * [Landing a PR manually](#landing-a-pr-manually)
     * [Landing a PR manually with several changes](#landing-a-pr-manually-with-several-changes)
     * [I just made a mistake](#i-just-made-a-mistake)
-      * [I accidentally pushed a broken commit or incorrect commit to master](#i-accidentally-pushed-a-broken-commit-or-incorrect-commit-to-master)
+      * [I accidentally pushed a broken commit or incorrect commit to main](#i-accidentally-pushed-a-broken-commit-or-incorrect-commit-to-main)
       * [I lost changes](#i-lost-changes)
-      * [I accidentally committed a broken change to master](#i-accidentally-committed-a-broken-change-to-master)
+      * [I accidentally committed a broken change to main](#i-accidentally-committed-a-broken-change-to-main)
 * [video.js releases](#videojs-releases)
   * [Getting dependencies](#getting-dependencies)
     * [npm access](#npm-access)
@@ -113,12 +113,12 @@ git am --abort
 git rebase --abort
 ```
 
-Checkout and update the master branch:
+Checkout and update the main branch:
 
 ```sh
-git checkout master
+git checkout main
 git remote update
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 Check out the PR:
@@ -135,16 +135,16 @@ git checkout -t {{name of branch}}
 > git checkout -t gkatsev-html5-fix
 > ```
 
-_Optional:_ If necessary, rebase against master. If you have multiple features in the PR, [landing a PR manually with several changes](#landing-a-pr-manually-with-several-changes)
+_Optional:_ If necessary, rebase against main. If you have multiple features in the PR, [landing a PR manually with several changes](#landing-a-pr-manually-with-several-changes)
 
 ```sh
-git rebase master
+git rebase main
 ```
 
-Fix up any issues that arise from the rebase, change back to the master branch and squash merge:
+Fix up any issues that arise from the rebase, change back to the main branch and squash merge:
 
 ```sh
-git checkout master
+git checkout main
 git merge --squash --no-commit gkatsev-html5-fix
 ```
 
@@ -175,20 +175,20 @@ Now you can commit the change the change with the author, following our commit g
 git commit --author "Gary Katsevman <git@gkatsev.com>"
 ```
 
-Now that it's committed, push to master
+Now that it's committed, push to main
 
 ```sh
-git push upstream master
+git push upstream main
 ```
 
-Congratulate yourself for a job well done and the contributor for having his change landed in master.
+Congratulate yourself for a job well done and the contributor for having his change landed in main.
 
 #### Landing a PR manually with several changes
 
-Follow the same steps as before but when you rebase against master, you want to do an interactive rebase and then squash the changes into just a few commits.
+Follow the same steps as before but when you rebase against main, you want to do an interactive rebase and then squash the changes into just a few commits.
 
 ```sh
-git rebase -i master
+git rebase -i main
 ```
 
 This will give you an output like the following:
@@ -242,13 +242,13 @@ When you get to the edit commits, git will give more information, but you'd want
 git commit --amend
 ```
 
-After going through and making the commits you want, you want to change back to master and then rebase the branch onto master so we get a clean history
+After going through and making the commits you want, you want to change back to main and then rebase the branch onto main so we get a clean history
 
 ```sh
 git rebase gkatsev-html5-fix
 ```
 
-This will put our two commits into master:
+This will put our two commits into main:
 
 ```txt
 b4dc15d chore(contributing.md): Update CONTRIBUTING.md with latest info <Gary Katsevman>
@@ -256,28 +256,28 @@ b4dc15d chore(contributing.md): Update CONTRIBUTING.md with latest info <Gary Ka
 9e20386 v5.12.6 <Gary Katsevman>
 ```
 
-Now you're ready to push to master as in the normal instructions.
+Now you're ready to push to main as in the normal instructions.
 
 #### I just made a mistake
 
 While `git` allows you to update the remote branch with a force push (`git push -f`). This is generally frowned upon since you're rewriting public history. However, if you just pushed the change and it's been less than 10 minutes since you've done with, you may force push to update the commit, assuming no one else has already pushed after you.
 
-##### I accidentally pushed a broken commit or incorrect commit to master
+##### I accidentally pushed a broken commit or incorrect commit to main
 
-Assuming no more than 10 minutes have passed, you may force-push to update or remove the commit. If someone else has already pushed to master or 10 minutes have passed, you should instead use the revert command (`git revert`) to revert the commit and then commit the proper change, or just fix it forward with a followup commit that fixes things.
+Assuming no more than 10 minutes have passed, you may force-push to update or remove the commit. If someone else has already pushed to main or 10 minutes have passed, you should instead use the revert command (`git revert`) to revert the commit and then commit the proper change, or just fix it forward with a followup commit that fixes things.
 
 ##### I lost changes
 
 Assuming that the changes were committed, even if you lost the commit in your current history does not mean that it is lost. In a lot of cases you can still recover it from the PR branch or if all else fails look at [git's reflog](https://git-scm.com/docs/git-reflog).
 
-##### I accidentally committed a broken change to master
+##### I accidentally committed a broken change to main
 
 This is a great time to discover that something is broken. Because it hasn't been pushed to GitHub yet, it's very easy to reset the change as if nothing has happened and try again.
 
-To do so, just reset the branch against master.
+To do so, just reset the branch against main.
 
 ```sh
-git reset --hard upstream/master
+git reset --hard upstream/main
 ```
 
 ## video.js releases
@@ -321,7 +321,7 @@ Most common releases will be either `patch` or `minor`.
 ### Doing a release
 
 It is also recommended you have a clean clone of Video.js for each release line you want to release.
-That means having a folder for master/v6 and one for 5.x.
+That means having a folder for main/v6 and one for 5.x.
 This is because 5.x and 6.x have different versions expecations for release process and have different dependencies.
 Plus, during development you could end up with a dirty repo, so, it just usually easier if you have a clean release repo.
 
@@ -334,11 +334,11 @@ git clone git@github.com:videojs/video.js.git videojs-5-release
 
 #### Current Video.js
 
-Make sure go to the master branch and grab the latest updates.
+Make sure go to the main branch and grab the latest updates.
 
 ```sh
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 ```
 
 At this point, you should run `npm install` because dependencies may have changed.
@@ -359,7 +359,7 @@ It's necessary to do this before running `npm publish` because our GitHub releas
 relies on the commit being available on GitHub.
 
 ```sh
-git push --tags origin master
+git push --tags origin main
 ```
 
 Finally, run `npm publish` with an appropriate tag. Don't forget to supply your token.
@@ -461,7 +461,7 @@ This collaborator guide was heavily inspired by [node.js's guide](https://github
 
 [pr template]: /.github/PULL_REQUEST_TEMPLATE.md
 
-[conventions]: https://github.com/videojs/conventional-changelog-videojs/blob/master/convention.md
+[conventions]: https://github.com/videojs/conventional-changelog-videojs/blob/main/convention.md
 
 [vjs npm]: https://www.npmjs.com/org/videojs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Guidelines for bug reports:
 
 1. If your issue is with a particular video.js plugin or subproject, please open an issue against that project. See [list of some potential other projects above](#other-repositories-where-issues-could-be-filed)
 1. Use the [GitHub issue search](https://github.com/videojs/video.js/issues) — check if the issue has already been reported.
-1. Check if the issue has already been fixed — try to reproduce it using the latest `master` branch in the repository.
+1. Check if the issue has already been fixed — try to reproduce it using the latest `main` branch in the repository.
 1. Isolate the problem — **create a [reduced test case](https://css-tricks.com/reduced-test-cases/)** with a live example. You can possibly use [this codepen template](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0) as a starting point -- don't forget to update it to the videojs version you use.
 1. Answer all questions in the [issue template][]. The questions in the issue template are designed to try and provide the maintainers with as much information possible to minimize back-and-forth to get the issue resolved.
 
@@ -124,8 +124,8 @@ git remote add upstream https://github.com/videojs/video.js.git
 >
 > ```sh
 > git remote update
-> git checkout master
-> git pull upstream master
+> git checkout main
+> git pull upstream main
 > ```
 
 #### Installing local dependencies
@@ -216,8 +216,8 @@ Before starting work, you want to update your local repository to have all the l
 
 ```sh
 git remote update
-git checkout master
-git rebase upstream/master
+git checkout main
+git rebase upstream/main
 ```
 
 #### Step 3: Branch
@@ -231,7 +231,7 @@ git checkout -b my-branch
 #### Step 4: Commit
 
 Commit changes as you go. Write thorough descriptions of your changes in your commit messages.
-For more information see our [conventional changelog guidelines for video.js](https://github.com/videojs/conventional-changelog-videojs/blob/master/convention.md)
+For more information see our [conventional changelog guidelines for video.js](https://github.com/videojs/conventional-changelog-videojs/blob/main/convention.md)
 Follow these guidelines:
 
 1. The first line should be less than 50 characters and contain a short description of the commit.
@@ -288,7 +288,7 @@ Then go to the [repo page](https://github.com/videojs/video.js) and click the "P
 
 Our javascript is linted using [videojs-standard][linter].
 
-## [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
+## [Developer's Certificate of Origin 1.1](https://github.com/nodejs/node/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
 
 By making a contribution to this project, I certify that:
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 Thanks to the awesome folks over at [Fastly][fastly], there's a free, CDN hosted version of Video.js that anyone can use. Add these tags to your document's `<head>`:
 
 ```html
-<link href="//vjs.zencdn.net/7.8.2/video-js.min.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/7.8.2/video.min.js"></script>
+<link href="//vjs.zencdn.net/7.10.2/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/7.10.2/video.min.js"></script>
 ```
 
 > For the latest version of video.js and URLs to use, check out the [Getting Started][getting-started] page on our website.
@@ -45,12 +45,12 @@ Alternatively, you can include Video.js by getting it from [npm](https://videojs
 <script src="https://unpkg.com/video.js/dist/video.min.js"></script>
 
 <!-- unpkg : use a specific version of Video.js (change the version numbers as necessary) -->
-<link href="https://unpkg.com/video.js@7.8.2/dist/video-js.min.css" rel="stylesheet">
-<script src="https://unpkg.com/video.js@7.8.2/dist/video.min.js"></script>
+<link href="https://unpkg.com/video.js@7.10.2/dist/video-js.min.css" rel="stylesheet">
+<script src="https://unpkg.com/video.js@7.10.2/dist/video.min.js"></script>
 
 <!-- cdnjs : use a specific version of Video.js (change the version numbers as necessary) -->
-<link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.8.1/video-js.min.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.8.1/video.min.js"></script>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.10.2/video-js.min.css" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.10.2/video.min.js"></script>
 ```
 
 Next, using Video.js is as simple as creating a `<video>` element, but with an additional `data-setup` attribute. At a minimum, this attribute must have a value of `'{}'`, but it can include any Video.js [options][options] - just make sure it contains valid JSON!
@@ -125,9 +125,9 @@ Video.js is [licensed][license] under the Apache License, Version 2.0.
 
 [contributing]: CONTRIBUTING.md
 
-[coveralls-icon]: https://coveralls.io/repos/github/videojs/video.js/badge.svg?branch=master
+[coveralls-icon]: https://coveralls.io/repos/github/videojs/video.js/badge.svg?branch=main
 
-[coveralls-link]: https://coveralls.io/github/videojs/video.js?branch=master
+[coveralls-link]: https://coveralls.io/github/videojs/video.js?branch=main
 
 [docs]: https://docs.videojs.com
 

--- a/build/license-header.txt
+++ b/build/license-header.txt
@@ -3,9 +3,9 @@
  * Video.js <%= version %> <http://videojs.com/>
  * <%= copyright %>
  * Available under Apache License Version 2.0
- * <https://github.com/videojs/video.js/blob/master/LICENSE>
+ * <https://github.com/videojs/video.js/blob/main/LICENSE>
 <% if (includesVtt) { %> *
  * Includes vtt.js <https://github.com/mozilla/vtt.js>
  * Available under Apache License Version 2.0
- * <https://github.com/mozilla/vtt.js/blob/master/LICENSE>
+ * <https://github.com/mozilla/vtt.js/blob/main/LICENSE>
 <% } %> */

--- a/docs/guides/angular.md
+++ b/docs/guides/angular.md
@@ -21,7 +21,7 @@ import videojs from 'video.js';
 })
 export class VjsPlayerComponent implements OnInit, OnDestroy {
   @ViewChild('target', {static: true}) target: ElementRef;
-  // see options: https://github.com/videojs/video.js/blob/master/docs/guides/options.md
+  // see options: https://github.com/videojs/video.js/blob/main/docs/guides/options.md
   @Input() options: {
       fluid: boolean,
       aspectRatio: string,

--- a/docs/guides/audio-tracks.md
+++ b/docs/guides/audio-tracks.md
@@ -139,7 +139,7 @@ the different languages available as alternate audio tracks.
 The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of the audio
 track, e.g. `"en"` for English or `"es"` for Spanish.
 
-For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang)
+For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/main/lang)
 located in the Video.js root and refer to the [languages guide][languages-guide] for more
 information on languages in Video.js.
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -279,9 +279,9 @@ Yes! See [ReactJS integration example][react-guide].
 
 [autoplay-option]: /docs/guides/options.md#autoplay
 
-[contributing-issues]: https://github.com/videojs/video.js/blob/master/CONTRIBUTING.md#filing-issues
+[contributing-issues]: https://github.com/videojs/video.js/blob/main/CONTRIBUTING.md#filing-issues
 
-[contributing-prs]: https://github.com/videojs/video.js/blob/master/CONTRIBUTING.md#contributing-code
+[contributing-prs]: https://github.com/videojs/video.js/blob/main/CONTRIBUTING.md#contributing-code
 
 [components-guide]: /docs/guides/components.md
 
@@ -303,7 +303,7 @@ Yes! See [ReactJS integration example][react-guide].
 
 [install-guide]: https://videojs.com/getting-started/
 
-[issue-template]: https://github.com/videojs/video.js/blob/master/.github/ISSUE_TEMPLATE.md
+[issue-template]: https://github.com/videojs/video.js/blob/main/.github/ISSUE_TEMPLATE.md
 
 [node]: https://www.npmjs.com/package/video.js
 
@@ -315,7 +315,7 @@ Yes! See [ReactJS integration example][react-guide].
 
 [pr-issue-question]: #q-i-think-i-found-a-bug-with-videojs-or-i-want-to-add-a-feature-what-should-i-do
 
-[pr-template]: https://github.com/videojs/video.js/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+[pr-template]: https://github.com/videojs/video.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md
 
 [react-guide]: /docs/guides/react.md
 

--- a/docs/guides/languages.md
+++ b/docs/guides/languages.md
@@ -153,4 +153,4 @@ For all existing/supported languages, please see the [languages folder (`lang/`)
 
 [lang-codes]: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
 
-[translations-needed]: https://github.com/videojs/video.js/blob/master/docs/translations-needed.md
+[translations-needed]: https://github.com/videojs/video.js/blob/main/docs/translations-needed.md

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -194,7 +194,7 @@ var myMiddleware = function(player) {
 videojs.use('*', myMiddleware);
 ```
 
-This middleware allows the call to `play()` to go through to the `Tech`, and checks in `play` whether the play succeeded or not. A more detailed example can be found in our [sandbox](https://github.com/videojs/video.js/blob/master/sandbox/middleware-play.html.example).
+This middleware allows the call to `play()` to go through to the `Tech`, and checks in `play` whether the play succeeded or not. A more detailed example can be found in our [sandbox](https://github.com/videojs/video.js/blob/main/sandbox/middleware-play.html.example).
 
 ### Terminating Mediator Methods
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -374,6 +374,6 @@ These events work for both basic and advanced plugins. They are triggered on the
 
 [spellbook]: https://github.com/videojs/spellbook
 
-[standards]: https://github.com/videojs/generator-videojs-plugin/blob/master/docs/standards.md
+[standards]: https://github.com/videojs/generator-videojs-plugin/blob/main/docs/standards.md
 
 [yeoman]: http://yeoman.io

--- a/docs/guides/skins.md
+++ b/docs/guides/skins.md
@@ -36,7 +36,7 @@ When `VIDEOJS_NO_DYNAMIC_STYLE` is set, `Player#width()` and `Player#height()` w
 
 Video.js ships with a number of icons built into the skin via an icon font.
 
-You can view all of the icons available in the default skin by renaming [`sandbox/icons.html.example`](https://github.com/videojs/video.js/blob/master/sandbox/icons.html.example) to `sandbox/icons.html`, building Video.js with `npm run build`, and opening `sandbox/icons.html` in your browser of choice.
+You can view all of the icons available in the default skin by renaming [`sandbox/icons.html.example`](https://github.com/videojs/video.js/blob/main/sandbox/icons.html.example) to `sandbox/icons.html`, building Video.js with `npm run build`, and opening `sandbox/icons.html` in your browser of choice.
 
 ## Creating a Skin
 

--- a/docs/guides/tech.md
+++ b/docs/guides/tech.md
@@ -8,7 +8,7 @@ In addition to techs there are source handlers. Source handlers add the capabili
 
 ## Building an API Wrapper
 
-We'll write a more complete guide on writing a wrapper soon, but for now the best resource is the [Video.js](https://github.com/videojs/video.js/tree/master/src/js/tech) source where you can see how the HTML5 API wrapper is created.
+We'll write a more complete guide on writing a wrapper soon, but for now the best resource is the [Video.js](https://github.com/videojs/video.js/tree/main/src/js/tech) source where you can see how the HTML5 API wrapper is created.
 
 ## Required Methods
 
@@ -59,11 +59,11 @@ videojs("videoID", {
 
 ### Posters
 
-By default, techs will have to handle their own posters and are somewhat locked out of the player's poster lifecycle. 
-However, when the player is initialized with the `techCanOverridePoster` option 
+By default, techs will have to handle their own posters and are somewhat locked out of the player's poster lifecycle.
+However, when the player is initialized with the `techCanOverridePoster` option
 it will be possible for techs to integrate into that lifecycle  and the player's `PosterImage` component to be used.
 
-Techs can check if they have this capability by checking the `canOverridePoster` boolean in their options. 
+Techs can check if they have this capability by checking the `canOverridePoster` boolean in their options.
 
 **`techCanOverridePoster` requirements**
 

--- a/docs/guides/text-tracks.md
+++ b/docs/guides/text-tracks.md
@@ -91,7 +91,7 @@ The boolean `default` attribute can be used to indicate that a track's mode shou
 
 The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of the text track, e.g. `"en"` for English or `"es"` for Spanish.
 
-For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
+For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/main/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
 
 ### Text Tracks from Another Domain
 

--- a/docs/guides/video-tracks.md
+++ b/docs/guides/video-tracks.md
@@ -127,7 +127,7 @@ The label for the track that will be shown to the user. For example, in a menu t
 
 The valid [BCP 47](https://tools.ietf.org/html/bcp47) code for the language of the video track, e.g. `"en"` for English or `"es"` for Spanish.
 
-For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/master/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
+For supported language translations, please see the [languages folder (/lang)](https://github.com/videojs/video.js/tree/main/lang) folder located in the Video.js root and refer to the [languages guide](/docs/guides/languages.md) for more information on languages in Video.js.
 
 #### `selected`
 


### PR DESCRIPTION
Noticed that a lot of our docs point to the master branch, which is out of date and unused now. Along with this pull request we will have to update https://github.com/videojs/conventional-changelog-videojs to use `main`. 