### PR TITLE
fix(time-display): fix IE11 appending times instead of replacing

### DIFF
--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -89,7 +89,7 @@ class TimeDisplay extends Component {
 
       let oldNode = this.textNode_;
 
-      if (oldNode && !this.contentEl_.contains(oldNode)) {
+      if (oldNode && this.contentEl_.firstChild !== oldNode) {
         oldNode = null;
 
         log.warn('TimeDisplay#updateTextnode_: Prevented replacement of text node element since it was no longer a child of this node. Appending a new node instead.');


### PR DESCRIPTION
IE11 only supports HTMLElement and not text nodes in the contains
method. See https://developer.mozilla.org/en-US/docs/Web/API/Node/contains
Instead, compare firstChild.