### PR TITLE
Fix up preventDefault error on Android

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2023,7 +2023,9 @@ class Player extends Component {
    */
   handleTechTouchEnd_(event) {
     // Stop the mouse events from also happening
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
Focus on video player and scroll will raise the error
```
Ignored attempt to cancel a touchend event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```

![image](https://user-images.githubusercontent.com/3832925/105689374-a4ef8c80-5f35-11eb-8dbd-4ec3c96ea1d1.png)


To reproduce the error:
1. Put your finger on video player (do not lift up the finger)
2. Scroll up and down

## Specific Changes proposed
Check `event.cancelable` before executing `event.preventDefault`

see: https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault#notes

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
