### PR TITLE
fix(dom): stop findPosition at a fullscreenElement

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -4,6 +4,7 @@
  */
 import document from 'global/document';
 import window from 'global/window';
+import fs from '../fullscreen-api';
 import log from './log.js';
 import {isObject} from './obj';
 import computedStyle from './computed-style';
@@ -564,12 +565,12 @@ export function findPosition(el) {
   let left = 0;
   let top = 0;
 
-  do {
+  while (el.offsetParent && el !== document[fs.fullscreenElement]) {
     left += el.offsetLeft;
     top += el.offsetTop;
 
     el = el.offsetParent;
-  } while (el);
+  }
 
   return {
     left,


### PR DESCRIPTION
On iPads, if the player is inside a floating div, when fullscreen, we'll have an incorrect offset value. Instead, we should stop counting our offsets once we get to our fullscreen element (i.e. the player) because in fullscreen it's outside the regular flow, and we don't actually want to add offset the float gives us inline.