### PR TITLE
chore: update rollup for upcoming vhs changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4629,8 +4629,7 @@
     "estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -9373,7 +9372,6 @@
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
       "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -12722,6 +12720,15 @@
         "chalk": "^2.4.2"
       }
     },
+    "rollup-plugin-replace": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",
+      "integrity": "sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==",
+      "requires": {
+        "magic-string": "^0.25.2",
+        "rollup-pluginutils": "^2.6.0"
+      }
+    },
     "rollup-plugin-stub": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-stub/-/rollup-plugin-stub-1.2.0.tgz",
@@ -12770,7 +12777,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
       "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       }
@@ -13397,8 +13403,7 @@
     "sourcemap-codec": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
-      "dev": true
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@videojs/xhr": "2.5.1",
     "global": "4.3.2",
     "keycode": "^2.2.0",
+    "rollup-plugin-replace": "^2.2.0",
     "safe-json-parse": "4.0.0",
     "videojs-font": "3.2.0",
     "videojs-vtt.js": "^0.15.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ import pkg from './package.json';
 import multiEntry from 'rollup-plugin-multi-entry';
 import stub from 'rollup-plugin-stub';
 import isCI from 'is-ci';
+import replace from 'rollup-plugin-replace';
 
 const compiledLicense = _.template(fs.readFileSync('./build/license-header.txt', 'utf8'));
 const bannerData = _.pick(pkg, ['version', 'copyright']);
@@ -174,6 +175,12 @@ export default cliargs => [
       alias({
         'video.js': path.resolve(__dirname, './src/js/video.js'),
         '@videojs/http-streaming': path.resolve(__dirname, './node_modules/@videojs/http-streaming/dist/videojs-http-streaming.es.js')
+      }),
+      replace({
+        // single quote replace
+        "require('@videojs/vhs-utils/es": "require('@videojs/vhs-utils/cjs",
+        // double quote replace
+        'require("@videojs/vhs-utils/es': 'require("@videojs/vhs-utils/cjs'
       }),
       json(),
       primedBabel,


### PR DESCRIPTION
## Description
Adds rollup-plugin-replace for the soon to occur vhs update that will cause our cjs build to fail. We could also split the cjs and es build and alias es to `@videojs/http-streaming/dist/videojs-http-streaming.es.js` and cjs to `@videojs/http-streaming/dist/videojs-http-streaming.es.js` but the build will take longer with that change.