### PR TITLE
fix(dom): account for translated parent in pointer position

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -645,9 +645,7 @@ export function findPosition2(el) {
 export function getPointerPosition(el, event) {
   const translated = {
     x: 0,
-    y: 0,
-    sx: 1,
-    sy: 1
+    y: 0
   };
 
   if (browser.IS_IOS) {
@@ -659,15 +657,11 @@ export function getPointerPosition(el, event) {
       if (/^matrix/.test(transform)) {
         const values = transform.slice(7, -1).split(/,\s/).map(Number);
 
-        translated.sx *= values[0];
-        translated.sy *= values[3];
         translated.x += values[4];
         translated.y += values[5];
       } else if (/^matrix3d/.test(transform)) {
         const values = transform.slice(9, -1).split(/,\s/).map(Number);
 
-        translated.sx *= values[0];
-        translated.sy *= values[5];
         translated.x += values[12];
         translated.y += values[13];
       }

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -581,40 +581,6 @@ export function findPosition(el) {
   };
 }
 
-export function findPosition2(el) {
-  let box;
-
-  if (el.getBoundingClientRect && el.parentNode) {
-    box = el.getBoundingClientRect();
-  }
-
-  if (!box) {
-    return {
-      left: 0,
-      top: 0
-    };
-  }
-
-  const docEl = document.documentElement;
-  const body = document.body;
-
-  const clientLeft = docEl.clientLeft || body.clientLeft || 0;
-  const scrollLeft = window.pageXOffset || body.scrollLeft;
-  const left = box.left + scrollLeft - clientLeft;
-
-  const clientTop = docEl.clientTop || body.clientTop || 0;
-  const scrollTop = window.pageYOffset || body.scrollTop;
-  const top = box.top + scrollTop - clientTop;
-
-  // Android sometimes returns slightly off decimal values, so need to round
-  return {
-    left: Math.round(left),
-    top: Math.round(top),
-    width: box.width,
-    height: box.height
-  };
-}
-
 /**
  * Represents x and y coordinates for a DOM element or mouse pointer.
  *

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -8,7 +8,6 @@ import fs from '../fullscreen-api';
 import log from './log.js';
 import {isObject} from './obj';
 import computedStyle from './computed-style';
-import * as browser from './browser.js';
 
 /**
  * Detect if a value is a string with any non-whitespace characters.
@@ -566,15 +565,12 @@ export function findPosition(el) {
   let left = 0;
   let top = 0;
 
-  // console.log('!!!!!!!');
   while (el.offsetParent && el !== document[fs.fullscreenElement]) {
-    // console.log(el.className);
     left += el.offsetLeft;
     top += el.offsetTop;
 
     el = el.offsetParent;
   }
-  // console.log('######', left);
 
   return {
     left,
@@ -583,41 +579,6 @@ export function findPosition(el) {
     height
   };
 }
-
-export function findPosition2(el) {
-  let box;
-
-  if (el.getBoundingClientRect && el.parentNode) {
-    box = el.getBoundingClientRect();
-  }
-
-  if (!box) {
-    return {
-      left: 0,
-      top: 0
-    };
-  }
-
-  const docEl = document.documentElement;
-  const body = document.body;
-
-  const clientLeft = docEl.clientLeft || body.clientLeft || 0;
-  const scrollLeft = window.pageXOffset || body.scrollLeft;
-  const left = box.left + scrollLeft - clientLeft;
-
-  const clientTop = docEl.clientTop || body.clientTop || 0;
-  const scrollTop = window.pageYOffset || body.scrollTop;
-  const top = box.top + scrollTop - clientTop;
-
-  // Android sometimes returns slightly off decimal values, so need to round
-  return {
-    left: Math.round(left),
-    top: Math.round(top),
-    width: box.width,
-    height: box.height
-  };
-}
-
 
 /**
  * Represents x and y coordinates for a DOM element or mouse pointer.
@@ -647,56 +608,21 @@ export function findPosition2(el) {
  *
  */
 export function getPointerPosition(el, event) {
-  let translated = {
-    x: 0,
-    y: 0,
-    sx: 1,
-    sy: 1
-  };
-
-  // if (browser.IS_IOS) {
-    let item = el;
-    while(item && item.nodeName.toLowerCase() !== 'html') {
-      const transform = computedStyle(item, 'transform');
-      if (/^matrix/.test(transform)) {
-        const values = transform.slice(7, -1).split(/,\s/).map(Number)
-        translated.sx *= values[0];
-        translated.sy *= values[3];
-        translated.x += values[4];
-        translated.y += values[5];
-      } else if (/^matrix3d/.test(transform)) {
-        const values = transform.slice(9, -1).split(/,\s/).map(Number)
-        translated.sx *= values[0];
-        translated.sy *= values[5];
-        translated.x += values[12];
-        translated.y += values[13];
-      }
-
-      item = item.parentNode;
-    }
-  // }
-
   const position = {};
-  const boxTarget = findPosition2(event.target);
-  const box = findPosition2(el);
+  const boxTarget = findPosition(event.target);
+  const box = findPosition(el);
   const boxW = box.width;
   const boxH = box.height;
-  let offsetY = event.pageY - (box.top - boxTarget.top);
-  let offsetX = event.pageX - (box.left - boxTarget.left) + translated.x*translated.sx;
-
-  const box2 = findPosition2(el);
-  const boxTarget2 = findPosition2(event.target);
+  let offsetY = event.offsetY - (box.top - boxTarget.top);
+  let offsetX = event.offsetX - (box.left - boxTarget.left);
 
   if (event.changedTouches) {
     offsetX = event.changedTouches[0].pageX - box.left;
     offsetY = event.changedTouches[0].pageY + box.top;
   }
 
-  position.y = (1 - Math.max(0, Math.min(1, (offsetY / boxH)/translated.sy)));
-  position.x = Math.max(0, Math.min(1, ((offsetX - box.left) / boxW)/translated.sx));
-  console.log({boxW, offsetX, sx:translated.sx, x:position.x,
-    left: el.getBoundingClientRect().left,
-    boxW2: box2.width})
+  position.y = (1 - Math.max(0, Math.min(1, offsetY / boxH)));
+  position.x = Math.max(0, Math.min(1, offsetX / boxW));
   return position;
 }
 


### PR DESCRIPTION
Since we switched to using adding up offsets to calculate the pointer position relative to the current element, we've had some issues, particularly on iOS, where a translated parent would cause us to miscalculate the position. This is currently a quickfix for the issue, and I'd like to spend some time to figure out a better solution that hopefully won't require us to iterate through the DOM and add up the transform matrix.