### PR TITLE
chore: video.js debug build

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <li><a href="sandbox/language.html">Laungage Demo</a></li>
     <li><a href="sandbox/hls.html">Hls Demo</a></li>
     <li><a href="sandbox/autoplay-tests.html">Autoplay Tests</a></li>
+    <li><a href="sandbox/debug.html">Videojs debug build test page</a></li>
   </ul>
 
   <h2>Simple Demo (in an iframe)</h2>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,6 +129,30 @@ export default cliargs => [
     onwarn,
     watch
   },
+  // debug umd file
+  {
+    input: 'src/js/debug.js',
+    output: {
+      format: 'umd',
+      file: 'dist/alt/video.debug.js',
+      name: 'videojs',
+      banner,
+      globals: globals.browser
+    },
+    external: externals.browser,
+    plugins: [
+      alias({
+        'video.js': path.resolve(__dirname, './src/js/video.js')
+      }),
+      primedResolve,
+      json(),
+      primedCjs,
+      primedBabel,
+      cliargs.progress !== false ? progress() : {}
+    ],
+    onwarn,
+    watch
+  },
   {
     input: 'test/unit/**/*.test.js',
     output: {

--- a/sandbox/debug.html.example
+++ b/sandbox/debug.html.example
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Sandbox</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/alt/video.debug.js"></script>
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started run `npm start` and open the index.html</p>
+    <pre>npm start</pre>
+    <pre>open http://localhost:9999/sandbox/debug.html</pre>
+  </div>
+
+  <video-js
+    id="vid1"
+    controls
+    preload="auto"
+    width="640"
+    height="264">
+    <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video-js>
+
+  <script>
+    var vid = document.getElementById('vid1');
+    var player = videojs(vid);
+  </script>
+
+</body>
+</html>

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -1,0 +1,8 @@
+import videojs from './video';
+import '@videojs/http-streaming';
+import DomData from './utils/dom-data.js';
+
+videojs.DomData = DomData;
+
+videojs.log.level('debug');
+export default videojs;


### PR DESCRIPTION
Adds a debug build to video.js that does the following:
* Exposes DomData on video.js. DomData our internal event tracking object and should be empty on player dispose.
* Set log level to debug by default.