### PR TITLE
fix: add display block to mute control icon placeholder

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -3,6 +3,7 @@
   @include flex(none);
 
   & .vjs-icon-placeholder {
+    display: block;
     @extend .vjs-icon-volume-high;
   }
 }


### PR DESCRIPTION
When sliding volume down to mute it sticks and then repositions incorrectly

Fixes #6989

## Description
#6989

## Specific Changes proposed
Just added `display: block` to `.vjs-icon-placeholder`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created ([from issue description](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
