### PR TITLE
feat: enable responsive controls on fullscreen 

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -18,7 +18,7 @@
 // - Volume Mute button
 // - Fullscreen Button
 //
-.video-js:not(.vjs-fullscreen) {
+.video-js {
 
   &.vjs-layout-small,
   &.vjs-layout-x-small,
@@ -34,7 +34,7 @@
     .vjs-subtitles-button,
     .vjs-audio-button,
     .vjs-volume-control {
-      display: none;
+      display: none !important;
     }
 
     // Reset the size of the volume panel to the default so we don't see a big


### PR DESCRIPTION
A client reported that control buttons are not positioned correctly when player is full-screened and screen is small.

Currently we are excluding our responsive controls on fullscreen and changes include removing that. This solves the issue for small screens. Also added _!important_ rule to override BC skin properties and hide controls when necessary.
