### PR TITLE
fix: clear progress control related rAFs when tab is hidden

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -135,6 +135,11 @@ class SeekBar extends Slider {
    *          The current percent at a number from 0-1
    */
   update(event) {
+    // ignore updates while the tab is hidden
+    if (document.visibilityState === 'hidden') {
+      return;
+    }
+
     const percent = super.update();
 
     this.requestNamedAnimationFrame('SeekBar#update', () => {

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -74,6 +74,8 @@ class SeekBar extends Slider {
 
   toggleVisibility_(e) {
     if (document.visibilityState === 'hidden') {
+      this.cancelNamedAnimationFrame('SeekBar#update');
+      this.cancelNamedAnimationFrame('Slider#update');
       this.disableInterval_(e);
     } else {
       if (!this.player_.ended() && !this.player_.paused()) {

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -73,10 +73,12 @@ class SeekBar extends Slider {
   }
 
   toggleVisibility_(e) {
-    if (document.hidden) {
+    if (document.visibilityState === 'hidden') {
       this.disableInterval_(e);
     } else {
-      this.enableInterval_();
+      if (!this.player_.ended() && !this.player_.paused()) {
+        this.enableInterval_();
+      }
 
       // we just switched back to the page and someone may be looking, so, update ASAP
       this.update();


### PR DESCRIPTION
The progress control is updated inside of requestAnimationFrames (rAFs). Normally, this is fine. However, when a tab is hidden, rAFs are generally not triggered. So, what happens is that we get a cached rAF from the last time the tab was active. When we come back to be active, we update again, but because we already have a named rAF, we don't clear it out and instead that one gets triggered. This isn't an issue if the video is still playing, because in a second, another rAF will be triggered which will update things. However, if the video has ended, we won't get any more updated and the progress bar will still be in the old position.

Instead, when the document becomes hidden, we should clear out *both* the `SeekBar#update` and the `Slider#update` rAFs. Doing just one, unfortunately, isn't enough. In addition, we also only re-enable the interval if we aren't ended or paused and ignore the update method if the tab is hidden.

Fixes #7086