### PR TITLE
docs: fix broken blogpost urls

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -68,7 +68,7 @@ see the [setup guide][install-guide].
 ## Q: Is Video.js on bower?
 
 Versions prior to Video.js 6 support bower, however, as of Video.js 6, bower is no
-longer officially supported. Please see <https://github.com/videojs/video.js/issues/4012>
+longer officially supported. Please see [issue #4012][issue-4012]
 for more information.
 
 ## Q: What do Video.js version numbers mean?
@@ -302,6 +302,8 @@ Yes! See [ReactJS integration example][react-guide].
 [hls]: https://github.com/videojs/http-streaming
 
 [install-guide]: https://videojs.com/getting-started/
+
+[issue-4012]: https://github.com/videojs/video.js/issues/4012
 
 [issue-template]: https://github.com/videojs/video.js/blob/main/.github/ISSUE_TEMPLATE.md
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -92,7 +92,7 @@ player.autoplay('muted');
 
 #### More info on autoplay support and changes:
 
-* See our blog post: <https://videojs.com/blog/autoplay-best-practices-with-video-js/>
+* See our blog post: [Autoplay Best Practices with Video.js](https://videojs.com/blog/autoplay-best-practices-with-video-js/)
 
 ### `controls`
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -374,6 +374,6 @@ These events work for both basic and advanced plugins. They are triggered on the
 
 [spellbook]: https://github.com/videojs/spellbook
 
-[standards]: https://github.com/videojs/generator-videojs-plugin/blob/main/docs/standards.md
+[standards]: https://github.com/videojs/generator-videojs-plugin/blob/master/docs/conventions.md
 
 [yeoman]: http://yeoman.io


### PR DESCRIPTION
## Description
1. can't access current link [https://github.com/videojs/generator-videojs-plugin/blob/main/docs/standards.md](https://github.com/videojs/generator-videojs-plugin/blob/main/docs/standards.md) in `plugins.md` since it has changed to [https://github.com/videojs/generator-videojs-plugin/blob/master/docs/conventions.md](https://github.com/videojs/generator-videojs-plugin/blob/master/docs/conventions.md)
2. links in `faq.md` and `options.md` have same problem as [#6905](https://github.com/videojs/video.js/issues/6905)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
