### PR TITLE
fix: ModalDialog, PosterImage :focus styles

### DIFF
--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -60,8 +60,8 @@
   background: none;
 }
 
-.video-js *:focus:not(:focus-visible),
-.video-js .vjs-menu *:focus:not(:focus-visible) {
+.video-js *:focus:not(:focus-visible):not([tabindex="-1"]),
+.video-js .vjs-menu *:focus:not(:focus-visible):not([tabindex="-1"]) {
   outline: none;
   background: none;
 }


### PR DESCRIPTION
Fixes #7112

## Description
Fixes a styling issue that occurred after #6871 where the background styles would be removed from ModalDialog and PosterImage components when they received focus due to a click.

## Specific Changes proposed
Use `:not([tabindex="-1"])` to prevent the global styles for mouse/keyboard focus on a control from applying to ModalDialog and PosterImage components' backgrounds.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
