### PR TITLE
fix: Remove extra timeupdate event when progress controls disabled

### DIFF
--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -5,6 +5,7 @@ import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import clamp from '../../utils/clamp.js';
 import {bind, throttle, UPDATE_REFRESH_INTERVAL} from '../../utils/fn.js';
+import {silencePromise} from '../../utils/promise';
 
 import './seek-bar.js';
 
@@ -143,6 +144,17 @@ class ProgressControl extends Component {
     this.addClass('disabled');
 
     this.enabled_ = false;
+
+    // Restore normal playback state if controls are disabled while scrubbing
+    if (this.player_.scrubbing()) {
+      const seekBar = this.getChild('seekBar');
+
+      this.player_.scrubbing(false);
+
+      if (seekBar.videoWasPlaying) {
+        silencePromise(this.player_.play());
+      }
+    }
   }
 
   /**

--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -137,7 +137,8 @@ class ProgressControl extends Component {
 
     this.off(['mousedown', 'touchstart'], this.handleMouseDown);
     this.off(this.el_, 'mousemove', this.handleMouseMove);
-    this.handleMouseUp();
+
+    this.removeListenersAddedOnMousedownAndTouchstart();
 
     this.addClass('disabled');
 
@@ -159,6 +160,18 @@ class ProgressControl extends Component {
     this.removeClass('disabled');
 
     this.enabled_ = true;
+  }
+
+  /**
+   * Cleanup listeners after the user finishes interacting with the progress controls
+   */
+  removeListenersAddedOnMousedownAndTouchstart() {
+    const doc = this.el_.ownerDocument;
+
+    this.off(doc, 'mousemove', this.throttledHandleMouseSeek);
+    this.off(doc, 'touchmove', this.throttledHandleMouseSeek);
+    this.off(doc, 'mouseup', this.handleMouseUp);
+    this.off(doc, 'touchend', this.handleMouseUp);
   }
 
   /**
@@ -194,17 +207,13 @@ class ProgressControl extends Component {
    * @listens mouseup
    */
   handleMouseUp(event) {
-    const doc = this.el_.ownerDocument;
     const seekBar = this.getChild('seekBar');
 
     if (seekBar) {
       seekBar.handleMouseUp(event);
     }
 
-    this.off(doc, 'mousemove', this.throttledHandleMouseSeek);
-    this.off(doc, 'touchmove', this.throttledHandleMouseSeek);
-    this.off(doc, 'mouseup', this.handleMouseUp);
-    this.off(doc, 'touchend', this.handleMouseUp);
+    this.removeListenersAddedOnMousedownAndTouchstart();
   }
 }
 


### PR DESCRIPTION
## Description
`SeekBar.handleMouseUp()` is a side-effect of disabling progress controls via `ProgressControls.disable()`. This is an issue because `SeekBar.handleMouseUp()` [manually triggers](https://github.com/videojs/video.js/blob/main/src/js/control-bar/progress-control/seek-bar.js#L352) a `'timeupdate'` event (because it assumes a seek has just taken place). If someone attempts to disable the progress controls before playback starts, a `'timeupdate'` will fire potentially before we even have `'loadedmetadata'`, which can cause problems.

## Specific Additions
- Move the relevant mouse and touch event listener removal that is needed by the `disable()` method from `handleMouseUp()` into its own function.
- Preserve the behavior where `ProgressControls.disable()` will resume a normal playback state if it is invoked while the player is scrubbing.