### PR TITLE
fix: always have an enabled audio track when switching

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -76,17 +76,11 @@ class AudioTrackMenuItem extends MenuItem {
    * @listens click
    */
   handleClick(event) {
-    const tracks = this.player_.audioTracks();
-
     super.handleClick(event);
 
-    for (let i = 0; i < tracks.length; i++) {
-      const track = tracks[i];
-
-      if (track === this.track) {
-        track.enabled = true;
-      }
-    }
+    // the audio track list will automatically toggle other tracks
+    // off for us.
+    this.track.enabled = true;
   }
 
   /**

--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -83,7 +83,9 @@ class AudioTrackMenuItem extends MenuItem {
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
 
-      track.enabled = track === this.track;
+      if (track === this.track) {
+        track.enabled = true;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Only change enabled on one track, the others will automatically be turned off. This prevents us from getting two  `AudioTrackList` `change` events where the first will have no tracks enabled, and the second has a track enabled.
