### PR TITLE
chore: never skip github actions workflows in main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
   ci:
     needs: should-skip
-    if: ${{needs.should-skip.outputs.should-skip-job != 'true'}}
+    if: ${{needs.should-skip.outputs.should-skip-job != 'true' || github.ref == 'refs/heads/main'}}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
In a recent update from the VHS repo we added something so that we don't skip main workflows. I think we want it here too.
