### PR TITLE
add MenuRadioButton to unselect other items when selected

### DIFF
--- a/src/js/menu/menu-radio-item.js
+++ b/src/js/menu/menu-radio-item.js
@@ -11,12 +11,14 @@ import Component from '../../component.js';
  * @extends MenuItem
  */
 class MenuRadioItem extends MenuItem {
-  constructor(player, options) {
-    // only one item should be selectable in menu
+  constructor(player, options, clickHandler) {
+    // one and only one item should be selectable in menu at a time
+    options.selectable = true;
     options.selectable = true;
     options.multiSelectable = false;
     super(player, options);
 
+    this.clickHandler = clickHandler;
     this.selected(options.defaultSelection);
   }
 
@@ -32,8 +34,15 @@ class MenuRadioItem extends MenuItem {
    * @listens click
    */
   handleClick(event) {
+    // loop through the menu items, selecting this one and unselecting others
     for (const item of this.parentComponent_.parentComponent_.items) {
       item.selected(item.id_ === this.id_);
+    }
+
+    // allow clickHandler so MenuRadioItems can be created directly
+    // (see ClickableComponent.handleClick(). For some reason MenuItem overrides it. Here we restore it)
+    if (typeof this.clickHandler === 'function') {
+      this.clickHandler(event, this.options_);
     }
   }
 }

--- a/src/js/menu/menu-radio-item.js
+++ b/src/js/menu/menu-radio-item.js
@@ -1,0 +1,42 @@
+
+/**
+ * @file menu-radio-item.js
+ */
+import MenuItem from '../../menu/menu-item.js';
+import Component from '../../component.js';
+
+/**
+ * The specific menu item type for selecting a language within a text track kind
+ *
+ * @extends MenuItem
+ */
+class MenuRadioItem extends MenuItem {
+  constructor(player, options) {
+    // only one item should be selectable in menu
+    options.selectable = true;
+    options.multiSelectable = false;
+    super(player, options);
+
+    this.selected(options.defaultSelection);
+  }
+
+  /**
+   * This gets called when an `MenuRadioItem` is "clicked". See
+   * {@link ClickableComponent} for more detailed information on what a click can be.
+   *
+   * @param {EventTarget~Event} event
+   *        The `keydown`, `tap`, or `click` event that caused this function to be
+   *        called.
+   *
+   * @listens tap
+   * @listens click
+   */
+  handleClick(event) {
+    for (const item of this.parentComponent_.parentComponent_.items) {
+      item.selected(item.id_ === this.id_);
+    }
+  }
+}
+
+Component.registerComponent('MenuRadioItem', MenuRadioItem);
+export default MenuRadioItem;

--- a/src/js/menu/menu-radio-item.js
+++ b/src/js/menu/menu-radio-item.js
@@ -14,7 +14,6 @@ class MenuRadioItem extends MenuItem {
   constructor(player, options, clickHandler) {
     // one and only one item should be selectable in menu at a time
     options.selectable = true;
-    options.selectable = true;
     options.multiSelectable = false;
     super(player, options);
 


### PR DESCRIPTION
## Description
Most time, when you select an item in a menu, the other items should be unselected.
Currently, each custom Menu or MenuItem must figure out how to manage this, such as by iterating through items on some event, and removing the vjs-selected class or calling unselected.

Many plugins and derived menus implement some kind of special logic just to unselect the other items

## Specific Changes proposed
In order to not conflict with existing menus and plugins, the MenuRadioItem is a new more specialized MenuItem that by default will call select(false) on the other items when one item is clicked on.  

The main change of the proposal is a default check to unselect other items:
```javascript
  handleClick(event) {
    for (const item of this.parentComponent_.parentComponent_.items) {
      item.selected(item.id_ === this.id_);
    }
  }
```

With this change, making a specialized menu item, only involves handleClick.

```javascript
class MyCoolMenuItem extends MenuRadioItem
{
  handleClick(event) {
    super.handleClick(event)
    this.player().trigger('MyItemSelected', this.options_)
  }
}
```

furthermore, I'm suggesting to add a clickHandler parameter so entire menus can be created **without needing to subclass the menuitem** (i mean really it's just an item in a menu, associated to an object value) like this:

```javascript
var MenuButton = videojs.getComponent('MenuButton');
var MenuRadioItem = videojs.getComponent('MenuRadioItem');

class MyBasicMenuButton extends MenuButton
{
  createItems() {
    return this.options_.items.map(item => 
      new MenuRadioItem(this.player_, item, this.options_.clickHandler)
    );
  }
}
videojs.registerComponent('MyBasicMenuButton', MyBasicMenuButton);

player = videojs('my-player', null, function() {
  let menuOptions = {
      items: [{"label":"item 1", val: 1}, {"label":"item 2", val: 2}, {"label":"item 3", val: 3}], 
      clickHandler: (e, item) => alert(item.val)
  };
  this.getChild('controlBar').addChild('MyBasicMenuButton', menuOptions);
});



```

The big difference is that the code above seems 'normal' and does what you think.  But without the MenuRadioItem you must add code to handle unselecting other items, you end up with a weird mix of very unexpected low-level code handling html or reflecting to find the parent and iterate through the children all for 'nothing' (just unselect other items).

The modified MenuItem makes creating menus clean and simple.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
