### PR TITLE
Update deprecated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@videojs/xhr": "2.5.1",
     "global": "4.3.2",
     "keycode": "^2.2.0",
-    "rollup-plugin-replace": "^2.2.0",
+    "@rollup/plugin-replace": "^2.4.1",
     "safe-json-parse": "4.0.0",
     "videojs-font": "3.2.0",
     "videojs-vtt.js": "^0.15.2"
@@ -97,7 +97,6 @@
     "@babel/plugin-transform-object-assign": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
-    "@rollup/plugin-replace": "^2.4.1",
     "access-sniff": "^3.2.0",
     "autoprefixer": "^9.6.0",
     "bestzip": "^2.1.4",


### PR DESCRIPTION
Error message in console: `npm WARN deprecated rollup-plugin-replace@2.2.0: This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.`

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
