### PR TITLE
fix: Better text for exit fullscreen

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -10,7 +10,7 @@
   "Loaded": "Geladen",
   "Progress": "Status",
   "Fullscreen": "Vollbild",
-  "Non-Fullscreen": "Kein Vollbild",
+  "Non-Fullscreen": "Vollbildmodus beenden",
   "Mute": "Ton aus",
   "Unmute": "Ton ein",
   "Playback Rate": "Wiedergabegeschwindigkeit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,7 +16,7 @@
   "Progress Bar": "Progress Bar",
   "progress bar timing: currentTime={1} duration={2}": "{1} of {2}",
   "Fullscreen": "Fullscreen",
-  "Non-Fullscreen": "Non-Fullscreen",
+  "Non-Fullscreen": "Exit Fullscreen",
   "Mute": "Mute",
   "Unmute": "Unmute",
   "Playback Rate": "Playback Rate",

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -569,5 +569,9 @@ videojs.url = Url;
 
 videojs.defineLazyProperty = defineLazyProperty;
 
+// Adding less ambiguous text for fullscreen button.
+// In a major update this could become the default text and key.
+videojs.addLanguage('en', {'Non-Fullscreen': 'Exit Fullscreen'});
+
 export default videojs;
 


### PR DESCRIPTION
Improves the tooltip/accessibility text for the fullscreen button so it's clearer the action is to leave fullscreen mode.

Adds an English translation within src/video.js rather than make it the default text which would change the translation key.
Updates English and German translations, some existing translations already translate it more like "exit fullscreen". 