### PR TITLE
feat: Add normalizeAutoplay option to treat autoplay: true as autoplay: "play"

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -297,7 +297,7 @@ Explicitly set a default value for [the associated tech option](#nativecontrolsf
 
 > Type: `boolean`
 
-Specify whether setting `autoplay: true` should be treated the same as `autoplay: 'play'` 
+Specify whether setting `autoplay: true` should be treated the same as `autoplay: 'play'`, i.e. the `autoplay` attribute should be removed and the `play()` should be initiated manually by video.js rather than the browser.
 
 ### `notSupportedMessage`
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -297,7 +297,7 @@ Explicitly set a default value for [the associated tech option](#nativecontrolsf
 
 > Type: `boolean`
 
-Specify whether setting `autoplay: true` should be treated the same as `autoplay: 'play'`, i.e. the `autoplay` attribute should be removed and the `play()` should be initiated manually by video.js rather than the browser.
+Specify whether setting `autoplay: true` and `<video autoplay>` should be treated the same as `autoplay: 'play'`, i.e. the `autoplay` attribute should be removed from (or not added to) the video element and `play()` be initiated manually by Video.js rather than the browser.
 
 ### `notSupportedMessage`
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -31,6 +31,7 @@
   * [liveTracker.trackingThreshold](#livetrackertrackingthreshold)
   * [liveTracker.liveTolerance](#livetrackerlivetolerance)
   * [nativeControlsForTouch](#nativecontrolsfortouch)
+  * [normalizeAutoplay](#normalizeautoplay)
   * [notSupportedMessage](#notsupportedmessage)
   * [noUITitleAttributes](#nouititleattributes)
   * [fullscreen](#fullscreen)
@@ -291,6 +292,12 @@ An option for the liveTracker component of the player that controls how far from
 > Type: `boolean`
 
 Explicitly set a default value for [the associated tech option](#nativecontrolsfortouch).
+
+### `normalizeAutoplay`
+
+> Type: `boolean`
+
+Specify whether setting `autoplay: true` should be treated the same as `autoplay: 'play'` 
 
 ### `notSupportedMessage`
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3677,24 +3677,16 @@ class Player extends Component {
 
     let techAutoplay;
 
-    // if the value is a valid string set it to that
-    if (typeof value === 'string' && (/(any|play|muted)/).test(value)) {
+    // if the value is a valid string set it to that, or normalize `true` to 'play if need be'
+    if (typeof value === 'string' && (/(any|play|muted)/).test(value) || value === true && this.options_.normalizeAutoplay) {
       this.options_.autoplay = value;
-      this.manualAutoplay_(value);
+      this.manualAutoplay_(typeof value === 'string' ? value : 'play');
       techAutoplay = false;
 
     // any falsy value sets autoplay to false in the browser,
     // lets do the same
     } else if (!value) {
       this.options_.autoplay = false;
-
-    // normalize `true` as 'play' if need be
-    } else if (value === true && this.options_.normalizeAutoplay) {
-      // we still want player.autoplay() to return the provided setting,
-      // even though it will be treated as a 'play' behind the scenes
-      this.options_.autoplay = value;
-      this.manualAutoplay_('play');
-      techAutoplay = false;
 
     // any other value (ie truthy) sets autoplay to true
     } else {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3677,7 +3677,7 @@ class Player extends Component {
 
     let techAutoplay;
 
-    // if the value is a valid string set it to that, or normalize `true` to 'play if need be'
+    // if the value is a valid string set it to that, or normalize `true` to 'play', if need be
     if (typeof value === 'string' && (/(any|play|muted)/).test(value) || value === true && this.options_.normalizeAutoplay) {
       this.options_.autoplay = value;
       this.manualAutoplay_(typeof value === 'string' ? value : 'play');

--- a/test/unit/autoplay.test.js
+++ b/test/unit/autoplay.test.js
@@ -189,6 +189,28 @@ QUnit.test('option = "play" play, no muted', function(assert) {
   assert.equal(this.counts.failure, 0, 'failure count');
 });
 
+QUnit.test('option = true w/ normalizeAutoplay = true play, no muted', function(assert) {
+  this.createPlayer({
+    autoplay: true,
+    normalizeAutoplay: true
+  }, {}, this.resolvePromise);
+
+  assert.equal(this.player.autoplay(), true, 'player.autoplay getter');
+  assert.equal(this.player.tech_.autoplay(), false, 'tech.autoplay getter');
+
+  this.player.tech_.trigger('loadstart');
+  assert.equal(this.counts.play, 1, 'play count');
+  assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 1, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+
+  this.player.tech_.trigger('loadstart');
+  assert.equal(this.counts.play, 2, 'play count');
+  assert.equal(this.counts.muted, 0, 'muted count');
+  assert.equal(this.counts.success, 2, 'success count');
+  assert.equal(this.counts.failure, 0, 'failure count');
+});
+
 QUnit.test('option = "any" play, no muted', function(assert) {
   this.createPlayer({autoplay: 'any'}, {}, this.resolvePromise);
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -322,6 +322,27 @@ QUnit.test('should get current sources from src set', function(assert) {
   player.dispose();
 });
 
+QUnit.test('should remove autoplay attribute when normalizeAutoplay: true', function(assert) {
+  const fixture = document.getElementById('qunit-fixture');
+
+  let html = '<video id="example_1" class="video-js" autoplay preload="none">';
+
+  html += '<source src="http://google.com" type="video/mp4">';
+  html += '<source src="http://google.com" type="video/webm">';
+  html += '<track kind="captions" attrtest>';
+  html += '</video>';
+
+  fixture.innerHTML += html;
+
+  const tag = document.getElementById('example_1');
+  const player = TestHelpers.makePlayer({normalizeAutoplay: true}, tag);
+
+  player.loadTech_('Html5');
+
+  assert.equal(player.options_.autoplay, true, 'autoplay option is set to true');
+  assert.equal(tag.getAttribute('autoplay'), null, 'autoplay attribute removed');
+});
+
 QUnit.test('should asynchronously fire error events during source selection', function(assert) {
   assert.expect(2);
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -339,7 +339,7 @@ QUnit.test('should remove autoplay attribute when normalizeAutoplay: true', func
 
   player.loadTech_('Html5');
 
-  assert.equal(player.options_.autoplay, true, 'autoplay option is set to true');
+  assert.equal(player.autoplay(), true, 'autoplay option is set to true');
   assert.equal(tag.getAttribute('autoplay'), null, 'autoplay attribute removed');
 });
 


### PR DESCRIPTION
## Description
This PR adds a new option to treat `autoplay: true` the same as `autoplay: 'play'`. In general we want video.js to handle as much of the autoplay logic itself as possible, since the browser's treatment of the video element's `autoplay` attribute is less predictable. For now the default option value is `false`, but it may be made the default behavior in a future major version.