### PR TITLE
Make Playback Rate control work with screen readers - fixes #7121

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -26,6 +26,8 @@ class PlaybackRateMenuButton extends MenuButton {
   constructor(player, options) {
     super(player, options);
 
+    this.menuButton_.el_.setAttribute('aria-describedby', this.labelElId_);
+
     this.updateVisibility();
     this.updateLabel();
 
@@ -42,8 +44,11 @@ class PlaybackRateMenuButton extends MenuButton {
   createEl() {
     const el = super.createEl();
 
+    this.labelElId_ = 'vjs-playback-rate-value-label-' + this.id_;
+
     this.labelEl_ = Dom.createEl('div', {
       className: 'vjs-playback-rate-value',
+      id: this.labelElId_,
       innerHTML: '1x'
     });
 


### PR DESCRIPTION
## Description
The Playback Rate control is a MenuButton, but has been modified from the standard MenuButton operation so that clicking on the button just switches to the next playback rate without displaying the menu. Also, the label of the button visually includes the current playback rate but that visual indication is not included in the accessible name or description of the button. As a result, screen reader users cannot perceive the current setting of the control, and do not realize that they actually can change the setting (by activating the button) since activating the button does not open a menu but also does not announce the rate change.

This temporary fix associates the current rate selection display in the button with the button itself using `aria-describedby`, so that it is announced by screen readers when the button receives focus, but is not included as part of the name/label of the button (which would be confusing). The new rate is also announced by the screen reader when the setting is changed by activating the button.

This fixes #7121.

Long term, the button needs to be fixed to correctly operate as a menu button for screen reader users, but for now, this change doesn't change any of the DOM structure or any of the behavior for sighted mouse users or sighted keyboard-only users.

## Specific Changes proposed
Add a unique HTML ID to the visible rate label in the Playback Rate menu button control, and associate it with the button via `aria-describedby`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome + JAWS)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
