### PR TITLE
fix: don't reset background styles of selected MenuItem when focused

### DIFF
--- a/src/css/components/menu/_menu.scss
+++ b/src/css/components/menu/_menu.scss
@@ -56,8 +56,8 @@
   color: $primary-background-color;
 }
 
-.video-js .vjs-menu *:focus:not(:focus-visible),
-.js-focus-visible .vjs-menu *:focus:not(.focus-visible) {
+.video-js .vjs-menu *:not(.vjs-selected):focus:not(:focus-visible),
+.js-focus-visible .vjs-menu *:not(.vjs-selected):focus:not(.focus-visible) {
   background: none;
 }
 


### PR DESCRIPTION
Fixes #7200

## Description
Fixes a styling issue with the MenuItem component that caused it to display dark text over a dark background when focused, if it was the currently selected MenuItem (`.vjs-selected`).

## Specific Changes proposed
Use `:not(.vjs-selected)` to prevent the menu styles from resetting the background of a selected MenuItem on focus.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
