### PR TITLE
fix: live user seek

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -302,6 +302,12 @@ class SeekBar extends Slider {
       }
     }
 
+    // tell live tracker that the current seek can be
+    // behind live.
+    if (liveTracker) {
+      liveTracker.userSeek_(true);
+    }
+
     // Set new time (tell player to seek to new time)
     this.player_.currentTime(newTime);
   }

--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -186,6 +186,13 @@ class SeekBar extends Slider {
     return percent;
   }
 
+  /**
+   * Prevent liveThreshold from causing seeks to seem like they
+   * are not happening from a user perspective.
+   *
+   * @param {number} ct
+   *        current time to seek to
+   */
   userSeek_(ct) {
     if (this.player_.liveTracker && this.player_.liveTracker.isLive()) {
       this.player_.liveTracker.nextSeekedFromUser();

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -191,8 +191,8 @@ class LiveTracker extends Component {
   handleSeeked() {
     const timeDiff = Math.abs(this.liveCurrentTime() - this.player_.currentTime());
 
-    this.seekedBehindLive_ = this.userSeek__ && timeDiff > 2;
-    this.userSeek__ = false;
+    this.seekedBehindLive_ = this.nextSeekedFromUser_ && timeDiff > 2;
+    this.nextSeekedFromUser_ = false;
     this.trackLive_();
   }
 
@@ -215,7 +215,7 @@ class LiveTracker extends Component {
     this.behindLiveEdge_ = true;
     this.timeupdateSeen_ = false;
     this.seekedBehindLive_ = false;
-    this.userSeek__ = false;
+    this.nextSeekedFromUser_ = false;
 
     this.clearInterval(this.trackingInterval_);
     this.trackingInterval_ = null;
@@ -227,8 +227,13 @@ class LiveTracker extends Component {
     this.off(this.player_, 'timeupdate', this.seekToLiveEdge_);
   }
 
-  userSeek_(v) {
-    this.userSeek__ = v;
+  /**
+   * The next seeked event is from the user. Meaning that any seek
+   * > 2s behind live will be considered behind live for real and
+   * liveTolerance will be ignored.
+   */
+  nextSeekedFromUser() {
+    this.nextSeekedFromUser_ = true;
   }
 
   /**
@@ -375,10 +380,11 @@ class LiveTracker extends Component {
    * Seek to the live edge if we are behind the live edge
    */
   seekToLiveEdge() {
-    this.userSeek__ = false;
+    this.seekedBehindLive_ = false;
     if (this.atLiveEdge()) {
       return;
     }
+    this.nextSeekedFromUser_ = false;
     this.player_.currentTime(this.liveCurrentTime());
 
   }

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -191,8 +191,8 @@ class LiveTracker extends Component {
   handleSeeked() {
     const timeDiff = Math.abs(this.liveCurrentTime() - this.player_.currentTime());
 
-    this.seekedBehindLive_ = this.skipNextSeeked_ ? false : timeDiff > 2;
-    this.skipNextSeeked_ = false;
+    this.seekedBehindLive_ = this.userSeek__ && timeDiff > 2;
+    this.userSeek__ = false;
     this.trackLive_();
   }
 
@@ -215,7 +215,7 @@ class LiveTracker extends Component {
     this.behindLiveEdge_ = true;
     this.timeupdateSeen_ = false;
     this.seekedBehindLive_ = false;
-    this.skipNextSeeked_ = false;
+    this.userSeek__ = false;
 
     this.clearInterval(this.trackingInterval_);
     this.trackingInterval_ = null;
@@ -225,6 +225,10 @@ class LiveTracker extends Component {
     this.off(this.player_, 'play', this.handlePlay_);
     this.off(this.player_, 'timeupdate', this.handleFirstTimeupdate_);
     this.off(this.player_, 'timeupdate', this.seekToLiveEdge_);
+  }
+
+  userSeek_(v) {
+    this.userSeek__ = v;
   }
 
   /**
@@ -371,12 +375,10 @@ class LiveTracker extends Component {
    * Seek to the live edge if we are behind the live edge
    */
   seekToLiveEdge() {
-    this.seekedBehindLive_ = false;
+    this.userSeek__ = false;
     if (this.atLiveEdge()) {
       return;
     }
-    // skipNextSeeked_
-    this.skipNextSeeked_ = true;
     this.player_.currentTime(this.liveCurrentTime());
 
   }

--- a/test/unit/live-tracker.test.js
+++ b/test/unit/live-tracker.test.js
@@ -148,7 +148,7 @@ QUnit.module('LiveTracker', () => {
     assert.ok(this.liveTracker.behindLiveEdge(), 'behindLiveEdge live edge');
   });
 
-  QUnit.test('is behindLiveEdge when seeking backwards', function(assert) {
+  QUnit.test('is behindLiveEdge when seeking behind liveTolerance with API', function(assert) {
     this.liveTracker.options_.liveTolerance = 6;
     this.player.seekable = () => createTimeRanges(0, 20);
     this.player.trigger('timeupdate');
@@ -157,6 +157,23 @@ QUnit.module('LiveTracker', () => {
 
     assert.ok(this.liveTracker.atLiveEdge(), 'at live edge');
 
+    this.player.currentTime = () => 14;
+    this.player.trigger('seeked');
+
+    assert.equal(this.liveEdgeChanges, 1, 'should have one live edge change');
+    assert.ok(this.liveTracker.behindLiveEdge(), 'behindLiveEdge live edge');
+  });
+
+  QUnit.test('is behindLiveEdge when seeking >2s behind with ui', function(assert) {
+    this.liveTracker.options_.liveTolerance = 6;
+    this.player.seekable = () => createTimeRanges(0, 20);
+    this.player.trigger('timeupdate');
+    this.player.currentTime = () => 20;
+    this.clock.tick(1000);
+
+    assert.ok(this.liveTracker.atLiveEdge(), 'at live edge');
+
+    this.liveTracker.nextSeekedFromUser();
     this.player.currentTime = () => 17;
     this.player.trigger('seeked');
 


### PR DESCRIPTION
## Description
This fixes two issues.
1. The current keybinds for seekbar do not take into account that duration will be `Infinity` for live playback. Which means that they will often throw an error when using for a live video. I fixed this by using the values from live tracker.
2. API seeks should abide by the liveThreshold this prevents seeks in vhs to just before seekableEnd from causing us to appear behind live. In general the original intention for `seekedBehindLive_` was to allow the user to seek behind live and ignore liveThreshold so that it wasn't jarring to the user that they couldn't seek.
