### PR TITLE
chore: update 'global' package in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6526,12 +6526,12 @@
       "dev": true
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -11794,9 +11794,9 @@
       "dev": true
     },
     "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -15024,6 +15024,22 @@
                 "min-document": "^2.19.0",
                 "process": "^0.11.10"
               }
+            }
+          }
+        },
+        "global": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+          "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          },
+          "dependencies": {
+            "process": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+              "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/runtime": "^7.9.2",
     "@videojs/http-streaming": "2.7.1",
     "@videojs/xhr": "2.5.1",
-    "global": "4.3.2",
+    "global": "^4.4.0",
     "keycode": "^2.2.0",
     "rollup-plugin-replace": "^2.2.0",
     "safe-json-parse": "4.0.0",


### PR DESCRIPTION
## Description

Update the `global` dependency to a recent version. The change already hapenned in http-streaming ( https://github.com/videojs/http-streaming/pull/1031 ) but video.js itself had another dependecy specification. This unifies it.

## Specific Changes proposed

* Bumped the dependency in `package.json`
* Ran `npm install`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
