### PR TITLE
fix: add try and catch for computedStyle

### DIFF
--- a/src/js/utils/computed-style.js
+++ b/src/js/utils/computed-style.js
@@ -26,7 +26,13 @@ function computedStyle(el, prop) {
   }
 
   if (typeof window.getComputedStyle === 'function') {
-    const computedStyleValue = window.getComputedStyle(el);
+    let computedStyleValue;
+
+    try {
+      computedStyleValue = window.getComputedStyle(el);
+    } catch (_) {
+      return '';
+    }
 
     return computedStyleValue ? computedStyleValue.getPropertyValue(prop) || computedStyleValue[prop] : '';
   }


### PR DESCRIPTION
## Description
With shadow root enable component, computedStyle gets called on dragging the progress bar. and since we are traversing the path back to the top,  if you have a shadow root component in the path, it will try to call computeStyle for shadow root (document fragment) which will then cause  the following error
`Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.`

https://github.com/videojs/video.js/blob/4238f5c1d88890547153e7e1de7bd0d1d8e0b236/src/js/utils/dom.js#L620

## Specific Changes proposed

Adding try and catch so the code can continue to run despite the error

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
