### PR TITLE
fix: Don't hide menus with one item and a title

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -120,8 +120,6 @@ class MenuButton extends Component {
         tabIndex: -1
       });
 
-      this.hideThreshold_ += 1;
-
       const titleComponent = new Component(this.player_, {el: titleEl});
 
       menu.addItem(titleComponent);

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -43,6 +43,24 @@ QUnit.test('should place title list item into ul', function(assert) {
   player.dispose();
 });
 
+QUnit.test('should not include menu title in hide threshold', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  const menuButton = new MenuButton(player, {
+    title: 'testTitle'
+  });
+
+  assert.strictEqual(menuButton.hideThreshold_, 0, 'title should not increment hideThreshold_');
+
+  menuButton.createItems = () => [new MenuItem(player, { label: 'menu-item1' })];
+  menuButton.update();
+
+  assert.strictEqual(menuButton.hasClass('vjs-hidden'), false, 'menu button with single (non-title) item is not hidden');
+
+  menuButton.dispose();
+  player.dispose();
+});
+
 QUnit.test('clicking should display the menu', function(assert) {
   assert.expect(6);
 


### PR DESCRIPTION
## Description
Menus with one item are hidden if they have a title, because adding the title increments the hide threshold, but the title is not counted as an item. e.g. the chapters menu if there is a single chapter - `player.addRemoteTextTrack({src: 'data:text/vtt;base64,' + btoa('WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nChapter 1\n'), kind: 'chapters'}, true);`

## Specific Changes proposed
Don't increment `hideThreshold_` for the title. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
