### PR TITLE
feat: Add helper classes for 9:16 and 1:1

### DIFF
--- a/docs/guides/layout.md
+++ b/docs/guides/layout.md
@@ -20,11 +20,11 @@ You can enable fluid in a few ways:
 
 ### Classes
 
-There are three classes associated with fluid mode, `vjs-fluid`, `vjs-16-9`, and `vjs-4-3`.
+There are five classes associated with fluid mode, `vjs-fluid`, `vjs-16-9`, `vjs-4-3`, `vjs-9-16` and `vjs-1-1`.
 
 `vjs-fluid` turns on the general fluid mode which will wait for the video to load to calculate the aspect ratio of the video.
 
-Alternatively, because 16:9 and 4:3 aspect ratios are so common, we provided them as classes by default for you to use if you know that your videos are 16:9 or 4:3.
+Alternatively, because 16:9, 4:3, 9:16 and 1:1  aspect ratios are so common, we provided them as classes by default for you to use if you know that your videos are 16:9 or , 4:3, 9:16 or 1:1.
 
 ### Enabling Fluid Mode
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -37,7 +37,6 @@
     * [options](#options)
   * [playbackRates](#playbackrates)
   * [plugins](#plugins)
-  * [preferFullWindow](#preferfullwindow)
   * [responsive](#responsive)
   * [sources](#sources)
   * [suppressNotSupportedError](#suppressnotsupportederror)
@@ -367,12 +366,6 @@ player.boo({baz: false});
 Although, since the `plugins` option is an object, the order of initialization is not guaranteed!
 
 See [the plugins guide][plugins] for more information on Video.js plugins.
-
-### `preferFullWindow`
-
-> Type: `boolean`, Defaut: `false`
-
-Setting this to `true` will change fullscreen behaviour on devices which do not support the HTML5 fullscreen API but do support fullscreen on the video element, i.e. iPhone. Instead of making the video fullscreen, the player will be stretched to fill the browser window.  
 
 ### `responsive`
 

--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -37,6 +37,7 @@
     * [options](#options)
   * [playbackRates](#playbackrates)
   * [plugins](#plugins)
+  * [preferFullWindow](#preferfullwindow)
   * [responsive](#responsive)
   * [sources](#sources)
   * [suppressNotSupportedError](#suppressnotsupportederror)
@@ -169,6 +170,8 @@ Each option is `undefined` by default unless otherwise specified.
 
 Puts the player in [fluid](#fluid) mode and the value is used when calculating the dynamic size of the player. The value should represent a ratio - two numbers separated by a colon (e.g. `"16:9"` or `"4:3"`).
 
+Alternatively, the classes `vjs-16-9`, `vjs-9-16`, `vjs-4-3` or `vjs-1-1` can be added to the player.
+
 ### `autoSetup`
 
 > Type: `boolean`
@@ -229,7 +232,7 @@ This option is inherited from the [`Component` base class](#component-options).
 
 > Type: `boolean`
 
-When `true`, the Video.js player will have a fluid size. In other words, it will scale to fit its container.
+When `true`, the Video.js player will have a fluid size. In other words, it will scale to fit its container at the video's intrinsic aspect ratio, or at a specified [`aspectRatio`](#aspectRatio).
 
 Also, if the `<video>` element has the `"vjs-fluid"`, this option is automatically set to `true`.
 
@@ -365,6 +368,12 @@ Although, since the `plugins` option is an object, the order of initialization i
 
 See [the plugins guide][plugins] for more information on Video.js plugins.
 
+### `preferFullWindow`
+
+> Type: `boolean`, Defaut: `false`
+
+Setting this to `true` will change fullscreen behaviour on devices which do not support the HTML5 fullscreen API but do support fullscreen on the video element, i.e. iPhone. Instead of making the video fullscreen, the player will be stretched to fill the browser window.  
+
 ### `responsive`
 
 > Type: `boolean`, Default: `false`
@@ -372,6 +381,8 @@ See [the plugins guide][plugins] for more information on Video.js plugins.
 Setting this option to `true` will cause the player to customize itself based on responsive breakpoints (see: [`breakpoints` option](#breakpoints)).
 
 When this option is `false` (the default), responsive breakpoints will be ignored.
+
+> Note this is about the responsiveness of the controls within the player, not responsive sizing of the pplayer itself. For that, see [fluid](#fluid).
 
 ### `sources`
 

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -70,7 +70,9 @@
 // the user set AR injected into the header.
 .video-js.vjs-fluid,
 .video-js.vjs-16-9,
-.video-js.vjs-4-3 {
+.video-js.vjs-4-3,
+.video-js.vjs-9-16,
+.video-js.vjs-1-1 {
   width: 100%;
   max-width: 100%;
   height: 0;
@@ -82,6 +84,14 @@
 
 .video-js.vjs-4-3 {
   @include apply-aspect-ratio(4, 3);
+}
+
+.video-js.vjs-9-16 {
+  @include apply-aspect-ratio(9, 16);
+}
+
+.video-js.vjs-1-1 {
+  @include apply-aspect-ratio(1, 1);
 }
 
 .video-js.vjs-fill {


### PR DESCRIPTION
## Description
Fluid mode's automatic detection is nice but there can be a layout jump once the video dimensions are known. We have the `vjs-16-9` and `vjs-9-16` classes already, but square and portrait are also common now. 

## Specific Changes proposed
Adds `vjs-9-16` and `vjs-1-1` classes for those aspect ratios.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
