### PR TITLE
fix: fullWindowOnEscKey handler

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2979,9 +2979,11 @@ class Player extends Component {
   fullWindowOnEscKey(event) {
     if (keycode.isEventKey(event, 'Esc')) {
       if (this.isFullscreen() === true) {
-        this.exitFullscreen();
-      } else {
-        this.exitFullWindow();
+        if (!this.isFullWindow) {
+          this.exitFullscreen();
+        } else {
+          this.exitFullWindow();
+        }
       }
     }
   }

--- a/test/unit/player-fullscreen.test.js
+++ b/test/unit/player-fullscreen.test.js
@@ -207,3 +207,20 @@ QUnit.test('fullscreenOptions from function args should override player options'
 
   player.dispose();
 });
+
+QUnit.test('fullwindow mode should exit when ESC event triggered', function(assert) {
+  const player = FullscreenTestHelpers.makePlayer(true);
+
+  player.enterFullWindow();
+  assert.ok(player.isFullWindow, 'enterFullWindow should be called');
+
+  const evt = TestHelpers.createEvent('keydown');
+
+  evt.keyCode = 27;
+  evt.which = 27;
+  player.boundFullWindowOnEscKey_(evt);
+  // player.fullWindowOnEscKey(evt);
+  assert.equal(player.isFullWindow, false, 'exitFullWindow should be called');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
Calling `player.enterFullWindow()` directly will cause `ESC` keydown listener not working as expect.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
