### PR TITLE
feat(player): Add playbackRates() method

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -2,7 +2,6 @@
  * @file playback-rate-menu-button.js
  */
 import MenuButton from '../../menu/menu-button.js';
-import Menu from '../../menu/menu.js';
 import PlaybackRateMenuItem from './playback-rate-menu-item.js';
 import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
@@ -33,6 +32,7 @@ class PlaybackRateMenuButton extends MenuButton {
 
     this.on(player, 'loadstart', (e) => this.updateVisibility(e));
     this.on(player, 'ratechange', (e) => this.updateLabel(e));
+    this.on(player, 'rateschange', (e) => this.handleRateschange(e));
   }
 
   /**
@@ -78,22 +78,18 @@ class PlaybackRateMenuButton extends MenuButton {
   }
 
   /**
-   * Create the playback rate menu
+   * Create the list of menu items. Specific to each subclass.
    *
-   * @return {Menu}
-   *         Menu object populated with {@link PlaybackRateMenuItem}s
    */
-  createMenu() {
-    const menu = new Menu(this.player());
+  createItems() {
     const rates = this.playbackRates();
+    const items = [];
 
-    if (rates) {
-      for (let i = rates.length - 1; i >= 0; i--) {
-        menu.addChild(new PlaybackRateMenuItem(this.player(), {rate: rates[i] + 'x'}));
-      }
+    for (let i = rates.length - 1; i >= 0; i--) {
+      items.push(new PlaybackRateMenuItem(this.player(), {rate: rates[i] + 'x'}));
     }
 
-    return menu;
+    return items;
   }
 
   /**
@@ -133,13 +129,22 @@ class PlaybackRateMenuButton extends MenuButton {
   }
 
   /**
+   * On rateschange, update the menu to account for the new items.
+   *
+   * @listens Player#rateschange
+   */
+  handleRateschange(event) {
+    this.update();
+  }
+
+  /**
    * Get possible playback rates
    *
    * @return {Array}
    *         All possible playback rates
    */
   playbackRates() {
-    return this.options_.playbackRates || (this.options_.playerOptions && this.options_.playerOptions.playbackRates);
+    return this.player().playbackRates() || [];
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -508,6 +508,8 @@ class Player extends Component {
 
     this.middleware_ = [];
 
+    this.playbackRates(options.playbackRates);
+
     this.initChildren();
 
     // Set isAudio based on whether or not an audio tag was used
@@ -4856,6 +4858,40 @@ class Player extends Component {
       this.previousLogLevel_ = undefined;
       this.debugEnabled_ = false;
     }
+
+  }
+
+  /**
+   * Set or get current playback rates.
+   * Takes an array and updates the playback rates menu with the new items.
+   * Pass in an empty array to hide the menu.
+   * Values other than arrays are ignored.
+   *
+   * @fires Player#rateschange
+   * @param {number[]} newRates
+   *                   The new rates that the playback rates menu should update to.
+   *                   An empty array will hide the menu
+   * @return {number[]} When used as a getter will return the current playback rates
+   */
+  playbackRates(newRates) {
+    if (newRates === undefined) {
+      return this.cache_.playbackRates;
+    }
+
+    // ignore any value that isn't an array
+    if (!Array.isArray(newRates)) {
+      return;
+    }
+
+    this.cache_.playbackRates = newRates;
+
+    /**
+    * fires when the player language change
+    *
+    * @event Player#rateschange
+    * @type {EventTarget~Event}
+    */
+    this.trigger('rateschange');
   }
 }
 


### PR DESCRIPTION
Adds a new playbackRates() method that takes an Array of numbers
representing the rates that are wanted to show up in the playback rates
menu. When new rates are given, a rateschange event will trigger, which
will be used by the PlaybackRatesMenuButton to update itself.

An empty array will hide the menu. No value will return the currently
set playback rates. Other values will be ignored.

Fixes #7198