### PR TITLE
Feature detect setTimeout in auto setup for SSR

### DIFF
--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -16,8 +16,7 @@ let videojs;
  */
 const autoSetup = function() {
 
-  // Protect against breakage in non-browser environments and check global autoSetup option.
-  if (!Dom.isReal() || videojs.options.autoSetup === false) {
+  if (videojs.options.autoSetup === false) {
     return;
   }
 
@@ -71,6 +70,11 @@ const autoSetup = function() {
  *        The videojs library function
  */
 function autoSetupTimeout(wait, vjs) {
+  // Protect against breakage in non-browser environments
+  if (!Dom.isReal()) {
+    return;
+  }
+
   if (vjs) {
     videojs = vjs;
   }


### PR DESCRIPTION
In some server side rendering environments (e.g., `execjs` since
version 2.8.0 [1]) `setTimeout` is not available. Since
`autoSetupTimeout` runs when Video.js is imported and tries to
schedule `autoSetup`, this can lead to errors of the following form in
server side rendering:

    TypeError: scheduler is not a function

`autoSetup` already bailed out if run outside of a browser environment
or if globally disabled. To prevent calling `setTimeout`, we already
perform the `Dom.isReal` check in `autoSetupTimeout`. Checking
`options.autoSetup` has to remain in `autoSetup` to preserve backwards
compatiblity with apps that set the option after Video.js has loaded
but before the next tick.

[1] https://github.com/rails/execjs/pull/43

## Requirements Checklist

- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
