### PR TITLE
fix: player.loadTech_ incorrect arrow function

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1209,8 +1209,8 @@ class Player extends Component {
     this.on(this.tech_, 'firstplay', (e) => this.handleTechFirstPlay_(e));
     this.on(this.tech_, 'pause', (e) => this.handleTechPause_(e));
     this.on(this.tech_, 'durationchange', (e) => this.handleTechDurationChange_(e));
-    this.on(this.tech_, 'fullscreenchange', (e) => this.handleTechFullscreenChange_(e));
-    this.on(this.tech_, 'fullscreenerror', (e) => this.handleTechFullscreenError_(e));
+    this.on(this.tech_, 'fullscreenchange', (e, data) => this.handleTechFullscreenChange_(e, data));
+    this.on(this.tech_, 'fullscreenerror', (e, err) => this.handleTechFullscreenError_(e, err));
     this.on(this.tech_, 'enterpictureinpicture', (e) => this.handleTechEnterPictureInPicture_(e));
     this.on(this.tech_, 'leavepictureinpicture', (e) => this.handleTechLeavePictureInPicture_(e));
     this.on(this.tech_, 'error', (e) => this.handleTechError_(e));

--- a/test/unit/player-fullscreen.test.js
+++ b/test/unit/player-fullscreen.test.js
@@ -224,3 +224,39 @@ QUnit.test('fullwindow mode should exit when ESC event triggered', function(asse
 
   player.dispose();
 });
+
+QUnit.test('fullscreenchange event from Html5 should change player.isFullscreen_', function(assert) {
+  const player = FullscreenTestHelpers.makePlayer(false);
+  const html5 = player.tech(true);
+
+  // simulate html5.proxyWebkitFullscreen_
+  html5.trigger('fullscreenchange', {
+    isFullscreen: true,
+    nativeIOSFullscreen: true
+  });
+
+  assert.ok(player.isFullscreen(), 'player.isFullscreen_ should be true');
+
+  html5.trigger('fullscreenchange', { isFullscreen: false });
+
+  assert.ok(!player.isFullscreen(), 'player.isFullscreen_ should be false');
+
+  player.dispose();
+});
+
+QUnit.test('fullscreenerror event from Html5 should pass through player', function(assert) {
+  const player = FullscreenTestHelpers.makePlayer(false);
+  const html5 = player.tech(true);
+  const err = new Error('This is test');
+  let fullscreenerror;
+
+  player.on('fullscreenerror', function(evt, error) {
+    fullscreenerror = error;
+  });
+
+  html5.trigger('fullscreenerror', err);
+
+  assert.strictEqual(fullscreenerror, err);
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
`fullscreenchange`, `fullscreenerror` events triggered by `Html5` were not handled as expected by `player` since some arrow functions missing necessary argument.

### Steps to reproduce
1. calling `player.requestFullscreen()` on any iOS device
2. runing code below to exit fullscreen
```js
function exitfullscreen() {
    if (player.isFullscreen()) {
        player.exitFullscreen();
    }
}
```

### Results
#### Expected
video can exit fullscreen

#### Actual
video cannot exit fullscreen

#### Reason
After entered fullscreen, `player.isFullscreen()` still remain `false`.

## Specific Changes proposed
None.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
