### PR TITLE
Fix attaching instead of detaching an event listener

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -471,7 +471,7 @@ class SeekBar extends Slider {
 
     this.off(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
     if (this.player_.liveTracker) {
-      this.on(this.player_.liveTracker, 'liveedgechange', this.update);
+      this.off(this.player_.liveTracker, 'liveedgechange', this.update);
     }
 
     this.off(this.player_, ['playing'], this.enableIntervalHandler_);


### PR DESCRIPTION
## Description
I believe this is a bug. In `dispose` event listeners should be detached instead of reattached.

## Specific Changes proposed
Changed `on` to `off`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
