### PR TITLE
feat(package): add VHS deps as Video.js deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,9 +1078,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }

--- a/package.json
+++ b/package.json
@@ -82,11 +82,16 @@
     "url": "https://github.com/videojs/video.js.git"
   },
   "dependencies": {
-    "@babel/runtime": "^7.9.2",
+    "@babel/runtime": "^7.12.5",
     "@videojs/http-streaming": "2.8.2",
+    "@videojs/vhs-utils": "^3.0.2",
     "@videojs/xhr": "2.5.1",
+    "aes-decrypter": "3.1.2",
     "global": "^4.4.0",
     "keycode": "^2.2.0",
+    "m3u8-parser": "4.7.0",
+    "mpd-parser": "0.16.0",
+    "mux.js": "5.11.0",
     "safe-json-parse": "4.0.0",
     "videojs-font": "3.2.0",
     "videojs-vtt.js": "^0.15.3"


### PR DESCRIPTION
Because VHS is inlined into Video.js, we should depend on what VHS
depends on.

Fixes #7091, fixes #7209, fixes #7144, fixes #7109