### PR TITLE
feat: Add ended middleware

### DIFF
--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -188,7 +188,8 @@ export const allowedGetters = {
   played: 1,
   paused: 1,
   seekable: 1,
-  volume: 1
+  volume: 1,
+  ended: 1
 };
 
 /**


### PR DESCRIPTION
## Description
Pretty straightforward. As far as I can tell, this is the only change needed to add support for ended() getter middleware. One use case for this is for client-side postroll ads, when the ended state of the tech is `true` but the player is still displaying ad content.