### PR TITLE
Fix mouse time tooltip when moved to far right of progress bar

### DIFF
--- a/src/js/control-bar/progress-control/progress-control.js
+++ b/src/js/control-bar/progress-control/progress-control.js
@@ -72,7 +72,7 @@ class ProgressControl extends Component {
     }
 
     const seekBarEl = seekBar.el();
-    const seekBarRect = Dom.findPosition(seekBarEl);
+    const seekBarRect = Dom.getBoundingClientRect(seekBarEl);
     let seekBarPoint = Dom.getPointerPosition(seekBarEl, event).x;
 
     // The default skin has a gap on either side of the `SeekBar`. This means


### PR DESCRIPTION
## Description
Fix mouse time tooltip when moved to far right of progress bar

Linked issue: #7248

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (FreeTube dev version)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
