### PR TITLE
fix: remove loading spinner on ended

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1894,6 +1894,7 @@ class Player extends Component {
    */
   handleTechEnded_() {
     this.addClass('vjs-ended');
+    this.removeClass('vjs-waiting');
     if (this.options_.loop) {
       this.currentTime(0);
       this.play();


### PR DESCRIPTION
If we've ended, there's no point in having the loading spinner. In
addition, there are cases where we get a waiting event immediately
before ended, and this works around that.

Fixes videojs/http-streaming#1156