### PR TITLE
fix: prevent control bar clicks/taps with while hidden

### DIFF
--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -25,6 +25,7 @@
   // Remain visible for screen reader and keyboard users
   visibility: visible;
   opacity: 0;
+  pointer-events: none;
 
   $trans: visibility 1.0s, opacity 1.0s;
   @include transition($trans);

--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -25,6 +25,8 @@
   // Remain visible for screen reader and keyboard users
   visibility: visible;
   opacity: 0;
+  // prevent a click/tap from interacting with vjs-lock-showing menu's
+  // or other controls while we are inactive/hidden
   pointer-events: none;
 
   $trans: visibility 1.0s, opacity 1.0s;


### PR DESCRIPTION
## Description
1. On mobile tap a menu (such as the captions menu)
2. Wait for the menu to timeout and hide, but remember where the menu's position was on the player
3. Attempt to select one of the menu options, even though they are not visible
4. Notice that the menu item will be selected.

## Specific Changes proposed
Prevent `pointer-events` from being triggered on the control bar while it is hidden or going into a hidden state.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
