### PR TITLE
feat(time-ranges): make iteratable if Symbol.iterator exists

### DIFF
--- a/src/js/utils/time-ranges.js
+++ b/src/js/utils/time-ranges.js
@@ -2,6 +2,7 @@
  * @file time-ranges.js
  * @module time-ranges
  */
+import window from 'global/window';
 
 /**
  * Returns the time for the specified index at the start or end
@@ -94,8 +95,10 @@ function getRange(fnName, valueIndex, ranges, rangeIndex) {
  *          An array of time ranges.
  */
 function createTimeRangesObj(ranges) {
+  let timeRangesObj;
+
   if (ranges === undefined || ranges.length === 0) {
-    return {
+    timeRangesObj = {
       length: 0,
       start() {
         throw new Error('This TimeRanges object is empty');
@@ -104,12 +107,19 @@ function createTimeRangesObj(ranges) {
         throw new Error('This TimeRanges object is empty');
       }
     };
+  } else {
+    timeRangesObj = {
+      length: ranges.length,
+      start: getRange.bind(null, 'start', 0, ranges),
+      end: getRange.bind(null, 'end', 1, ranges)
+    };
   }
-  return {
-    length: ranges.length,
-    start: getRange.bind(null, 'start', 0, ranges),
-    end: getRange.bind(null, 'end', 1, ranges)
-  };
+
+  if (window.Symbol && window.Symbol.iterator) {
+    timeRangesObj[window.Symbol.iterator] = () => (ranges || []).values();
+  }
+
+  return timeRangesObj;
 }
 
 /**

--- a/test/unit/utils/time-ranges.test.js
+++ b/test/unit/utils/time-ranges.test.js
@@ -1,5 +1,6 @@
 /* eslint-env qunit */
 import { createTimeRanges, createTimeRange } from '../../../src/js/utils/time-ranges.js';
+import window from 'global/window';
 
 QUnit.module('time-ranges');
 
@@ -75,4 +76,22 @@ QUnit.test('should throw without being given an index', function(assert) {
     /Failed to execute 'end'/,
     'end throws if no index is given'
   );
+});
+
+let testOrSkip = 'skip';
+
+if (window.Symbol && window.Symbol.iterator) {
+  testOrSkip = 'test';
+}
+QUnit[testOrSkip]('Array.from works on our time ranges object', function(assert) {
+  const trRepresentation = [
+    [0, 10],
+    [20, 30]
+  ];
+  let tr = createTimeRanges(trRepresentation);
+
+  assert.deepEqual(Array.from(tr), trRepresentation, 'we got back what we put in');
+
+  tr = createTimeRanges(0, 10);
+  assert.deepEqual(Array.from(tr), [[0, 10]], 'we got back a ranges representation');
 });


### PR DESCRIPTION
This allows us to call `Array.from()` on TimeRange objects created by Video.js. For example:
```js
var input = [[0, 10], [20, 30]];
var timeRangeObj = videojs.createTimeRanges(input);
var output = Array.from(timeRangeObj);
assert.deepEqual(input, output, "they're the same!");
```