### PR TITLE
fix: Correctly dispose of html5 media element for chrome 92

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1322,8 +1322,7 @@ Html5.disposeMediaElement = function(el) {
     el.removeChild(el.firstChild);
   }
 
-  // remove any src reference. not setting `src=''` because that causes a warning
-  // in firefox
+  el.src = '';
   el.removeAttribute('src');
 
   // force the media element to update its loading state by calling load()

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1351,8 +1351,7 @@ Html5.resetMediaElement = function(el) {
     el.removeChild(sources[i]);
   }
 
-  // remove any src reference.
-  // not setting `src=''` because that throws an error
+  el.src = '';
   el.removeAttribute('src');
 
   if (typeof el.load === 'function') {


### PR DESCRIPTION
## Description
Chrome 92 requires media elements to be torn down completely before they are removed from memory. This includes unsetting the src property and removing the src attribute.

This is only an issue when a lot of players are created and disposed on a page. For us this mostly happens in tests.

The error in question:
Blocked attempt to create a WebMediaPlayer as there are too many WebMediaPlayers already in existence. See crbug.com/1144736#c27
