### PR TITLE
fix: evented should cleanup dom data

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -7,7 +7,6 @@ import window from 'global/window';
 import evented from './mixins/evented';
 import stateful from './mixins/stateful';
 import * as Dom from './utils/dom.js';
-import DomData from './utils/dom-data';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import {toTitleCase, toLowerCase} from './utils/string-cases.js';
@@ -178,9 +177,6 @@ class Component {
         this.el_.parentNode.removeChild(this.el_);
       }
 
-      if (DomData.has(this.el_)) {
-        DomData.delete(this.el_);
-      }
       this.el_ = null;
     }
 

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -8,6 +8,7 @@ import * as Events from '../utils/events';
 import * as Fn from '../utils/fn';
 import * as Obj from '../utils/obj';
 import EventTarget from '../event-target';
+import DomData from '../utils/dom-data';
 import log from '../utils/log';
 
 const objName = (obj) => {
@@ -499,6 +500,11 @@ function evented(target, options = {}) {
   // When any evented object is disposed, it removes all its listeners.
   target.on('dispose', () => {
     target.off();
+    [target, target.el_, target.eventBusEl_].forEach(function(val) {
+      if (val && DomData.has(val)) {
+        DomData.delete(val);
+      }
+    });
     window.setTimeout(() => {
       target.eventBusEl_ = null;
     }, 0);


### PR DESCRIPTION
## Description
Since `evented` is a mixin, it should cleanup after itself. I migrated the DomData cleanup from Component to the mixin dispose event listener.