### PR TITLE
Fix typo in de locale for progress bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -78,7 +78,7 @@
   "End of dialog window.": "Ende des Dialogfensters.",
   "Audio Player": "Audio-Player",
   "Video Player": "Video-Player",
-  "Progress Bar": "Forschrittsbalken",
+  "Progress Bar": "Fortschrittsbalken",
   "progress bar timing: currentTime={1} duration={2}": "{1} von {2}",
   "Volume Level": "Lautstärke",
   "{1} is loading.": "{1} wird geladen.",


### PR DESCRIPTION
## Description
Fix typoe in German translations for "progress bar"

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
