### PR TITLE
fix: prevent cached inactivityTimeout from being overwritten

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4141,7 +4141,9 @@ class Player extends Component {
     if (controlBar && !browser.IS_IOS && !browser.IS_ANDROID) {
 
       controlBar.on('mouseenter', function(event) {
-        this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
+        if (this.player().options_.inactivityTimeout !== 0) {
+          this.player().cache_.inactivityTimeout = this.player().options_.inactivityTimeout;
+        }
         this.player().options_.inactivityTimeout = 0;
       });
 


### PR DESCRIPTION
Fixes https://github.com/videojs/video.js/issues/7313

## Description
If multiple `mouseenter` events fire on the controlBar before a `mouseleave` event occurs, the cached inactivityTimeout value will get overwitten with a 0. This prevents the control bar from being hidden when the inactivity timeout is reached because the hide call is skipped when inactivityTimeout <= 0.

The circumstances around multiple `mouseenter` events firing before a `mouseleave` event are when a menubutton on the toolbar has its `update()` method called: the menu popup is disposed but a `mouseleave` event isn't fired for it. Once any mouse activity is detected the control bar's `mouseenter` fires again, wiping out the cached value.

An example of this occurring on a plugin https://github.com/FoxCouncil/videojs-max-quality-selector/issues/8

## Specific Changes proposed
This PR adds a check to the caching of the inactivityTimeout value to not set it if the current value is `0`. This is safe since the value is about to be set to `0` below, and the cache will already have the initial value stored in it (if it happened to already be `0`). So no negative change in behaviour should occur.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
