### PR TITLE
fix: remove deprecation of getComponent feature

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1706,11 +1706,6 @@ class Component {
    *
    * @return {Component}
    *         The `Component` that got registered under the given name.
-   *
-   * @deprecated In `videojs` 6 this will not return `Component`s that were not
-   *             registered using {@link Component.registerComponent}. Currently we
-   *             check the global `videojs` object for a `Component` name and
-   *             return that if it exists.
    */
   static getComponent(name) {
     if (!name || !Component.components_) {


### PR DESCRIPTION
Since Video.js 6, we've removed the deprecated functionality, we no longer need to have a deprecation warning.