### PR TITLE
fix: remove rule on small layout

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -34,7 +34,7 @@
     .vjs-subtitles-button,
     .vjs-audio-button,
     .vjs-volume-control {
-      display: none !important;
+      display: none;
     }
 
     // Reset the size of the volume panel to the default so we don't see a big


### PR DESCRIPTION
Previously we introduced _!important_ rule to override BC skin properties and fix the layout for small screens. I've done several tests in Chrome, Firefox and this is not longer needed, so we can safely remove it.
