### PR TITLE
fix(accessibility): avoid button names being read out twice by screen reader

### DIFF
--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -104,9 +104,6 @@ class ClickableComponent extends Component {
   createControlTextEl(el) {
     this.controlTextEl_ = Dom.createEl('span', {
       className: 'vjs-control-text'
-    }, {
-      // let the screen reader user know that the text of the element may change
-      'aria-live': 'polite'
     });
 
     if (el) {


### PR DESCRIPTION
fix #7450

## Description
Avoid button names being read out twice

Since the button elements are focused, any text changes are readout by the Screen Readers. Presence of aria-live is adding to the repeated read out.

## Background

At work we use a media-player that uses, video.js internally. Recently this issue (#7450) was flagged by the external accessibility auditor.

We mitigated it like so:

```js
  removeAriaLiveAttributes(rootElement) {
    const ariaLiveNodes = [...rootElement.querySelectorAll('[aria-live]')];
    ariaLiveNodes.forEach(ariaLiveNode => {
      ariaLiveNode.removeAttribute('aria-live');
    });
  }
```

Please `unmute` the below video to listen to the VoiceOver feedback.
https://user-images.githubusercontent.com/949380/135203949-23e41514-bdaf-4de8-a02f-e5297120c5a2.mp4

## Specific Changes proposed
>Please list the specific changes involved in this pull request.

Removed the `aria-live` attribute from the control buttons.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
