### PR TITLE
fix: volume button empty space

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -42,7 +42,8 @@
     .vjs-volume-panel.vjs-volume-panel-horizontal {
       &:hover,
       &:active,
-      &.vjs-slider-active {
+      &.vjs-slider-active,
+      &.vjs-hover {
         width: auto;
         width: initial;
       }

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -39,11 +39,13 @@
 
     // Reset the size of the volume panel to the default so we don't see a big
     // empty space to the right of the mute button.
-    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-      width: auto;
-      width: initial;
+    .vjs-volume-panel.vjs-volume-panel-horizontal {
+      &:hover,
+      &:active,
+      &.vjs-slider-active {
+        width: auto;
+        width: initial;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

When responsive mode is used and the player layout is small or smaller, an empty space appears to the right of the mute button on hover.

Fixes #7465 

## Specific Changes proposed

Add class vjs-hover to .vjs-volume-panel.vjs-volume-panel-horizontal.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
