### PR TITLE
fix: don't let the player be translated except captions

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -803,6 +803,8 @@ class Player extends Component {
     // if it's been set to something different to the doc
     this.el_.setAttribute('lang', this.language_);
 
+    this.el_.setAttribute('translate', 'no');
+
     this.el_ = el;
 
     return el;

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -218,6 +218,7 @@ class TextTrackDisplay extends Component {
     return super.createEl('div', {
       className: 'vjs-text-track-display'
     }, {
+      'translate': 'yes',
       'aria-live': 'off',
       'aria-atomic': 'true'
     });


### PR DESCRIPTION
This is another follow-up to #6699.

Potentially, it means we could get rid of #6977