### PR TITLE
fix: try again on volume feature detection on iOS

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1032,7 +1032,20 @@ Html5.canControlVolume = function() {
     const volume = Html5.TEST_VID.volume;
 
     Html5.TEST_VID.volume = (volume / 2) + 0.1;
-    return volume !== Html5.TEST_VID.volume;
+
+    const canControl = volume !== Html5.TEST_VID.volume;
+
+    // on latest iOS, there are cases where we read the volume as changed.
+    // In those cases, we should add a timeout and check again later.
+    // Since features doesn't currently work asynchronously,
+    // we then have to manually set the new value.
+    if (canControl && browser.IS_IOS) {
+      setTimeout(() => {
+        Html5.prototype.featuresVolumeControl = volume !== Html5.TEST_VID.volume;
+      });
+    }
+
+    return canControl;
   } catch (e) {
     return false;
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1040,7 +1040,7 @@ Html5.canControlVolume = function() {
     // Since features doesn't currently work asynchronously,
     // we then have to manually set the new value.
     if (canControl && browser.IS_IOS) {
-      setTimeout(() => {
+      window.setTimeout(() => {
         Html5.prototype.featuresVolumeControl = volume !== Html5.TEST_VID.volume;
       });
     }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1035,10 +1035,11 @@ Html5.canControlVolume = function() {
 
     const canControl = volume !== Html5.TEST_VID.volume;
 
-    // on latest iOS, there are cases where we read the volume as changed.
-    // In those cases, we should add a timeout and check again later.
-    // Since features doesn't currently work asynchronously,
-    // we then have to manually set the new value.
+    // With the introduction of iOS 15, there are cases where the volume is read as
+    // changed but reverts back to its original state at the start of the next tick.
+    // To determine whether volume can be controlled on iOS,
+    // a timeout is set and the volume is checked asynchronously.
+    // Since `features` doesn't currently work asynchronously, the value is manually set.
     if (canControl && browser.IS_IOS) {
       window.setTimeout(() => {
         Html5.prototype.featuresVolumeControl = volume !== Html5.TEST_VID.volume;


### PR DESCRIPTION
On latest iOS, we are seeing times when the volume feature detection is
showing that we are able to change the volume, though, that is not the
case. Instead, on iOS, when we detect that we can control the volume, we
set a short timer to retest and reset the featuresVolumeControl property.

Fixes #7040