### PR TITLE
fix: turn off other tracks with native audio track

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -80,6 +80,22 @@ class AudioTrackMenuItem extends MenuItem {
     // the audio track list will automatically toggle other tracks
     // off for us.
     this.track.enabled = true;
+
+    // when native audio tracks are used, we want to make sure that other tracks are turned off
+    if (this.player_.tech_.featuresNativeAudioTracks) {
+      const tracks = this.player_.audioTracks();
+
+      for (let i = 0; i < tracks.length; i++) {
+        const track = tracks[i];
+
+        // skip the current track since we enabled it above
+        if (track === this.track) {
+          continue;
+        }
+
+        track.enabled = track === this.track;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Audio Tracks are supposed to allow multiple tracks at the same time.
Safari 15 has added, at least partial support for this.

In #7163, we stopped turning other tracks of manually since we already
were doing so in the AudioTrackList. However, this only worked for
non-native AudioTracks. Before Safari 15, Safari automatically turned
off the other tracks for us so things continued to work.

With this change, when native audio tracks are used, we will turn off
the other tracks, partially reverting #7163.

We currently do not have any tests or are set up for writing tests for
these proxy tracks. Adding such tests will take too long for not a lot
of benefit, unfortunately.

Fixes #7494.