### PR TITLE
fix: regression with AD audio track menu items

### DIFF
--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -3,6 +3,7 @@
  */
 import MenuItem from '../../menu/menu-item.js';
 import Component from '../../component.js';
+import * as Dom from '../../utils/dom.js';
 
 /**
  * An {@link AudioTrack} {@link MenuItem}
@@ -49,14 +50,14 @@ class AudioTrackMenuItem extends MenuItem {
     const parentSpan = el.querySelector('.vjs-menu-item-text');
 
     if (this.options_.track.kind === 'main-desc') {
-      parentSpan.appendChild(super.createEl('span', {
+      parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-icon-placeholder'
       }, {
         'aria-hidden': true
       }));
-      parentSpan.appendChild(super.createEl('span', {
+      parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-control-text',
-        textContent: this.localize('Descriptions')
+        textContent: ' ' + this.localize('Descriptions')
       }));
     }
 


### PR DESCRIPTION
In #7337, a lot of code was updated to no longer user innerHTML, but we
accidentally caused an issue with Audio Description (AD) tracks where
the track title was included twice. Once before and once after the AD
icon.

This is because we were calling `super.createEl()` but MenuItem created
a specific element and didn't just pass things the arguments along.
Instead, we should use `Dom.createEl()` directly.

Fixes #7556