### PR TITLE
feat: make negative sign on remaining time optional

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -7,6 +7,7 @@
 * [Standard &lt;video> Element Options](#standard-video-element-options)
   * [autoplay](#autoplay)
     * [More info on autoplay support and changes:](#more-info-on-autoplay-support-and-changes)
+  * [controlBar.remainingTimeDisplay.displayNegative](#controlbarremainingtimedisplaydisplaynegative)
   * [controls](#controls)
   * [height](#height)
   * [loop](#loop)
@@ -99,6 +100,12 @@ player.autoplay('muted');
 #### More info on autoplay support and changes:
 
 * See our blog post: [Autoplay Best Practices with Video.js](https://videojs.com/blog/autoplay-best-practices-with-video-js/)
+
+### `controlBar.remainingTimeDisplay.displayNegative`
+
+> Type: `boolean`
+
+Bu default the remaining time display shows as negative time. To not show the negative sign set `controlBar.remainingTimeDisplay.displayNegative` to `false`.
 
 ### `controls`
 

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -45,7 +45,9 @@ class RemainingTimeDisplay extends TimeDisplay {
   createEl() {
     const el = super.createEl();
 
-    el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);
+    if (this.options_.displayNegative !== false) {
+      el.insertBefore(Dom.createEl('span', {}, {'aria-hidden': true}, '-'), this.contentEl_);
+    }
     return el;
   }
 

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -10,6 +10,7 @@ import PictureInPictureToggle from '../../src/js/control-bar/picture-in-picture-
 import FullscreenToggle from '../../src/js/control-bar/fullscreen-toggle.js';
 import ControlBar from '../../src/js/control-bar/control-bar.js';
 import SeekBar from '../../src/js/control-bar/progress-control/seek-bar.js';
+import RemainingTimeDisplay from '../../src/js/control-bar/time-controls/remaining-time-display.js';
 import TestHelpers from './test-helpers.js';
 import document from 'global/document';
 import sinon from 'sinon';
@@ -439,4 +440,20 @@ QUnit.test('all controlbar children to false, does not cause an assertion', func
   player.triggerReady();
   player.dispose();
   assert.ok(true, 'did not cause an assertion');
+});
+
+QUnit.test('Remaing time negative sign can be optional', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+
+  const rtd1 = new RemainingTimeDisplay(player);
+  const rtd2 = new RemainingTimeDisplay(player, {displayNegative: false});
+
+  this.clock.tick(1);
+
+  assert.ok(rtd1.el().textContent.indexOf('-') > 0, 'Value is negative by default');
+  assert.equal(rtd2.el().textContent.indexOf('-'), -1, 'Value is positive with option');
+
+  rtd1.dispose();
+  rtd2.dispose();
+  player.dispose();
 });


### PR DESCRIPTION
## Description
Make the negative sign on the remaining time display optional. Closes #7565 

## Specific Changes proposed
Adds `displayNegative` to `RemainingTimeDisplay` which defaults to true for current behaviour. Can be set to `false` to remove the - sign.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
