### PR TITLE
Introduce an option to allow disabling of extra event data being added to events triggered by advanced plugins

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -45,6 +45,7 @@
   * [suppressNotSupportedError](#suppressnotsupportederror)
   * [techCanOverridePoster](#techcanoverrideposter)
   * [techOrder](#techorder)
+  * [includeExtraPluginEventData](#includeextraplugineventdata)
   * [userActions](#useractions)
   * [userActions.click](#useractionsclick)
   * [userActions.doubleClick](#useractionsdoubleclick)
@@ -446,6 +447,18 @@ This can be useful when multiple techs are used and each has to set their own po
 > Type: `Array`, Default: `['html5']`
 
 Defines the order in which Video.js techs are preferred. By default, this means that the `Html5` tech is preferred. Other registered techs will be added after this tech in the order in which they are registered.
+
+### `includeExtraPluginEventData`
+
+> Type: `boolean`, Default: `true`
+
+When enabled, custom events emitted by _advanced_ plugins, via calls to `Plugin.trigger`, will include an additional data object as a second argument. The object has three properties:
+
+* `name`: The name of the plugin (e.g `"examplePlugin"`) as a string.
+* `plugin`: The plugin constructor (e.g `ExamplePlugin`).
+* `instance`: The plugin constructor instance
+
+If custom event data is provided to `Plugin.trigger`, the above fields will be merged with that data.
 
 ### `userActions`
 

--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -242,9 +242,14 @@ class Plugin {
    *          An event hash object with provided properties mixed-in.
    */
   getEventHash(hash = {}) {
-    hash.name = this.name;
-    hash.plugin = this.constructor;
-    hash.instance = this;
+    const { includeExtraPluginEventData } = this.player.options();
+
+    if (includeExtraPluginEventData) {
+      hash.name = this.name;
+      hash.plugin = this.constructor;
+      hash.instance = this;
+    }
+
     return hash;
   }
 

--- a/test/unit/plugin-advanced.test.js
+++ b/test/unit/plugin-advanced.test.js
@@ -193,6 +193,30 @@ QUnit.test('arbitrary events', function(assert) {
   }, 'the event hash object is correct');
 });
 
+QUnit.test('arbitrary events do not include additional fields when `includeExtraPluginEventData` option is false', function(assert) {
+  const fooSpy = sinon.spy();
+
+  this.player = TestHelpers.makePlayer({
+    includeExtraPluginEventData: false
+  });
+
+  const instance = this.player.mock();
+
+  instance.on('foo', fooSpy);
+  instance.trigger('foo', { customProperty: 'custom-value' });
+
+  const event = fooSpy.firstCall.args[0];
+  const hash = fooSpy.firstCall.args[1];
+
+  assert.strictEqual(fooSpy.callCount, 1, 'the "foo" event was triggered');
+  assert.strictEqual(event.type, 'foo', 'the event has the correct type');
+  assert.strictEqual(event.target, instance.eventBusEl_, 'the event has the correct target');
+
+  assert.deepEqual(hash, {
+    customProperty: 'custom-value'
+  }, 'the event hash includes user-provided properties but not additional videojs-provided data about the plugin');
+});
+
 QUnit.test('handleStateChanged() method is automatically bound to the "statechanged" event', function(assert) {
   const spy = sinon.spy();
 


### PR DESCRIPTION
## Description
Today, custom events that are triggered by advanced plugins via `Plugin.trigger` include three additional fields, populated by video.js: `name`, `instance`, `plugin`. In some cases, having these fields auto-included can be confusing, and in other cases problematic (e.g name collision). I provide a library that allows consumers to create plugins and often have to explain to these consumers why there are unexpected fields in their event payloads. This can be solved by making these fields optional.

## Specific Changes proposed
I've introduced a new option, `includeExtraPluginEventData`, which is `false` by default for backward compatibility. When enabled, the `name`, `plugin` and `instance` fields will not be auto-included in event payloads emitted by calls to `Plugin.trigger`.

A couple of notes/design decisions that I'd like feedback on from the community:
1. This change only applies to advanced plugins. I made this decision since consumers likely are not interacting with the default events emitted by basic plugins and, if they are, should be fine with whatever system information is included in those payloads. Custom events, on the other hand, should provide a payload that matches that which the user created.
2. This option is implemented at the player level, as opposed to being enabled by each plugin. I felt that this API was easier to understand and simpler to implement. While it does add overhead to the global options object, it will make configuration simpler for the end-user.

## Requirements Checklist
- [ x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ x ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [  x ] Unit Tests updated or fixed
  - [ x ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
