### PR TITLE
Display time tooltip for mobile when sliding

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -129,7 +129,9 @@
 }
 
 .video-js .vjs-progress-control:hover .vjs-time-tooltip,
-.video-js .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
+.video-js .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip,
+// For mobile
+.video-js .vjs-progress-control .vjs-sliding .vjs-time-tooltip {
   display: block;
 
   // Ensure that we maintain a font-size of ~10px.

--- a/src/js/control-bar/progress-control/play-progress-bar.js
+++ b/src/js/control-bar/progress-control/play-progress-bar.js
@@ -2,7 +2,6 @@
  * @file play-progress-bar.js
  */
 import Component from '../../component.js';
-import {IS_IOS, IS_ANDROID} from '../../utils/browser.js';
 import * as Fn from '../../utils/fn.js';
 
 import './time-tooltip';
@@ -79,10 +78,7 @@ PlayProgressBar.prototype.options_ = {
   children: []
 };
 
-// Time tooltips should not be added to a player on mobile devices
-if (!IS_IOS && !IS_ANDROID) {
-  PlayProgressBar.prototype.options_.children.push('timeTooltip');
-}
+PlayProgressBar.prototype.options_.children.push('timeTooltip');
 
 Component.registerComponent('PlayProgressBar', PlayProgressBar);
 export default PlayProgressBar;


### PR DESCRIPTION
Hi :)

## Description

Display time tooltip when sliding on mobile. Without this, it's difficult to move to the desired timestamp on android/ios.

## Specific Changes proposed

Enable `timeTooltip` for mobile and adapt CSS to always display it when sliding.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
