### PR TITLE
feat: Assume DASH MIME type when an MPD source URL is given

### DIFF
--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -3,7 +3,7 @@ import * as Url from '../utils/url.js';
 /**
  * Mimetypes
  *
- * @see http://hul.harvard.edu/ois/////systems/wax/wax-public-help/mimetypes.htm
+ * @see https://www.iana.org/assignments/media-types/media-types.xhtml
  * @typedef Mimetypes~Kind
  * @enum
  */

--- a/src/js/utils/mimetypes.js
+++ b/src/js/utils/mimetypes.js
@@ -22,6 +22,7 @@ export const MimetypesKind = {
   oga: 'audio/ogg',
   wav: 'audio/wav',
   m3u8: 'application/x-mpegURL',
+  mpd: 'application/dash+xml',
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   gif: 'image/gif',


### PR DESCRIPTION
## Description

Since [http-streaming](https://github.com/videojs/http-streaming) plays DASH, adding this feature will allow a DASH source to be provided without necessarily indicating the media type. 

```JavaScript 
player.src('https://domain.com/video.mpd') //👌
```

## Specific Changes proposed

- [x] Add `application/dash+xml` to the [MimetypesKind](https://github.com/videojs/video.js/blob/main/src/js/utils/mimetypes.js#L10) object
- [x] Update old unavailable link listing different mime types

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
