### PR TITLE
fix(accessibility): By default, show track selection buttons at all responsive breakpoints

### DIFF
--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -4,18 +4,23 @@
 // - Play button
 // - Volume Mute button
 // - Progress bar
-// - Subs-Caps button
+// - Track buttons
+// - Native PiP button
 // - Fullscreen button
 //
-// When the player is "small", display only:
+// When the player is "x-small", display only:
 // - Play button
 // - Volume Mute button
-// - Progress bar
+// - Spacer
+// - Track buttons
+// - Native PiP button
 // - Fullscreen button
 //
 // When the player is "tiny", display only:
 // - Play button
 // - Volume Mute button
+// - Track buttons
+// - Native PiP button
 // - Fullscreen Button
 //
 .video-js {
@@ -28,11 +33,6 @@
     .vjs-duration,
     .vjs-remaining-time,
     .vjs-playback-rate,
-    .vjs-chapters-button,
-    .vjs-descriptions-button,
-    .vjs-captions-button,
-    .vjs-subtitles-button,
-    .vjs-audio-button,
     .vjs-volume-control {
       display: none;
     }
@@ -50,20 +50,18 @@
     }
   }
 
-  // Hide the subs-caps button for non-Live UI "x-small" and for "tiny" players.
-  &.vjs-layout-x-small:not(.vjs-liveui),
-  &.vjs-layout-x-small:not(.vjs-live),
+  // At x-small and tiny, the progress control is too narrow to be useful.
+  &.vjs-layout-x-small,
   &.vjs-layout-tiny {
-    .vjs-subs-caps-button {
+
+    .vjs-progress-control {
       display: none;
     }
   }
 
-  // With the new Live UI, we can have the same treatment as "tiny". At
-  // "x-small", the Live UI makes the progress control very small and almost
-  // useless.
-  &.vjs-layout-x-small.vjs-liveui,
-  &.vjs-layout-tiny {
+  // At x-small, the buttons alone leave a large gap on the right. Fill it with
+  // the spacer element.
+  &.vjs-layout-x-small {
 
     .vjs-custom-control-spacer {
       @include flex(auto);
@@ -72,10 +70,6 @@
 
     &.vjs-no-flex .vjs-custom-control-spacer {
       width: auto;
-    }
-
-    .vjs-progress-control {
-      display: none;
     }
   }
 }


### PR DESCRIPTION
## Description
This addresses a possible accessibility issue. It was noticed that the subtitles/captions button was hidden by default at responsive breakpoints `x-small` and `tiny`. This meant, by default, on players 320px or narrower, that the subtitles/captions button was inaccessible.

## Specific Changes proposed
- Display all track selection buttons, by default, at all sizes.
- Hide the progress control at `x-small` and `tiny` (instead of only when using the new Live UI at `x-small`)

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
