### PR TITLE
Fix chapters

### DIFF
--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -30,7 +30,7 @@ class ChaptersButton extends TextTrackButton {
   constructor(player, options, ready) {
     super(player, options, ready);
 
-    this.selectCurrentChild_ = () => {
+    this.selectCurrentItem_ = () => {
       this.items.forEach(item => {
         item.selected(this.track_.activeCues[0] === item.cue);
       });
@@ -69,11 +69,10 @@ class ChaptersButton extends TextTrackButton {
     const track = this.findChaptersTrack();
 
     if (track !== this.track_) {
-      // Set new track
       this.setTrack(track);
       super.update();
     } else if (!this.items || (track && track.cues && track.cues.length !== this.items.length)) {
-      // Update the menu initially and if the number of cues has changed
+      // Update the menu initially or if the number of cues has changed since set
       super.update();
     }
   }
@@ -102,7 +101,7 @@ class ChaptersButton extends TextTrackButton {
         remoteTextTrackEl.removeEventListener('load', this.updateHandler_);
       }
 
-      this.track_.removeEventListener('cuechange', this.selectCurrentChild_);
+      this.track_.removeEventListener('cuechange', this.selectCurrentItem_);
 
       this.track_ = null;
     }
@@ -119,7 +118,7 @@ class ChaptersButton extends TextTrackButton {
         remoteTextTrackEl.addEventListener('load', this.updateHandler_);
       }
 
-      this.track_.addEventListener('cuechange', this.selectCurrentChild_);
+      this.track_.addEventListener('cuechange', this.selectCurrentItem_);
     }
   }
 

--- a/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/chapters-track-menu-item.js
@@ -3,7 +3,6 @@
  */
 import MenuItem from '../../menu/menu-item.js';
 import Component from '../../component.js';
-import * as Fn from '../../utils/fn.js';
 
 /**
  * The chapter track menu item
@@ -35,7 +34,6 @@ class ChaptersTrackMenuItem extends MenuItem {
 
     this.track = track;
     this.cue = cue;
-    track.addEventListener('cuechange', Fn.bind(this, this.update));
   }
 
   /**
@@ -52,23 +50,6 @@ class ChaptersTrackMenuItem extends MenuItem {
   handleClick(event) {
     super.handleClick();
     this.player_.currentTime(this.cue.startTime);
-    this.update(this.cue.startTime);
-  }
-
-  /**
-   * Update chapter menu item
-   *
-   * @param {EventTarget~Event} [event]
-   *        The `cuechange` event that caused this function to run.
-   *
-   * @listens TextTrack#cuechange
-   */
-  update(event) {
-    const cue = this.cue;
-    const currentTime = this.player_.currentTime();
-
-    // vjs.log(currentTime, cue.startTime);
-    this.selected(cue.startTime <= currentTime && currentTime < cue.endTime);
   }
 
 }

--- a/test/unit/tracks/text-track-controls.test.js
+++ b/test/unit/tracks/text-track-controls.test.js
@@ -527,3 +527,46 @@ QUnit.test('chapters should be displayed when remote track added and load event 
 
   player.dispose();
 });
+
+QUnit.test('chapters button should update selected menu item', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  this.clock.tick(1000);
+
+  const chaptersEl = player.addRemoteTextTrack(chaptersTrack, true);
+
+  chaptersEl.track.addCue({
+    startTime: 0,
+    endTime: 2,
+    text: 'Chapter 1'
+  });
+  chaptersEl.track.addCue({
+    startTime: 2,
+    endTime: 4,
+    text: 'Chapter 2'
+  });
+
+  assert.equal(chaptersEl.track.cues.length, 2);
+
+  if (player.tech_.featuresNativeTextTracks) {
+    TestHelpers.triggerDomEvent(chaptersEl, 'load');
+  } else {
+    chaptersEl.trigger('load');
+  }
+
+  const menuItems = player.controlBar.chaptersButton.items;
+
+  assert.ok(menuItems.find(i => i.isSelected_) === menuItems[0], 'item with startTime 0 selected on init');
+
+  player.currentTime(4);
+  player.trigger('timeupdate');
+
+  assert.ok(menuItems.find(i => i.isSelected_) === menuItems[1], 'second item selected on cuechange');
+
+  player.currentTime(1);
+  player.trigger('timeupdate');
+
+  assert.ok(menuItems.find(i => i.isSelected_) === menuItems[0], 'first item selected on cuechange');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description
The chapters button can create its menu multiple times if several tracks of any kind are present, and each menu item adds an event listener on the track which is not removed when it is replaced.

## Specific Changes proposed
Reduces the instances the menu will be created.
Switches to a single event listener on the menu button to manage its menu's selected item.
Fixes #7595

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
