### PR TITLE
feat: Add text button, and component options

### DIFF
--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -95,7 +95,7 @@ myButton.controlText('def');
 The control text of a button is normally not visible (but present for screen readers) as the default buttons all display only an icon. The text can be displayed by adding a `vjs-text-visible` class to the button. This or any other class may be set as a setup option, or later by API.
 
 ```js
-const myButton = player.addChild('button', {class: 'vjs-text-visible'});
+const myButton = player.addChild('button', {className: 'vjs-text-visible'});
 ```
 
 or set later:

--- a/docs/guides/components.md
+++ b/docs/guides/components.md
@@ -63,9 +63,10 @@ console.log(button.el());
 The above code will output
 
 ```html
-<div class="video-js">
-  <div class="vjs-button">Button</div>
-</div>
+<button class="vjs-control vjs-button" type="button" aria-disabled="false">
+  <span class="vjs-icon-placeholder" aria-hidden="true"></span>
+  <span class="vjs-control-text" aria-live="polite"></span>
+</button>
 ```
 
 Adding the new button to the player
@@ -77,6 +78,30 @@ var button = player.addChild('button');
 
 console.log(button.el());
 // will have the same html result as the previous example
+```
+
+The text of the button can be set as an option:
+
+```js
+const myButton = player.addChild('button', {controlText: 'abc'});
+```
+
+or set later:
+
+```js
+myButton.controlText('def');
+```
+
+The control text of a button is normally not visible (but present for screen readers) as the default buttons all display only an icon. The text can be displayed by adding a `vjs-text-visible` class to the button. This or any other class may be set as a setup option, or later by API.
+
+```js
+const myButton = player.addChild('button', {class: 'vjs-text-visible'});
+```
+
+or set later:
+
+```js
+myButton.addClass('vjs-text-visible');
 ```
 
 ## Component Children

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -9,8 +9,14 @@
   height: 100%;
   width: 4em;
   @include flex(none);
-
 }
+
+.video-js .vjs-control.vjs-visible-text {
+  width: unset;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
 .vjs-button > .vjs-icon-placeholder:before {
   font-size: 1.8em;
   line-height: 1.67;
@@ -30,7 +36,7 @@
 }
 
 // Hide control text visually, but have it available for screenreaders
-.video-js .vjs-control-text {
+.video-js *:not(.vjs-visible-text) > .vjs-control-text {
   @include hide-visually;
 }
 

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -12,7 +12,7 @@
 }
 
 .video-js .vjs-control.vjs-visible-text {
-  width: unset;
+  width: auto;
   padding-left: 1em;
   padding-right: 1em;
 }

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -22,13 +22,25 @@ class ClickableComponent extends Component {
    *         The `Player` that this class should be attached to.
    *
    * @param  {Object} [options]
-   *         The key/value store of player options.
+   *         The key/value store of component options.
    *
    * @param  {function} [options.clickHandler]
    *         The function to call when the button is clicked / activated
+   *
+   * @param  {string} [options.controlText]
+   *         The text to set on the button
+   *
+   * @param  {string} [options.className]
+   *         A class or space separated list of classes to add the component
+   *
    */
   constructor(player, options) {
+
     super(player, options);
+
+    if (this.options_.controlText) {
+      this.controlText(this.options_.controlText);
+    }
 
     this.handleMouseOver_ = (e) => this.handleMouseOver(e);
     this.handleMouseOut_ = (e) => this.handleMouseOut(e);

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -40,12 +40,15 @@ class Component {
    *        The `Player` that this class should be attached to.
    *
    * @param {Object} [options]
-   *        The key/value store of player options.
+   *        The key/value store of component options.
    *
    * @param {Object[]} [options.children]
    *        An array of children objects to intialize this component with. Children objects have
    *        a name property that will be used if more than one component of the same type needs to be
    *        added.
+   *
+   * @param  {string} [options.className]
+   *         A class or space separated list of classes to add the component
    *
    * @param {Component~ReadyCallback} [ready]
    *        Function that gets called when the `Component` is ready.
@@ -88,6 +91,10 @@ class Component {
       this.el_ = options.el;
     } else if (options.createEl !== false) {
       this.el_ = this.createEl();
+    }
+
+    if (options.className && this.el_) {
+      options.className.split(' ').forEach(c => this.addClass(c));
     }
 
     // if evented is anything except false, we want to mixin in evented

--- a/test/unit/clickable-component.test.js
+++ b/test/unit/clickable-component.test.js
@@ -140,3 +140,17 @@ QUnit.test('language change should localize its text', function(assert) {
   testClickableComponent.dispose();
   player.dispose();
 });
+
+QUnit.test('class and text should be settable from options', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const testClickableComponent = new ClickableComponent(player, {
+    className: 'class1',
+    controlText: 'some text'
+  });
+
+  assert.equal(testClickableComponent.controlText(), 'some text', 'text was set');
+  assert.ok(testClickableComponent.hasClass('class1'), 'class was set');
+
+  testClickableComponent.dispose();
+  player.dispose();
+});

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -677,6 +677,21 @@ QUnit.test('should add and remove a CSS class', function(assert) {
   comp.dispose();
 });
 
+QUnit.test('should add CSS class passed in options', function(assert) {
+  const comp = new Component(this.player, {className: 'class1 class2'});
+
+  assert.ok(comp.el().className.indexOf('class1') !== -1, 'first of multiple classes added');
+  assert.ok(comp.el().className.indexOf('class2') !== -1, 'second of multiple classes added');
+
+  comp.dispose();
+
+  const comp2 = new Component(this.player, {className: 'class1'});
+
+  assert.ok(comp2.el().className.indexOf('class1') !== -1, 'singe class added');
+
+  comp2.dispose();
+});
+
 QUnit.test('should show and hide an element', function(assert) {
   const comp = new Component(this.player, {});
 


### PR DESCRIPTION
## Description
Makes it a little easier to add ad hoc components, particularly buttons. Most significant change is a class to allow buttons that display their control text without having to add styles to unset the default styles. Also allows class(es) and control text to be included as component options for simplicity.

## Specific Changes proposed
* Adds a `.vjs-visible-text` class for controls. This omits the styles to hide control text, unsets button width and adds some padding.
* Adds `controlText` as an option to `ClickableComponent`, so text can be passed as a setup option.
* Adds `className` as an option to `Component`, so additional classes can be passed as a setup option.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [x] Example created at https://codepen.io/mister-ben/pen/oNGmOVv
- [ ] Reviewed by Two Core Contributors
