### PR TITLE
play promise error prevention

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2345,7 +2345,7 @@ class Player extends Component {
     if (PromiseClass) {
       return new PromiseClass((resolve) => {
         this.play_(resolve);
-      });
+      }).catch();
     }
 
     return this.play_();


### PR DESCRIPTION
## Description
If the vast plugin starts a vast ad it pauses the player.
Because the player before has applied a play promise the browser will throw the error:
Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().

## Specific Changes proposed
To not having an error displayed in the console I added a catch pipe to the play promise to handle the thrown error

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
