### PR TITLE
Fix: Fixing playback rate iteration if rates are not in the ascending order

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -115,17 +115,11 @@ class PlaybackRateMenuButton extends MenuButton {
     // select next rate option
     const currentRate = this.player().playbackRate();
     const rates = this.playbackRates();
+    const currentIndex = rates.indexOf(currentRate);
+    // this get the next rate and it will select first one if the last one currently selected
+    const newIndex = (currentIndex + 1) % rates.length;
 
-    // this will select first one if the last one currently selected
-    let newRate = rates[0];
-
-    for (let i = 0; i < rates.length; i++) {
-      if (rates[i] > currentRate) {
-        newRate = rates[i];
-        break;
-      }
-    }
-    this.player().playbackRate(newRate);
+    this.player().playbackRate(rates[newIndex]);
   }
 
   /**


### PR DESCRIPTION
On the playback rate button's click, the iteration over all possible rates will not happen as expected. E.g. if you follow youtube's pattern ([ 2, 1.75, 1.5, 1.25, 1, 0.75, 0.5, 0.25 ]), and click on the playback rate button it will change to 2x and you won't be able to change it anymore.

## Description
Fixes #7617

## Specific Changes proposed
The iteration over the rates array are now done by the array's index.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
