### PR TITLE
feat: Add audioPosterMode option

### DIFF
--- a/docs/guides/options.md
+++ b/docs/guides/options.md
@@ -21,6 +21,7 @@
   * [width](#width)
 * [Video.js-specific Options](#videojs-specific-options)
   * [aspectRatio](#aspectratio)
+  * [audioPosterMode](#audiopostermode)
   * [autoSetup](#autosetup)
   * [breakpoints](#breakpoints)
   * [children](#children)
@@ -180,6 +181,13 @@ Each option is `undefined` by default unless otherwise specified.
 Puts the player in [fluid](#fluid) mode and the value is used when calculating the dynamic size of the player. The value should represent a ratio - two numbers separated by a colon (e.g. `"16:9"` or `"4:3"`).
 
 Alternatively, the classes `vjs-16-9`, `vjs-9-16`, `vjs-4-3` or `vjs-1-1` can be added to the player.
+
+### `audioPosterMode`
+
+> Type: `boolean`
+> Default: `false`
+
+If set to true, it enables the poster viewer experience by hiding the video element and displaying the poster image persistently. This option can be set to `true` or `false` by calling `audioPosterMode([true|false])` at runtime.
 
 ### `autoSetup`
 

--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -16,22 +16,14 @@
   height: 100%;
 }
 
-// Hide the poster after the video has started playing
-.vjs-has-started .vjs-poster {
-  display: none;
-}
-
-// Don't hide the poster if we're playing audio
-.vjs-audio.vjs-has-started .vjs-poster {
-  display: block;
-}
-
-// Hide the poster when native controls are used otherwise it covers them
+// Hide the poster after the video has started playing and when native controls are used
+.vjs-has-started .vjs-poster,
 .vjs-using-native-controls .vjs-poster {
   display: none;
 }
 
-// Don't hide the poster when audio-poster-mode is true
-.vjs-has-started.vjs-audio-poster-mode .vjs-poster {
+// Don't hide the poster if we're playing audio or when audio-poster-mode is true
+.vjs-audio.vjs-has-started .vjs-poster, 
+.vjs-has-started.vjs-audio-poster-mode  .vjs-poster {
   display: block;
 }

--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -30,3 +30,8 @@
 .vjs-using-native-controls .vjs-poster {
   display: none;
 }
+
+// Don't hide the poster when audio-poster-mode is true
+.vjs-has-started.vjs-audio-poster-mode .vjs-poster {
+  display: block;
+}

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -349,8 +349,6 @@ class Player extends Component {
       }
     }
 
-    options.audioPosterMode = false;
-
     // Run base component initializing with new options
     super(null, options, ready);
 
@@ -4303,10 +4301,13 @@ class Player extends Component {
    */
   audioPosterMode(value) {
 
-    if (value === undefined) {
+    value = value && Boolean(value);
+
+    if (value === undefined || value === this.options_.audioPosterMode) {
       return this.options_.audioPosterMode;
     }
-    this.options_.audioPosterMode = !!value && !this.options_.audioOnlyMode;
+
+    this.options_.audioPosterMode = value;
 
     if (this.options_.audioPosterMode) {
       this.tech_.hide();
@@ -5124,7 +5125,8 @@ Player.prototype.options_ = {
   },
 
   breakpoints: {},
-  responsive: false
+  responsive: false,
+  audioPosterMode: false
 };
 
 [

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4301,15 +4301,19 @@ class Player extends Component {
    */
   audioPosterMode(value) {
 
-    value = value && Boolean(value);
-
-    if (value === undefined || value === this.options_.audioPosterMode) {
-      return this.options_.audioPosterMode;
+    if (this.audioPosterMode_ === undefined) {
+      this.audioPosterMode_ = this.options_.audioPosterMode;
     }
 
-    this.options_.audioPosterMode = value;
+    value = value && Boolean(value);
 
-    if (this.options_.audioPosterMode) {
+    if (value === undefined || typeof value !== 'boolean' || value === this.audioPosterMode_) {
+      return this.audioPosterMode_;
+    }
+
+    this.audioPosterMode_ = value;
+
+    if (this.audioPosterMode_) {
       this.tech_.hide();
       this.addClass('vjs-audio-poster-mode');
       return;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4305,9 +4305,7 @@ class Player extends Component {
       this.audioPosterMode_ = this.options_.audioPosterMode;
     }
 
-    value = value && Boolean(value);
-
-    if (value === undefined || typeof value !== 'boolean' || value === this.audioPosterMode_) {
+    if (typeof value !== 'boolean' || value === this.audioPosterMode_) {
       return this.audioPosterMode_;
     }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -349,6 +349,8 @@ class Player extends Component {
       }
     }
 
+    options.audioPosterMode = false;
+
     // Run base component initializing with new options
     super(null, options, ready);
 
@@ -4288,6 +4290,32 @@ class Player extends Component {
     }
 
     return !!this.isAudio_;
+  }
+
+  /**
+   * Get the current audioPosterMode state or set audioPosterMode to true or false
+   *
+   * @param {boolean} [value]
+   *         The value to set audioPosterMode to.
+   *
+   * @return {boolean}
+   *         True if audioPosterMode is on, false otherwise.
+   */
+  audioPosterMode(value) {
+
+    if (value === undefined) {
+      return this.options_.audioPosterMode;
+    }
+    this.options_.audioPosterMode = !!value && !this.options_.audioOnlyMode;
+
+    if (this.options_.audioPosterMode) {
+      this.tech_.hide();
+      this.addClass('vjs-audio-poster-mode');
+      return;
+    }
+    // Show the video element and hide the poster image if audioPosterMode is set to false
+    this.tech_.show();
+    this.removeClass('vjs-audio-poster-mode');
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1570,19 +1570,37 @@ QUnit.test('should add an audio player region if an audio el is used', function(
   player.dispose();
 });
 
-QUnit.test('should turn on/off audioPosterMode when audioPosterMode is called with true/false', function(assert) {
+QUnit.test('default audioPosterMode value at player creation', function(assert) {
   const player = TestHelpers.makePlayer({});
 
-  assert.ok(player.options_.audioPosterMode === false, 'audioPosterMode is initially false');
-  player.options_.audioOnlyMode = true;
+  assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false by default');
+
+  const player2 = TestHelpers.makePlayer({
+    audioPosterMode: true
+  });
+
+  assert.ok(player2.audioPosterMode() === true, 'audioPosterMode can be set to true when the player is created');
+  player.dispose();
+  player2.dispose();
+});
+
+QUnit.test('get and set audioPosterMode value', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
   player.audioPosterMode(true);
-  assert.ok(player.options_.audioPosterMode === false, 'audioPosterMode is cannot be set to true if audioOnlyMode is true');
-  player.options_.audioOnlyMode = false;
+  assert.ok(player.audioPosterMode() === true, 'audioPosterMode is set to true');
+});
+
+QUnit.test('vjs-audio-poster-mode class and video element visibility when audioPosterMode is true', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
   player.audioPosterMode(true);
-  assert.ok(player.options_.audioPosterMode === true, 'audioPosterMode is set to true');
-  assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is added');
+  assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is present');
+  assert.ok(player.tech_.el().className.indexOf('vjs-hidden') !== -1, 'video element is hidden');
+
   player.audioPosterMode(false);
   assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') === -1, 'vjs-audio-poster-mode class is removed');
+  assert.ok(player.tech_.el().className.indexOf('vjs-hidden') === -1, 'video element is visible');
 });
 
 QUnit.test('should setScrubbing when seeking or not seeking', function(assert) {

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1570,6 +1570,21 @@ QUnit.test('should add an audio player region if an audio el is used', function(
   player.dispose();
 });
 
+QUnit.test('should turn on/off audioPosterMode when audioPosterMode is called with true/false', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
+  assert.ok(player.options_.audioPosterMode === false, 'audioPosterMode is initially false');
+  player.options_.audioOnlyMode = true;
+  player.audioPosterMode(true);
+  assert.ok(player.options_.audioPosterMode === false, 'audioPosterMode is cannot be set to true if audioOnlyMode is true');
+  player.options_.audioOnlyMode = false;
+  player.audioPosterMode(true);
+  assert.ok(player.options_.audioPosterMode === true, 'audioPosterMode is set to true');
+  assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is added');
+  player.audioPosterMode(false);
+  assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') === -1, 'vjs-audio-poster-mode class is removed');
+});
+
 QUnit.test('should setScrubbing when seeking or not seeking', function(assert) {
   const player = TestHelpers.makePlayer();
   let isScrubbing;


### PR DESCRIPTION
## Description
Adds audioPosterMode option that is false by default. Turning the audioPosterMode on will enable the Poster Viewer experience by hiding the video element and persistently displaying the poster image. If no poster is defined, the video player will be black.