### PR TITLE
feat: Greater text track precision

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -739,6 +739,32 @@ class Html5 extends Tech {
   }
 
   /**
+   * Native requestVideoFrameCallback if supported by browser/tech, or fallback
+   *
+   * @param {function} cb function to call
+   * @return {number} id of request
+   */
+  requestVideoFrameCallback(cb) {
+    if (this.featuresVideoFrameCallback) {
+      return this.el_.requestVideoFrameCallback(cb);
+    }
+    return super.requestVideoFrameCallback(cb);
+  }
+
+  /**
+   * Native or fallback requestVideoFrameCallback
+   *
+   * @param {number} id request id to cancel
+   */
+  cancelVideoFrameCallback(id) {
+    if (this.featuresVideoFrameCallback) {
+      this.el_.cancelVideoFrameCallback(id);
+    } else {
+      super.cancelVideoFrameCallback(id);
+    }
+  }
+
+  /**
    * A getter/setter for the `Html5` Tech's source object.
    * > Note: Please use {@link Html5#setSource}
    *
@@ -1295,6 +1321,13 @@ Html5.prototype.featuresProgressEvents = true;
  * @default
  */
 Html5.prototype.featuresTimeupdateEvents = true;
+
+/**
+ * Whether the HTML5 el supports `requestVideoFrameCallback`
+ *
+ * @type {boolean}
+ */
+Html5.prototype.featuresVideoFrameCallback = window.HTMLVideoElement && 'requestVideoFrameCallback' in window.HTMLVideoElement.prototype;
 
 // HTML5 Feature detection and Device Fixes --------------------------------- //
 let canPlayType;

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -1327,7 +1327,7 @@ Html5.prototype.featuresTimeupdateEvents = true;
  *
  * @type {boolean}
  */
-Html5.prototype.featuresVideoFrameCallback = window.HTMLVideoElement && 'requestVideoFrameCallback' in window.HTMLVideoElement.prototype;
+Html5.prototype.featuresVideoFrameCallback = !!(Html5.TEST_VID && Html5.TEST_VID.requestVideoFrameCallback);
 
 // HTML5 Feature detection and Device Fixes --------------------------------- //
 let canPlayType;

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -255,6 +255,7 @@ QUnit.test('can only remove one cue at a time', function(assert) {
 
 QUnit.test('does not fire cuechange before Tech is ready', function(assert) {
   const done = assert.async();
+  const clock = sinon.useFakeTimers();
   const player = TestHelpers.makePlayer({techfaker: {autoReady: false}});
   let changes = 0;
   const tt = new TextTrack({
@@ -278,7 +279,7 @@ QUnit.test('does not fire cuechange before Tech is ready', function(assert) {
     return 0;
   };
 
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
   assert.equal(changes, 0, 'a cuechange event is not triggered');
 
   player.tech_.on('ready', function() {
@@ -286,15 +287,18 @@ QUnit.test('does not fire cuechange before Tech is ready', function(assert) {
       return 0.2;
     };
 
-    player.tech_.trigger('timeupdate');
+    player.tech_.trigger('playing');
+    clock.tick(1);
 
     assert.equal(changes, 2, 'a cuechange event trigger addEventListener and oncuechange');
 
     tt.off();
     player.dispose();
+    clock.restore();
     done();
   });
   player.tech_.triggerReady();
+  clock.tick(1);
 });
 
 QUnit.test('fires cuechange when cues become active and inactive', function(assert) {
@@ -321,7 +325,7 @@ QUnit.test('fires cuechange when cues become active and inactive', function(asse
     return 2;
   };
 
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(changes, 2, 'a cuechange event trigger addEventListener and oncuechange');
 
@@ -329,7 +333,7 @@ QUnit.test('fires cuechange when cues become active and inactive', function(asse
     return 7;
   };
 
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(changes, 4, 'a cuechange event trigger addEventListener and oncuechange');
 
@@ -360,17 +364,18 @@ QUnit.test('enabled and disabled cuechange handler when changing mode to hidden'
   player.tech_.currentTime = function() {
     return 2;
   };
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(changes, 1, 'a cuechange event trigger');
 
   changes = 0;
+  // debugger;
   tt.mode = 'disabled';
 
   player.tech_.currentTime = function() {
     return 7;
   };
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(changes, 0, 'NO cuechange event trigger');
 
@@ -379,6 +384,7 @@ QUnit.test('enabled and disabled cuechange handler when changing mode to hidden'
 });
 
 QUnit.test('enabled and disabled cuechange handler when changing mode to showing', function(assert) {
+  const clock = sinon.useFakeTimers();
   const player = TestHelpers.makePlayer();
   let changes = 0;
   const tt = new TextTrack({
@@ -401,7 +407,8 @@ QUnit.test('enabled and disabled cuechange handler when changing mode to showing
   player.tech_.currentTime = function() {
     return 2;
   };
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
+  clock.tick(10);
 
   assert.equal(changes, 1, 'a cuechange event trigger');
 
@@ -411,12 +418,13 @@ QUnit.test('enabled and disabled cuechange handler when changing mode to showing
   player.tech_.currentTime = function() {
     return 7;
   };
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(changes, 0, 'NO cuechange event trigger');
 
   tt.off();
   player.dispose();
+  clock.restore();
 });
 
 QUnit.test('if preloadTextTracks is false, default tracks are not parsed until mode is showing', function(assert) {

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -338,7 +338,7 @@ QUnit.test('no lang attribute on cue elements if one is provided', function(asse
   player.tech_.textTracks().addTrack(tt);
 
   player.currentTime(2);
-  player.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.notOk(tt.activeCues[0].displayState.hasAttribute('lang'), 'no lang attribute should be set');
 
@@ -361,7 +361,7 @@ QUnit.test('set lang attribute on cue elements if one is provided', function(ass
   player.tech_.textTracks().addTrack(tt);
 
   player.currentTime(2);
-  player.trigger('timeupdate');
+  player.tech_.trigger('playing');
 
   assert.equal(tt.activeCues[0].displayState.getAttribute('lang'), 'en', 'the lang should be set to en');
 
@@ -404,7 +404,7 @@ QUnit.test('removes cuechange event when text track is hidden for emulated track
   player.tech_.currentTime = function() {
     return 3;
   };
-  player.tech_.trigger('timeupdate');
+  player.tech_.trigger('playing');
   assert.equal(
     numTextTrackChanges, 3,
     'texttrackchange should be triggered once for the cuechange'


### PR DESCRIPTION
## Description
Text tracks currently update on `timeupdate`, which can can be too slow and/or unpredictable for some (edge) cases. This PR switches to using [`requestVideoFrameCallback()`](https://web.dev/requestvideoframecallback-rvfc/) instead, with a fallback to `requestAnimationFrame()`. There was some previous work along these lines with rAF in #2985.

Closes #2985, closes #7026.

## Specific Changes proposed
* Implements `Tech.requestVideoFrameCallback()` as a fallback to `requestAnimationFrame()` whilst playing.
* Implements `Html5.requestVideoFrameCallback()` if the HTML5 element supports it.
* Switches text track to use this method instead of the `timeupdate` event.

## Requirements Checklist
- x ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created https://codepen.io/mister-ben/pen/jOarxro?editors=1011
- [ ] Reviewed by Two Core Contributors
