### PR TITLE
fix: Guard against Safari adding native controls after fullscreen

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2124,7 +2124,10 @@ class Player extends Component {
   handleTechFullscreenChange_(event, data) {
     if (data) {
       if (data.nativeIOSFullscreen) {
-        this.toggleClass('vjs-ios-native-fs');
+        this.addClass('vjs-ios-native-fs');
+        this.tech_.one('webkitendfullscreen', () => {
+          this.removeClass('vjs-ios-native-fs');
+        });
       }
       this.isFullscreen(data.isFullscreen);
     }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -641,11 +641,14 @@ class Html5 extends Tech {
 
     const endFn = function() {
       this.trigger('fullscreenchange', { isFullscreen: false });
+      // Safari will sometimes set contols on the videoelement when existing fullscreen.
+      if (this.el_.controls && !this.options_.nativeControlsForTouch && this.controls()) {
+        this.el_.controls = false;
+      }
     };
 
     const beginFn = function() {
-      if ('webkitPresentationMode' in this.el_ &&
-        this.el_.webkitPresentationMode !== 'picture-in-picture') {
+      if ('webkitPresentationMode' in this.el_ && this.el_.webkitPresentationMode !== 'picture-in-picture') {
         this.one('webkitendfullscreen', endFn);
 
         this.trigger('fullscreenchange', {


### PR DESCRIPTION
## Description
Sometimes iOS Safari enabled native controls on the video el when existing fullscreen, resulting in both the native controls and Video.js controls being visible. Fixes #3762  

## Specific Changes proposed
* Set `controls` to `false` on the tech el when iOS exits fullscreen, as long as `nativeControlsForTouch` is not being used.
* Not pertinent to the double controls issue, but also fixes the behaviour of the `vjs-ios-native-fs`, which is currently toggling when entering fullscreen and remaining as is on exiting fullscreen. (Although this class may be able to be removed altogether if it wasn't being applied as intended anyway).

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, Safari)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
