### PR TITLE
fix(lang): remove trailing comma from fr.json

### DIFF
--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -394,8 +394,10 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | {1} is loading.                                                                     |
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
-| fr.json (missing 2)     | Seek to live, currently behind live                                                 |
-|                         | Seek to live, currently playing live												|
+| fr.json (missing 4)     | Seek to live, currently behind live                                                 |
+|                         | Seek to live, currently playing live                                                |
+|                         | Exit Picture-in-Picture                                                             |
+|                         | Picture-in-Picture                                                                  |
 | gd.json (missing 2)     | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 | gl.json (missing 2)     | Exit Picture-in-Picture                                                             |
@@ -405,6 +407,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | {1} is loading.                                                                     |
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
+| hi.json (Complete)      |                                                                                     |
 | hr.json (missing 63)    | Audio Player                                                                        |
 |                         | Video Player                                                                        |
 |                         | Replay                                                                              |
@@ -488,6 +491,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Dropshadow                                                                          |
 |                         | Casual                                                                              |
 |                         | Script                                                                              |
+| lv.json (Complete)      |                                                                                     |
 | nb.json (missing 2)     | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 | nl.json (missing 5)     | Seek to live, currently behind live                                                 |
@@ -499,45 +503,9 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Picture-in-Picture                                                                  |
 | oc.json (missing 2)     | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
-| pl.json (missing 55)    | Audio Player                                                                        |
-|                         | Video Player                                                                        |
-|                         | Replay                                                                              |
-|                         | Seek to live, currently behind live                                                 |
+| pl.json (missing 11)    | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
-|                         | Progress Bar                                                                        |
 |                         | progress bar timing: currentTime={1} duration={2}                                   |
-|                         | Descriptions                                                                        |
-|                         | descriptions off                                                                    |
-|                         | Audio Track                                                                         |
-|                         | Volume Level                                                                        |
-|                         | The media is encrypted and we do not have the keys to decrypt it.                   |
-|                         | Close Modal Dialog                                                                  |
-|                         | , opens descriptions settings dialog                                                |
-|                         | captions settings                                                                   |
-|                         | subtitles settings                                                                  |
-|                         | descriptions settings                                                               |
-|                         | Text                                                                                |
-|                         | White                                                                               |
-|                         | Black                                                                               |
-|                         | Red                                                                                 |
-|                         | Green                                                                               |
-|                         | Blue                                                                                |
-|                         | Yellow                                                                              |
-|                         | Magenta                                                                             |
-|                         | Cyan                                                                                |
-|                         | Background                                                                          |
-|                         | Window                                                                              |
-|                         | Transparent                                                                         |
-|                         | Semi-Transparent                                                                    |
-|                         | Opaque                                                                              |
-|                         | Font Size                                                                           |
-|                         | Text Edge Style                                                                     |
-|                         | None                                                                                |
-|                         | Raised                                                                              |
-|                         | Depressed                                                                           |
-|                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
-|                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
 |                         | Proportional Serif                                                                  |
@@ -545,15 +513,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Casual                                                                              |
 |                         | Script                                                                              |
 |                         | Small Caps                                                                          |
-|                         | Reset                                                                               |
-|                         | restore all settings to the default values                                          |
-|                         | Done                                                                                |
-|                         | Caption Settings Dialog                                                             |
-|                         | Beginning of dialog window. Escape will cancel and close the window.                |
-|                         | End of dialog window.                                                               |
 |                         | {1} is loading.                                                                     |
-|                         | Exit Picture-in-Picture                                                             |
-|                         | Picture-in-Picture                                                                  |
 | pt-BR.json (missing 2)  | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
 | pt-PT.json (missing 48) | Audio Player                                                                        |
@@ -684,6 +644,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Picture-in-Picture                                                                  |
 | sv.json (missing 2)     | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
+| te.json (Complete)      |                                                                                     |
 | th.json (Complete)      |                                                                                     |
 | tr.json (missing 13)    | Audio Player                                                                        |
 |                         | Video Player                                                                        |

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -83,5 +83,5 @@
   "End of dialog window.": "Fin de la fenêtre de dialogue.",
   "Exit Picture-in-Picture ": "Quitter le mode image dans l'image",
   "Picture-in-Picture ": "Image dans l'image",
-  "{1} is loading.": "{1} en cours de chargement.",
+  "{1} is loading.": "{1} en cours de chargement."
 }


### PR DESCRIPTION
A trailing comma was not noticed before merging in a JSON file, which caused automation to fail. This fixes it.