### PR TITLE
refactor: Unify audioOnly mode and audioPoster mode

### DIFF
--- a/src/js/control-bar/picture-in-picture-toggle.js
+++ b/src/js/control-bar/picture-in-picture-toggle.js
@@ -29,6 +29,20 @@ class PictureInPictureToggle extends Button {
     this.on(player, ['enterpictureinpicture', 'leavepictureinpicture'], (e) => this.handlePictureInPictureChange(e));
     this.on(player, ['disablepictureinpicturechanged', 'loadedmetadata'], (e) => this.handlePictureInPictureEnabledChange(e));
 
+    this.on(player, ['loadedmetadata', 'audioonlymodechange', 'audiopostermodechange'], () => {
+      const isSourceAudio = player.currentSource().type.includes('audio');
+
+      if (isSourceAudio || player.audioPosterMode() || player.audioOnlyMode()) {
+        if (player.isInPictureInPicture()) {
+          player.exitPictureInPicture();
+        }
+        this.hide();
+      } else {
+        this.show();
+      }
+
+    });
+
     // TODO: Deactivate button on player emptied event.
     this.disable();
   }

--- a/src/js/control-bar/picture-in-picture-toggle.js
+++ b/src/js/control-bar/picture-in-picture-toggle.js
@@ -30,6 +30,7 @@ class PictureInPictureToggle extends Button {
     this.on(player, ['disablepictureinpicturechanged', 'loadedmetadata'], (e) => this.handlePictureInPictureEnabledChange(e));
 
     this.on(player, ['loadedmetadata', 'audioonlymodechange', 'audiopostermodechange'], () => {
+      // This audio detection will not detect HLS or DASH audio-only streams because there was no reliable way to detect them at the time
       const isSourceAudio = player.currentType().substring(0, 5) === 'audio';
 
       if (isSourceAudio || player.audioPosterMode() || player.audioOnlyMode()) {

--- a/src/js/control-bar/picture-in-picture-toggle.js
+++ b/src/js/control-bar/picture-in-picture-toggle.js
@@ -30,7 +30,7 @@ class PictureInPictureToggle extends Button {
     this.on(player, ['disablepictureinpicturechanged', 'loadedmetadata'], (e) => this.handlePictureInPictureEnabledChange(e));
 
     this.on(player, ['loadedmetadata', 'audioonlymodechange', 'audiopostermodechange'], () => {
-      const isSourceAudio = player.currentSource().type.includes('audio');
+      const isSourceAudio = player.currentType().substring(0, 5) === 'audio';
 
       if (isSourceAudio || player.audioPosterMode() || player.audioOnlyMode()) {
         if (player.isInPictureInPicture()) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4453,18 +4453,18 @@ class Player extends Component {
     if (PromiseClass) {
 
       if (value) {
-        const exitPromises = [];
 
         if (this.audioOnlyMode()) {
-          exitPromises.push(this.audioOnlyMode(false));
+          const audioOnlyModePromise = this.audioOnlyMode(false);
 
-          return PromiseClass.all(exitPromises).then(() => {
+          return audioOnlyModePromise.then(() => {
             // enable audio poster mode after audio only mode is disabled
             this.enablePosterModeUI_();
           });
         }
 
         return PromiseClass.resolve().then(() => {
+          // enable audio poster mode
           this.enablePosterModeUI_();
         });
       }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -587,7 +587,7 @@ class Player extends Component {
     this.breakpoints(this.options_.breakpoints);
     this.responsive(this.options_.responsive);
 
-    // Calling both the audio mode mothods after the player is fully
+    // Calling both the audio mode methods after the player is fully
     // setup to be able to listen to the events triggered by them
     this.on('ready', () => {
       // Calling the audioPosterMode method first so that

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -590,7 +590,6 @@ class Player extends Component {
     this.on('ready', () => {
       this.audioPosterMode(this.options_.audioPosterMode);
       this.audioOnlyMode(this.options_.audioOnlyMode);
-
     });
   }
 
@@ -4432,8 +4431,6 @@ class Player extends Component {
     }
 
     this.audioPosterMode_ = value;
-    // eslint-disable-next-line
-    console.log('triggering');
     this.trigger('audiopostermodechange');
 
     const techEl = this.tech_ && this.tech_;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -398,6 +398,9 @@ class Player extends Component {
     // Init state audioOnlyMode_
     this.audioOnlyMode_ = false;
 
+    // Init state audioPosterMode_
+    this.audioPosterMode_ = false;
+
     // Init state audioOnlyCache_
     this.audioOnlyCache_ = {
       playerHeight: null,
@@ -583,7 +586,12 @@ class Player extends Component {
 
     this.breakpoints(this.options_.breakpoints);
     this.responsive(this.options_.responsive);
-    this.audioOnlyMode(this.options_.audioOnlyMode);
+
+    this.on('ready', () => {
+      this.audioPosterMode(this.options_.audioPosterMode);
+      this.audioOnlyMode(this.options_.audioOnlyMode);
+
+    });
   }
 
   /**
@@ -4305,6 +4313,10 @@ class Player extends Component {
 
   updateAudioOnlyModeState_(value) {
     this.audioOnlyMode_ = value;
+
+    if (value && this.audioPosterMode()) {
+      this.audioPosterMode(false);
+    }
     this.trigger('audioonlymodechange');
   }
 
@@ -4415,23 +4427,27 @@ class Player extends Component {
    */
   audioPosterMode(value) {
 
-    if (this.audioPosterMode_ === undefined) {
-      this.audioPosterMode_ = this.options_.audioPosterMode;
-    }
-
     if (typeof value !== 'boolean' || value === this.audioPosterMode_) {
       return this.audioPosterMode_;
     }
 
     this.audioPosterMode_ = value;
+    // eslint-disable-next-line
+    console.log('triggering');
+    this.trigger('audiopostermodechange');
+
+    const techEl = this.tech_ && this.tech_;
 
     if (this.audioPosterMode_) {
-      this.tech_.hide();
+      if (this.audioOnlyMode()) {
+        this.audioOnlyMode(false);
+      }
+      techEl.hide();
       this.addClass('vjs-audio-poster-mode');
       return;
     }
     // Show the video element and hide the poster image if audioPosterMode is set to false
-    this.tech_.show();
+    techEl.show();
     this.removeClass('vjs-audio-poster-mode');
   }
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -587,7 +587,11 @@ class Player extends Component {
     this.breakpoints(this.options_.breakpoints);
     this.responsive(this.options_.responsive);
 
+    // Calling both the audio mode mothods after the player is fully
+    // setup to be able to listen to the events triggered by them
     this.on('ready', () => {
+      // Calling the audioPosterMode method first so that
+      // the audioOnlyMode can take precedence when both options are set to true
       this.audioPosterMode(this.options_.audioPosterMode);
       this.audioOnlyMode(this.options_.audioOnlyMode);
     });

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -283,6 +283,19 @@ QUnit.test('Picture-in-Picture control enabled property value should be correct 
   pictureInPictureToggle.dispose();
 });
 
+QUnit.test('Picture-in-Picture control is hidden when the source is audio', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const pictureInPictureToggle = new PictureInPictureToggle(player);
+
+  player.src({src: 'example.mp3', type: 'audio/mp3'});
+
+  player.trigger('loadedmetadata');
+  assert.equal(pictureInPictureToggle.hasClass('vjs-hidden'), true, 'pictureInPictureToggle button hidden');
+
+  player.dispose();
+  pictureInPictureToggle.dispose();
+});
+
 QUnit.test('Fullscreen control text should be correct when fullscreenchange is triggered', function(assert) {
   const player = TestHelpers.makePlayer({controlBar: false});
   const fullscreentoggle = new FullscreenToggle(player);

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -287,10 +287,14 @@ QUnit.test('Picture-in-Picture control is hidden when the source is audio', func
   const player = TestHelpers.makePlayer({});
   const pictureInPictureToggle = new PictureInPictureToggle(player);
 
-  player.src({src: 'example.mp3', type: 'audio/mp3'});
-
+  player.src({src: 'example.mp4', type: 'video/mp4'});
   player.trigger('loadedmetadata');
-  assert.equal(pictureInPictureToggle.hasClass('vjs-hidden'), true, 'pictureInPictureToggle button hidden');
+
+  assert.notOk(pictureInPictureToggle.hasClass('vjs-hidden'), 'pictureInPictureToggle button is not hidden initially');
+
+  player.src({src: 'example1.mp3', type: 'audio/mp3'});
+  player.trigger('loadedmetadata');
+  assert.ok(pictureInPictureToggle.hasClass('vjs-hidden'), 'pictureInPictureToggle button is hidden whenh the source is audio');
 
   player.dispose();
   pictureInPictureToggle.dispose();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1579,10 +1579,12 @@ QUnit.test('default audioPosterMode value at player creation', function(assert) 
   const player2 = TestHelpers.makePlayer({
     audioPosterMode: true
   });
+  const done = assert.async();
 
   player2.trigger('ready');
   player2.one('audiopostermodechange', () => {
     assert.ok(player2.audioPosterMode() === true, 'audioPosterMode can be set to true when the player is created');
+    done();
   });
 });
 
@@ -1597,31 +1599,30 @@ QUnit.test('get and set audioPosterMode value', function(assert) {
 
 QUnit.test('vjs-audio-poster-mode class and video element visibility when audioPosterMode is true', function(assert) {
   const player = TestHelpers.makePlayer({});
-  const done = assert.async();
 
   player.trigger('ready');
-  player.audioPosterMode(true)
-    .then(() => {
-      assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is present');
-      assert.ok(player.tech_.el().className.indexOf('vjs-hidden') !== -1, 'video element is hidden');
-      done();
-    });
 
   assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') === -1, 'vjs-audio-poster-mode class is not present initially');
   assert.ok(player.tech_.el().className.indexOf('vjs-hidden') === -1, 'video element is visible');
+
+  return player.audioPosterMode(true)
+    .then(() => {
+      assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is present');
+      assert.ok(player.tech_.el().className.indexOf('vjs-hidden') !== -1, 'video element is hidden');
+    });
 });
 
 QUnit.test('setting audioPosterMode() should trigger audiopostermodechange event', function(assert) {
   const player = TestHelpers.makePlayer({
     audioPosterMode: true
   });
-  let triggered = false;
+  const done = assert.async();
 
   player.trigger('ready');
   player.one('audiopostermodechange', () => {
-    triggered = true;
-    assert.equal(triggered, true, 'audiopostermodechange event was triggered');
+    assert.ok(true, 'audiopostermodechange event was triggered');
     assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
+    done();
   });
 });
 
@@ -3114,12 +3115,14 @@ QUnit.test('audioOnlyMode(true/false) hides/shows video-specific control bar com
 
 QUnit.test('setting both audioOnlyMode and audioPosterMode options to true will only turn audioOnlyMode', function(assert) {
   const player = TestHelpers.makePlayer({audioOnlyMode: true, audioPosterMode: true});
+  const done = assert.async();
 
   player.trigger('ready');
 
   player.one('audioonlymodechange', () => {
     assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
     assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
+    done();
   });
 });
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1579,23 +1579,19 @@ QUnit.test('default audioPosterMode value at player creation', function(assert) 
   const player2 = TestHelpers.makePlayer({
     audioPosterMode: true
   });
-  const done = assert.async();
 
   player2.trigger('ready');
   player2.one('audiopostermodechange', () => {
     assert.ok(player2.audioPosterMode() === true, 'audioPosterMode can be set to true when the player is created');
-    done();
   });
 });
 
 QUnit.test('get and set audioPosterMode value', function(assert) {
   const player = TestHelpers.makePlayer({});
-  const done = assert.async();
 
   return player.audioPosterMode(true)
     .then(() => {
       assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
-      done();
     });
 });
 
@@ -1619,7 +1615,6 @@ QUnit.test('setting audioPosterMode() should trigger audiopostermodechange event
   const player = TestHelpers.makePlayer({
     audioPosterMode: true
   });
-  const done = assert.async();
   let triggered = false;
 
   player.trigger('ready');
@@ -1627,8 +1622,27 @@ QUnit.test('setting audioPosterMode() should trigger audiopostermodechange event
     triggered = true;
     assert.equal(triggered, true, 'audiopostermodechange event was triggered');
     assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
-    done();
   });
+});
+
+QUnit.test('audioPosterMode is synchronous and returns undefined when promises are unsupported', function(assert) {
+  const originalPromise = window.Promise;
+  const player = TestHelpers.makePlayer({});
+
+  player.trigger('ready');
+  window.Promise = undefined;
+
+  const returnValTrue = player.audioPosterMode(true);
+
+  assert.equal(returnValTrue, undefined, 'return value is undefined');
+  assert.ok(player.audioPosterMode(), 'state synchronously set to true');
+
+  const returnValFalse = player.audioPosterMode(false);
+
+  assert.equal(returnValFalse, undefined, 'return value is undefined');
+  assert.notOk(player.audioPosterMode(), 'state synchronously set to false');
+
+  window.Promise = originalPromise;
 });
 
 QUnit.test('should setScrubbing when seeking or not seeking', function(assert) {
@@ -2835,7 +2849,7 @@ QUnit.test('playbackRates only accepts arrays of numbers', function(assert) {
 });
 
 QUnit.test('audioOnlyMode can be set by option', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   const done = assert.async();
   const player = TestHelpers.makePlayer({audioOnlyMode: true});
@@ -2846,6 +2860,7 @@ QUnit.test('audioOnlyMode can be set by option', function(assert) {
     assert.equal(player.hasClass('vjs-audio-only-mode'), true, 'class added asynchronously');
     done();
   });
+  assert.equal(player.hasClass('vjs-audio-only-mode'), false, 'initially does not have class');
 });
 
 QUnit.test('audioOnlyMode(true) returns Promise when promises are supported', function(assert) {
@@ -3098,7 +3113,6 @@ QUnit.test('audioOnlyMode(true/false) hides/shows video-specific control bar com
 });
 
 QUnit.test('setting both audioOnlyMode and audioPosterMode options to true will only turn audioOnlyMode', function(assert) {
-  const done = assert.async();
   const player = TestHelpers.makePlayer({audioOnlyMode: true, audioPosterMode: true});
 
   player.trigger('ready');
@@ -3106,12 +3120,10 @@ QUnit.test('setting both audioOnlyMode and audioPosterMode options to true will 
   player.one('audioonlymodechange', () => {
     assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
     assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
-    done();
   });
 });
 
 QUnit.test('turning on audioOnlyMode when audioPosterMode is already on will turn off audioPosterMode', function(assert) {
-  const done = assert.async();
   const player = TestHelpers.makePlayer({audioPosterMode: true});
 
   player.trigger('ready');
@@ -3120,7 +3132,6 @@ QUnit.test('turning on audioOnlyMode when audioPosterMode is already on will tur
     .then(() => {
       assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
       assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
-      done();
     });
 });
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1573,12 +1573,14 @@ QUnit.test('should add an audio player region if an audio el is used', function(
 QUnit.test('default audioPosterMode value at player creation', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false by default');
 
   const player2 = TestHelpers.makePlayer({
     audioPosterMode: true
   });
 
+  player2.trigger('ready');
   assert.ok(player2.audioPosterMode() === true, 'audioPosterMode can be set to true when the player is created');
   player.dispose();
   player2.dispose();
@@ -1587,6 +1589,7 @@ QUnit.test('default audioPosterMode value at player creation', function(assert) 
 QUnit.test('get and set audioPosterMode value', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   player.audioPosterMode(true);
   assert.ok(player.audioPosterMode() === true, 'audioPosterMode is set to true');
 });
@@ -1594,6 +1597,7 @@ QUnit.test('get and set audioPosterMode value', function(assert) {
 QUnit.test('vjs-audio-poster-mode class and video element visibility when audioPosterMode is true', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   player.audioPosterMode(true);
   assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') !== -1, 'vjs-audio-poster-mode class is present');
   assert.ok(player.tech_.el().className.indexOf('vjs-hidden') !== -1, 'video element is hidden');
@@ -1601,6 +1605,21 @@ QUnit.test('vjs-audio-poster-mode class and video element visibility when audioP
   player.audioPosterMode(false);
   assert.ok(player.el().className.indexOf('vjs-audio-poster-mode') === -1, 'vjs-audio-poster-mode class is removed');
   assert.ok(player.tech_.el().className.indexOf('vjs-hidden') === -1, 'video element is visible');
+});
+
+QUnit.test('setting audioPosterMode() should trigger audiopostermodechange event', function(assert) {
+  const player = TestHelpers.makePlayer({
+    audioPosterMode: true
+  });
+  let triggered = false;
+
+  player.on('audiopostermodechange', () => {
+    triggered = true;
+  });
+  player.trigger('ready');
+
+  assert.equal(triggered, true, 'audiopostermodechange event was triggered');
+  assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
 });
 
 QUnit.test('should setScrubbing when seeking or not seeking', function(assert) {
@@ -2812,6 +2831,7 @@ QUnit.test('audioOnlyMode can be set by option', function(assert) {
   const done = assert.async();
   const player = TestHelpers.makePlayer({audioOnlyMode: true});
 
+  player.trigger('ready');
   player.one('audioonlymodechange', () => {
     assert.equal(player.audioOnlyMode(), true, 'asynchronously set via option');
     assert.equal(player.hasClass('vjs-audio-only-mode'), true, 'class added asynchronously');
@@ -2824,6 +2844,8 @@ QUnit.test('audioOnlyMode can be set by option', function(assert) {
 
 QUnit.test('audioOnlyMode(true) returns Promise when promises are supported', function(assert) {
   const player = TestHelpers.makePlayer({});
+
+  player.trigger('ready');
   const returnValTrue = player.audioOnlyMode(true);
 
   if (window.Promise) {
@@ -2835,6 +2857,7 @@ QUnit.test('audioOnlyMode(false) returns Promise when promises are supported', f
   const done = assert.async();
   const player = TestHelpers.makePlayer({audioOnlyMode: true});
 
+  player.trigger('ready');
   player.one('audioonlymodechange', () => {
     const returnValFalse = player.audioOnlyMode(false);
 
@@ -2848,6 +2871,7 @@ QUnit.test('audioOnlyMode(false) returns Promise when promises are supported', f
 QUnit.test('audioOnlyMode() getter returns Boolean', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   assert.ok(typeof player.audioOnlyMode() === 'boolean', 'getter correctly returns boolean');
 });
 
@@ -2855,6 +2879,7 @@ QUnit.test('audioOnlyMode(true/false) is synchronous and returns undefined when 
   const originalPromise = window.Promise;
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   window.Promise = undefined;
 
   const returnValTrue = player.audioOnlyMode(true);
@@ -2873,6 +2898,7 @@ QUnit.test('audioOnlyMode(true/false) is synchronous and returns undefined when 
 QUnit.test('audioOnlyMode() gets the correct audioOnlyMode state', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   assert.equal(player.audioOnlyMode(), false, 'defaults to false');
 
   return player.audioOnlyMode(true)
@@ -2885,6 +2911,7 @@ QUnit.test('audioOnlyMode() gets the correct audioOnlyMode state', function(asse
 QUnit.test('audioOnlyMode(true/false) adds or removes vjs-audio-only-mode class to player', function(assert) {
   const player = TestHelpers.makePlayer({});
 
+  player.trigger('ready');
   assert.equal(player.hasClass('vjs-audio-only-mode'), false, 'class not initially present');
 
   return player.audioOnlyMode(true)
@@ -2899,6 +2926,7 @@ QUnit.test('setting audioOnlyMode() triggers audioonlymodechange event', functio
   let audioOnlyModeState = false;
   let audioOnlyModeChangeEvents = 0;
 
+  player.trigger('ready');
   player.on('audioonlymodechange', () => {
     audioOnlyModeChangeEvents++;
     audioOnlyModeState = player.audioOnlyMode();
@@ -2920,6 +2948,7 @@ QUnit.test('setting audioOnlyMode() triggers audioonlymodechange event', functio
 QUnit.test('audioOnlyMode(true/false) changes player height', function(assert) {
   const player = TestHelpers.makePlayer({controls: true, height: 600});
 
+  player.trigger('ready');
   player.hasStarted(true);
 
   const controlBarHeight = player.getChild('ControlBar').currentHeight();
@@ -2938,6 +2967,7 @@ QUnit.test('audioOnlyMode(true/false) changes player height', function(assert) {
 QUnit.test('audioOnlyMode(true/false) hides/shows player components except control bar', function(assert) {
   const player = TestHelpers.makePlayer({controls: true});
 
+  player.trigger('ready');
   player.hasStarted(true);
 
   assert.equal(TestHelpers.getComputedStyle(player.getChild('TextTrackDisplay').el_, 'display'), 'block', 'TextTrackDisplay is initially visible');
@@ -3016,6 +3046,7 @@ QUnit.test('audioOnlyMode(true/false) hides/shows video-specific control bar com
   // ChaptersButton only shows once cues added and update() called
   controlBar.getChild('ChaptersButton').update();
 
+  player.trigger('ready');
   player.hasStarted(true);
 
   // Show all control bar children
@@ -3059,3 +3090,44 @@ QUnit.test('audioOnlyMode(true/false) hides/shows video-specific control bar com
     })
     .catch(() => assert.ok(false, 'test error'));
 });
+
+QUnit.test('setting both audioOnlyMode and audioPosterMode options to true will only turn on audioOnlyMode', function(assert) {
+  const done = assert.async();
+  const player = TestHelpers.makePlayer({audioOnlyMode: true, audioPosterMode: true});
+
+  player.trigger('ready');
+
+  player.one('audioonlymodechange', () => {
+    assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
+    done();
+    assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
+  });
+});
+
+QUnit.test('turning on audioOnlyMode when audioPosterMode is already on will turn off audioPosterMode', function(assert) {
+  const player = TestHelpers.makePlayer({audioPosterMode: true});
+
+  player.trigger('ready');
+  assert.ok(player.audioPosterMode() === true, 'audioPosterMode is true');
+  return player.audioOnlyMode(true)
+    .then(() => {
+      assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
+      assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
+    });
+});
+
+QUnit.test('turning on audioPosterMode when audioOnlyMode is already on will turn off audioOnlyMode', function(assert) {
+  const done = assert.async();
+  const player = TestHelpers.makePlayer({audioOnlyMode: true});
+
+  player.trigger('ready');
+
+  player.one('audioonlymodechange', () => {
+    assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
+    done();
+  });
+  player.audioPosterMode(true);
+  assert.ok(player.audioPosterMode() === true, 'audioPosterMode is true');
+  assert.ok(player.audioOnlyMode() === false, 'audioOnlyMode is false');
+});
+

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1583,7 +1583,7 @@ QUnit.test('default audioPosterMode value at player creation', function(assert) 
 
   player2.trigger('ready');
   player2.one('audiopostermodechange', () => {
-    assert.ok(player2.audioPosterMode() === true, 'audioPosterMode can be set to true when the player is created');
+    assert.ok(player2.audioPosterMode(), 'audioPosterMode can be set to true when the player is created');
     done();
   });
 });
@@ -1593,7 +1593,7 @@ QUnit.test('get and set audioPosterMode value', function(assert) {
 
   return player.audioPosterMode(true)
     .then(() => {
-      assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
+      assert.ok(player.audioPosterMode(), 'audioPosterMode is set to true');
     });
 });
 
@@ -1621,7 +1621,7 @@ QUnit.test('setting audioPosterMode() should trigger audiopostermodechange event
   player.trigger('ready');
   player.one('audiopostermodechange', () => {
     assert.ok(true, 'audiopostermodechange event was triggered');
-    assert.equal(player.audioPosterMode(), true, 'audioPosterMode is set to true');
+    assert.ok(player.audioPosterMode(), 'audioPosterMode is set to true');
     done();
   });
 });
@@ -3120,8 +3120,8 @@ QUnit.test('setting both audioOnlyMode and audioPosterMode options to true will 
   player.trigger('ready');
 
   player.one('audioonlymodechange', () => {
-    assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
-    assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
+    assert.ok(player.audioOnlyMode(), 'audioOnlyMode is true');
+    assert.notOk(player.audioPosterMode(), 'audioPosterMode is false');
     done();
   });
 });
@@ -3130,11 +3130,11 @@ QUnit.test('turning on audioOnlyMode when audioPosterMode is already on will tur
   const player = TestHelpers.makePlayer({audioPosterMode: true});
 
   player.trigger('ready');
-  assert.ok(player.audioPosterMode() === true, 'audioPosterMode is true');
+  assert.ok(player.audioPosterMode(), 'audioPosterMode is true');
   return player.audioOnlyMode(true)
     .then(() => {
-      assert.ok(player.audioPosterMode() === false, 'audioPosterMode is false');
-      assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
+      assert.notOk(player.audioPosterMode(), 'audioPosterMode is false');
+      assert.ok(player.audioOnlyMode(), 'audioOnlyMode is true');
     });
 });
 
@@ -3142,11 +3142,11 @@ QUnit.test('turning on audioPosterMode when audioOnlyMode is already on will tur
   const player = TestHelpers.makePlayer({audioOnlyMode: true});
 
   player.trigger('ready');
-  assert.ok(player.audioOnlyMode() === true, 'audioOnlyMode is true');
+  assert.ok(player.audioOnlyMode(), 'audioOnlyMode is true');
   return player.audioPosterMode(true)
     .then(() => {
-      assert.equal(player.audioPosterMode(), true, 'audioPosterMode is true');
-      assert.equal(player.audioOnlyMode(), false, 'audioOnlyMode is false');
+      assert.ok(player.audioPosterMode(), 'audioPosterMode is true');
+      assert.notOk(player.audioOnlyMode(), 'audioOnlyMode is false');
     });
 });
 


### PR DESCRIPTION
Modify the `audioPosterMode` method to  return a promise and unify `audioOnlyMode` and `audioPosterMode` by turning off one mode when the other mode is turned on.

This change also disables/hides PIP for an audio source and when either of the two audio modes are true