### PR TITLE
fix: text-track-display position with no ui

### DIFF
--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -9,6 +9,7 @@
 }
 
 // Move captions down when controls aren't being shown
+.video-js.vjs-controls-disabled .vjs-text-track-display,
 .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
   bottom: 1em;
 }
@@ -30,6 +31,7 @@ video::-webkit-media-text-track-display {
 }
 
 // Move captions down when controls aren't being shown
+.video-js.vjs-controls-disabled video::-webkit-media-text-track-display,
 .video-js.vjs-user-inactive.vjs-playing video::-webkit-media-text-track-display {
   @include transform(translateY(-1.5em));
 }


### PR DESCRIPTION
- Text track display position changes when the controls are shown
- (based on paused state or user activity)
- When controls aren't shown its position should be consistent

Fixes #7681.

## Description
Updates to css so that when the controls are disabled, the positioning of the text track display is the same as when the content is playing and there's no user activity.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
