### PR TITLE
test(text-track-controls): fix failing test caused by incompatibility between PRs

### DIFF
--- a/test/unit/tracks/text-track-controls.test.js
+++ b/test/unit/tracks/text-track-controls.test.js
@@ -559,12 +559,12 @@ QUnit.test('chapters button should update selected menu item', function(assert) 
   assert.ok(menuItems.find(i => i.isSelected_) === menuItems[0], 'item with startTime 0 selected on init');
 
   player.currentTime(4);
-  player.trigger('timeupdate');
+  chaptersEl.track.timeupdateHandler();
 
   assert.ok(menuItems.find(i => i.isSelected_) === menuItems[1], 'second item selected on cuechange');
 
   player.currentTime(1);
-  player.trigger('timeupdate');
+  chaptersEl.track.timeupdateHandler();
 
   assert.ok(menuItems.find(i => i.isSelected_) === menuItems[0], 'first item selected on cuechange');
 


### PR DESCRIPTION
## Description
An incompatibility was introduced between a test written for #7604 and the changes introduced in #7633 - this addresses it to unblock release of 7.19.

## Specific Changes proposed
Since text tracks no longer rely on the `timeupdate` event (though they still have a `timeupdateHandler` method), triggering the chapter menu item update on `timeupdate` simply did not work. Calling `timeupdateHandler()` manually does.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] ~Change has been verified in an actual browser (Chrome, Firefox, IE)~
  - [x] Unit Tests updated or fixed
  - [ ] ~Docs/guides updated~
  - [ ] ~Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))~
- [ ] Reviewed by Two Core Contributors
