### PR TITLE
fix: tight controlbar coupling (#7689)

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3605,7 +3605,7 @@ class Player extends Component {
   resetProgressBar_() {
     this.currentTime(0);
 
-    const { durationDisplay, remainingTimeDisplay } = this.controlBar;
+    const { durationDisplay, remainingTimeDisplay } = this.controlBar || {};
 
     if (durationDisplay) {
       durationDisplay.updateContent();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2073,6 +2073,7 @@ QUnit.test('player#reset progress bar', function(assert) {
   const player = TestHelpers.makePlayer();
 
   player.removeChild('controlBar');
+  player.controlBar = null;
 
   try {
     player.resetProgressBar_();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2066,6 +2066,23 @@ QUnit.test('player#reset removes remote text tracks', function(assert) {
   log.warn.restore();
 });
 
+QUnit.test('player#reset progress bar', function(assert) {
+
+  let error;
+
+  const player = TestHelpers.makePlayer();
+
+  player.removeChild('controlBar');
+
+  try {
+    player.resetProgressBar_();
+  } catch (e) {
+    error = e;
+  }
+
+  assert.notOk(error, 'Function did not throw an error on resetProgressBar');
+});
+
 QUnit.test('Remove waiting class after tech waiting when timeupdate shows a time change', function(assert) {
   const player = TestHelpers.makePlayer();
 


### PR DESCRIPTION
## Description
We have tight coupling in player.js Class Player method resetControlBarUI_(), when using reset() method.
ControlBar component may be not exists or exists on another nesting level.
Fixes #7689

## Specific Changes proposed
Added condition

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
