### PR TITLE
fix(accessibility): fix broken aria menu

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -88,8 +88,11 @@ class MenuButton extends Component {
 
     if (this.items && this.items.length <= this.hideThreshold_) {
       this.hide();
+      this.menu.contentEl_.removeAttribute('role', 'menu');
+
     } else {
       this.show();
+      this.menu.contentEl_.setAttribute('role', 'menu');
     }
   }
 

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -139,6 +139,23 @@ QUnit.test('should keep all the added menu items', function(assert) {
   MenuButton.prototype.createItems = oldCreateItems;
 });
 
+QUnit.test('should add or remove role menu for accessibility purpose', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const menuButton = new MenuButton(player);
+
+  menuButton.createItems = () => [];
+  menuButton.update();
+  assert.equal(menuButton.menu.contentEl_.hasAttribute('role'), false, 'the menu does not have a role attribute when it contains no menu items');
+
+  menuButton.createItems = () => [new MenuItem(player, { label: 'menu-item' })];
+  menuButton.update();
+  assert.equal(menuButton.menu.contentEl_.hasAttribute('role'), true, 'the menu has a role attribute when it contains menu items');
+  assert.strictEqual(menuButton.menu.contentEl_.getAttribute('role'), 'menu', 'the menu role is `menu`');
+
+  menuButton.dispose();
+  player.dispose();
+});
+
 QUnit.test('should remove old event listeners when the menu item adds to the new menu', function(assert) {
   const player = TestHelpers.makePlayer();
   const menuButton = new MenuButton(player, {});


### PR DESCRIPTION
## Description
Fix for issue : https://github.com/videojs/video.js/issues/7688 by @dave105010
Remove role="menu" in html on hidden player options if they are not used (no chapters added or no CC added etc.).

## Specific Changes proposed
Add/remove role="menu"

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
![image](https://user-images.githubusercontent.com/19805135/160644039-b830efcc-5ab4-4b9b-8d35-dc4d72447259.png)
![image](https://user-images.githubusercontent.com/19805135/160644106-43c9c9e9-a551-4904-90e2-7db389c09917.png)

  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
