### PR TITLE
chore: Remove IE-specific code

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -4,7 +4,6 @@
 import Button from './button.js';
 import Component from './component.js';
 import {isPromise, silencePromise} from './utils/promise';
-import * as browser from './utils/browser.js';
 
 /**
  * The initial play button that shows before the video has played. The hiding of the
@@ -47,18 +46,12 @@ class BigPlayButton extends Button {
 
     // exit early if clicked via the mouse
     if (this.mouseused_ && event.clientX && event.clientY) {
-      const sourceIsEncrypted = this.player_.usingPlugin('eme') &&
-                                this.player_.eme.sessions &&
-                                this.player_.eme.sessions.length > 0;
-
       silencePromise(playPromise);
-      if (this.player_.tech(true) &&
-         // We've observed a bug in IE and Edge when playing back DRM content where
-         // calling .focus() on the video element causes the video to go black,
-         // so we avoid it in that specific case
-         !((browser.IE_VERSION || browser.IS_EDGE) && sourceIsEncrypted)) {
+
+      if (this.player_.tech(true)) {
         this.player_.tech(true).focus();
       }
+
       return;
     }
 

--- a/src/js/live-tracker.js
+++ b/src/js/live-tracker.js
@@ -1,7 +1,5 @@
 import Component from './component.js';
 import mergeOptions from './utils/merge-options.js';
-import document from 'global/document';
-import * as browser from './utils/browser.js';
 import window from 'global/window';
 import * as Fn from './utils/fn.js';
 
@@ -44,7 +42,6 @@ class LiveTracker extends Component {
 
     super(player, options_);
 
-    this.handleVisibilityChange_ = (e) => this.handleVisibilityChange(e);
     this.trackLiveHandler_ = () => this.trackLive_();
     this.handlePlay_ = (e) => this.handlePlay(e);
     this.handleFirstTimeupdate_ = (e) => this.handleFirstTimeupdate(e);
@@ -57,28 +54,6 @@ class LiveTracker extends Component {
     // we should try to toggle tracking on canplay as native playback engines, like Safari
     // may not have the proper values for things like seekableEnd until then
     this.on(this.player_, 'canplay', () => this.toggleTracking());
-
-    // we don't need to track live playback if the document is hidden,
-    // also, tracking when the document is hidden can
-    // cause the CPU to spike and eventually crash the page on IE11.
-    if (browser.IE_VERSION && 'hidden' in document && 'visibilityState' in document) {
-      this.on(document, 'visibilitychange', this.handleVisibilityChange_);
-    }
-  }
-
-  /**
-   * toggle tracking based on document visiblility
-   */
-  handleVisibilityChange() {
-    if (this.player_.duration() !== Infinity) {
-      return;
-    }
-
-    if (document.hidden) {
-      this.stopTracking();
-    } else {
-      this.startTracking();
-    }
   }
 
   /**
@@ -393,7 +368,6 @@ class LiveTracker extends Component {
    * Dispose of liveTracker
    */
   dispose() {
-    this.off(document, 'visibilitychange', this.handleVisibilityChange_);
     this.stopTracking();
     super.dispose();
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -14,7 +14,7 @@ import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import {IE_VERSION, IS_CHROME, IS_WINDOWS} from './utils/browser.js';
+import {IS_CHROME, IS_WINDOWS} from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
 import {toTitleCase, titleCaseEquals} from './utils/string-cases.js';
 import { createTimeRange } from './utils/time-ranges.js';
@@ -723,12 +723,11 @@ class Player extends Component {
     tag.setAttribute('tabindex', '-1');
     attrs.tabindex = '-1';
 
-    // Workaround for #4583 (JAWS+IE doesn't announce BPB or play button), and
-    // for the same issue with Chrome (on Windows) with JAWS.
+    // Workaround for #4583 on Chrome (on Windows) with JAWS.
     // See https://github.com/FreedomScientific/VFO-standards-support/issues/78
     // Note that we can't detect if JAWS is being used, but this ARIA attribute
-    //  doesn't change behavior of IE11 or Chrome if JAWS is not being used
-    if (IE_VERSION || (IS_CHROME && IS_WINDOWS)) {
+    // doesn't change behavior of Chrome if JAWS is not being used
+    if (IS_CHROME && IS_WINDOWS) {
       tag.setAttribute('role', 'application');
       attrs.role = 'application';
     }

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -5,7 +5,6 @@ import ClickableComponent from './clickable-component.js';
 import Component from './component.js';
 import * as Dom from './utils/dom.js';
 import {silencePromise} from './utils/promise';
-import * as browser from './utils/browser.js';
 
 /**
  * A `ClickableComponent` that handles showing the poster image for the player.
@@ -114,15 +113,7 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
-    const sourceIsEncrypted = this.player_.usingPlugin('eme') &&
-                                this.player_.eme.sessions &&
-                                this.player_.eme.sessions.length > 0;
-
-    if (this.player_.tech(true) &&
-    // We've observed a bug in IE and Edge when playing back DRM content where
-    // calling .focus() on the video element causes the video to go black,
-    // so we avoid it in that specific case
-    !((browser.IE_VERSION || browser.IS_EDGE) && sourceIsEncrypted)) {
+    if (this.player_.tech(true)) {
       this.player_.tech(true).focus();
     }
 

--- a/test/unit/tracks/text-tracks.test.js
+++ b/test/unit/tracks/text-tracks.test.js
@@ -517,10 +517,10 @@ QUnit.test('should uniformly create html track element when adding text track', 
   player.dispose();
 });
 
-// disable in Firefox and IE because while the code works in practice,
-// during the tests, somehow the text track object isn't ready and thus it won't
-// allow us to change the mode of the track rendering the test non-functional.
-if (!browser.IS_FIREFOX && !browser.IE_VERSION === 11) {
+// disable in Firefox because while the code works in practice, during the
+// tests, somehow the text track object isn't ready and thus it won't allow
+// us to change the mode of the track rendering the test non-functional.
+if (!browser.IS_FIREFOX) {
   QUnit.test('remote text tracks change event should fire when using native text tracks', function(assert) {
     const done = assert.async();
 

--- a/test/unit/utils/log.test.js
+++ b/test/unit/utils/log.test.js
@@ -1,5 +1,4 @@
 /* eslint-env qunit */
-import {IE_VERSION} from '../../../src/js/utils/browser';
 import log from '../../../src/js/utils/log.js';
 import window from 'global/window';
 import sinon from 'sinon';
@@ -38,9 +37,6 @@ QUnit.module('utils/log', {
   }
 });
 
-const getConsoleArgs = (...arr) =>
-  IE_VERSION && IE_VERSION < 11 ? [arr.join(' ')] : arr;
-
 QUnit.test('logging functions should work', function(assert) {
 
   // Need to reset history here because there are extra messages logged
@@ -55,7 +51,7 @@ QUnit.test('logging functions should work', function(assert) {
   assert.ok(window.console.log.called, 'log was called');
   assert.deepEqual(
     window.console.log.firstCall.args,
-    getConsoleArgs('VIDEOJS:', 'log1', 'log2')
+    ['VIDEOJS:', 'log1', 'log2']
   );
 
   // debug isn't enabled by default
@@ -64,13 +60,13 @@ QUnit.test('logging functions should work', function(assert) {
   assert.ok(window.console.warn.called, 'warn was called');
   assert.deepEqual(
     window.console.warn.firstCall.args,
-    getConsoleArgs('VIDEOJS:', 'WARN:', 'warn1', 'warn2')
+    ['VIDEOJS:', 'WARN:', 'warn1', 'warn2']
   );
 
   assert.ok(window.console.error.called, 'error was called');
   assert.deepEqual(
     window.console.error.firstCall.args,
-    getConsoleArgs('VIDEOJS:', 'ERROR:', 'error1', 'error2')
+    ['VIDEOJS:', 'ERROR:', 'error1', 'error2']
   );
 
   const history = log.history();
@@ -205,7 +201,7 @@ QUnit.test('falls back to info and log when debug is not supported', function(as
   assert.notOk(window.console.error.called, 'error was not called');
   assert.deepEqual(
     window.console.info.firstCall.args,
-    getConsoleArgs('VIDEOJS:', 'DEBUG:', 'debug1', 'debug2'),
+    ['VIDEOJS:', 'DEBUG:', 'debug1', 'debug2'],
     'logged the right message'
   );
 
@@ -217,7 +213,7 @@ QUnit.test('falls back to info and log when debug is not supported', function(as
   assert.notOk(window.console.error.called, 'error was not called');
   assert.deepEqual(
     window.console.log.firstCall.args,
-    getConsoleArgs('VIDEOJS:', 'DEBUG:', 'debug3', 'debug4'),
+    ['VIDEOJS:', 'DEBUG:', 'debug3', 'debug4'],
     'logged the right message'
   );
 


### PR DESCRIPTION
## Description
Remove any IE-specific code, which is no longer needed once https://github.com/videojs/video.js/pull/7482 is merged to drop build support for IE.
