### PR TITLE
refactor: Remove workarounds for platforms without native promise support

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1177,8 +1177,7 @@ class Player extends Component {
       'playerElIngest': this.playerElIngest_ || false,
       'vtt.js': this.options_['vtt.js'],
       'canOverridePoster': !!this.options_.techCanOverridePoster,
-      'enableSourceset': this.options_.enableSourceset,
-      'Promise': this.options_.Promise
+      'enableSourceset': this.options_.enableSourceset
     };
 
     TRACK_TYPES.names.forEach((name) => {
@@ -2364,15 +2363,9 @@ class Player extends Component {
    *         the promise from play is fulfilled.
    */
   play() {
-    const PromiseClass = this.options_.Promise || window.Promise;
-
-    if (PromiseClass) {
-      return new PromiseClass((resolve) => {
-        this.play_(resolve);
-      });
-    }
-
-    return this.play_();
+    return new Promise((resolve) => {
+      this.play_(resolve);
+    });
   }
 
   /**
@@ -2860,38 +2853,32 @@ class Player extends Component {
    * @fires Player#fullscreenchange
    */
   requestFullscreen(fullscreenOptions) {
-    const PromiseClass = this.options_.Promise || window.Promise;
+    const self = this;
 
-    if (PromiseClass) {
-      const self = this;
+    return new Promise((resolve, reject) => {
+      function offHandler() {
+        self.off('fullscreenerror', errorHandler);
+        self.off('fullscreenchange', changeHandler);
+      }
+      function changeHandler() {
+        offHandler();
+        resolve();
+      }
+      function errorHandler(e, err) {
+        offHandler();
+        reject(err);
+      }
 
-      return new PromiseClass((resolve, reject) => {
-        function offHandler() {
-          self.off('fullscreenerror', errorHandler);
-          self.off('fullscreenchange', changeHandler);
-        }
-        function changeHandler() {
-          offHandler();
-          resolve();
-        }
-        function errorHandler(e, err) {
-          offHandler();
-          reject(err);
-        }
+      self.one('fullscreenchange', changeHandler);
+      self.one('fullscreenerror', errorHandler);
 
-        self.one('fullscreenchange', changeHandler);
-        self.one('fullscreenerror', errorHandler);
+      const promise = self.requestFullscreenHelper_(fullscreenOptions);
 
-        const promise = self.requestFullscreenHelper_(fullscreenOptions);
-
-        if (promise) {
-          promise.then(offHandler, offHandler);
-          promise.then(resolve, reject);
-        }
-      });
-    }
-
-    return this.requestFullscreenHelper_();
+      if (promise) {
+        promise.then(offHandler, offHandler);
+        promise.then(resolve, reject);
+      }
+    });
   }
 
   requestFullscreenHelper_(fullscreenOptions) {
@@ -2916,6 +2903,7 @@ class Player extends Component {
     if (this.fsApi_.requestFullscreen) {
       const promise = this.el_[this.fsApi_.requestFullscreen](fsOptions);
 
+      // Even on browsers with promise support this may not return a promise
       if (promise) {
         promise.then(() => this.isFullscreen(true), () => this.isFullscreen(false));
       }
@@ -2938,45 +2926,40 @@ class Player extends Component {
    * @fires Player#fullscreenchange
    */
   exitFullscreen() {
-    const PromiseClass = this.options_.Promise || window.Promise;
+    const self = this;
 
-    if (PromiseClass) {
-      const self = this;
+    return new Promise((resolve, reject) => {
+      function offHandler() {
+        self.off('fullscreenerror', errorHandler);
+        self.off('fullscreenchange', changeHandler);
+      }
+      function changeHandler() {
+        offHandler();
+        resolve();
+      }
+      function errorHandler(e, err) {
+        offHandler();
+        reject(err);
+      }
 
-      return new PromiseClass((resolve, reject) => {
-        function offHandler() {
-          self.off('fullscreenerror', errorHandler);
-          self.off('fullscreenchange', changeHandler);
-        }
-        function changeHandler() {
-          offHandler();
-          resolve();
-        }
-        function errorHandler(e, err) {
-          offHandler();
-          reject(err);
-        }
+      self.one('fullscreenchange', changeHandler);
+      self.one('fullscreenerror', errorHandler);
 
-        self.one('fullscreenchange', changeHandler);
-        self.one('fullscreenerror', errorHandler);
+      const promise = self.exitFullscreenHelper_();
 
-        const promise = self.exitFullscreenHelper_();
-
-        if (promise) {
-          promise.then(offHandler, offHandler);
-          // map the promise to our resolve/reject methods
-          promise.then(resolve, reject);
-        }
-      });
-    }
-
-    return this.exitFullscreenHelper_();
+      if (promise) {
+        promise.then(offHandler, offHandler);
+        // map the promise to our resolve/reject methods
+        promise.then(resolve, reject);
+      }
+    });
   }
 
   exitFullscreenHelper_() {
     if (this.fsApi_.requestFullscreen) {
       const promise = document[this.fsApi_.exitFullscreen]();
 
+      // Even on browsers with promise support this may not return a promise
       if (promise) {
         // we're splitting the promise here, so, we want to catch the
         // potential error so that this chain doesn't have unhandled errors
@@ -3564,9 +3547,7 @@ class Player extends Component {
    * and calls `reset` on the `tech`.
    */
   reset() {
-    const PromiseClass = this.options_.Promise || window.Promise;
-
-    if (this.paused() || !PromiseClass) {
+    if (this.paused()) {
       this.doReset_();
     } else {
       const playPromise = this.play();

--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -831,11 +831,7 @@ class Tech extends Component {
    * @abstract
    */
   requestPictureInPicture() {
-    const PromiseClass = this.options_.Promise || window.Promise;
-
-    if (PromiseClass) {
-      return PromiseClass.reject();
-    }
+    return Promise.reject();
   }
 
   /**

--- a/test/unit/utils/promise.test.js
+++ b/test/unit/utils/promise.test.js
@@ -5,12 +5,6 @@ import * as promise from '../../../src/js/utils/promise';
 QUnit.module('utils/promise');
 
 QUnit.test('can correctly identify a native Promise (if supported)', function(assert) {
-
-  // If Promises aren't supported, skip this.
-  if (!window.Promise) {
-    return assert.expect(0);
-  }
-
   assert.ok(promise.isPromise(new window.Promise((resolve) => resolve())), 'a native Promise was recognized');
 });
 


### PR DESCRIPTION
## Description
Remove `Promise` option and any workarounds for platforms without native promise support.

**Note:** Merge with `BREAKING CHANGE` header
