### PR TITLE
feat: Merge `data-setup` options on player init

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -136,7 +136,7 @@ function videojs(id, options, ready) {
 
   if (player) {
     if (options) {
-      log.warn(`Player "${id}" is already initialised. Options will not be applied.`);
+      log.warn(`Player "${id}" is already initialised. New options were not applied.`);
     }
     if (ready) {
       player.ready(ready);
@@ -161,6 +161,10 @@ function videojs(id, options, ready) {
   }
 
   options = options || {};
+
+  if (el.hasAttribute('data-setup')) {
+    options = videojs.mergeOptions(JSON.parse(el.getAttribute('data-setup')), options);
+  }
 
   hooks('beforesetup').forEach((hookFunction) => {
     const opts = hookFunction(el, mergeOptions(options));

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -163,6 +163,7 @@ function videojs(id, options, ready) {
   options = options || {};
 
   if (el.hasAttribute('data-setup')) {
+    log.warn('Using videojs() as a constructor and data-setup options together is not recommended.');
     options = videojs.mergeOptions(JSON.parse(el.getAttribute('data-setup')), options);
   }
 

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -579,3 +579,18 @@ QUnit.test('adds video-js class name with the video-js embed', function(assert) 
   assert.ok(player.hasClass('video-js'), 'video-js class was added to the first embed');
   assert.ok(player2.hasClass('video-js'), 'video-js class was preserved to the second embed');
 });
+
+QUnit.test(
+  'should merge any data-setup options',
+  function(assert) {
+    const fixture = document.getElementById('qunit-fixture');
+
+    fixture.innerHTML += '<video id="test_vid_id" data-setup=\'{"opt1": "a", "opt2": "b"}\'></video>';
+
+    const player = videojs('test_vid_id', { opt2: 'c' });
+
+    assert.ok(player, 'created player from tag');
+    assert.equal(player.options_.opt1, 'a', 'data-setup options were merged');
+    assert.equal(player.options_.opt2, 'c', 'constructor options take precedence');
+  }
+);


### PR DESCRIPTION
## Description
Plenty of people get confused where they've included `data-setup` options but use `videojs()` to init the player, not realising that `data-setup` options only apply to auto setup.

This merges any `data-setup` options on the el when a player is initialised.

Also makes the warning a bit clearer for the other case, where `videojs()` is used with options on an already initialised player.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
