### PR TITLE
fix: Audio only mode styling conflicts with fluid mode

### DIFF
--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -70,13 +70,20 @@
 
 // Not including a default AR in vjs-fluid because it would override
 // the user set AR injected into the header.
+.video-js.vjs-fluid,
+.video-js.vjs-16-9,
+.video-js.vjs-4-3,
+.video-js.vjs-9-16,
+.video-js.vjs-1-1 {
+  width: 100%;
+  max-width: 100%;
+}
+
 .video-js.vjs-fluid:not(.vjs-audio-only-mode),
 .video-js.vjs-16-9:not(.vjs-audio-only-mode),
 .video-js.vjs-4-3:not(.vjs-audio-only-mode),
 .video-js.vjs-9-16:not(.vjs-audio-only-mode),
 .video-js.vjs-1-1:not(.vjs-audio-only-mode) {
-  width: 100%;
-  max-width: 100%;
   height: 0;
 }
 

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -70,33 +70,33 @@
 
 // Not including a default AR in vjs-fluid because it would override
 // the user set AR injected into the header.
-.video-js.vjs-fluid,
-.video-js.vjs-16-9,
-.video-js.vjs-4-3,
-.video-js.vjs-9-16,
-.video-js.vjs-1-1 {
+.video-js.vjs-fluid:not(.vjs-audio-only-mode),
+.video-js.vjs-16-9:not(.vjs-audio-only-mode),
+.video-js.vjs-4-3:not(.vjs-audio-only-mode),
+.video-js.vjs-9-16:not(.vjs-audio-only-mode),
+.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
   width: 100%;
   max-width: 100%;
   height: 0;
 }
 
-.video-js.vjs-16-9 {
+.video-js.vjs-16-9:not(.vjs-audio-only-mode) {
   @include apply-aspect-ratio(16, 9);
 }
 
-.video-js.vjs-4-3 {
+.video-js.vjs-4-3:not(.vjs-audio-only-mode) {
   @include apply-aspect-ratio(4, 3);
 }
 
-.video-js.vjs-9-16 {
+.video-js.vjs-9-16:not(.vjs-audio-only-mode) {
   @include apply-aspect-ratio(9, 16);
 }
 
-.video-js.vjs-1-1 {
+.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
   @include apply-aspect-ratio(1, 1);
 }
 
-.video-js.vjs-fill {
+.video-js.vjs-fill:not(.vjs-audio-only-mode) {
   width: 100%;
   height: 100%;
 }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1112,7 +1112,7 @@ class Player extends Component {
         height: ${height}px;
       }
 
-      .${idClass}.vjs-fluid {
+      .${idClass}.vjs-fluid:not(.vjs-audio-only-mode) {
         padding-top: ${ratioMultiplier * 100}%;
       }
     `);

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -207,7 +207,7 @@ if (window.VIDEOJS_NO_DYNAMIC_STYLE !== true && Dom.isReal()) {
         height: 150px;
       }
 
-      .vjs-fluid {
+      .vjs-fluid:not(.vjs-audio-only-mode) {
         padding-top: 56.25%
       }
     `);


### PR DESCRIPTION
## Description
Disable all fluid and fill mode CSS when in audio only mode, except for that which adjusts the player's width responsively. This fixes a styling conflict that broke the player UI when both fluid and audio only mode were simultaneously enabled.
