### PR TITLE
fix(accessibility): frame must have a title attribute

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -85,5 +85,6 @@
   "End of dialog window.": "End of dialog window.",
   "{1} is loading.": "{1} is loading.",
   "Exit Picture-in-Picture": "Exit Picture-in-Picture",
-  "Picture-in-Picture": "Picture-in-Picture"
+  "Picture-in-Picture": "Picture-in-Picture",
+  "No content": "No content"
 }

--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -93,7 +93,7 @@ class ResizeManager extends Component {
     return super.createEl('iframe', {
       className: 'vjs-resize-manager',
       tabIndex: -1,
-      title: 'No content'
+      title: this.localize('No content')
     }, {
       'aria-hidden': 'true'
     });

--- a/src/js/resize-manager.js
+++ b/src/js/resize-manager.js
@@ -92,7 +92,8 @@ class ResizeManager extends Component {
   createEl() {
     return super.createEl('iframe', {
       className: 'vjs-resize-manager',
-      tabIndex: -1
+      tabIndex: -1,
+      title: 'No content'
     }, {
       'aria-hidden': 'true'
     });


### PR DESCRIPTION
## Description

According to some HTML validators, the resize manager frame doesn't pass validation because the title attribute is not present.
Please check the below validators for details
1. https://rocketvalidator.com/accessibility-validation/frame-title-unique
2. https://equalizedigital.com/accessibility-checker/iframe-missing-title/

## Specific Changes proposed
Add 'title' attribute.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
