### PR TITLE
test: stop running placeholder el test in IE and Safari to prevent errors

### DIFF
--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -580,7 +580,15 @@ QUnit.test('adds video-js class name with the video-js embed', function(assert) 
   assert.ok(player2.hasClass('video-js'), 'video-js class was preserved to the second embed');
 });
 
-QUnit.test('stores placeholder el and restores on dispose', function(assert) {
+let testOrSkip = 'test';
+
+// The following test uses some DocumentFragment properties that are not
+// available in IE or older Safaris, so we skip it.
+if (videojs.browser.IE_VERSION || videojs.browser.IS_ANY_SAFARI) {
+  testOrSkip = 'skip';
+}
+
+QUnit[testOrSkip]('stores placeholder el and restores on dispose', function(assert) {
   const fixture = document.getElementById('qunit-fixture');
 
   const embeds = [


### PR DESCRIPTION
## Description
We realized that tests were failing in IE11 and Safari 9 because some new tests introduced in #7722 seem to use unsupported `DocumentFragment` features.

Rather than try to fix that, we will simply not run these tests in IE or Safari. In 8.0, we will not support IE at all or older Safaris.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
