### PR TITLE
fix: error message should not be localized in the player class

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3408,7 +3408,7 @@ class Player extends Component {
     // show an error
     if (!sources.length) {
       this.setTimeout(function() {
-        this.error({ code: 4, message: this.localize(this.options_.notSupportedMessage) });
+        this.error({ code: 4, message: this.options_.notSupportedMessage });
       }, 0);
       return;
     }
@@ -3447,7 +3447,7 @@ class Player extends Component {
 
         // We need to wrap this in a timeout to give folks a chance to add error event handlers
         this.setTimeout(function() {
-          this.error({ code: 4, message: this.localize(this.options_.notSupportedMessage) });
+          this.error({ code: 4, message: this.options_.notSupportedMessage });
         }, 0);
 
         // we could not find an appropriate tech, but let's still notify the delegate that this is it


### PR DESCRIPTION
## Description
The "not supported message" should not be localized in the player class because an "Error Display" class localizes all error messages before showing them to the user.
https://github.com/videojs/video.js/blob/main/src/js/error-display.js#L50 

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
