### PR TITLE
chore: Lock old closed issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          issue-inactive-days: '60'
+          process-only: 'issues'


### PR DESCRIPTION
Locks issues that have been closed for 60 days.

## Why
People occasionally comment on old, closed issues that they are also having the "same issue". This is rarely useful:
* the comment is less likely to be seen or responded to
* it's probably not the _same_ issue, even if a symptom is similar (like a generic error message)
* the assertion that it's "still happening" is usually not presented with any actionable information, such as steps to reproduce

If someone believes they are having the "same" issue, they should create a new issue with their steps to reproduce and include a link to the closed issue.

## Implementation
* Uses [Lock Threads](https://github.com/marketplace/actions/lock-threads) action.
* Locks closed issues after 60 days.
* Does not lock PRs.
* Runs once an hour, as the action processes max 50 items at a time. It can be reduced to daily once the backlog is clear.
* Does not comment on the issue, the notifications would be annoying for old issues.