### PR TITLE
fix: HTML5 tech with audio tag shouldn't use requestVideoFrameCallback

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -114,6 +114,8 @@ class Html5 extends Tech {
     // into a `fullscreenchange` event
     this.proxyWebkitFullscreen_();
 
+    this.featuresVideoFrameCallback = this.featuresVideoFrameCallback && this.el_.tagName === 'VIDEO';
+
     this.triggerReady();
   }
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -1032,3 +1032,12 @@ QUnit.test('supports getting available media playback quality metrics', function
   window.performance = origPerformance;
   window.Date = origDate;
 });
+
+QUnit.test('featuresVideoFrameCallback is false for audio elements', function(assert) {
+  const el = document.createElement('audio');
+  const audioTech = new Html5({el});
+
+  assert.strictEqual(audioTech.featuresVideoFrameCallback, false, 'Html5 with audio element should not support rvf');
+
+  audioTech.dispose();
+});


### PR DESCRIPTION
## Description
The check for `requestAnimationFrameCallback` assumes a video element, which breaks track updates if an audio el is used.

## Specific Changes proposed
Additional check in htmlt tech constructor.

Fixes #7772 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
