### PR TITLE
fix: Don't copy deprecated Event.path

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -117,8 +117,10 @@ export function fixEvent(event) {
       // Safari 6.0.3 warns you if you try to copy deprecated layerX/Y
       // Chrome warns you if you try to copy deprecated keyboardEvent.keyLocation
       // and webkitMovementX/Y
+      // Lighthouse complains if Event.path is copied
       if (key !== 'layerX' && key !== 'layerY' && key !== 'keyLocation' &&
-          key !== 'webkitMovementX' && key !== 'webkitMovementY') {
+          key !== 'webkitMovementX' && key !== 'webkitMovementY' &&
+          key !== 'path') {
         // Chrome 32+ warns if you try to copy deprecated returnValue, but
         // we still want to if preventDefault isn't supported (IE8).
         if (!(key === 'returnValue' && old.preventDefault)) {

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -383,3 +383,21 @@ QUnit.test('only the first event should call listener via any', function(assert)
   Events.trigger(el, 'event2');
   assert.equal(triggered, 1, 'listener was not triggered again');
 });
+
+QUnit.test('fixEvent should not copy excluded properties', function(assert) {
+  const event = Events.fixEvent({
+    a: 'a',
+    layerX: 0,
+    layerY: 0,
+    keyLocation: 0,
+    webkitMovementX: 0,
+    webkitMovementY: 0,
+    path: 0
+  });
+
+  assert.true(event.fixed_, 'event is a fixed event');
+  assert.strictEqual(event.a, 'a', 'other props copied');
+  ['layerX', 'layerY', 'keyLocation', 'webkitMovementX', 'webkitMovementY', 'path'].forEach(prop => {
+    assert.equal(event[prop], undefined, `${prop} is undefined`);
+  });
+});


### PR DESCRIPTION
## Description
Lighthouse complains if `path` is copied from the event as `Event.path` is deprecated.

## Specific Changes proposed
Adds `path` to the list of excluded properties.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
