### PR TITLE
feat: add a new title bar component

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,8 @@
     <li><a href="sandbox/live.html">Live Demo</a></li>
     <li><a href="sandbox/liveui.html">LiveUI Demo</a></li>
     <li><a href="sandbox/vertical-volume.html">Vertical Volume Demo</a></li>
-    <li><a href="sandbox/language.html">Laungage Demo</a></li>
+    <li><a href="sandbox/language.html">Language Demo</a></li>
+    <li><a href="sandbox/load-media.html"><code>loadMedia</code> Demo</a></li>
     <li><a href="sandbox/hls.html">Hls Demo</a></li>
     <li><a href="sandbox/autoplay-tests.html">Autoplay Tests</a></li>
     <li><a href="sandbox/noUITitleAttributes.html">noUITitleAttributes Demo</a></li>

--- a/sandbox/index.html.example
+++ b/sandbox/index.html.example
@@ -30,6 +30,7 @@
   <script>
     var vid = document.getElementById('vid1');
     var player = videojs(vid);
+    player.log('window.player created', player);
   </script>
 
 </body>

--- a/sandbox/load-media.html.example
+++ b/sandbox/load-media.html.example
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js loadMedia Demo</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+</head>
+<body>
+  <h1>Video.js <code>loadMedia</code> Demo</h1>
+  <p>This shows how the <code>loadMedia</code> method is used and the effect it has on the player.</p>
+
+  <video-js
+    id="vid1"
+    controls
+    width="640"
+    height="264">
+  </video-js>
+
+  <script>
+    var vid = document.getElementById('vid1');
+    var player = videojs(vid);
+
+    player.log('window.player created', player);
+
+    player.loadMedia({
+      artist: 'Disney',
+      album: 'Oceans',
+      title: 'Oceans',
+      description: 'Journey in to the depths of a wonderland filled with mystery, beauty and power. Oceans is a spectacular story, narrated by Pierce Brosnan, about remarkable creatures under the sea. It\'s an unprecedented look at the lives of these elusive deepwater creatures through their own eyes. Incredible state-of-the-art-underwater filmmaking will take your breath away as you migrate with whales, swim alongside a great white shark and race with dolphins at play.',
+      poster: 'https://vjs.zencdn.net/v/oceans.png',
+      src: [{
+        src: 'https://vjs.zencdn.net/v/oceans.mp4',
+        type: 'video/mp4'
+      }, {
+        src: 'https://vjs.zencdn.net/v/oceans.webm',
+        type: 'video/webm'
+      }, {
+        src: 'https://vjs.zencdn.net/v/oceans.ogv',
+        type: 'video/ogv'
+      }],
+      textTracks: [{
+        kind: 'captions',
+        label: 'English',
+        src: '../docs/examples/shared/example-captions.vtt',
+        srclang: 'en'
+      }]
+    })
+  </script>
+
+</body>
+</html>

--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -7,9 +7,11 @@
   width: $big-play-button--width; // Firefox bug: For some reason without width the icon wouldn't show up. Switched to using width and removed padding.
   display: block;
   position: absolute;
-  top: 10px;
-  left: 10px;
+  top: 50%;
+  left: 50%;
   padding: 0;
+  margin-top: -(math.div($big-play-button--height, 2));
+  margin-left: -(math.div($big-play-button--width, 2));
   cursor: pointer;
   opacity: 1;
   border: $big-play-button--border-size solid $primary-foreground-color;
@@ -26,14 +28,6 @@
 
     @extend %icon-default;
   }
-}
-
-// Allow people that hate their poster image to center the big play button.
-.vjs-big-play-centered .vjs-big-play-button {
-  top: 50%;
-  left: 50%;
-  margin-top: -(math.div($big-play-button--height, 2));
-  margin-left: -(math.div($big-play-button--width, 2));
 }
 
 .video-js:hover .vjs-big-play-button,

--- a/src/css/components/_title-bar.scss
+++ b/src/css/components/_title-bar.scss
@@ -1,0 +1,3 @@
+.vjs-title-bar {
+
+}

--- a/src/css/components/_title-bar.scss
+++ b/src/css/components/_title-bar.scss
@@ -1,3 +1,36 @@
 .vjs-title-bar {
 
+  // At a base inherited font-size of 10px, the title bar overall height should
+  // be 96px with the area of text occupying the first 48px and the rest being
+  // padding. This leaves plenty of room for the gradient to fade to
+  // transparent while maintaining an WCAG AA-compliant contrast ratio (tested
+  // using the TPGi Color Contrast Analyzer application) even on top of a solid
+  // white background.
+  @include linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.9) 0%,
+    rgba(0, 0, 0, 0.7) 60%,
+    rgba(0, 0, 0, 0) 100%
+  );
+  font-size: 1.2em; // 12px
+  line-height: 1.5; // 18px
+  @include transition(opacity 0.1s);
+  padding: 0.666em 1.333em 4em; // 8px 16px 48px
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.vjs-title-bar-title,
+.vjs-title-bar-desc {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vjs-title-bar-title {
+  font-weight: bold;
+  margin-bottom: 0.333em; // 4px
 }

--- a/src/css/components/_title-bar.scss
+++ b/src/css/components/_title-bar.scss
@@ -23,7 +23,7 @@
 }
 
 .vjs-title-bar-title,
-.vjs-title-bar-desc {
+.vjs-title-bar-description {
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -33,4 +33,9 @@
 .vjs-title-bar-title {
   font-weight: bold;
   margin-bottom: 0.333em; // 4px
+}
+
+.vjs-playing.vjs-user-inactive .vjs-title-bar {
+  opacity: 0;
+  @include transition(opacity 1s);
 }

--- a/src/css/video-js.scss
+++ b/src/css/video-js.scss
@@ -41,6 +41,7 @@
 @import "components/audio";
 @import "components/adaptive";
 @import "components/captions-settings";
+@import "components/title-bar";
 
 @import "print";
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4845,7 +4845,7 @@ class Player extends Component {
     // Clone the media object so it cannot be mutated from outside.
     this.cache_.media = merge(media);
 
-    const {artwork, poster, src, textTracks} = this.cache_.media;
+    const {artwork, description, poster, src, textTracks, title} = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
@@ -4865,6 +4865,10 @@ class Player extends Component {
 
     if (Array.isArray(textTracks)) {
       textTracks.forEach(tt => this.addRemoteTextTrack(tt, false));
+    }
+
+    if (this.titleBar) {
+      this.titleBar.update({title, description});
     }
 
     this.ready(ready);
@@ -5149,6 +5153,7 @@ Player.prototype.options_ = {
   children: [
     'mediaLoader',
     'posterImage',
+    'titleBar',
     'textTrackDisplay',
     'loadingSpinner',
     'bigPlayButton',
@@ -5156,8 +5161,7 @@ Player.prototype.options_ = {
     'controlBar',
     'errorDisplay',
     'textTrackSettings',
-    'resizeManager',
-    'titleBar'
+    'resizeManager'
   ],
 
   language: navigator && (navigator.languages && navigator.languages[0] || navigator.userLanguage || navigator.language) || 'en',

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4845,7 +4845,7 @@ class Player extends Component {
     // Clone the media object so it cannot be mutated from outside.
     this.cache_.media = merge(media);
 
-    const {artwork, description, poster, src, textTracks, title} = this.cache_.media;
+    const {artist, artwork, description, poster, src, textTracks, title} = this.cache_.media;
 
     // If `artwork` is not given, create it using `poster`.
     if (!artwork && poster) {
@@ -4868,7 +4868,10 @@ class Player extends Component {
     }
 
     if (this.titleBar) {
-      this.titleBar.update({title, description});
+      this.titleBar.update({
+        title,
+        description: description || artist || ''
+      });
     }
 
     this.ready(ready);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -50,6 +50,7 @@ import './error-display.js';
 import './tracks/text-track-settings.js';
 import './resize-manager.js';
 import './live-tracker.js';
+import './title-bar.js';
 
 // Import Html5 tech, at least for disposing the original video tag.
 import './tech/html5.js';
@@ -5155,7 +5156,8 @@ Player.prototype.options_ = {
     'controlBar',
     'errorDisplay',
     'textTrackSettings',
-    'resizeManager'
+    'resizeManager',
+    'titleBar'
   ],
 
   language: navigator && (navigator.languages && navigator.languages[0] || navigator.userLanguage || navigator.language) || 'en',

--- a/src/js/title-bar.js
+++ b/src/js/title-bar.js
@@ -1,0 +1,104 @@
+import Component from './component';
+import * as Dom from './utils/dom';
+import * as Guid from './utils/guid';
+
+/**
+ * Displays an element over the player which contains an optional title and
+ * description for the current content.
+ *
+ * Much of the code for this component originated in the now obsolete
+ * videojs-dock plugin: https://github.com/brightcove/videojs-dock/
+ *
+ * @extends Component
+ */
+class TitleBar extends Component {
+
+  constructor(player, options) {
+    super(player, options);
+
+    this.update = this.update.bind(this);
+    this.update(options);
+  }
+
+  /**
+   * Create the `TitleBar`'s DOM element
+   *
+   * @return {Element}
+   *         The element that was created.
+   */
+  createEl() {
+    this.titleEl = Dom.createEl('div', {
+      className: 'vjs-title-bar-title',
+      id: `vjs-title-bar-title-${Guid.newGUID()}`
+    });
+
+    this.descEl = Dom.createEl('div', {
+      className: 'vjs-title-bar-desc',
+      id: `vjs-title-bar-desc-${Guid.newGUID()}`
+    });
+
+    return Dom.createEl('div', {
+      className: 'vjs-title-bar'
+    }, {}, [
+      this.titleEl,
+      this.descEl
+    ]);
+  }
+
+  /**
+   * Update the contents of the title bar with new title and description text.
+   *
+   * @param  {Object} [options]
+   * @param  {string} [options.title]
+   * @param  {string} [options.desc]
+   */
+  update({title = '', desc = ''} = {}) {
+    const {titleEl, descEl} = this;
+    const tech = this.player_.tech_;
+    const techEl = tech && tech.el_;
+
+    Dom.emptyEl(titleEl);
+    Dom.emptyEl(descEl);
+
+    // If there is a tech element available, update its ARIA attributes
+    // according to whether a title and/or description have been provided.
+    if (techEl) {
+      techEl.removeAttribute('aria-labelledby');
+      techEl.removeAttribute('aria-describedby');
+
+      if (title) {
+        techEl.setAttribute('aria-labelledby', titleEl.id);
+      }
+      if (desc) {
+        techEl.setAttribute('aria-describedby', descEl.id);
+      }
+    }
+
+    Dom.textContent(titleEl, title);
+    Dom.textContent(descEl, desc);
+
+    if (title || desc) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  dispose() {
+    const tech = this.player_.tech_;
+    const techEl = tech && tech.el_;
+
+    if (techEl) {
+      techEl.removeAttribute('aria-labelledby');
+      techEl.removeAttribute('aria-describedby');
+    }
+
+    super.dispose();
+    this.titleEl = null;
+    this.descEl = null;
+  }
+}
+
+Component.registerComponent('TitleBar', TitleBar);
+
+export default TitleBar;

--- a/src/js/title-bar.js
+++ b/src/js/title-bar.js
@@ -73,13 +73,13 @@ class TitleBar extends Component {
     // according to whether a title and/or description have been provided.
     if (techEl) {
       techEl.removeAttribute('aria-labelledby');
-      techEl.removeAttribute('aria-descriptionribedby');
+      techEl.removeAttribute('aria-describedby');
 
       if (title) {
         techEl.setAttribute('aria-labelledby', titleEl.id);
       }
       if (description) {
-        techEl.setAttribute('aria-descriptionribedby', descriptionEl.id);
+        techEl.setAttribute('aria-describedby', descriptionEl.id);
       }
     }
 
@@ -99,7 +99,7 @@ class TitleBar extends Component {
 
     if (techEl) {
       techEl.removeAttribute('aria-labelledby');
-      techEl.removeAttribute('aria-descriptionribedby');
+      techEl.removeAttribute('aria-describedby');
     }
 
     super.dispose();

--- a/src/js/title-bar.js
+++ b/src/js/title-bar.js
@@ -32,52 +32,61 @@ class TitleBar extends Component {
       id: `vjs-title-bar-title-${Guid.newGUID()}`
     });
 
-    this.descEl = Dom.createEl('div', {
-      className: 'vjs-title-bar-desc',
-      id: `vjs-title-bar-desc-${Guid.newGUID()}`
+    this.descriptionEl = Dom.createEl('div', {
+      className: 'vjs-title-bar-description',
+      id: `vjs-title-bar-description-${Guid.newGUID()}`
     });
 
     return Dom.createEl('div', {
       className: 'vjs-title-bar'
     }, {}, [
       this.titleEl,
-      this.descEl
+      this.descriptionEl
     ]);
   }
 
   /**
    * Update the contents of the title bar with new title and description text.
    *
-   * @param  {Object} [options]
+   * If both title and description are missing, the title bar will be hidden.
+   *
+   * If either title or description are present, the title bar will be visible.
+   *
+   * @param  {Object} [options={}]
+   *         An options object. When empty, the title bar will be hidden.
+   *
    * @param  {string} [options.title]
-   * @param  {string} [options.desc]
+   *         A title to display in the title bar.
+   *
+   * @param  {string} [options.description]
+   *         A description to display in the title bar.
    */
-  update({title = '', desc = ''} = {}) {
-    const {titleEl, descEl} = this;
+  update({title = '', description = ''} = {}) {
+    const {titleEl, descriptionEl} = this;
     const tech = this.player_.tech_;
     const techEl = tech && tech.el_;
 
     Dom.emptyEl(titleEl);
-    Dom.emptyEl(descEl);
+    Dom.emptyEl(descriptionEl);
 
     // If there is a tech element available, update its ARIA attributes
     // according to whether a title and/or description have been provided.
     if (techEl) {
       techEl.removeAttribute('aria-labelledby');
-      techEl.removeAttribute('aria-describedby');
+      techEl.removeAttribute('aria-descriptionribedby');
 
       if (title) {
         techEl.setAttribute('aria-labelledby', titleEl.id);
       }
-      if (desc) {
-        techEl.setAttribute('aria-describedby', descEl.id);
+      if (description) {
+        techEl.setAttribute('aria-descriptionribedby', descriptionEl.id);
       }
     }
 
     Dom.textContent(titleEl, title);
-    Dom.textContent(descEl, desc);
+    Dom.textContent(descriptionEl, description);
 
-    if (title || desc) {
+    if (title || description) {
       this.show();
     } else {
       this.hide();
@@ -90,12 +99,12 @@ class TitleBar extends Component {
 
     if (techEl) {
       techEl.removeAttribute('aria-labelledby');
-      techEl.removeAttribute('aria-describedby');
+      techEl.removeAttribute('aria-descriptionribedby');
     }
 
     super.dispose();
     this.titleEl = null;
-    this.descEl = null;
+    this.descriptionEl = null;
   }
 }
 

--- a/src/js/title-bar.js
+++ b/src/js/title-bar.js
@@ -90,6 +90,18 @@ class TitleBar extends Component {
    *
    * If either title or description are present, the title bar will be visible.
    *
+   * NOTE: Any previously set value will be preserved. To unset a previously
+   * set value, you must pass an empty string or null.
+   *
+   * For example:
+   *
+   * ```
+   * update({title: 'foo', description: 'bar'}) // title: 'foo', description: 'bar'
+   * update({description: 'bar2'}) // title: 'foo', description: 'bar2'
+   * update({title: ''}) // title: '', description: 'bar2'
+   * update({title: 'foo', description: null}) // title: 'foo', description: null
+   * ```
+   *
    * @param  {Object} [options={}]
    *         An options object. When empty, the title bar will be hidden.
    *

--- a/test/unit/title-bar.test.js
+++ b/test/unit/title-bar.test.js
@@ -26,25 +26,25 @@ QUnit.test('has the expected DOM structure and pointers', function(assert) {
   assert.ok(Dom.hasClass(el, 'vjs-title-bar'), 'TitleBar element has the expected class');
   assert.ok(Dom.hasClass(el, 'vjs-hidden'), 'TitleBar element has the expected class');
   assert.strictEqual(el.children[0], titleBar.titleEl, 'TitleBar title element is first child');
-  assert.strictEqual(el.children[1], titleBar.descEl, 'TitleBar desc element is first child');
+  assert.strictEqual(el.children[1], titleBar.descriptionEl, 'TitleBar description element is first child');
   assert.ok(Dom.hasClass(titleBar.titleEl, 'vjs-title-bar-title'), 'TitleBar title element has expected class');
-  assert.ok(Dom.hasClass(titleBar.descEl, 'vjs-title-bar-desc'), 'TitleBar desc element has expected class');
+  assert.ok(Dom.hasClass(titleBar.descriptionEl, 'vjs-title-bar-description'), 'TitleBar description element has expected class');
 });
 
-QUnit.test('setting title and desc from options', function(assert) {
+QUnit.test('setting title and description from options', function(assert) {
   const titleBar = new TitleBar(this.player, {
     title: 'test title',
-    desc: 'test desc'
+    description: 'test description'
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descEl.textContent, 'test desc', 'TitleBar desc element has expected content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
 });
 
 QUnit.test('setting title only from options', function(assert) {
@@ -54,66 +54,66 @@ QUnit.test('setting title only from options', function(assert) {
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
 
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
 });
 
-QUnit.test('setting desc only from options', function(assert) {
+QUnit.test('setting description only from options', function(assert) {
   const titleBar = new TitleBar(this.player, {
-    desc: 'test desc'
+    description: 'test description'
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descEl.textContent, 'test desc', 'TitleBar desc element has expected content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
 });
-QUnit.test('setting no title or desc', function(assert) {
+QUnit.test('setting no title or description', function(assert) {
   const titleBar = new TitleBar(this.player);
 
   assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
 
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
 });
 
-QUnit.test('updating title and desc', function(assert) {
+QUnit.test('updating title and description', function(assert) {
   const titleBar = new TitleBar(this.player, {
     title: 'test title',
-    desc: 'test desc'
+    description: 'test description'
   });
 
   titleBar.update({
     title: 'test title two',
-    desc: 'test desc two'
+    description: 'test description two'
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descEl.textContent, 'test desc two', 'TitleBar desc element has expected content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description two', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
 });
 
 QUnit.test('updating title only', function(assert) {
   const titleBar = new TitleBar(this.player, {
     title: 'test title',
-    desc: 'test desc'
+    description: 'test description'
   });
 
   titleBar.update({
@@ -122,48 +122,48 @@ QUnit.test('updating title only', function(assert) {
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
 
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
 });
 
-QUnit.test('updating desc only from options', function(assert) {
+QUnit.test('updating description only from options', function(assert) {
   const titleBar = new TitleBar(this.player, {
     title: 'test title',
-    desc: 'test desc'
+    description: 'test description'
   });
 
   titleBar.update({
-    desc: 'test desc two'
+    description: 'test description two'
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descEl.textContent, 'test desc two', 'TitleBar desc element has expected content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description two', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
 });
 
-QUnit.test('updating no title or desc', function(assert) {
+QUnit.test('updating no title or description', function(assert) {
   const titleBar = new TitleBar(this.player, {
     title: 'test title',
-    desc: 'test desc'
+    description: 'test description'
   });
 
   titleBar.update();
 
   assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
   assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
 
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
 });

--- a/test/unit/title-bar.test.js
+++ b/test/unit/title-bar.test.js
@@ -44,7 +44,7 @@ QUnit.test('setting title and description from options', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
 });
 
 QUnit.test('setting title only from options', function(assert) {
@@ -59,7 +59,7 @@ QUnit.test('setting title only from options', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
 });
 
 QUnit.test('setting description only from options', function(assert) {
@@ -74,7 +74,7 @@ QUnit.test('setting description only from options', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
 });
 QUnit.test('setting no title or description', function(assert) {
   const titleBar = new TitleBar(this.player);
@@ -86,7 +86,7 @@ QUnit.test('setting no title or description', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
 });
 
 QUnit.test('updating title and description', function(assert) {
@@ -107,7 +107,7 @@ QUnit.test('updating title and description', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
 });
 
 QUnit.test('updating title only', function(assert) {
@@ -127,7 +127,7 @@ QUnit.test('updating title only', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
 });
 
 QUnit.test('updating description only from options', function(assert) {
@@ -147,7 +147,7 @@ QUnit.test('updating description only from options', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-descriptionribedby'), titleBar.descriptionEl.id, 'tech aria-descriptionribedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
 });
 
 QUnit.test('updating no title or description', function(assert) {
@@ -165,5 +165,25 @@ QUnit.test('updating no title or description', function(assert) {
   const techEl = this.player.tech_.el_;
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-descriptionribedby'), 'tech aria-descriptionribedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+});
+
+QUnit.test('disposing removes aria attributes on the tech and removes child DOM refs', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    description: 'test description'
+  });
+
+  const techEl = this.player.tech_.el_;
+
+  assert.ok(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is set');
+  assert.ok(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is set');
+
+  titleBar.dispose();
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(titleBar.titleEl, 'titleEl is nulled');
+  assert.notOk(titleBar.descriptionEl, 'descriptionEl is nulled');
+
 });

--- a/test/unit/title-bar.test.js
+++ b/test/unit/title-bar.test.js
@@ -1,0 +1,169 @@
+/* eslint-env qunit */
+import sinon from 'sinon';
+import * as Dom from '../../src/js/utils/dom.js';
+import TitleBar from '../../src/js/title-bar.js';
+import TestHelpers from './test-helpers.js';
+
+QUnit.module('TitleBar', {
+  beforeEach() {
+    this.clock = sinon.useFakeTimers();
+    this.player = TestHelpers.makePlayer();
+
+    // Tick forward to make the player ready.
+    this.clock.tick(1);
+  },
+  afterEach() {
+    this.player.dispose();
+    this.player = null;
+    this.clock.restore();
+  }
+});
+
+QUnit.test('has the expected DOM structure and pointers', function(assert) {
+  const titleBar = new TitleBar(this.player);
+  const el = titleBar.el();
+
+  assert.ok(Dom.hasClass(el, 'vjs-title-bar'), 'TitleBar element has the expected class');
+  assert.ok(Dom.hasClass(el, 'vjs-hidden'), 'TitleBar element has the expected class');
+  assert.strictEqual(el.children[0], titleBar.titleEl, 'TitleBar title element is first child');
+  assert.strictEqual(el.children[1], titleBar.descEl, 'TitleBar desc element is first child');
+  assert.ok(Dom.hasClass(titleBar.titleEl, 'vjs-title-bar-title'), 'TitleBar title element has expected class');
+  assert.ok(Dom.hasClass(titleBar.descEl, 'vjs-title-bar-desc'), 'TitleBar desc element has expected class');
+});
+
+QUnit.test('setting title and desc from options', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    desc: 'test desc'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.descEl.textContent, 'test desc', 'TitleBar desc element has expected content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+});
+
+QUnit.test('setting title only from options', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+});
+
+QUnit.test('setting desc only from options', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    desc: 'test desc'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.descEl.textContent, 'test desc', 'TitleBar desc element has expected content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+});
+QUnit.test('setting no title or desc', function(assert) {
+  const titleBar = new TitleBar(this.player);
+
+  assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+});
+
+QUnit.test('updating title and desc', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    desc: 'test desc'
+  });
+
+  titleBar.update({
+    title: 'test title two',
+    desc: 'test desc two'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.descEl.textContent, 'test desc two', 'TitleBar desc element has expected content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+});
+
+QUnit.test('updating title only', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    desc: 'test desc'
+  });
+
+  titleBar.update({
+    title: 'test title two'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+});
+
+QUnit.test('updating desc only from options', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    desc: 'test desc'
+  });
+
+  titleBar.update({
+    desc: 'test desc two'
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.descEl.textContent, 'test desc two', 'TitleBar desc element has expected content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descEl.id, 'tech aria-describedby matches TitleBar desc element');
+});
+
+QUnit.test('updating no title or desc', function(assert) {
+  const titleBar = new TitleBar(this.player, {
+    title: 'test title',
+    desc: 'test desc'
+  });
+
+  titleBar.update();
+
+  assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.descEl.textContent, '', 'TitleBar desc element has no content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+});

--- a/test/unit/title-bar.test.js
+++ b/test/unit/title-bar.test.js
@@ -25,93 +25,34 @@ QUnit.test('has the expected DOM structure and pointers', function(assert) {
 
   assert.ok(Dom.hasClass(el, 'vjs-title-bar'), 'TitleBar element has the expected class');
   assert.ok(Dom.hasClass(el, 'vjs-hidden'), 'TitleBar element has the expected class');
-  assert.strictEqual(el.children[0], titleBar.titleEl, 'TitleBar title element is first child');
-  assert.strictEqual(el.children[1], titleBar.descriptionEl, 'TitleBar description element is first child');
-  assert.ok(Dom.hasClass(titleBar.titleEl, 'vjs-title-bar-title'), 'TitleBar title element has expected class');
-  assert.ok(Dom.hasClass(titleBar.descriptionEl, 'vjs-title-bar-description'), 'TitleBar description element has expected class');
+  assert.strictEqual(el.children[0], titleBar.els.title, 'TitleBar title element is first child');
+  assert.strictEqual(el.children[1], titleBar.els.description, 'TitleBar description element is first child');
+  assert.ok(Dom.hasClass(titleBar.els.title, 'vjs-title-bar-title'), 'TitleBar title element has expected class');
+  assert.ok(Dom.hasClass(titleBar.els.description, 'vjs-title-bar-description'), 'TitleBar description element has expected class');
 });
 
-QUnit.test('setting title and description from options', function(assert) {
-  const titleBar = new TitleBar(this.player, {
-    title: 'test title',
-    description: 'test description'
-  });
-
-  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description', 'TitleBar description element has expected content');
-
-  const techEl = this.player.tech_.el_;
-
-  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
-});
-
-QUnit.test('setting title only from options', function(assert) {
-  const titleBar = new TitleBar(this.player, {
-    title: 'test title'
-  });
-
-  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, 'test title', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
-
-  const techEl = this.player.tech_.el_;
-
-  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
-});
-
-QUnit.test('setting description only from options', function(assert) {
-  const titleBar = new TitleBar(this.player, {
-    description: 'test description'
-  });
-
-  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description', 'TitleBar description element has expected content');
-
-  const techEl = this.player.tech_.el_;
-
-  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
-});
-QUnit.test('setting no title or description', function(assert) {
+QUnit.test('setting title and description', function(assert) {
   const titleBar = new TitleBar(this.player);
 
-  assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
-
-  const techEl = this.player.tech_.el_;
-
-  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
-});
-
-QUnit.test('updating title and description', function(assert) {
-  const titleBar = new TitleBar(this.player, {
+  titleBar.update({
     title: 'test title',
     description: 'test description'
   });
 
-  titleBar.update({
-    title: 'test title two',
-    description: 'test description two'
-  });
-
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description two', 'TitleBar description element has expected content');
+  assert.strictEqual(titleBar.els.title.textContent, 'test title', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.els.description.textContent, 'test description', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
-  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.els.title.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.els.description.id, 'tech aria-describedby matches TitleBar description element');
 });
 
 QUnit.test('updating title only', function(assert) {
-  const titleBar = new TitleBar(this.player, {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
     title: 'test title',
     description: 'test description'
   });
@@ -121,17 +62,19 @@ QUnit.test('updating title only', function(assert) {
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, 'test title two', 'TitleBar title element has expected content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
+  assert.strictEqual(titleBar.els.title.textContent, 'test title two', 'TitleBar title element has expected content');
+  assert.strictEqual(titleBar.els.description.textContent, 'test description', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
-  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.titleEl.id, 'tech aria-labelledby matches TitleBar title element');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.els.title.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.els.description.id, 'tech aria-describedby matches TitleBar description element');
 });
 
-QUnit.test('updating description only from options', function(assert) {
-  const titleBar = new TitleBar(this.player, {
+QUnit.test('updating description only', function(assert) {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
     title: 'test title',
     description: 'test description'
   });
@@ -141,35 +84,86 @@ QUnit.test('updating description only from options', function(assert) {
   });
 
   assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, 'test description two', 'TitleBar description element has expected content');
+  assert.strictEqual(titleBar.els.title.textContent, 'test title', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.els.description.textContent, 'test description two', 'TitleBar description element has expected content');
 
   const techEl = this.player.tech_.el_;
 
-  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.descriptionEl.id, 'tech aria-describedby matches TitleBar description element');
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.els.title.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.els.description.id, 'tech aria-describedby matches TitleBar description element');
 });
 
-QUnit.test('updating no title or description', function(assert) {
-  const titleBar = new TitleBar(this.player, {
+QUnit.test('removing title and description', function(assert) {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
     title: 'test title',
     description: 'test description'
   });
 
-  titleBar.update();
+  titleBar.update({
+    title: '',
+    description: ''
+  });
 
-  assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
-  assert.strictEqual(titleBar.titleEl.textContent, '', 'TitleBar title element has no content');
-  assert.strictEqual(titleBar.descriptionEl.textContent, '', 'TitleBar description element has no content');
+  assert.ok(titleBar.hasClass('vjs-hidden'), 'TitleBar is hidden');
+  assert.strictEqual(titleBar.els.title.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.els.description.textContent, '', 'TitleBar description element has no content');
 
   const techEl = this.player.tech_.el_;
 
-  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
-  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby does not exist');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby does not exist');
+});
+
+QUnit.test('removing title only', function(assert) {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
+    title: 'test title',
+    description: 'test description'
+  });
+
+  titleBar.update({
+    title: ''
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.els.title.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.els.description.textContent, 'test description', 'TitleBar description element has expected content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby does not exist');
+  assert.strictEqual(techEl.getAttribute('aria-describedby'), titleBar.els.description.id, 'tech aria-describedby matches TitleBar description element');
+});
+
+QUnit.test('removing description only', function(assert) {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
+    title: 'test title',
+    description: 'test description'
+  });
+
+  titleBar.update({
+    description: ''
+  });
+
+  assert.notOk(titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(titleBar.els.title.textContent, 'test title', 'TitleBar title element has no content');
+  assert.strictEqual(titleBar.els.description.textContent, '', 'TitleBar description element has no content');
+
+  const techEl = this.player.tech_.el_;
+
+  assert.strictEqual(techEl.getAttribute('aria-labelledby'), titleBar.els.title.id, 'tech aria-labelledby matches TitleBar title element');
+  assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby does not exist');
 });
 
 QUnit.test('disposing removes aria attributes on the tech and removes child DOM refs', function(assert) {
-  const titleBar = new TitleBar(this.player, {
+  const titleBar = new TitleBar(this.player);
+
+  titleBar.update({
     title: 'test title',
     description: 'test description'
   });
@@ -183,7 +177,5 @@ QUnit.test('disposing removes aria attributes on the tech and removes child DOM 
 
   assert.notOk(techEl.hasAttribute('aria-labelledby'), 'tech aria-labelledby is not set');
   assert.notOk(techEl.hasAttribute('aria-describedby'), 'tech aria-describedby is not set');
-  assert.notOk(titleBar.titleEl, 'titleEl is nulled');
-  assert.notOk(titleBar.descriptionEl, 'descriptionEl is nulled');
-
+  assert.notOk(titleBar.els, 'els object is is nulled');
 });


### PR DESCRIPTION
## Description
This PR mostly adopts [the Brightcove videojs-dock plugin](https://github.com/brightcove/videojs-dock) as a first-class feature of Video.js.

One key difference is the lack of a "shelf" element as an empty `<div>` without a clear purpose felt a bit unnecessary in the context of Video.js itself (and may not survive in the Brightcove Player either).

### BREAKING CHANGE

This removes the `vjs-big-play-centered` class and moves the Big Play Button to the center of the player by default to make room for the title bar. This is a more common UI convention in 2022.

## Specific Changes proposed
- Add `TitleBar` component, which is a new default child of the player.
- The component is empty (and, therefore, hidden) by default.
- Providing the `Player` with video metadata via `loadMedia` will automatically populate the `TitleBar` with a `title` and `description` (both optional).
  - The `TitleBar` can be independently updated using `player.titleBar.update()`.
    - To unset a previously set value, set it to a falsy value like `''` or `null`.
  - If neither is provided in `loadMedia()` or `titleBar.update()`, the `TitleBar` component is hidden.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created (in repo)
- [ ] Reviewed by Two Core Contributors
