### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,13 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+"
     # match semver pre-releases
     - "v[0-9]+.[0-9]+.[0-9]+-*"
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     env:
       NETLIFY_BASE: 'videojs-preview.netlify.app'
     runs-on: ubuntu-latest
@@ -66,6 +71,8 @@ jobs:
           discussion_category_name: Releases
 
   deploy:
+    permissions:
+      contents: none
     needs: release
     runs-on: ubuntu-latest
     environment: Deploy


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
