### PR TITLE
feat: setup Crowdin Localization

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -23,6 +23,7 @@ jobs:
           upload_sources: true
           # Upload translations to Crowdin, only use true at initial run
           upload_translations: true
+          upload_translations_args: '--import-eq-suggestions'
           # Make pull request of Crowdin translations
           download_translations: true
           # To download translations to the specified version branch

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -4,9 +4,9 @@
 name: Crowdin Action
 
 # Controls when the action will run.
-on:
-  schedule:
-    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+# on:
+  # schedule:
+  #  - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
 
 jobs:
   synchronize-with-crowdin:

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,38 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Action
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.4.9
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+          # Make pull request of Crowdin translations
+          download_translations: true
+          # To download translations to the specified version branch
+          localization_branch_name: l10n_crowdin_translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,60 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "/lang/en.json",
+    "translation": "/lang/%locale%.json",
+    "languages_mapping": {
+      "locale": {
+        "ar": "ar",
+        "ba": "ba",
+        "bg": "bg",
+        "ca": "ca",
+        "cs": "cs",
+        "cy": "cy",
+        "da": "da",
+        "de": "de",
+        "el": "el",
+        "es-ES": "es",
+        "et": "et",
+        "eu": "eu",
+        "fa": "fa",
+        "fi": "fi",
+        "fr": "fr",
+        "gd": "gd",
+        "gl": "gl",
+        "he": "he",
+        "hi": "hi",
+        "hr": "hr",
+        "hu": "hu",
+        "it": "it",
+        "ja": "ja",
+        "ko": "ko",
+        "lv": "lv",
+        "nb": "nb",
+        "nl": "nl",
+        "oc": "oc",
+        "pl": "pl",
+        "ro": "ro",
+        "ru": "ru",
+        "sk": "sk",
+        "sl": "sl",
+        "sr": "sr",
+        "sv-SE": "sv",
+        "te": "te",
+        "th": "th",
+        "tr": "tr",
+        "uk": "uk",
+        "vi": "vi",
+        "pt-BR": "pt-BR",
+        "pt-PT": "pt-PT",
+        "zh-CN": "zh-CN",
+        "zh-TW": "zh-TW"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Hey everyone,

It's Andrii from Crowdin. I'm using video.js in some of my projects and I'd like to fully translate the app into the Ukrainian language.

Just did some analysis of the current i18n workflow and it feels like GitHub issues and PRs reported by the community are not so easy to handle. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with Crowdin via GitHub Actions. Crowdin is free for open-source projects. This integration works in the following way:
- the action runs every 6 hours (actually, it's up to you what trigger to use, it could also be a push to the default branch, for example). Workflow example - [here](https://github.com/andrii-bodnar/video.js/runs/6902572500?check_suite_focus=true)
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin (using the `upload_translations` action config parameter, it's necessary only for the first time)
- download all the new translations from Crowdin and commit these translations to the `localization_branch_name`
- open a Pull Request with the latest translations.

You can find my demo Crowdin project here - [videojs-demo](https://crowdin.com/project/videojs-demo) (not all the target languages are here).

Example of the first PR that will be created by Crowdin Action - https://github.com/andrii-bodnar/video.js/pull/3/ (Don't worry about the diffs - it just sorted keys according to keys order in the English file and added some missing keys with the English translations that later will be replaced with the translations made in Crowdin)

Later, you will be able to set up the [Docusaurus integration](https://docusaurus.io/docs/i18n/crowdin) for your docs also (#5144)
