### PR TITLE
feat: add an option to suppress out of dom warning

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -150,17 +150,17 @@ function videojs(id, options, ready) {
     throw new TypeError('The element or ID supplied is not valid. (videojs)');
   }
 
+  options = options || {};
+
   // document.body.contains(el) will only check if el is contained within that one document.
   // This causes problems for elements in iframes.
   // Instead, use the element's ownerDocument instead of the global document.
   // This will make sure that the element is indeed in the dom of that document.
   // Additionally, check that the document in question has a default view.
   // If the document is no longer attached to the dom, the defaultView of the document will be null.
-  if (!el.ownerDocument.defaultView || !el.ownerDocument.body.contains(el)) {
+  if ((!el.ownerDocument.defaultView || !el.ownerDocument.body.contains(el)) && !options.noWarnOutOfDom) {
     log.warn('The element supplied is not included in the DOM');
   }
-
-  options = options || {};
 
   // Store a copy of the el before modification, if it is to be restored in destroy()
   // If div ingest, store the parent div

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -80,6 +80,13 @@ QUnit.test(
     videojs('test_vid_id2');
     assert.equal(warnLogs.length, 1, 'did not log another warning');
 
+    const vid3 = document.createElement('video');
+
+    videojs(vid3, {
+      noWarnOutOfDom: true
+    });
+    assert.equal(warnLogs.length, 1, 'did not log another warning');
+
     log.warn = origWarnLog;
   }
 );


### PR DESCRIPTION
## Description
Adds an option to suppress the "The element supplied is not included in the DOM" warning for intentionally detached video/audio elements. 

Use case: video.js wrapping html5 audio element but not using video.js UI and video.js wrapping html5 video rendered into a WebGL scene. 

## Specific Changes proposed
add a player option that, when set to true, suppresses the warning

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
