### PR TITLE
chore(docs): use https URLs in noUITitleAtttributes example

### DIFF
--- a/sandbox/noUITitleAttributes.html.example
+++ b/sandbox/noUITitleAttributes.html.example
@@ -22,13 +22,13 @@
   </div>
 
   <video id="vid1" class="video-js vjs-default-skin" controls preload="auto" width="640" height="264"
-      poster="http://vjs.zencdn.net/v/oceans.png"
+      poster="https://vjs.zencdn.net/v/oceans.png"
       data-setup='{"controlBar": {"volumePanel": {"inline": false}}, "noUITitleAttributes" : true}'>
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
+    <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="https://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="https://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <track kind="captions" src="../docs/examples/shared/example-captions.vtt" srclang="en" label="English">
-    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </video>
   <p>This demo shows the effect of setting the <strong>noUITitleAttributes</strong> option for video.js. It also includes the <strong>:focus-visible</strong> polyfill (see focus-visible.html)</p>
   <script>


### PR DESCRIPTION
Updates example to use https URLs, as the build previews are delivered with https. Resolves netlify warning.