### PR TITLE
refactor: Remove logic and style that accommodates non-flex fallbacks

### DIFF
--- a/src/css/_utilities.scss
+++ b/src/css/_utilities.scss
@@ -66,14 +66,6 @@
 }
 
 @mixin flex($value) {
-  // @include context('.video-js', '.video-js.vjs-no-flex') {
-  //   display: table-cell;
-  //   vertical-align: middle;
-  //   @if ($value == 'auto') {
-  //     width: auto;
-  //   }
-  // }
-
   -webkit-box-flex: $value;
   -moz-box-flex: $value;
   -webkit-flex: $value;

--- a/src/css/components/_adaptive.scss
+++ b/src/css/components/_adaptive.scss
@@ -67,9 +67,5 @@
       @include flex(auto);
       display: block;
     }
-
-    &.vjs-no-flex .vjs-custom-control-spacer {
-      width: auto;
-    }
   }
 }

--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -48,8 +48,3 @@
   opacity: 1;
   visibility: visible;
 }
-
-// no flex support
-.vjs-has-started.vjs-no-flex .vjs-control-bar {
-  display: table;
-}

--- a/src/css/components/_control.scss
+++ b/src/css/components/_control.scss
@@ -39,8 +39,3 @@
 .video-js *:not(.vjs-visible-text) > .vjs-control-text {
   @include hide-visually;
 }
-
-.vjs-no-flex .vjs-control {
-  display: table-cell;
-  vertical-align: middle;
-}

--- a/src/css/components/_live.scss
+++ b/src/css/components/_live.scss
@@ -6,12 +6,6 @@
   line-height: 3em;
 }
 
-.vjs-no-flex .vjs-live-control {
-  display: table-cell;
-  width: auto;
-  text-align: left;
-}
-
 // hide the LiveDisplay when not live or when
 // the new liveui is in use
 .video-js:not(.vjs-live) .vjs-live-control,
@@ -32,12 +26,6 @@
   line-height: 3em;
   width: auto;
   min-width: 4em;
-}
-
-.vjs-no-flex .vjs-seek-to-live-control {
-  display: table-cell;
-  width: auto;
-  text-align: left;
 }
 
 // hide the SeekToLive button when not live and

--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -21,10 +21,6 @@
   @include display-flex(center);
 }
 
-.vjs-no-flex .vjs-progress-control {
-  width: auto;
-}
-
 // .vjs-progress-holder / SeekBar
 //
 // Box containing play and load progress bars. It also acts as seek scrubber.
@@ -154,10 +150,6 @@
   z-index: 1;
 }
 
-.vjs-no-flex .vjs-progress-control .vjs-mouse-display {
-  z-index: 0;
-}
-
 .video-js .vjs-progress-control:hover .vjs-mouse-display {
   display: block;
 }
@@ -167,10 +159,6 @@
   opacity: 0;
   $trans: visibility 1.0s, opacity 1.0s;
   @include transition($trans);
-}
-
-.video-js.vjs-user-inactive.vjs-no-flex .vjs-progress-control .vjs-mouse-display {
-  display: none;
 }
 
 .vjs-mouse-display .vjs-time-tooltip {

--- a/src/css/components/_time.scss
+++ b/src/css/components/_time.scss
@@ -8,28 +8,14 @@
   padding-right: 1em;
 }
 
-.vjs-live .vjs-time-control {
-  display: none;
-}
-
-// We need the extra specificity that referencing .vjs-no-flex provides.
+.vjs-live .vjs-time-control,
+.vjs-live .vjs-time-divider,
 .video-js .vjs-current-time,
-.vjs-no-flex .vjs-current-time {
-  display: none;
-}
-
-.video-js .vjs-duration,
-.vjs-no-flex .vjs-duration {
+.video-js .vjs-duration {
   display: none;
 }
 
 .vjs-time-divider {
   display: none;
   line-height: 3em;
-}
-
-.vjs-live .vjs-time-divider {
-  // Already the default, but we want to ensure when the player is live
-  // this hides in the same way as the other time controls for other skins
-  display: none;
 }

--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -88,24 +88,6 @@
   @include transition($transition-property)
 }
 
-.video-js.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
-  width: 5em;
-  height: 3em;
-
-  visibility: visible;
-  opacity: 1;
-  position: relative;
-
-  @include transition(none);
-}
-
-.video-js.vjs-no-flex .vjs-volume-control.vjs-volume-vertical,
-.video-js.vjs-no-flex .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-  position: absolute;
-  bottom: 3em;
-  left: 0.5em;
-}
-
 .video-js .vjs-volume-panel {
   @include display-flex;
 }
@@ -243,10 +225,6 @@
   height: 100%;
 }
 
-.vjs-no-flex .vjs-volume-control .vjs-mouse-display {
-  z-index: 0;
-}
-
 .video-js .vjs-volume-control:hover .vjs-mouse-display {
   display: block;
 }
@@ -256,10 +234,6 @@
   opacity: 0;
   $trans: visibility 1.0s, opacity 1.0s;
   @include transition($trans);
-}
-
-.video-js.vjs-user-inactive.vjs-no-flex .vjs-volume-control .vjs-mouse-display {
-  display: none;
 }
 
 .vjs-mouse-display .vjs-volume-tooltip {

--- a/src/css/components/menu/_menu-inline.scss
+++ b/src/css/components/menu/_menu-inline.scss
@@ -13,8 +13,7 @@
 // Hover state
 .video-js .vjs-menu-button-inline:hover,
 .video-js .vjs-menu-button-inline:focus,
-.video-js .vjs-menu-button-inline.vjs-slider-active,
-.video-js.vjs-no-flex .vjs-menu-button-inline {
+.video-js .vjs-menu-button-inline.vjs-slider-active {
   // This width is currently specific to the inline volume bar.
   width: 12em;
 }
@@ -39,19 +38,6 @@
 .vjs-menu-button-inline.vjs-slider-active .vjs-menu {
   display: block;
   opacity: 1;
-}
-
-.vjs-no-flex .vjs-menu-button-inline .vjs-menu {
-  display: block;
-  opacity: 1;
-  position: relative;
-  width: auto;
-}
-
-.vjs-no-flex .vjs-menu-button-inline:hover .vjs-menu,
-.vjs-no-flex .vjs-menu-button-inline:focus .vjs-menu,
-.vjs-no-flex .vjs-menu-button-inline.vjs-slider-active .vjs-menu {
-  width: auto;
 }
 
 .vjs-menu-button-inline .vjs-menu-content {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -548,10 +548,6 @@ class Player extends Component {
       this.addClass('vjs-audio');
     }
 
-    if (this.flexNotSupported_()) {
-      this.addClass('vjs-no-flex');
-    }
-
     // TODO: Make this smarter. Toggle user state between touching/mousing
     // using events, since devices can have both touch and mouse events.
     // TODO: Make this check be performed again when the window switches between monitors
@@ -4966,26 +4962,6 @@ class Player extends Component {
     }
 
     return baseOptions;
-  }
-
-  /**
-   * Determine whether or not flexbox is supported
-   *
-   * @return {boolean}
-   *         - true if flexbox is supported
-   *         - false if flexbox is not supported
-   */
-  flexNotSupported_() {
-    const elem = document.createElement('i');
-
-    // Note: We don't actually use flexBasis (or flexOrder), but it's one of the more
-    // common flex features that we can rely on when checking for flex support.
-    return !('flexBasis' in elem.style ||
-            'webkitFlexBasis' in elem.style ||
-            'mozFlexBasis' in elem.style ||
-            'msFlexBasis' in elem.style ||
-            // IE10-specific (2012 flex spec), available for completeness
-            'msFlexOrder' in elem.style);
   }
 
   /**


### PR DESCRIPTION
## Description
_This is [a duplicate PR](https://github.com/videojs/video.js/pull/7811) with changes based off of the `next` branch, instead of `main`, to avoid pulling updates from `7.20.1`._

Remove logic that checks for browser flexbox feature support and any style rules that specifically target the .vjs-no-flex class. We are assuming standard flex support for Video.js 8 and onward.

## Specific Changes proposed

- Remove flexNotSupported_() and associated call.
- Remove specific style rules that target the .vjs-no-flex class added by the flexNotSupported_()method. Consolidate css rule groups where .vjs-no-flex targeting was removed.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
