### PR TITLE
fix(control-bar): audio player no longer responds to touch events

### DIFF
--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -47,6 +47,7 @@
 .vjs-audio-only-mode.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   opacity: 1;
   visibility: visible;
+  pointer-events: auto;
 }
 
 // no flex support


### PR DESCRIPTION
## Description

1. On mobile initialize an audio player
2. Start the playback
3. Wait for the `vjs-user-inactive`
4. Attempt to use the slider to seek through the media
5. Notice that it is no longer possible to use the slider unless you tap the control bar before.

This issue was introduced by #7329 in video.js v7.15.0

## Specific Changes proposed

The idea is to reset the `pointer-events` to `auto` for the audio player so that the slider can be used on touch devices.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
