### PR TITLE
chore(lock-threads): run only daily at 1:00 am, and skip in forks

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   action:
+    if: ${{ github.repository_owner == 'videojs' }}
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 1 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

The github action introduced by #7777 in charge of locking old issues runs every hour and is followed by an e-mail. 

![github-lock-action](https://user-images.githubusercontent.com/34163393/177852796-65bfad3a-0678-4dff-a6ec-704aaf78cb73.png)

## Specific Changes proposed

The [Lock Threads](https://github.com/dessant/lock-threads) does not seem to allow restricting its execution to a named repo. The proposal would be to execute the action only once a day to avoid spamming those who have a fork of the project.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
