### PR TITLE
fix(lang): fixes key spacing within fr.json file

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -81,7 +81,7 @@
   "Caption Settings Dialog": "Boîte de dialogue des paramètres des sous-titres transcrits",
   "Beginning of dialog window. Escape will cancel and close the window.": "Début de la fenêtre de dialogue. La touche d'échappement annulera et fermera la fenêtre.",
   "End of dialog window.": "Fin de la fenêtre de dialogue.",
-  "Exit Picture-in-Picture ": "Quitter le mode image dans l'image",
-  "Picture-in-Picture ": "Image dans l'image",
+  "Exit Picture-in-Picture": "Quitter le mode image dans l'image",
+  "Picture-in-Picture": "Image dans l'image",
   "{1} is loading.": "{1} en cours de chargement."
 }


### PR DESCRIPTION
## Description
When implementing video.js's option `language` for `fr`, we noticed that "Picture-in-Picture" wasn't being translated properly. We noticed [#7589](https://github.com/videojs/video.js/pull/7589) introduced this issue within the `fr.json` file.

## Specific Changes proposed
Please refer to issue #7847 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
