### PR TITLE
feature: Remove support for setting nonstandard attributes as props

### DIFF
--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -133,8 +133,7 @@ class Slider extends Component {
       'role': 'slider',
       'aria-valuenow': 0,
       'aria-valuemin': 0,
-      'aria-valuemax': 100,
-      'tabIndex': 0
+      'aria-valuemax': 100
     }, attributes);
 
     return super.createEl(type, props, attributes);

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -153,18 +153,9 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
   Object.getOwnPropertyNames(properties).forEach(function(propName) {
     const val = properties[propName];
 
-    // See #2176
-    // We originally were accepting both properties and attributes in the
-    // same object, but that doesn't work so well.
-    if (propName.indexOf('aria-') !== -1 || propName === 'role' || propName === 'type') {
-      log.warn('Setting attributes in the second argument of createEl()\n' +
-               'has been deprecated. Use the third argument instead.\n' +
-               `createEl(type, properties, attributes). Attempting to set ${propName} to ${val}.`);
-      el.setAttribute(propName, val);
-
     // Handle textContent since it's not supported everywhere and we have a
     // method for it.
-    } else if (propName === 'textContent') {
+    if (propName === 'textContent') {
       textContent(el, val);
     } else if (el[propName] !== val || propName === 'tabIndex') {
       el[propName] = val;

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -150,11 +150,7 @@ function createQuerier(method) {
 export function createEl(tagName = 'div', properties = {}, attributes = {}, content) {
   const el = document.createElement(tagName);
 
-  Object.getOwnPropertyNames(properties).forEach(function(propName) {
-    const val = properties[propName];
-
-    // Handle textContent since it's not supported everywhere and we have a
-    // method for it.
+  Object.entries(properties).forEach(([propName, val]) => {
     if (propName === 'textContent') {
       textContent(el, val);
     } else if (el[propName] !== val || propName === 'tabIndex') {
@@ -162,8 +158,8 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
     }
   });
 
-  Object.getOwnPropertyNames(attributes).forEach(function(attrName) {
-    el.setAttribute(attrName, attributes[attrName]);
+  Object.entries(attributes).forEach(([attrName, val]) => {
+    el.setAttribute(attrName, val);
   });
 
   if (content) {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -150,7 +150,11 @@ function createQuerier(method) {
 export function createEl(tagName = 'div', properties = {}, attributes = {}, content) {
   const el = document.createElement(tagName);
 
-  Object.entries(properties).forEach(([propName, val]) => {
+  Object.getOwnPropertyNames(properties).forEach(function(propName) {
+    const val = properties[propName];
+
+    // Handle textContent since it's not supported everywhere and we have a
+    // method for it.
     if (propName === 'textContent') {
       textContent(el, val);
     } else if (el[propName] !== val || propName === 'tabIndex') {
@@ -158,8 +162,8 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
     }
   });
 
-  Object.entries(attributes).forEach(([attrName, val]) => {
-    el.setAttribute(attrName, val);
+  Object.getOwnPropertyNames(attributes).forEach(function(attrName) {
+    el.setAttribute(attrName, attributes[attrName]);
   });
 
   if (content) {

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -43,6 +43,13 @@ QUnit.test('should create an element with content', function(assert) {
   assert.strictEqual(div.firstChild, span);
 });
 
+QUnit.test('should be able to set standard props as attributes, and vice versa, on a created element', function(assert) {
+  const span = Dom.createEl('span', {className: 'bar'}, {id: 'foo'});
+
+  assert.strictEqual(span.getAttribute('class'), 'bar');
+  assert.strictEqual(span.id, 'foo');
+});
+
 QUnit.test('should insert an element first in another', function(assert) {
   const el1 = document.createElement('div');
   const el2 = document.createElement('div');

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -30,6 +30,12 @@ QUnit.test('should create an element, supporting textContent', function(assert) 
   }
 });
 
+QUnit.test('should create an element with tabIndex prop', function(assert) {
+  const span = Dom.createEl('span', {tabIndex: '5'});
+
+  assert.strictEqual(span.tabIndex, 5);
+});
+
 QUnit.test('should create an element with content', function(assert) {
   const span = Dom.createEl('span');
   const div = Dom.createEl('div', undefined, undefined, span);


### PR DESCRIPTION
Amend the `createEl` method on the Dom class to remove logic that allows `role`,` type`, and `aria-*` attributes to be set as part of the properties object on an element.

**Changes include:**

- Remove conditional statement from `createEl` method that checks for nonstandard attributes in the properties object and sets them as element attributes.
- Remove duplicate `tabIndex` attribute assignment in `Slider.creatEl` method.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
