### PR TITLE
fix: allow for techs that init slowly in rvfc

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -869,7 +869,7 @@ class Tech extends Component {
   requestVideoFrameCallback(cb) {
     const id = Guid.newGUID();
 
-    if (this.paused()) {
+    if (!this.isReady_ || this.paused()) {
       this.queuedHanders_.add(id);
       this.one('playing', () => {
         if (this.queuedHanders_.has(id)) {

--- a/test/unit/tech/tech.test.js
+++ b/test/unit/tech/tech.test.js
@@ -770,3 +770,21 @@ QUnit.test('returns an empty object for getVideoPlaybackQuality', function(asser
   assert.deepEqual(tech.getVideoPlaybackQuality(), {}, 'returns an empty object');
   tech.dispose();
 });
+
+QUnit.test('requestVideoFrameCallback waits if tech not ready', function(assert) {
+  const tech = new Tech();
+  const cbSpy = sinon.spy();
+
+  tech.paused = sinon.spy();
+  tech.isReady_ = false;
+
+  tech.requestVideoFrameCallback(cbSpy);
+
+  assert.notOk(tech.paused.called, 'paused not called on tech that is not ready');
+
+  tech.trigger('playing');
+
+  assert.ok(cbSpy.called, 'callback was called on tech playing');
+
+  tech.dispose();
+});


### PR DESCRIPTION
## Description
Don't call tech.paused() in the requestVideoFrameCallback fallback if the tech is not ready. I've seen this is an issue in the Flash tech, as its methods are set up after the swf loads. Yes, Flash, it's 2022, but in theory another tech could be impacted if it's also async.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
