### PR TITLE
feat: make retryOnError be the default

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3371,7 +3371,7 @@ class Player extends Component {
     });
 
     // Try another available source if this one fails before playback.
-    if (this.options_.retryOnError && sources.length > 1) {
+    if (sources.length > 1) {
       const retry = () => {
         // Remove the error modal
         this.error(null);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -384,10 +384,9 @@ QUnit.test('should asynchronously fire error events during source selection', fu
   log.error.restore();
 });
 
-QUnit.test('should retry setting source if error occurs and retryOnError: true', function(assert) {
+QUnit.test('should retry setting source if error occurs', function(assert) {
   const player = TestHelpers.makePlayer({
     techOrder: ['html5'],
-    retryOnError: true,
     sources: [
       { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
       { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
@@ -439,10 +438,9 @@ QUnit.test('should retry setting source if error occurs and retryOnError: true',
   player.dispose();
 });
 
-QUnit.test('should not retry setting source if retryOnError: true and error occurs during playback', function(assert) {
+QUnit.test('should not retry setting source if error occurs during playback', function(assert) {
   const player = TestHelpers.makePlayer({
     techOrder: ['html5'],
-    retryOnError: true,
     sources: [
       { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
       { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },
@@ -490,7 +488,6 @@ QUnit.test('should not retry setting source if retryOnError: true and error occu
 QUnit.test('aborts and resets retryOnError behavior if new src() call made during a retry', function(assert) {
   const player = TestHelpers.makePlayer({
     techOrder: ['html5'],
-    retryOnError: true,
     sources: [
       { src: 'http://vjs.zencdn.net/v/oceans.mp4', type: 'video/mp4' },
       { src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' },

--- a/test/unit/sourceset.test.js
+++ b/test/unit/sourceset.test.js
@@ -17,9 +17,11 @@ const testSrc = {
   src: 'http://example.com/testSrc.mp4',
   type: 'video/mp4'
 };
-const sourceOne = {src: 'http://example.com/one.mp4', type: 'video/mp4'};
-const sourceTwo = {src: 'http://example.com/two.mp4', type: 'video/mp4'};
-const sourceThree = {src: 'http://example.com/three.mp4', type: 'video/mp4'};
+// Using a real URL here makes the tests work with retryOnError by default
+// however, this means that it may fail offline
+const sourceOne = {src: 'https://vjs.zencdn.net/v/oceans.mp4?one', type: 'video/mp4'};
+const sourceTwo = {src: 'https://vjs.zencdn.net/v/oceans.mp4?two', type: 'video/mp4'};
+const sourceThree = {src: 'https://vjs.zencdn.net/v/oceans.mp4?three', type: 'video/mp4'};
 
 if (!Html5.canOverrideAttributes()) {
   qunitFn = 'skip';


### PR DESCRIPTION
This means that a retryOnError is removed and is no longer needed for
this behavior, which means that during source selection, if a source
fails, it'll try the next source that's available, to match the video
element.

BREAKING CHANGE: remove retryOnError option, turn it on by default