### PR TITLE
Add a player option keepTimeTooltipInSeekBar to prevent time tooltip overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     <li><a href="sandbox/hls.html">Hls Demo</a></li>
     <li><a href="sandbox/autoplay-tests.html">Autoplay Tests</a></li>
     <li><a href="sandbox/noUITitleAttributes.html">noUITitleAttributes Demo</a></li>
+    <li><a href="sandbox/keepTimeTooltipInSeekBar.html">keepTimeTooltipInSeekBar Demo</a></li>
     <li><a href="sandbox/debug.html">Videojs debug build test page</a></li>
   </ul>
 

--- a/sandbox/keepTimeTooltipInSeekBar.html.example
+++ b/sandbox/keepTimeTooltipInSeekBar.html.example
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js keep time tooltip in seek bar example</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started run `npm start` and open the index.html</p>
+    <pre>npm start</pre>
+    <pre>open http://localhost:9999/sandbox/keepTimeTooltipInSeekBar.html</pre>
+  </div>
+
+  <video-js
+    id="vid1"
+    controls
+    preload="auto"
+    width="640"
+    height="264"
+    poster="https://vjs.zencdn.net/v/oceans.png">
+    <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="https://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="https://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
+    <track kind="captions" src="../docs/examples/shared/example-captions.vtt" srclang="en" label="English">
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video-js>
+
+  <script>
+    var vid = document.getElementById('vid1');
+    var player = videojs(vid, {
+      keepTimeTooltipInSeekBar: true
+    });
+  </script>
+
+</body>
+</html>

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -66,34 +66,60 @@ class TimeTooltip extends Component {
     // of the player. We calculate any gap between the left edge of the player
     // and the left edge of the `SeekBar` and add the number of pixels in the
     // `SeekBar` before hitting the `seekBarPoint`
-    const spaceLeftOfPoint = (seekBarRect.left - playerRect.left) + seekBarPointPx;
+    let spaceLeftOfPoint = (seekBarRect.left - playerRect.left) + seekBarPointPx;
 
     // This is the space right of the `seekBarPoint` available within the bounds
     // of the player. We calculate the number of pixels from the `seekBarPoint`
     // to the right edge of the `SeekBar` and add to that any gap between the
     // right edge of the `SeekBar` and the player.
-    const spaceRightOfPoint = (seekBarRect.width - seekBarPointPx) +
+    let spaceRightOfPoint = (seekBarRect.width - seekBarPointPx) +
       (playerRect.right - seekBarRect.right);
+
+    if (this.options_.playerOptions.keepTimeTooltipInSeekBar) {
+      // This is the space right of the `seekBarPoint` in the `SeekBar`
+      spaceRightOfPoint = seekBarRect.width - seekBarPointPx;
+
+      // This is the space left of the `seekBarPoint` in the `SeekBar`
+      spaceLeftOfPoint = seekBarRect.width - spaceRightOfPoint;
+    }
 
     // This is the number of pixels by which the tooltip will need to be pulled
     // further to the right to center it over the `seekBarPoint`.
     let pullTooltipBy = tooltipRect.width / 2;
 
-    // Adjust the `pullTooltipBy` distance to the left or right depending on
-    // the results of the space calculations above.
-    if (spaceLeftOfPoint < pullTooltipBy) {
-      pullTooltipBy += pullTooltipBy - spaceLeftOfPoint;
-    } else if (spaceRightOfPoint < pullTooltipBy) {
-      pullTooltipBy = spaceRightOfPoint;
-    }
+    if (this.options_.playerOptions.keepTimeTooltipInSeekBar) {
+      // The center of `seekBar`
+      const centerPosition = seekBarRect.width / 2;
 
-    // Due to the imprecision of decimal/ratio based calculations and varying
-    // rounding behaviors, there are cases where the spacing adjustment is off
-    // by a pixel or two. This adds insurance to these calculations.
-    if (pullTooltipBy < 0) {
-      pullTooltipBy = 0;
-    } else if (pullTooltipBy > tooltipRect.width) {
-      pullTooltipBy = tooltipRect.width;
+      // Offset value of the `centerPosition`
+      const centerOffsetOfPoint = centerPosition - seekBarPointPx;
+
+      // If `tooltipRect` is greater than `seekBarRect` then center the tooltip,
+      // else patch the offset value of the tooltip overflow space.
+      if (tooltipRect.width > seekBarRect.width) {
+        pullTooltipBy += centerOffsetOfPoint;
+      } else if (spaceLeftOfPoint < pullTooltipBy) {
+        pullTooltipBy += pullTooltipBy - spaceLeftOfPoint;
+      } else if (spaceRightOfPoint < pullTooltipBy) {
+        pullTooltipBy -= pullTooltipBy - spaceRightOfPoint;
+      }
+    } else {
+      // Adjust the `pullTooltipBy` distance to the left or right depending on
+      // the results of the space calculations above.
+      if (spaceLeftOfPoint < pullTooltipBy) {
+        pullTooltipBy += pullTooltipBy - spaceLeftOfPoint;
+      } else if (spaceRightOfPoint < pullTooltipBy) {
+        pullTooltipBy = spaceRightOfPoint;
+      }
+
+      // Due to the imprecision of decimal/ratio based calculations and varying
+      // rounding behaviors, there are cases where the spacing adjustment is off
+      // by a pixel or two. This adds insurance to these calculations.
+      if (pullTooltipBy < 0) {
+        pullTooltipBy = 0;
+      } else if (pullTooltipBy > tooltipRect.width) {
+        pullTooltipBy = tooltipRect.width;
+      }
     }
 
     // prevent small width fluctuations within 0.4px from


### PR DESCRIPTION

![Screenshot from 2022-09-04 02-31-24](https://user-images.githubusercontent.com/58389183/188283742-90118213-34f4-42a3-a1fc-38dbb24abb1b.png)

## Description
Originally, the time tooltip was allowed to overflow into the seek bar, which is fine in general but for those who want to customize their skins, allowing overflow is not necessarily a good idea.

This PR allows developers to easily keep the time tooltip inside the seek bar with a single player configuration option.

## Specific Changes proposed
Add a player option `keepTimeTooltipInSeekBar`  which, if set to `true`, prevents the time tooltip overflow the seek bar

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
