### PR TITLE
fix: enter fullscreen from fullWindow does not trigger exitFullWindow

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2862,6 +2862,11 @@ class Player extends Component {
   requestFullscreen(fullscreenOptions) {
     const PromiseClass = this.options_.Promise || window.Promise;
 
+    // In case of requestFullscreen is happend when player is in fullWindow mode
+    if (this.isFullWindow) {
+      this.exitFullWindow();
+    }
+
     if (PromiseClass) {
       const self = this;
 


### PR DESCRIPTION

## Description
Fix #7705

## Specific Changes proposed
When the player is playing in full window mode and then calls `requestFullscreen()` but the full window state not get reset

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
