### PR TITLE
feat(deprecation): deprecate the extend function

### DIFF
--- a/src/js/extend.js
+++ b/src/js/extend.js
@@ -4,12 +4,16 @@
  */
 
 import _inherits from '@babel/runtime/helpers/inherits';
+import log from './utils/log.js';
+
+let hasLogged = false;
 
 /**
  * Used to subclass an existing class by emulating ES subclassing using the
  * `extends` keyword.
  *
  * @function
+ * @deprecated
  * @example
  * var MyComponent = videojs.extend(videojs.getComponent('Component'), {
  *   myCustomMethod: function() {
@@ -27,6 +31,15 @@ import _inherits from '@babel/runtime/helpers/inherits';
  *           The new class with subClassMethods that inherited superClass.
  */
 const extend = function(superClass, subClassMethods = {}) {
+
+  // Log a warning the first time extend is called to note that it is deprecated
+  // It was previously deprecated in our documentation (guides, specifically),
+  // but was never formally deprecated in code.
+  if (!hasLogged) {
+    log.warn('videojs.extend is deprecated as of Video.js 7.22.0 and will be removed in Video.js 8.0.0');
+    hasLogged = true;
+  }
+
   let subClass = function() {
     superClass.apply(this, arguments);
   };


### PR DESCRIPTION
## Description
Related to #7943, see that for details.

## Specific Changes proposed
- Deprecates the `extend` function

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
