### PR TITLE
fix: Picture in Picture visible while Fullscreen

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2918,6 +2918,11 @@ class Player extends Component {
 
       if (promise) {
         promise.then(() => this.isFullscreen(true), () => this.isFullscreen(false));
+        // When entering fullscreen disable picture in picture
+        // This is done with promises when supported
+        if (this.isInPictureInPicture()) {
+          promise.then(this.exitPictureInPicture());
+        }
       }
 
       return promise;
@@ -2929,6 +2934,10 @@ class Player extends Component {
       // fullscreen isn't supported so we'll just stretch the video element to
       // fill the viewport
       this.enterFullWindow();
+    }
+    // When entering fullscreen disable picture in picture
+    if (this.isInPictureInPicture()) {
+      this.exitPictureInPicture();
     }
   }
 


### PR DESCRIPTION
## Description
Picture in Picture remains open if entering fullscreen. This disables Picture in Picture when entering fullscreen.

Fix #7921 

## Specific Changes proposed
- Adds code to `requestFullscreenHelper_` to exit Picture in Picture if open.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
