### PR TITLE
feat: Deprecate extend() in favor of ES6 classes

### DIFF
--- a/src/js/extend.js
+++ b/src/js/extend.js
@@ -27,6 +27,8 @@ import _inherits from '@babel/runtime/helpers/inherits';
  *
  * @return   {Function}
  *           The new class with subClassMethods that inherited superClass.
+ *
+ * * @deprecated videojs.extend() is deprecated; use native ES6 classes instead
  */
 const extend = function(superClass, subClassMethods = {}) {
   log.warn('The extend() method is deprecated and will be removed in Video.js 8. Please use native ES6 classes instead.');

--- a/src/js/extend.js
+++ b/src/js/extend.js
@@ -1,3 +1,5 @@
+import log from './utils/log';
+
 /**
  * @file extend.js
  * @module extend
@@ -27,6 +29,8 @@ import _inherits from '@babel/runtime/helpers/inherits';
  *           The new class with subClassMethods that inherited superClass.
  */
 const extend = function(superClass, subClassMethods = {}) {
+  log.warn('The extend() method is deprecated and will be removed in Video.js 8. Please use native ES6 classes instead.');
+
   let subClass = function() {
     superClass.apply(this, arguments);
   };


### PR DESCRIPTION
## Description
`extend()` will be [removed](https://github.com/videojs/video.js/pull/7950) in Video.js 8 in favor of ES6 classes, so we should deprecate it in 7.x.
