### PR TITLE
fix: remove unnecessary handling of invalid cues

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -326,10 +326,6 @@ class TextTrack extends Track {
 
             if (cue.startTime <= ct && cue.endTime >= ct) {
               active.push(cue);
-            } else if (cue.startTime === cue.endTime &&
-                       cue.startTime <= ct &&
-                       cue.startTime + 0.5 >= ct) {
-              active.push(cue);
             }
           }
 

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -253,6 +253,43 @@ QUnit.test('can only remove one cue at a time', function(assert) {
   assert.equal(tt.cues.length, 0, 'we have removed the other instance of cue1');
 });
 
+QUnit.test('does not include past cues in activeCues', function(assert) {
+  // Testing for the absense of a previous behaviour, which considered cues with equal
+  // start and end times as active 0.5s after ending
+  const player = TestHelpers.makePlayer();
+  const tt = new TextTrack({
+    tech: player.tech_,
+    mode: 'showing'
+  });
+  const expectedCue = {
+    id: '2',
+    startTime: 2.555,
+    endTime: 3
+  };
+
+  player.tech_.currentTime = function() {
+    return 2.556;
+  };
+
+  tt.addCue({
+    id: '1',
+    startTime: 1,
+    endTime: 2.555
+  });
+  tt.addCue({
+    id: '2',
+    startTime: 2.555,
+    endTime: 2.555
+  });
+  // start 2.55
+  tt.addCue(expectedCue);
+
+  player.tech_.trigger('playing');
+
+  assert.equal(tt.activeCues_.length, 1, 'only one cue is present');
+  assert.equal(tt.activeCues_[0].originalCue_, expectedCue, 'correct active cue is present');
+});
+
 QUnit.test('does not fire cuechange before Tech is ready', function(assert) {
   const done = assert.async();
   const clock = sinon.useFakeTimers();


### PR DESCRIPTION
## Description
We had some special handling of cues which have equal start and end times, so they would be considered active 0.5 after they start/end. Cues with equal start and end times are not valid; the end time must be greater. However some painton style VTT in the wild contain many such cues, resulting in all such with a 0.5 seconds being displayed.

We thought this handling might still be needed for ID3 cues as ID3 only has a start time, but it's not: on adding to the track [the `endTime` is set](https://github.com/videojs/http-streaming/blob/9db9e99f1568049502058ce8312aff2dae77beab/src/util/text-tracks.js#L213) to the next cue's `startTime` or the video duration.

## Specific Changes proposed
Removes the handling of these cues. A cue with equal start and end times is not strictly ignored, but it will only render if active cues are updated at the precise millisecond they are to be active.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
