### PR TITLE
fix: last timeout in queueTrigger() never clears  map

### DIFF
--- a/src/js/event-target.js
+++ b/src/js/event-target.js
@@ -196,6 +196,7 @@ EventTarget.prototype.queueTrigger = function(event) {
   window.clearTimeout(oldTimeout);
 
   const timeout = window.setTimeout(() => {
+    map.delete(type);
     // if we cleared out all timeouts for the current target, delete its map
     if (map.size === 0) {
       map = null;


### PR DESCRIPTION
## Description
EventTarget.queueTrigger() method contains a timeout code that should clear map when map.size === 0. However, It looks like 
this statement will never trigger right now because the map has always size value bigger than 0.

## Specific Changes proposed
The last timeout should delete the type from the map.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
