### PR TITLE
fix(jsdoc): controlText_ should have a protected access modifier.

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -87,7 +87,7 @@ class BigPlayButton extends Button {
  * The text that should display over the `BigPlayButton`s controls. Added to for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 BigPlayButton.prototype.controlText_ = 'Play Video';
 

--- a/src/js/clickable-component.js
+++ b/src/js/clickable-component.js
@@ -148,6 +148,7 @@ class ClickableComponent extends Component {
 
     const localizedText = this.localize(text);
 
+    /** @protected */
     this.controlText_ = text;
     Dom.textContent(this.controlTextEl_, localizedText);
     if (!this.nonIconControl && !this.player_.options_.noUITitleAttributes) {

--- a/src/js/control-bar/audio-track-controls/audio-track-button.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-button.js
@@ -76,7 +76,7 @@ class AudioTrackButton extends TrackButton {
  * The text that should display over the `AudioTrackButton`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 AudioTrackButton.prototype.controlText_ = 'Audio Track';
 Component.registerComponent('AudioTrackButton', AudioTrackButton);

--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -82,7 +82,7 @@ class FullscreenToggle extends Button {
  * The text that should display over the `FullscreenToggle`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 FullscreenToggle.prototype.controlText_ = 'Fullscreen';
 

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -139,7 +139,7 @@ class MuteToggle extends Button {
  * The text that should display over the `MuteToggle`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 MuteToggle.prototype.controlText_ = 'Mute';
 

--- a/src/js/control-bar/picture-in-picture-toggle.js
+++ b/src/js/control-bar/picture-in-picture-toggle.js
@@ -114,7 +114,7 @@ class PictureInPictureToggle extends Button {
  * The text that should display over the `PictureInPictureToggle`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 PictureInPictureToggle.prototype.controlText_ = 'Picture-in-Picture';
 

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -136,7 +136,7 @@ class PlayToggle extends Button {
  * The text that should display over the `PlayToggle`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 PlayToggle.prototype.controlText_ = 'Play';
 

--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -166,7 +166,7 @@ class PlaybackRateMenuButton extends MenuButton {
  * Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 PlaybackRateMenuButton.prototype.controlText_ = 'Playback Rate';
 

--- a/src/js/control-bar/seek-to-live.js
+++ b/src/js/control-bar/seek-to-live.js
@@ -92,7 +92,12 @@ class SeekToLive extends Button {
     super.dispose();
   }
 }
-
+/**
+ * The text that should display over the `SeekToLive`s control. Added for localization.
+ *
+ * @type {string}
+ * @protected
+ */
 SeekToLive.prototype.controlText_ = 'Seek to live, currently playing live';
 
 Component.registerComponent('SeekToLive', SeekToLive);

--- a/src/js/control-bar/text-track-controls/captions-button.js
+++ b/src/js/control-bar/text-track-controls/captions-button.js
@@ -75,7 +75,7 @@ CaptionsButton.prototype.kind_ = 'captions';
  * The text that should display over the `CaptionsButton`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 CaptionsButton.prototype.controlText_ = 'Captions';
 

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -209,7 +209,7 @@ ChaptersButton.prototype.kind_ = 'chapters';
  * The text that should display over the `ChaptersButton`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 ChaptersButton.prototype.controlText_ = 'Chapters';
 

--- a/src/js/control-bar/text-track-controls/descriptions-button.js
+++ b/src/js/control-bar/text-track-controls/descriptions-button.js
@@ -93,7 +93,7 @@ DescriptionsButton.prototype.kind_ = 'descriptions';
  * The text that should display over the `DescriptionsButton`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 DescriptionsButton.prototype.controlText_ = 'Descriptions';
 

--- a/src/js/control-bar/text-track-controls/subs-caps-button.js
+++ b/src/js/control-bar/text-track-controls/subs-caps-button.js
@@ -74,7 +74,7 @@ SubsCapsButton.prototype.kinds_ = ['captions', 'subtitles'];
  *
  *
  * @type {string}
- * @private
+ * @protected
  */
 SubsCapsButton.prototype.controlText_ = 'Subtitles';
 

--- a/src/js/control-bar/text-track-controls/subtitles-button.js
+++ b/src/js/control-bar/text-track-controls/subtitles-button.js
@@ -54,7 +54,7 @@ SubtitlesButton.prototype.kind_ = 'subtitles';
  * The text that should display over the `SubtitlesButton`s controls. Added for localization.
  *
  * @type {string}
- * @private
+ * @protected
  */
 SubtitlesButton.prototype.controlText_ = 'Subtitles';
 

--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -55,7 +55,7 @@ CurrentTimeDisplay.prototype.labelText_ = 'Current Time';
  * The text that should display over the `CurrentTimeDisplay`s controls. Added to for localization.
  *
  * @type {string}
- * @private
+ * @protected
  *
  * @deprecated in v7; controlText_ is not used in non-active display Components
  */

--- a/src/js/control-bar/time-controls/duration-display.js
+++ b/src/js/control-bar/time-controls/duration-display.js
@@ -81,7 +81,7 @@ DurationDisplay.prototype.labelText_ = 'Duration';
  * The text that should display over the `DurationDisplay`s controls. Added to for localization.
  *
  * @type {string}
- * @private
+ * @protected
  *
  * @deprecated in v7; controlText_ is not used in non-active display Components
  */

--- a/src/js/control-bar/time-controls/remaining-time-display.js
+++ b/src/js/control-bar/time-controls/remaining-time-display.js
@@ -93,7 +93,7 @@ RemainingTimeDisplay.prototype.labelText_ = 'Remaining Time';
  * The text that should display over the `RemainingTimeDisplay`s controls. Added to for localization.
  *
  * @type {string}
- * @private
+ * @protected
  *
  * @deprecated in v7; controlText_ is not used in non-active display Components
  */

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -140,7 +140,7 @@ TimeDisplay.prototype.labelText_ = 'Time';
  * The text that should display over the `TimeDisplay`s controls. Added to for localization.
  *
  * @type {string}
- * @private
+ * @protected
  *
  * @deprecated in v7; controlText_ is not used in non-active display Components
  */


### PR DESCRIPTION
## Description
The controlText_ property should have a protected access modifier.
The PR is related to https://github.com/videojs/video.js/issues/7971


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
