### PR TITLE
fix: upgrade mpd-parser to fix xmldom vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "global": "^4.4.0",
     "keycode": "^2.2.0",
     "m3u8-parser": "4.8.0",
-    "mpd-parser": "0.22.0",
+    "mpd-parser": "0.22.1",
     "mux.js": "6.0.1",
     "safe-json-parse": "4.0.0",
     "videojs-font": "3.2.0",


### PR DESCRIPTION
## Description
The old version of mpd-parser is using the old version of xmldom which has a critical vulnerability refer to Snyk: https://security.snyk.io/vuln/SNYK-JS-XMLDOMXMLDOM-3092934

## Specific Changes proposed
Upgrade to the latest version of mpd-parser library which has the updated version of xmldom library.
