### PR TITLE
feat: text track display overlays a video

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -329,21 +329,19 @@ class TextTrackDisplay extends Component {
     const playerHeight = this.player_.currentHeight();
     const playerAspectRatio = playerWidth / playerHeight;
     const videoAspectRatio = this.player_.videoWidth() / this.player_.videoHeight();
-    let leftRight = 0;
-    let topBottom = 0;
+    let insetInlineMatch = 0;
+    let insetBlockMatch = 0;
 
-    if (Math.abs(playerAspectRatio - videoAspectRatio) > 0.01) {
+    if (Math.abs(playerAspectRatio - videoAspectRatio) > 0.1) {
       if (playerAspectRatio > videoAspectRatio) {
-        leftRight = Math.round((playerWidth - playerHeight * videoAspectRatio) / 2);
+        insetInlineMatch = Math.round((playerWidth - playerHeight * videoAspectRatio) / 2);
       } else {
-        topBottom = Math.round((playerHeight - playerWidth / videoAspectRatio) / 2);
+        insetBlockMatch = Math.round((playerHeight - playerWidth / videoAspectRatio) / 2);
       }
     }
 
-    tryUpdateStyle(this.el_, 'top', getCSSPositionValue(topBottom));
-    tryUpdateStyle(this.el_, 'bottom', getCSSPositionValue(topBottom));
-    tryUpdateStyle(this.el_, 'left', getCSSPositionValue(leftRight));
-    tryUpdateStyle(this.el_, 'right', getCSSPositionValue(leftRight));
+    tryUpdateStyle(this.el_, 'insetInline', getCSSPositionValue(insetInlineMatch));
+    tryUpdateStyle(this.el_, 'insetBlock', getCSSPositionValue(insetBlockMatch));
   }
 
   /**

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -420,19 +420,15 @@ if (!Html5.supportsNativeTextTracks()) {
     const textTrackDisplay = player.getChild('TextTrackDisplay');
     const textTrackDisplayStyle = textTrackDisplay.el().style;
 
-    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
-    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
-    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
-    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+    assert.ok(textTrackDisplayStyle.insetInline === '', 'text track display style insetInline equal to empty string');
+    assert.ok(textTrackDisplayStyle.insetBlock === '', 'text track display style insetBlock equal to empty string');
 
     // video aspect ratio equal to NaN
     player.tech_.videoWidth = () => 0;
     player.tech_.videoHeight = () => 0;
 
-    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
-    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
-    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
-    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+    assert.ok(textTrackDisplayStyle.insetInline === '', 'text track display style insetInline equal to empty string');
+    assert.ok(textTrackDisplayStyle.insetBlock === '', 'text track display style insetBlock equal to empty string');
 
     // video aspect ratio 2:1
     player.tech_.videoWidth = () => 100;
@@ -440,10 +436,8 @@ if (!Html5.supportsNativeTextTracks()) {
 
     textTrackDisplay.updateDisplayOverlay();
 
-    assert.ok(textTrackDisplayStyle.top === '10px', 'text track display style top equal to10px');
-    assert.ok(textTrackDisplayStyle.bottom === '10px', 'text track display style bottom equal to 10px');
-    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
-    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+    assert.ok(textTrackDisplayStyle.insetInline === '', 'text track display style insetInline equal to empty string');
+    assert.ok(textTrackDisplayStyle.insetBlock === '10px', 'text track display style insetBlock equal to 10px');
 
     // video aspect ratio 4:3
     player.tech_.videoWidth = () => 100;
@@ -451,10 +445,8 @@ if (!Html5.supportsNativeTextTracks()) {
 
     textTrackDisplay.updateDisplayOverlay();
 
-    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
-    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
-    assert.ok(textTrackDisplayStyle.left === '40px', 'text track display style left equal to 40px');
-    assert.ok(textTrackDisplayStyle.right === '40px', 'text track display style right equal to 40px');
+    assert.ok(textTrackDisplayStyle.insetInline === '40px', 'text track display style insetInline equal to 40px');
+    assert.ok(textTrackDisplayStyle.insetBlock === '', 'text track display style insetBlock equal to empty string');
 
     // video aspect ratio 16:9
     player.tech_.videoWidth = () => 320;
@@ -462,10 +454,8 @@ if (!Html5.supportsNativeTextTracks()) {
 
     textTrackDisplay.updateDisplayOverlay();
 
-    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
-    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
-    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
-    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+    assert.ok(textTrackDisplayStyle.insetInline === '', 'text track display style insetInline equal to empty string');
+    assert.ok(textTrackDisplayStyle.insetBlock === '', 'text track display style insetBlock equal to empty string');
 
     player.dispose();
   });

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -410,4 +410,63 @@ if (!Html5.supportsNativeTextTracks()) {
       'colors must be valid hex codes.'
     );
   });
+
+  QUnit.test('text track display should overlay a video', function(assert) {
+    const tag = document.createElement('video');
+
+    tag.width = 320;
+    tag.height = 180;
+    const player = TestHelpers.makePlayer({}, tag);
+    const textTrackDisplay = player.getChild('TextTrackDisplay');
+    const textTrackDisplayStyle = textTrackDisplay.el().style;
+
+    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
+    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
+    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
+    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+
+    // video aspect ratio equal to NaN
+    player.tech_.videoWidth = () => 0;
+    player.tech_.videoHeight = () => 0;
+
+    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
+    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
+    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
+    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+
+    // video aspect ratio 2:1
+    player.tech_.videoWidth = () => 100;
+    player.tech_.videoHeight = () => 50;
+
+    textTrackDisplay.updateDisplayOverlay();
+
+    assert.ok(textTrackDisplayStyle.top === '10px', 'text track display style top equal to10px');
+    assert.ok(textTrackDisplayStyle.bottom === '10px', 'text track display style bottom equal to 10px');
+    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
+    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+
+    // video aspect ratio 4:3
+    player.tech_.videoWidth = () => 100;
+    player.tech_.videoHeight = () => 75;
+
+    textTrackDisplay.updateDisplayOverlay();
+
+    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
+    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
+    assert.ok(textTrackDisplayStyle.left === '40px', 'text track display style left equal to 40px');
+    assert.ok(textTrackDisplayStyle.right === '40px', 'text track display style right equal to 40px');
+
+    // video aspect ratio 16:9
+    player.tech_.videoWidth = () => 320;
+    player.tech_.videoHeight = () => 180;
+
+    textTrackDisplay.updateDisplayOverlay();
+
+    assert.ok(textTrackDisplayStyle.top === '', 'text track display style top defaults to empty string');
+    assert.ok(textTrackDisplayStyle.bottom === '', 'text track display style bottom defaults to empty string');
+    assert.ok(textTrackDisplayStyle.left === '', 'text track display style left defaults to empty string');
+    assert.ok(textTrackDisplayStyle.right === '', 'text track display style right defaults to empty string');
+
+    player.dispose();
+  });
 }


### PR DESCRIPTION
## Description
Text track display does not always overlay a video which may generate a different text track size and position across different browsers and devices.

## Specific Changes proposed
The text track display always overlays a video.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
