### PR TITLE
chore(package): update videojs-contrib-quality-levels to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15646,12 +15646,12 @@
       }
     },
     "videojs-contrib-quality-levels": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-2.2.0.tgz",
-      "integrity": "sha512-r4LFNhjyeBmlGk4Ul43xl+f7sNJ9vFyM6p4NcZNbPlvs1IvykEXCqxvsvaR6KTBjHoHGJnr26grXWcJiLFP+cA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-2.2.1.tgz",
+      "integrity": "sha512-cnF6OGGgoC/2nUrbdz54nzPm3BpEZQzMTpyekiX6AXs8imATX2sHbrUz97xXVSHITldk/+d7ZAUrdQYJJTyuug==",
       "requires": {
         "global": "^4.3.2",
-        "video.js": "^6 || ^7"
+        "video.js": "^6 || ^7 || ^8"
       }
     },
     "videojs-font": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "mpd-parser": "^1.0.1",
     "mux.js": "^6.2.0",
     "safe-json-parse": "4.0.0",
-    "videojs-contrib-quality-levels": "2.2.0",
+    "videojs-contrib-quality-levels": "2.2.1",
     "videojs-font": "3.2.0",
     "videojs-vtt.js": "0.15.4"
   },


### PR DESCRIPTION
## Description
With 8.0.0 installed, you'll see the following when running `npm ls --depth=0`:
```
npm ERR! peer dep missing: video.js@^6 || ^7, required by videojs-contrib-quality-levels@2.2.0
```
This is because videojs-contrib-quality-levels 2.2.0 is not listed as being compatible with Video.js 8.0.0 - videojs-contrib-quality-levels 2.2.1 fixes this issue.

## Specific Changes proposed
Upgrade to videojs-contrib-quality-levels 2.2.1

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
