### PR TITLE
fix: Add poster size styles

### DIFF
--- a/src/css/components/_poster.scss
+++ b/src/css/components/_poster.scss
@@ -23,3 +23,9 @@
 .vjs-has-started.vjs-audio-poster-mode  .vjs-poster {
   display: block;
 }
+
+.vjs-poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}


### PR DESCRIPTION
## Description
Adds styling for the `img` el in the poster's `picture` so it scales correctly. 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
