### PR TITLE
chore: Update lock threads dependency

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: 'Lock Threads'
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1 * * 1,4'
   workflow_dispatch:
 
 permissions:
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.repository_owner == 'videojs' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v4
         with:
           issue-inactive-days: '60'
           process-only: 'issues'


### PR DESCRIPTION
## Description
- [Updates the lockthreads action](https://github.com/dessant/lock-threads/compare/e460dfe..c1b35ae) to resolve deprecation warnings like https://github.com/videojs/video.js/actions/runs/3666803961
- Also sets to run only twice a week to reduce noise in the acitons list. N.B. This does nothing for the occasional rate limiting errors. They're limits hit while the task runs, not because of how often it runs.