### PR TITLE
(WIP) feat: Allow picture sources to be set on poster

### DIFF
--- a/sandbox/poster.html.example
+++ b/sandbox/poster.html.example
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Sandbox</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started run `npm start` and open the index.html</p>
+    <pre>npm start</pre>
+    <pre>open http://localhost:9999/sandbox/index.html</pre>
+  </div>
+
+  <video-js
+    id="vid1"
+    controls
+    preload="auto"
+    width="640"
+    height="264">
+    <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="https://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="https://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
+    <track kind="captions" src="../docs/examples/shared/example-captions.vtt" srclang="en" label="English">
+    <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
+  </video-js>
+
+  <script>
+    var vid = document.getElementById('vid1');
+    var player = videojs(vid, {
+      posterOptions: {
+        sources: [{
+          type: 'image/webp',
+          srcset: 'https://www.gstatic.com/webp/gallery/1.webp'
+        },
+        {
+          type: 'image/png',
+          srcset: 'https://vjs.zencdn.net/v/oceans.png'
+        }],
+        alt: 'This would be descriptive text for a screen reader, if appropriate for the image.'
+      }
+    });
+    player.log('window.player created', player);
+  </script>
+
+</body>
+</html>

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -62,6 +62,7 @@ class PosterImage extends ClickableComponent {
   /**
    * Get or set the `PosterImage`'s crossOrigin option.
    *
+   *
    * @param {string|null} [value]
    *        The value to set the crossOrigin to. If an argument is
    *        given, must be one of `'anonymous'` or `'use-credentials'`, or 'null'.
@@ -105,13 +106,14 @@ class PosterImage extends ClickableComponent {
    *        The `Player#posterchange` event that triggered this function.
    */
   update(event) {
-    const url = this.player().poster();
+    const opts = this.player().posterOpts_;
 
-    this.setSrc(url);
+    this.setSrc(opts);
 
     // If there's no poster source we should display:none on this component
     // so it's not still clickable or right-clickable
-    if (url) {
+    // TODO: is this catching all unset scenarios
+    if (opts.img) {
       this.show();
     } else {
       this.hide();
@@ -123,9 +125,28 @@ class PosterImage extends ClickableComponent {
    *
    * @param {string} url
    *        The URL to the source for the `PosterImage`.
+   * @param {Object} [opts]
+   *        Image options
+   * @param {Object} [opts.sources]
+   *        An array of attributes to construct <picture> <source>s.
+   * @param {string} [opts.alt]
+   *        Alt text to set on the <picture>'s <img>..
    */
-  setSrc(url) {
-    this.el_.querySelector('img').src = url;
+  setSrc(opts) {
+    const imgEl = this.$('img');
+
+    imgEl.src = opts.img;
+    imgEl.setAttribute('alt', opts.alt || '');
+
+    this.$$('source').forEach(s => {
+      this.el_.removeChild(s);
+    });
+
+    if (opts.sources) {
+      opts.sources.forEach(s => {
+        this.el_.insertBefore(Dom.createEl('source', {}, s), imgEl);
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Now that the PosterImage uses a poster, we can make use of it to support multiple image formats. Very much a work in progress, needs tests, and there may well be edge cases yet to be considered.

## Changes:

- The argument to the `poster()` setter may now be a poster options object. A string is still supported to be non-breaking.
- The poster options object should specify an array of objects as `sources`. The object properties will be used as attributes of `<source>` elements of the `PosterImage`'s `<picture>`.
- The poster options object may include a string `img`, which is the `src` used for the `<picture>`'s `<img>`. If `sources` is set and `img` is not, `img` is set to the last item in `sources`.
- The poster options object may include a string `alt`, so alt text can be set on the `<img>`.
- The poster options object may also be passed as a player setup option, `posterOptions`.
- Adds a `posterOpts()` getter to fetch the poster options. However this is _not_ a setter, since the options are set with `poster()`.
- if sources are used, `poster()` as a getter will return the image actually used.
- If sources are used, the poster attribute is not set on the tech, so the tech and poster do not load different images.
- If sources are not used, the poster attriute is optionally not set if a new player option `noTechPoster` is set to true. This is useful since the poster now uses laszy loading, so the video el doesn't load the image.

## Examples

```js
// Works as currently
player.poster('https://example.com/image.jpeg');
// Would have the same effect
player.poster({img: 'https://example.com/image.jpeg'});
// Would set a poster, and its alt text
player.poster({img: 'https://example.com/image.jpeg', alt: 'Descriptive text for a screen reader'});
```

```js
// The browser would use webp if it suppports it
player.poster({
  sources: [{
    srcset: 'https://example.com/image.webp',
    type: 'image/webp'
  },
  {
    srcset: 'https://example.com/image.jpeg',
    type: 'image/jpeg'
  }],
  img: 'https://example.com/image.jpeg'
});
```

```js
// Where the fallback image is omited, the last source's image is used. This would be
// equivalent to the last example.
player.poster({
  sources: [{
    srcset: 'https://example.com/image.webp',
    type: 'image/webp'
  },
  {
    srcset: 'https://example.com/image.jpeg',
    type: 'image/jpeg'
  }]
});
```

To do

- [ ] Tests
- [ ] jsdoc/types