### PR TITLE
fix(package): Upgrade to videojs-contrib-quality-levels 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15646,12 +15646,11 @@
       }
     },
     "videojs-contrib-quality-levels": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-2.2.1.tgz",
-      "integrity": "sha512-cnF6OGGgoC/2nUrbdz54nzPm3BpEZQzMTpyekiX6AXs8imATX2sHbrUz97xXVSHITldk/+d7ZAUrdQYJJTyuug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-3.0.0.tgz",
+      "integrity": "sha512-sNx38EYUx+Q+gmup1gVTv9P9/sPs28rM7gZOx1sedaHoKxEdYB+ysOGfHj6MSELBMNGMj6ZspdrpSiWguGvGxA==",
       "requires": {
-        "global": "^4.3.2",
-        "video.js": "^6 || ^7 || ^8"
+        "global": "^4.4.0"
       }
     },
     "videojs-font": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mpd-parser": "^1.0.1",
     "mux.js": "^6.2.0",
     "safe-json-parse": "4.0.0",
-    "videojs-contrib-quality-levels": "2.2.1",
+    "videojs-contrib-quality-levels": "3.0.0",
     "videojs-font": "3.2.0",
     "videojs-vtt.js": "0.15.4"
   },


### PR DESCRIPTION
## Description
Pulls in this change https://github.com/videojs/videojs-contrib-quality-levels/pull/142, which fixes an incompatibility between video.js v8 and contrib-quality-levels.
