### PR TITLE
fix: Ensures iOS can use native fullscreen

### DIFF
--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -666,20 +666,14 @@ class Html5 extends Tech {
   }
 
   /**
-   * Check if fullscreen is supported on the current playback device.
+   * Check if fullscreen is supported on the video el.
    *
    * @return {boolean}
    *         - True if fullscreen is supported.
    *         - False if fullscreen is not supported.
    */
   supportsFullScreen() {
-    if (typeof this.el_.webkitEnterFullScreen === 'function') {
-      // Still needed?
-      if (browser.IS_ANDROID) {
-        return true;
-      }
-    }
-    return false;
+    return typeof this.el_.webkitEnterFullScreen === 'function';
   }
 
   /**

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -893,3 +893,15 @@ QUnit.test('featuresVideoFrameCallback is false for Safari DRM', function(assert
     assert.ok(true, 'skipped because webkitKeys not writable');
   }
 });
+
+QUnit.test('supportsFullScreen is always with `webkitEnterFullScreen`', function(assert) {
+  const oldEl = tech.el_;
+
+  tech.el_ = {
+    webkitEnterFullScreen: () => {}
+  };
+
+  assert.ok(tech.supportsFullScreen(), 'supportsFullScreen() true with webkitEnterFullScreen');
+
+  tech.el_ = oldEl;
+});


### PR DESCRIPTION
## Description
#7979 removed a check for an old OS X version but incorrectly, causing iPhones not to use their native fullscreen.

## Specific Changes proposed
Returns trues for any video el with `webkitEnterFullScreen()`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
