### PR TITLE
feat: Add middleware method to override currentSource()

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3305,7 +3305,7 @@ class Player extends Component {
   handleSrc_(source, isRetry) {
     // getter usage
     if (typeof source === 'undefined') {
-      return this.cache_.src || '';
+      return this.currentSrc();
     }
 
     // Reset retry behavior for new source

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3569,7 +3569,9 @@ class Player extends Component {
    *         The current source object
    */
   currentSource() {
-    return this.cache_.source || {};
+    const mw = this.middleware_;
+
+    return middleware.currentSource(this.cache_.source, mw) || this.cache_.source || {};
   }
 
   /**

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -82,6 +82,10 @@ export function setSource(player, src, next) {
   player.setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
 }
 
+export function currentSource(src, middleware) {
+  return middleware.reduceRight(middlewareIterator('currentSource'), src);
+}
+
 /**
  * When the tech is set, passes the tech to each middleware's `setTech` method.
  *

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -82,6 +82,16 @@ export function setSource(player, src, next) {
   player.setTimeout(() => setSourceHelper(src, middlewares[src.type], next, player), 1);
 }
 
+/**
+ * Allows user to override the returned value of player.currentSource() using middleware.
+ *
+ * @param {Tech~SourceObject} src
+ *         A source object.
+ * @param {Object[]} middleware
+ *        An array of middleware instances.
+ * @return {Tech~SourceObject}
+ *         A source object.
+ */
 export function currentSource(src, middleware) {
   return middleware.reduceRight(middlewareIterator('currentSource'), src);
 }

--- a/src/js/tech/middleware.js
+++ b/src/js/tech/middleware.js
@@ -92,7 +92,7 @@ export function setSource(player, src, next) {
  * @return {Tech~SourceObject}
  *         A source object.
  */
-export function currentSource(src, middleware) {
+export function currentSource(middleware, src) {
   return middleware.reduceRight(middlewareIterator('currentSource'), src);
 }
 

--- a/test/unit/tech/middleware.test.js
+++ b/test/unit/tech/middleware.test.js
@@ -536,3 +536,17 @@ QUnit.test('a middleware without a setSource gets chosen implicitly', function(a
 
   middleware.getMiddleware('video/foo').pop();
 });
+
+QUnit.test('middleware can override currentSource', function(assert) {
+  const middlewares = [
+    {
+      currentSource: (src) => {
+        return `foo${src}`;
+      }
+    }
+  ];
+
+  const result = middleware.currentSource('bar', middlewares);
+
+  assert.equal(result, 'foobar', 'value of currentSource() is overriden');
+});


### PR DESCRIPTION
## Description
We've come across a use case whereby an advanced user would want to to substitute the `src` attribute of the video using `setSource` middleware, but also requires `player.currentSource()` to continue to report the original src value, globally. 

Because `setSource` is used to effect the substitution it follows that the user should also have a way to control what is reported by the corresponding "getter", i.e. `player.currentSource()` and middleware seems to be a natural place to implement this.

## Specific Changes proposed
* implement `middleware.currentSource` to run through user-provided middleware and run a reduce on whatever currentSource implementations exist
  * because `player.currentSource` doesn't delegate to the tech, this needs it's own middleware function. 
* `player.currentSource()` will return `middleware.currentSource()` if possible
  * noting that this will have knock-on effects to the values returned by `player.currentSrc` & `player.currentType`
* Add unit test

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
