### PR TITLE
fix: Exit PIP if entering fullscreen

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2784,6 +2784,10 @@ class Player extends Component {
    * @fires Player#fullscreenchange
    */
   requestFullscreen(fullscreenOptions) {
+    if (this.isInPictureInPicture()) {
+      this.exitPictureInPicture();
+    }
+
     const self = this;
 
     return new Promise((resolve, reject) => {

--- a/test/unit/player-fullscreen.test.js
+++ b/test/unit/player-fullscreen.test.js
@@ -243,6 +243,29 @@ QUnit.test('full window can be preferred to fullscreen tech', function(assert) {
   player.dispose();
 });
 
+QUnit.test('fullscreen mode should exit picture-in-picture if it was enabled', function(assert) {
+  const player = FullscreenTestHelpers.makePlayer(false, {
+    preferFullWindow: true
+  });
+
+  const fakeExitPictureInPicture = sinon.replace(player, 'exitPictureInPicture', sinon.fake(() => {}));
+
+  player.fsApi_ = {};
+  player.tech_.supportsFullScreen = () => true;
+
+  assert.strictEqual(player.isFullscreen(), false, 'player should not be fullscreen initially');
+  player.isInPictureInPicture(true);
+  player.trigger('enterpictureinpicture');
+  assert.strictEqual(player.isInPictureInPicture(), true, 'player is in picture-in-picture');
+
+  assert.strictEqual(fakeExitPictureInPicture.called, false, 'should not have called exitPictureInPicture yet');
+  player.requestFullscreen();
+  assert.strictEqual(player.isFullscreen(), true, 'player should be fullscreen');
+  assert.strictEqual(fakeExitPictureInPicture.called, true, 'should have called exitPictureInPicture');
+
+  player.dispose();
+});
+
 QUnit.test('fullwindow mode should exit when ESC event triggered', function(assert) {
   const player = TestHelpers.makePlayer();
 


### PR DESCRIPTION
## Description
Updates video.js to exit PiP when requesting fullscreen per [this issue](https://github.com/videojs/video.js/issues/7921).

## Specific Changes proposed
- A check at the top of `requestFullscreen` for `isInPictureInPicture`, calling `exitPictureInPicture` if so.

Should more be done here?

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
