### PR TITLE
Fixed wrong Korean translation for "Playback Rate"

### DIFF
--- a/lang/ko.json
+++ b/lang/ko.json
@@ -19,7 +19,7 @@
   "Exit Fullscreen": "전체 화면 해제",
   "Mute": "음소거",
   "Unmute": "음소거 해제",
-  "Playback Rate": "재생 비율",
+  "Playback Rate": "재생 속도",
   "Subtitles": "서브타이틀",
   "subtitles off": "서브타이틀 끄기",
   "Captions": "자막",


### PR DESCRIPTION
## Description
It is incorrect to translate Playback Rate as "재생 비율" here. "재생 속도" is a fitting translation.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

- Fixed Korean translation for "Playback Rate" in ko.json.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
