### PR TITLE
chore: Update translations script to special case en-GB

### DIFF
--- a/build/translations.js
+++ b/build/translations.js
@@ -21,6 +21,15 @@ filepaths.forEach((filepath) => {
   }
 
   const target = require(filepath);
+
+  // Special case for English, the assumption being that since the keys are English only
+  // a  few strings need to be altered for regional differences, e.g. en-GB.
+  if (filename.startsWith('en-')) {
+    console.log(`${filename} English - should be manually checked.`);
+    tableData.push([`${filename} (has ${Object.keys(target).length})`, 'Needs manual checking. Can safely use most default strings.']);
+    return;
+  }
+
   const missing = [];
 
   for (const string in source) {

--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -335,6 +335,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 |                         | No content                                                                          |
+| en-GB.json (has 1)      | Needs manual checking. Can safely use most default strings.                         |
 | es.json (Complete)      |                                                                                     |
 | et.json (missing 1)     | No content                                                                          |
 | eu.json (missing 1)     | No content                                                                          |
@@ -641,20 +642,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | No content                                                                          |
 | te.json (missing 1)     | No content                                                                          |
 | th.json (missing 1)     | No content                                                                          |
-| tr.json (missing 14)    | Audio Player                                                                        |
-|                         | Video Player                                                                        |
-|                         | Seek to live, currently behind live                                                 |
-|                         | Seek to live, currently playing live                                                |
-|                         | Progress Bar                                                                        |
-|                         | progress bar timing: currentTime={1} duration={2}                                   |
-|                         | Volume Level                                                                        |
-|                         | Reset                                                                               |
-|                         | restore all settings to the default values                                          |
-|                         | End of dialog window.                                                               |
-|                         | {1} is loading.                                                                     |
-|                         | Exit Picture-in-Picture                                                             |
-|                         | Picture-in-Picture                                                                  |
-|                         | No content                                                                          |
+| tr.json (Complete)      |                                                                                     |
 | uk.json (missing 5)     | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
 |                         | Exit Picture-in-Picture                                                             |

--- a/lang/en-GB.json
+++ b/lang/en-GB.json
@@ -1,0 +1,4 @@
+{
+  "Color": "Colour"
+}
+


### PR DESCRIPTION
The default text in our translation system are English strings, so having a full JSON file for a variant of English that would only modifiy one or two strigns would be wasteful.

This changes the script that updates translations-needed.md to not highlight the number of "missing" translations in a en-* file and just state it needs to be manually checked instead.

Fixes #8105