### PR TITLE
fix: add padding to title bar text for icon space

### DIFF
--- a/src/css/components/_title-bar.scss
+++ b/src/css/components/_title-bar.scss
@@ -24,10 +24,17 @@
 
 .vjs-title-bar-title,
 .vjs-title-bar-description {
+  // The width of the 'shelf' component that existed in the deprecated 'videojs-dock' plugin.
+  // Adding this amount of padding to the right of the title bar title/descriptions allows for
+  // icons to be placed in the top right of the title bar without overlapping on the title/description
+  // text.
+  $shelf-width: 25%;
+
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding-right: $shelf-width;
 }
 
 .vjs-title-bar-title {


### PR DESCRIPTION
## Description
With the deprecation of the [videojs-dock plugin](https://github.com/brightcove/videojs-dock) and the creation of the `TitleBar` to replace it, the [`shelf`](https://github.com/brightcove/videojs-dock/blob/8309e7f28bdced765ca0421b0326967e0c870172/src/plugin.js#L61) component in the dock plugin was removed. The `shelf` component took up 25% of the dock and ensured that icons added to the dock would not overlap with the title/description text. This change is adding the padding that the `shelf` used to have so that any icons in the TitleBar do not overlap with the title/description text.

## Specific Changes proposed
- CSS to add padding to the right of the title and description text to ensure no overlap with any icons added to the `TitleBar`

### Example of the TitleBar before the proposed change
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/45859558/217517537-a4420d32-bbc5-45ee-ae55-3c5d97ee1d3a.png">

### Example after the proposed change
<img width="1344" alt="image" src="https://user-images.githubusercontent.com/45859558/217517769-3f840bc0-e746-4808-9ae4-0d9d4b532189.png">


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
