### PR TITLE
Update progress bar slider translation

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -14,7 +14,7 @@
   "Loaded": "Loaded",
   "Progress": "Progress",
   "Progress Bar": "Progress Bar",
-  "progress bar timing: currentTime={1} duration={2}": "{1} of {2}",
+  "progress bar timing: currentTime={1} duration={2}": "progress bar timing: currentTime={1} duration={2}",
   "Fullscreen": "Fullscreen",
   "Exit Fullscreen": "Exit Fullscreen",
   "Mute": "Mute",


### PR DESCRIPTION
## Description
Our app uses videoJS and there's an a11y report on the progress bar aria text is not specific enough. The string `progress bar timing: currentTime={1} duration={2}` should provide enough specificity. However, looks like videoJS is falling back to use the default translation string because we didn't add the `progress bar timing: currentTime={1} duration={2}` to the translation file 

## Specific Changes proposed
- update translation in english

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
