### PR TITLE
fix: Remove img el when there's no poster source

### DIFF
--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -101,43 +101,49 @@ class PosterImage extends ClickableComponent {
   update(event) {
     const url = this.player().poster();
 
+    this.setSrc(url);
+
+    // If there's no poster source we should display:none on this component
+    // so it's not still clickable or right-clickable
     if (url) {
-      // As there's a poster source, add a picture/img if not already present
-
-      if (!this.$('img')) {
-        this.el_.appendChild(Dom.createEl(
-          'picture', {
-            className: 'vjs-poster',
-
-            // Don't want poster to be tabbable.
-            tabIndex: -1
-          },
-          {},
-          Dom.createEl('img', {
-            loading: 'lazy',
-            crossOrigin: this.crossOrigin()
-          }, {
-            alt: ''
-          })
-        ));
-      }
-      this.setSrc(url);
       this.show();
     } else {
-      // With no source, remove child elements to not end up with an invalid img
-
-      this.el_.textContent = '';
       this.hide();
     }
   }
 
   /**
-   * Set the source of the `PosterImage` depending on the display method.
+   * Set the source of the `PosterImage` depending on the display method. (Re)creates
+   * the inner picture and img elementss when needed.
    *
-   * @param {string} url
-   *        The URL to the source for the `PosterImage`.
+   * @param {string} [url]
+   *        The URL to the source for the `PosterImage`. If not specified or falsy,
+   *        any source and ant inner picture/img are removed.
    */
   setSrc(url) {
+    if (!url) {
+      this.el_.textContent = '';
+      return;
+    }
+
+    if (!this.$('img')) {
+      this.el_.appendChild(Dom.createEl(
+        'picture', {
+          className: 'vjs-poster',
+
+          // Don't want poster to be tabbable.
+          tabIndex: -1
+        },
+        {},
+        Dom.createEl('img', {
+          loading: 'lazy',
+          crossOrigin: this.crossOrigin()
+        }, {
+          alt: ''
+        })
+      ));
+    }
+
     this.$('img').src = url;
   }
 

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -46,23 +46,9 @@ class PosterImage extends ClickableComponent {
    *         The element that gets created.
    */
   createEl() {
-    const el = Dom.createEl(
-      'picture', {
-        className: 'vjs-poster',
-
-        // Don't want poster to be tabbable.
-        tabIndex: -1
-      },
-      {},
-      Dom.createEl('img', {
-        loading: 'lazy',
-        crossOrigin: this.crossOrigin()
-      }, {
-        alt: ''
-      })
-    );
-
-    return el;
+    // The el is an empty div to keep position in the DOM
+    // A picture and img el will be inserted when a source is set
+    return Dom.createEl('div', { className: 'vjs-poster'});
   }
 
   /**
@@ -79,9 +65,9 @@ class PosterImage extends ClickableComponent {
   crossOrigin(value) {
     // `null` can be set to unset a value
     if (typeof value === 'undefined') {
-      if (this.el_) {
+      if (this.$('img')) {
         // If the poster's element exists, give its value
-        return this.el_.querySelector('img').crossOrigin;
+        return this.$('img').crossOrigin;
       } else if (this.player_.tech_ && this.player_.tech_.isReady_) {
         // If not but the tech is ready, query the tech
         return this.player_.crossOrigin();
@@ -97,7 +83,9 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
-    this.el_.querySelector('img').crossOrigin = value;
+    if (this.$('img')) {
+      this.$('img').crossOrigin = value;
+    }
 
     return;
   }
@@ -113,13 +101,32 @@ class PosterImage extends ClickableComponent {
   update(event) {
     const url = this.player().poster();
 
-    this.setSrc(url);
-
-    // If there's no poster source we should display:none on this component
-    // so it's not still clickable or right-clickable
     if (url) {
+      // As there's a poster source, add a picture/img if not already present
+
+      if (!this.$('img')) {
+        this.el_.appendChild(Dom.createEl(
+          'picture', {
+            className: 'vjs-poster',
+
+            // Don't want poster to be tabbable.
+            tabIndex: -1
+          },
+          {},
+          Dom.createEl('img', {
+            loading: 'lazy',
+            crossOrigin: this.crossOrigin()
+          }, {
+            alt: ''
+          })
+        ));
+      }
+      this.setSrc(url);
       this.show();
     } else {
+      // With no source, remove child elements to not end up with an invalid img
+
+      this.el_.textContent = '';
       this.hide();
     }
   }
@@ -131,7 +138,7 @@ class PosterImage extends ClickableComponent {
    *        The URL to the source for the `PosterImage`.
    */
   setSrc(url) {
-    this.el_.querySelector('img').src = url;
+    this.$('img').src = url;
   }
 
   /**

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -61,6 +61,7 @@ QUnit.test('should remove itself from the document flow when there is no poster'
     true,
     'Poster image hides with an empty source'
   );
+  assert.equal(posterImage.$('img'), null, 'Poster image with no source has no img el');
 
   // Updated with a valid source
   this.mockPlayer.poster_ = this.poster2;
@@ -70,6 +71,7 @@ QUnit.test('should remove itself from the document flow when there is no poster'
     false,
     'Poster image shows again when there is a source'
   );
+  assert.ok(posterImage.$('img'), 'Poster image with source restores img el');
 
   posterImage.dispose();
 });


### PR DESCRIPTION
## Description
If there is no poster source, an img el can't be present as it would be invalid.

## Specific Changes proposed
Use a div (again) as the top level element of the PosterImage, to keep position in the DOM. Insert/remove the picture/img els when a poster source is set/unset. 
Fixes #8122 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
