### PR TITLE
fix: replay button broken for native playback

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -58,12 +58,6 @@ class PlayToggle extends Button {
    */
   handleClick(event) {
     if (this.player_.paused()) {
-      // Safari will not restart playback on a play click when playing back natively, so we seek to 0, then play.
-      const endedNativePlayback = this.hasClass('vjs-ended') && !this.player_.lastSource_.tech.startsWith('blob');
-
-      if (endedNativePlayback) {
-        this.player_.currentTime(0);
-      }
       silencePromise(this.player_.play());
     } else {
       this.player_.pause();

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -132,9 +132,7 @@ class PlayToggle extends Button {
     this.addClass('vjs-ended');
     // change the button text to "Replay"
     this.controlText('Replay');
-    // console.dir(event);
-    // console.dir(this.player_.tech_);
-    // is not getting fired in Safari
+
     // on the next seek remove the replay button
     this.one(this.player_, 'seeked', (e) => this.handleSeeked(e));
   }

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -58,6 +58,12 @@ class PlayToggle extends Button {
    */
   handleClick(event) {
     if (this.player_.paused()) {
+      // Safari will not restart playback on a play click when playing back natively, so we seek to 0, then play.
+      const endedNativePlayback = this.hasClass('vjs-ended') && !this.player_.lastSource_.tech.startsWith('blob');
+
+      if (endedNativePlayback) {
+        this.player_.currentTime(0);
+      }
       silencePromise(this.player_.play());
     } else {
       this.player_.pause();
@@ -126,7 +132,9 @@ class PlayToggle extends Button {
     this.addClass('vjs-ended');
     // change the button text to "Replay"
     this.controlText('Replay');
-
+    // console.dir(event);
+    // console.dir(this.player_.tech_);
+    // is not getting fired in Safari
     // on the next seek remove the replay button
     this.one(this.player_, 'seeked', (e) => this.handleSeeked(e));
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2313,6 +2313,7 @@ class Player extends Component {
     this.playCallbacks_.push(callback);
 
     const isSrcReady = Boolean(!this.changingSrc_ && (this.src() || this.currentSrc()));
+    const isSafariOrIOS = Boolean(browser.IS_ANY_SAFARI || browser.IS_IOS);
 
     // treat calls to play_ somewhat like the `one` event function
     if (this.waitToPlay_) {
@@ -2330,7 +2331,7 @@ class Player extends Component {
 
       // if we are in Safari, there is a high chance that loadstart will trigger after the gesture timeperiod
       // in that case, we need to prime the video element by calling load so it'll be ready in time
-      if (!isSrcReady && (browser.IS_ANY_SAFARI || browser.IS_IOS)) {
+      if (!isSrcReady && isSafariOrIOS) {
         this.load();
       }
       return;
@@ -2339,6 +2340,12 @@ class Player extends Component {
     // If the player/tech is ready and we have a source, we can attempt playback.
     const val = this.techGet_('play');
 
+    // Reset the progress bar
+    const isNativeReplay = isSafariOrIOS && this.hasClass('vjs-ended');
+
+    if (isNativeReplay) {
+      this.resetProgressBar_();
+    }
     // play was terminated if the returned value is null
     if (val === null) {
       this.runPlayTerminatedQueue_();

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2340,7 +2340,7 @@ class Player extends Component {
     // If the player/tech is ready and we have a source, we can attempt playback.
     const val = this.techGet_('play');
 
-    // Reset the progress bar
+    // For native playback, reset the progress bar if we get a play call from a replay.
     const isNativeReplay = isSafariOrIOS && this.hasClass('vjs-ended');
 
     if (isNativeReplay) {

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -104,3 +104,20 @@ QUnit.test('tech ready + has source + changing source = wait for loadstart', fun
   this.player.trigger('loadstart');
   assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
+
+QUnit.test('play call from native replay', function(assert) {
+
+  // Mock the player having a source.
+  this.player.src('xyz.mp4');
+  this.clock.tick(100);
+
+  // Attempt to play, but silence the promise that might be returned.
+  silencePromise(this.player.play());
+  assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
+
+  // add vjs-ended for replay logic and play again.
+  this.player.addClass('vjs-ended');
+
+  silencePromise(this.player.play());
+  assert.strictEqual(this.techPlayCallCount, 2, 'tech_.play was called');
+});

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -106,9 +106,11 @@ QUnit.test('tech ready + has source + changing source = wait for loadstart', fun
   assert.strictEqual(this.techPlayCallCount, 1, 'tech_.play was called');
 });
 
-QUnit.test('play call from native replay', function(assert) {
+QUnit.test('play call from native replay calls resetProgressBar_', function(assert) {
+  const origSafari = browser.IS_ANY_SAFARI;
+  const origIOS = browser.IS_IOS;
+
   browser.stub_IS_ANY_SAFARI(true);
-  browser.stub_IS_IOS(true);
 
   // Mock the player having a source.
   this.player.src('xyz.mp4');
@@ -123,4 +125,15 @@ QUnit.test('play call from native replay', function(assert) {
 
   silencePromise(this.player.play());
   assert.strictEqual(this.techPlayCallCount, 2, 'tech_.play was called');
+  assert.strictEqual(this.techCurrentTimeCallCount, 1, 'tech_.currentTime was called');
+
+  // Reset safari stub and try replay in iOS.
+  browser.stub_IS_ANY_SAFARI(origSafari);
+  browser.stub_IS_IOS(true);
+
+  silencePromise(this.player.play());
+  assert.strictEqual(this.techPlayCallCount, 3, 'tech_.play was called');
+  assert.strictEqual(this.techCurrentTimeCallCount, 2, 'tech_.currentTime was called');
+
+  browser.stub_IS_IOS(origIOS);
 });

--- a/test/unit/player-play.test.js
+++ b/test/unit/player-play.test.js
@@ -2,6 +2,7 @@
 import sinon from 'sinon';
 import {silencePromise} from '../../src/js/utils/promise';
 import TestHelpers from './test-helpers';
+import * as browser from '../../src/js/utils/browser.js';
 
 QUnit.module('Player#play', {
 
@@ -106,6 +107,8 @@ QUnit.test('tech ready + has source + changing source = wait for loadstart', fun
 });
 
 QUnit.test('play call from native replay', function(assert) {
+  browser.stub_IS_ANY_SAFARI(true);
+  browser.stub_IS_IOS(true);
 
   // Mock the player having a source.
   this.player.src('xyz.mp4');


### PR DESCRIPTION
## Description
During native playback in Safari (desktop or iOS) if the user reaches the end of content in fullscreen, the replay button will no longer function with a single click. Meaning, the button will work and change state to `playing` however the video does not restart. It seems to be an issue with the content not ending correctly as the `ended` event is firing, however `video.ended` is returning `false`. Since it's native, we don't have the option of calling `endOfStream` on the mediaSource.

## Specific Changes proposed
If we detect native playback from the `tech` and the play toggle is still in the replay state, we can manually do a seek to 0 and call play.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
