### PR TITLE
fix(dom): handle slotted parent transform position

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -578,7 +578,15 @@ export function getPointerPosition(el, event) {
         translated.y += values[13];
       }
 
-      item = item.parentNode;
+      if (item.assignedSlot && item.assignedSlot.parentElement && window.WebKitCSSMatrix) {
+        const transformValue = window.getComputedStyle(item.assignedSlot.parentElement).transform;
+        const matrix = new window.WebKitCSSMatrix(transformValue);
+
+        translated.x += matrix.m41;
+        translated.y += matrix.m42;
+      }
+
+      item = item.parentNode || item.host;
     }
   }
 


### PR DESCRIPTION
## Description

`getPointerPosition` for IOS is not handling slot elements and nested web components due to the following: 

1. `item.parentNode` will stop at the first web component and any transform applied on the outer component won't be part of the calculation and `translate.x` will be wrong. 
2. `item.parentNode` will skip the slot parent wrapper entirely, so any transformation applied to the parent wrapper won't be counted. 

It would be useful to support this as we have a use case where we are displaying a list of videos inside the slides web component.(https://ionicframework.com/docs/api/slides) and here is a simple reproduction sample where the pointer position is miscalculated with a slotted video having a wrapper with transform. 
https://codepen.io/weiz18/pen/poOEjzJ?editors=1000


## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
