### PR TITLE
fix: Ensure additional components update on languagechange

### DIFF
--- a/src/js/control-bar/skip-buttons/skip-backward.js
+++ b/src/js/control-bar/skip-buttons/skip-backward.js
@@ -61,6 +61,9 @@ class SkipBackward extends Button {
     this.player_.currentTime(newTime);
   }
 
+  /**
+   * Update control text on languagechange
+   */
   handleLanguagechange() {
     this.controlText(this.localize('Skip backward {1} seconds', [this.skipTime]));
   }

--- a/src/js/control-bar/skip-buttons/skip-backward.js
+++ b/src/js/control-bar/skip-buttons/skip-backward.js
@@ -60,6 +60,10 @@ class SkipBackward extends Button {
     }
     this.player_.currentTime(newTime);
   }
+
+  handleLanguagechange() {
+    this.controlText(this.localize('Skip backward {1} seconds', [this.skipTime]));
+  }
 }
 
 SkipBackward.prototype.controlText_ = 'Skip Backward';

--- a/src/js/control-bar/skip-buttons/skip-forward.js
+++ b/src/js/control-bar/skip-buttons/skip-forward.js
@@ -60,6 +60,9 @@ class SkipForward extends Button {
     this.player_.currentTime(newTime);
   }
 
+  /**
+   * Update control text on languagechange
+   */
   handleLanguagechange() {
     this.controlText(this.localize('Skip forward {1} seconds', [this.skipTime]));
   }

--- a/src/js/control-bar/skip-buttons/skip-forward.js
+++ b/src/js/control-bar/skip-buttons/skip-forward.js
@@ -59,6 +59,10 @@ class SkipForward extends Button {
 
     this.player_.currentTime(newTime);
   }
+
+  handleLanguagechange() {
+    this.controlText(this.localize('Skip forward {1} seconds', [this.skipTime]));
+  }
 }
 
 Component.registerComponent('SkipForward', SkipForward);

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -59,6 +59,9 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
     this.player().getChild('textTrackSettings').open();
   }
 
+  /**
+   * Update control text and label on languagechange
+   */
   handleLanguagechange() {
     this.$('.vjs-menu-item-text').textContent = this.player_.localize(this.options_.kind + ' settings');
 

--- a/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
+++ b/src/js/control-bar/text-track-controls/caption-settings-menu-item.js
@@ -58,6 +58,12 @@ class CaptionSettingsMenuItem extends TextTrackMenuItem {
   handleClick(event) {
     this.player().getChild('textTrackSettings').open();
   }
+
+  handleLanguagechange() {
+    this.$('.vjs-menu-item-text').textContent = this.player_.localize(this.options_.kind + ' settings');
+
+    super.handleLanguagechange();
+  }
 }
 
 Component.registerComponent('CaptionSettingsMenuItem', CaptionSettingsMenuItem);

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -102,6 +102,12 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     }
   }
 
+  handleLanguagechange() {
+    this.$('.vjs-menu-item-text').textContent = this.player_.localize(this.options_.label);
+
+    super.handleLanguagechange();
+  }
+
 }
 
 Component.registerComponent('OffTextTrackMenuItem', OffTextTrackMenuItem);

--- a/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
+++ b/src/js/control-bar/text-track-controls/off-text-track-menu-item.js
@@ -102,6 +102,9 @@ class OffTextTrackMenuItem extends TextTrackMenuItem {
     }
   }
 
+  /**
+   * Update control text and label on languagechange
+   */
   handleLanguagechange() {
     this.$('.vjs-menu-item-text').textContent = this.player_.localize(this.options_.label);
 

--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -36,9 +36,7 @@ class LoadingSpinner extends Component {
   }
 
   /**
-   * Handles language change in ClickableComponent for the player in components
-   *
-   *
+   * Update control text on languagechange
    */
   handleLanguagechange() {
     this.$('.vjs-control-text').textContent = this.localize('{1} is loading.', [

--- a/src/js/loading-spinner.js
+++ b/src/js/loading-spinner.js
@@ -34,6 +34,17 @@ class LoadingSpinner extends Component {
 
     return el;
   }
+
+  /**
+   * Handles language change in ClickableComponent for the player in components
+   *
+   *
+   */
+  handleLanguagechange() {
+    this.$('.vjs-control-text').textContent = this.localize('{1} is loading.', [
+      this.player_.isAudio() ? 'Audio Player' : 'Video Player'
+    ]);
+  }
 }
 
 Component.registerComponent('LoadingSpinner', LoadingSpinner);

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -611,7 +611,7 @@ class TextTrackSettings extends ModalDialog {
   }
 
   /**
-   * Repopulate dialog with new localizations
+   * Repopulate dialog with new localizations on languagechange
    */
   handleLanguagechange() {
     this.fill();

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -610,6 +610,13 @@ class TextTrackSettings extends ModalDialog {
     }
   }
 
+  /**
+   * Repopulate dialog with new localizations
+   */
+  handleLanguagechange() {
+    this.fill();
+  }
+
 }
 
 Component.registerComponent('TextTrackSettings', TextTrackSettings);

--- a/test/unit/control-bar/skip-buttons/skip-backward-button.test.js
+++ b/test/unit/control-bar/skip-buttons/skip-backward-button.test.js
@@ -2,6 +2,7 @@
 import TestHelpers from '../../test-helpers';
 import sinon from 'sinon';
 import { createTimeRange } from '../../../../src/js/utils/time';
+import videojs from '../../../../src/js/video.js';
 
 QUnit.module('SkipBackwardButton');
 
@@ -93,6 +94,18 @@ QUnit.test('skip backward in video by configured skip backward time amount', fun
 
   assert.expect(1);
   assert.equal(curTimeSpy.getCall(1).args[0], 1, 'player current time set 30 seconds back on button click');
+
+  player.dispose();
+});
+
+QUnit.test('localizes on languagechange', function(assert) {
+  const player = TestHelpers.makePlayer({controlBar: {skipButtons: {backward: 30}}});
+  const button = player.controlBar.skipBackward;
+
+  videojs.addLanguage('test', {'Skip backward {1} seconds': '{1} BACKWARD'});
+  player.language('test');
+
+  assert.equal(button.$('.vjs-control-text').textContent, '30 BACKWARD', 'control text updates on languagechange');
 
   player.dispose();
 });

--- a/test/unit/control-bar/skip-buttons/skip-forward-button.test.js
+++ b/test/unit/control-bar/skip-buttons/skip-forward-button.test.js
@@ -2,6 +2,7 @@
 import TestHelpers from '../../test-helpers';
 import sinon from 'sinon';
 import { createTimeRange } from '../../../../src/js/utils/time';
+import videojs from '../../../../src/js/video.js';
 
 QUnit.module('SkipForwardButton');
 
@@ -112,6 +113,18 @@ QUnit.test('skips forward in video by configured skip forward time amount', func
 
   assert.expect(1);
   assert.equal(curTimeSpy.getCall(1).args[0], 30, 'player current time set 30 seconds forward after button click');
+
+  player.dispose();
+});
+
+QUnit.test('localizes on languagechange', function(assert) {
+  const player = TestHelpers.makePlayer({controlBar: {skipButtons: {forward: 30}}});
+  const button = player.controlBar.skipForward;
+
+  videojs.addLanguage('test', {'Skip forward {1} seconds': '{1} FORWARD'});
+  player.language('test');
+
+  assert.equal(button.$('.vjs-control-text').textContent, '30 FORWARD', 'control text updates on languagechange');
 
   player.dispose();
 });

--- a/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
+++ b/test/unit/control-bar/text-track-controls/text-track-menu-item.test.js
@@ -1,6 +1,9 @@
 /* eslint-env qunit */
 import TextTrackMenuItem from '../../../../src/js/control-bar/text-track-controls/text-track-menu-item.js';
+import OffTextTrackMenuItem from '../../../../src/js/control-bar/text-track-controls/off-text-track-menu-item.js';
+import CaptionSettingsMenuItem from '../../../../src/js/control-bar/text-track-controls/caption-settings-menu-item.js';
 import TestHelpers from '../../test-helpers.js';
+import videojs from '../../../../src/js/video.js';
 
 QUnit.module('TextTrackMenuItem', {
   beforeEach(assert) {
@@ -83,4 +86,19 @@ QUnit.test('clicking should disable non-selected tracks of the relevant kind(s)'
   fooItem.dispose();
   barItem.dispose();
   bipItem.dispose();
+});
+
+QUnit.test('should localize meu items on languagechage', function(assert) {
+  const OffItem = new OffTextTrackMenuItem(this.player, {kind: 'subtitles'});
+  const SettingsItem = new CaptionSettingsMenuItem(this.player, {kind: 'subtitles'});
+
+  videojs.addLanguage('test', {
+    'subtitles off': 'SUBSOFF',
+    'subtitles settings': 'SUBSSETTINGS'
+  });
+
+  this.player.language('test');
+
+  assert.equal(OffItem.$('.vjs-menu-item-text').textContent, 'SUBSOFF', 'subtitles settings text updates');
+  assert.equal(SettingsItem.$('.vjs-menu-item-text').textContent, 'SUBSSETTINGS', 'subtitles settings text updates');
 });

--- a/test/unit/loading-spinner.test.js
+++ b/test/unit/loading-spinner.test.js
@@ -1,0 +1,16 @@
+/* eslint-env qunit */
+import LoadingSpinner from '../../src/js/loading-spinner.js';
+import TestHelpers from './test-helpers.js';
+import videojs from '../../src/js/video.js';
+
+QUnit.module('Loading Spinner', {});
+
+QUnit.test('should localize on languagechange', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const spinner = new LoadingSpinner(player);
+
+  videojs.addLanguage('test', {'{1} is loading.': '{1} LOADING'});
+  player.language('test');
+
+  assert.equal(spinner.$('.vjs-control-text').textContent, 'Video Player LOADING', 'loading spinner text is localized');
+});

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -6,6 +6,7 @@ import safeParseTuple from 'safe-json-parse/tuple';
 import sinon from 'sinon';
 import window from 'global/window';
 import Component from '../../../src/js/component.js';
+import videojs from '../../../src/js/video.js';
 
 const tracks = [{
   kind: 'captions',
@@ -366,6 +367,19 @@ QUnit.test('should not restore saved settings', function(assert) {
   });
 
   assert.deepEqual(player.textTrackSettings.getValues(), defaultSettings);
+
+  player.dispose();
+});
+
+QUnit.test('should update on languagechange', function(assert) {
+  const player = TestHelpers.makePlayer({
+    tracks
+  });
+
+  videojs.addLanguage('test', {'Font Size': 'FONTSIZE'});
+  player.language('test');
+
+  assert.equal(player.$('.vjs-font-percent legend').textContent, 'FONTSIZE', 'settings dialog updates on languagechange');
 
   player.dispose();
 });


### PR DESCRIPTION
## Description
Components should update their text on `languagechange`, but some weren't where they had behaviour other than that inherited from `ClickableComponent`

## Specific Changes proposed
Added `handleLanguagechange()` behaviour for `LoadingSpinner`, `SkipForward`, `SkipBackward`, `CaptionSettingsMenuItem`, `OffTextTrackMenuItem` and `TextTrackSettings`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
