### PR TITLE
Shadow dom no warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minify:css:cdn": "cleancss dist/alt/video-js-cdn.css -o dist/alt/video-js-cdn.min.css",
     "minify:css:default": "cleancss dist/video-js.css -o dist/video-js.min.css",
     "watch": "npm-run-all -p watch:*",
-    "watch:lang": "chokidar --initial 'lang/**/!(zh-Hans|zh-Hant)*.json' -c 'npm run build:lang'",
+    "watch:lang": "chokidar --initial \"lang/**/!(zh-Hans|zh-Hant)*.json\" -c \"npm run build:lang\"",
     "watch:rollup": "rollup -c -w --no-progress",
     "watch:types": "tsc -w",
     "watch:css": "npm-run-all -p build:css:default build:css:cdn watch:css:*",

--- a/sandbox/shadow-dom-custom-elem.js.example
+++ b/sandbox/shadow-dom-custom-elem.js.example
@@ -1,0 +1,37 @@
+export class TestCustomElement extends HTMLElement {
+
+  constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({ mode: 'closed' });
+
+    const styleLinkElem = document.createElement('link');
+
+    styleLinkElem.setAttribute('rel', 'stylesheet');
+    styleLinkElem.setAttribute('href', '../dist/video-js.css')
+    shadowRoot.append(styleLinkElem);
+
+    const containerElem = document.createElement('div');
+
+    containerElem.setAttribute('data-vjs-player', '');
+    shadowRoot.appendChild(containerElem);
+
+    const videoElem = document.createElement('video');
+
+    videoElem.setAttribute('autoplay', 'true');
+    videoElem.setAttribute('preload', 'auto');
+    videoElem.setAttribute('width', 640);
+    videoElem.setAttribute('height', 260);
+    containerElem.appendChild(videoElem);
+
+    const sourceElem = document.createElement('source');
+
+    sourceElem.setAttribute('src', 'https://vjs.zencdn.net/v/oceans.mp4');
+    sourceElem.setAttribute('type', 'video/mp4');
+    videoElem.appendChild(sourceElem);
+
+    this.innerPlayer = videojs(videoElem);
+  }
+}
+
+window.customElements.define('test-custom-element', TestCustomElement);

--- a/sandbox/shadow-dom.html.example
+++ b/sandbox/shadow-dom.html.example
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Video.js Sandbox</title>
+  <link href="../dist/video-js.css" rel="stylesheet" type="text/css">
+  <script src="../dist/video.js"></script>
+  <script type="module" src="./shadow-dom-custom-elem.js"></script>
+  <link rel="icon" href="data:;base64,=">
+</head>
+<body>
+  <div style="background-color:#eee; border: 1px solid #777; padding: 10px; margin-bottom: 20px; font-size: .8em; line-height: 1.5em; font-family: Verdana, sans-serif;">
+    <p>You can use /sandbox/ for writing and testing your own code. Nothing in /sandbox/ will get checked into the repo, except files that end in .example (so don't edit or add those files). To get started run `npm start` and open the index.html</p>
+    <pre>npm start</pre>
+    <pre>open http://localhost:9999/sandbox/index.html</pre>
+  </div>
+
+  <test-custom-element id="customElement1"></test-custom-element>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      var customElem = document.getElementById('customElement1');
+      var innerPlayer = customElem.innerPlayer;
+      innerPlayer.log('Shadow DOM inner player created', innerPlayer);
+    });
+  </script>
+
+</body>
+</html>

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -149,7 +149,12 @@ function videojs(id, options, ready) {
   // This will make sure that the element is indeed in the dom of that document.
   // Additionally, check that the document in question has a default view.
   // If the document is no longer attached to the dom, the defaultView of the document will be null.
-  if (!el.ownerDocument.defaultView || !el.ownerDocument.body.contains(el)) {
+  // If element is inside Shadow DOM (e.g. is part of a Custom element), ownerDocument.body
+  // always returns false. Instead, use the Shadow DOM root.
+  const inShadowDom = el.getRootNode() instanceof window.ShadowRoot;
+  const rootNode = inShadowDom ? el.getRootNode() : el.ownerDocument.body;
+
+  if (!el.ownerDocument.defaultView || !rootNode.contains(el)) {
     log.warn('The element supplied is not included in the DOM');
   }
 

--- a/test/unit/utils/custom-element.test.js
+++ b/test/unit/utils/custom-element.test.js
@@ -1,0 +1,26 @@
+/* eslint-env browser */
+import videojs from '../../../src/js/video.js';
+
+export class TestCustomElement extends HTMLElement {
+
+  constructor() {
+    super();
+
+    const shadowRoot = this.attachShadow({ mode: 'closed' });
+
+    const containerElem = document.createElement('div');
+
+    containerElem.setAttribute('data-vjs-player', '');
+    shadowRoot.appendChild(containerElem);
+
+    const videoElem = document.createElement('video');
+
+    videoElem.setAttribute('width', 640);
+    videoElem.setAttribute('height', 260);
+    containerElem.appendChild(videoElem);
+
+    this.innerPlayer = videojs(videoElem);
+  }
+}
+
+window.customElements.define('test-custom-element', TestCustomElement);

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -85,7 +85,7 @@ QUnit.test(
 );
 
 QUnit.test(
-  'should log about already initalized players if options already passed',
+  'should log about already initialized players if options already passed',
   function(assert) {
     const origWarnLog = log.warn;
     const fixture = document.getElementById('qunit-fixture');
@@ -469,7 +469,7 @@ QUnit.test('should add video-js class to video-js embed if missing', function(as
 });
 
 QUnit.test(
-  'should log about already initalized players if options already passed',
+  'should log about already initialized players if options already passed',
   function(assert) {
     const origWarnLog = log.warn;
     const fixture = document.getElementById('qunit-fixture');

--- a/test/unit/video.test.js
+++ b/test/unit/video.test.js
@@ -4,6 +4,8 @@ import * as Dom from '../../src/js/utils/dom.js';
 import log from '../../src/js/utils/log.js';
 import document from 'global/document';
 import sinon from 'sinon';
+// import custom element for Shadow DOM test
+import './utils/custom-element.test';
 
 QUnit.module('video.js', {
   beforeEach() {
@@ -79,6 +81,29 @@ QUnit.test(
     videojs(vid2);
     videojs('test_vid_id2');
     assert.equal(warnLogs.length, 1, 'did not log another warning');
+
+    log.warn = origWarnLog;
+  }
+);
+
+QUnit.test(
+  'should not log if the supplied element is included in the Shadow DOM',
+  function(assert) {
+    const origWarnLog = log.warn;
+    const fixture = document.getElementById('qunit-fixture');
+    const warnLogs = [];
+
+    log.warn = (args) => {
+      warnLogs.push(args);
+    };
+
+    const customElem = document.createElement('test-custom-element');
+
+    fixture.appendChild(customElem);
+    const innerPlayer = customElem.innerPlayer;
+
+    assert.ok(innerPlayer, 'created player within Shadow DOM');
+    assert.equal(warnLogs.length, 0, 'no warn logs');
 
     log.warn = origWarnLog;
   }


### PR DESCRIPTION
## Description
Addresses #8136 . It prevents a misleading warning when video element is created within a custom element.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0)).  
  No codepen example created. Instead there's a dedicated sandbox example.
- [ ] Reviewed by Two Core Contributors
