### PR TITLE
7.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="7.8.4"></a>
+## [7.8.4](https://github.com/videojs/video.js/compare/v7.8.3...v7.8.4) (2020-07-08)
+
+### Bug Fixes
+
+* Fullscreen broken in iOS ([#6735](https://github.com/videojs/video.js/issues/6735)) ([d9408ee](https://github.com/videojs/video.js/commit/d9408ee)), closes [#6707](https://github.com/videojs/video.js/issues/6707) [#6684](https://github.com/videojs/video.js/issues/6684) [#6645](https://github.com/videojs/video.js/issues/6645)
+
 <a name="7.8.3"></a>
 ## [7.8.3](https://github.com/videojs/video.js/compare/v7.8.2...v7.8.3) (2020-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="7.8.3"></a>
+## [7.8.3](https://github.com/videojs/video.js/compare/v7.8.2...v7.8.3) (2020-05-28)
+
+### Bug Fixes
+
+* **fs:** don't set player element css props on native fullscreen ([#6677](https://github.com/videojs/video.js/issues/6677)) ([236b637](https://github.com/videojs/video.js/commit/236b637)), closes [#6673](https://github.com/videojs/video.js/issues/6673) [#6640](https://github.com/videojs/video.js/issues/6640)
+
 <a name="7.8.2"></a>
 ## [7.8.2](https://github.com/videojs/video.js/compare/v7.8.1...v7.8.2) (2020-05-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="7.8.2"></a>
+## [7.8.2](https://github.com/videojs/video.js/compare/v7.8.1...v7.8.2) (2020-05-26)
+
+### Bug Fixes
+
+* addChild with index should allow for children that are elements ([#6671](https://github.com/videojs/video.js/issues/6671)) ([cfb06ae](https://github.com/videojs/video.js/commit/cfb06ae)), closes [#6644](https://github.com/videojs/video.js/issues/6644)
+
 <a name="7.8.1"></a>
 ## [7.8.1](https://github.com/videojs/video.js/compare/v7.8.0...v7.8.1) (2020-04-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "version": "7.8.3",
+  "version": "7.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "video.js",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video.js",
   "description": "An HTML5 and Flash video player with a common API and skin for both.",
-  "version": "7.8.3",
+  "version": "7.8.4",
   "main": "./dist/video.cjs.js",
   "module": "./dist/video.es.js",
   "style": "./dist/video-js.css",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video.js",
   "description": "An HTML5 and Flash video player with a common API and skin for both.",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "main": "./dist/video.cjs.js",
   "module": "./dist/video.es.js",
   "style": "./dist/video-js.css",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video.js",
   "description": "An HTML5 and Flash video player with a common API and skin for both.",
-  "version": "7.8.1",
+  "version": "7.8.2",
   "main": "./dist/video.cjs.js",
   "module": "./dist/video.es.js",
   "style": "./dist/video-js.css",

--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -113,12 +113,13 @@ body.vjs-full-window {
   bottom: 0;
   right: 0;
 }
-.video-js.vjs-fullscreen {
+.video-js.vjs-fullscreen:not(.vjs-ios-native-fs) {
   width: 100% !important;
   height: 100% !important;
   // Undo any aspect ratio padding for fluid layouts
   padding-top: 0 !important;
 }
+
 .video-js.vjs-fullscreen.vjs-user-inactive {
   cursor: none;
 }

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -526,8 +526,13 @@ class Component {
       // If inserting before a component, insert before that component's element
       let refNode = null;
 
-      if (this.children_[index + 1] && this.children_[index + 1].el_) {
-        refNode = this.children_[index + 1].el_;
+      if (this.children_[index + 1]) {
+        // Most children are components, but the video tech is an HTML element
+        if (this.children_[index + 1].el_) {
+          refNode = this.children_[index + 1].el_;
+        } else if (Dom.isEl(this.children_[index + 1])) {
+          refNode = this.children_[index + 1];
+        }
       }
 
       this.contentEl().insertBefore(component.el(), refNode);

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2076,6 +2076,9 @@ class Player extends Component {
    */
   handleTechFullscreenChange_(event, data) {
     if (data) {
+      if (data.nativeIOSFullscreen) {
+        this.toggleClass('vjs-ios-native-fs');
+      }
       this.isFullscreen(data.isFullscreen);
     }
   }

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2792,8 +2792,8 @@ class Player extends Component {
 
       return new PromiseClass((resolve, reject) => {
         function offHandler() {
-          self.off(self.fsApi_.fullscreenerror, errorHandler);
-          self.off(self.fsApi_.fullscreenchange, changeHandler);
+          self.off('fullscreenerror', errorHandler);
+          self.off('fullscreenchange', changeHandler);
         }
         function changeHandler() {
           offHandler();
@@ -2870,8 +2870,8 @@ class Player extends Component {
 
       return new PromiseClass((resolve, reject) => {
         function offHandler() {
-          self.off(self.fsApi_.fullscreenerror, errorHandler);
-          self.off(self.fsApi_.fullscreenchange, changeHandler);
+          self.off('fullscreenerror', errorHandler);
+          self.off('fullscreenchange', changeHandler);
         }
         function changeHandler() {
           offHandler();

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -614,7 +614,11 @@ class Html5 extends Tech {
         this.el_.webkitPresentationMode !== 'picture-in-picture') {
         this.one('webkitendfullscreen', endFn);
 
-        this.trigger('fullscreenchange', { isFullscreen: true });
+        this.trigger('fullscreenchange', {
+          isFullscreen: true,
+          // set a flag in case another tech triggers fullscreenchange
+          nativeIOSFullscreen: true
+        });
       }
     };
 

--- a/test/unit/component.test.js
+++ b/test/unit/component.test.js
@@ -164,6 +164,26 @@ QUnit.test('should insert element relative to the element of the component to in
   /* eslint-enable no-unused-vars */
 });
 
+QUnit.test('should allow for children that are elements', function(assert) {
+
+  // for legibility of the test itself:
+  /* eslint-disable no-unused-vars */
+
+  const comp = new Component(getFakePlayer());
+  const testEl = Dom.createEl('div');
+
+  // Add element as video el gets added to player
+  comp.el().appendChild(testEl);
+  comp.children_.unshift(testEl);
+
+  const child1 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c1'})});
+  const child2 = comp.addChild('component', {el: Dom.createEl('div', {}, {class: 'c4'})}, 0);
+
+  assert.ok(child2.el_.nextSibling === testEl, 'addChild should insert el before a sibling that is an element');
+
+  /* eslint-enable no-unused-vars */
+});
+
 QUnit.test('addChild should throw if the child does not exist', function(assert) {
   const comp = new Component(getFakePlayer());
 


### PR DESCRIPTION
I don't know if you have notice but order video player like YouTube,vlc and more if you click on fullscreen on phone and if the video width is above the the video height in size the orientation should be landscape but instead is portrait then in a case where is the video height is above the video width it should be portrait, I have fix this problem in my video player I think you should do the same as well or add it as a new feature.
This is the code:
  
if(video.requestFullscreen){
    video.requestFullscreen();

if (video.videoHeight < video.videoWidth){
 
    if (screen.orientation.lock && screen.orientation) {
      screen.orientation.lock("landscape")
    }
 
  
}
  
  }