### PR TITLE
Fix ts imports

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -21,7 +21,7 @@
           "class": "link-vjs"
         },
         {
-          "title": "v8.0.2 source",
+          "title": "v8.2.1 source",
           "link": "https://github.com/videojs/video.js",
           "class": "link-gh"
         },
@@ -59,6 +59,7 @@
     }
   },
   "plugins": [
+    "node_modules/jsdoc-tsimport-plugin/index.js",
     "plugins/markdown",
     "build/jsdoc-typeof-plugin"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1672,21 +1672,6 @@
         "vfile-message": "*"
       }
     },
-    "@videojs/http-streaming": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.0.0.tgz",
-      "integrity": "sha512-AdKmY/W2dyeJP0uALgMRmhLa4pbHMvE4OMlg6yQvufnqsz6jDFo1DYnZRv2ENDYrmVdnPH58Ehgu59053+OIhQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "4.0.0",
-        "aes-decrypter": "4.0.1",
-        "global": "^4.4.0",
-        "m3u8-parser": "^6.0.0",
-        "mpd-parser": "^1.0.1",
-        "mux.js": "6.2.0",
-        "video.js": "^7 || ^8"
-      }
-    },
     "@videojs/vhs-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
@@ -8012,6 +7997,12 @@
         }
       }
     },
+    "jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true
+    },
     "jsdoc-type-pratt-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.2.0.tgz",
@@ -8556,12 +8547,6 @@
       "requires": {
         "graceful-fs": "^4.1.11"
       }
-    },
-    "kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
@@ -9467,7 +9452,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "media-typer": {
@@ -9614,161 +9599,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true
-        }
-      }
-    },
-    "mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
-    "micromark-util-decode-numeric-character-reference": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
-      "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-decode-string": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
-      "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
-      "dev": true,
-      "requires": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-encode": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
-      "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
-      "dev": true
-    },
-    "micromark-util-html-tag-name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
-      "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
-      "dev": true
-    },
-    "micromark-util-normalize-identifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
-      "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-resolve-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
-      "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
-      "dev": true,
-      "requires": {
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-sanitize-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
-      "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-subtokenize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
-      "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
-      "dev": true,
-      "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-util-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
-      "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
-      "dev": true
-    },
-    "micromark-util-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
-      "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
       "dev": true
     },
     "micromatch": {
@@ -15298,99 +15128,6 @@
       "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
       "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
       "dev": true
-    },
-    "video.js": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.21.1.tgz",
-      "integrity": "sha512-AvHfr14ePDHCfW5Lx35BvXk7oIonxF6VGhSxocmTyqotkQpxwYdmt4tnQSV7MYzNrYHb0GI8tJMt20NDkCQrxg==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "2.15.1",
-        "@videojs/vhs-utils": "^3.0.4",
-        "@videojs/xhr": "2.6.0",
-        "aes-decrypter": "3.1.3",
-        "global": "^4.4.0",
-        "keycode": "^2.2.0",
-        "m3u8-parser": "4.8.0",
-        "mpd-parser": "0.22.1",
-        "mux.js": "6.0.1",
-        "safe-json-parse": "4.0.0",
-        "videojs-font": "3.2.0",
-        "videojs-vtt.js": "^0.15.4"
-      },
-      "dependencies": {
-        "@videojs/http-streaming": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.15.1.tgz",
-          "integrity": "sha512-/uuN3bVkEeJAdrhu5Hyb19JoUo3CMys7yf2C1vUjeL1wQaZ4Oe8JrZzRrnWZ0rjvPgKfNLPXQomsRtgrMoRMJQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "3.0.5",
-            "aes-decrypter": "3.1.3",
-            "global": "^4.4.0",
-            "m3u8-parser": "4.8.0",
-            "mpd-parser": "^0.22.1",
-            "mux.js": "6.0.1",
-            "video.js": "^6 || ^7"
-          }
-        },
-        "@videojs/vhs-utils": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "global": "^4.4.0",
-            "url-toolkit": "^2.2.1"
-          }
-        },
-        "aes-decrypter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.3.tgz",
-          "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.5",
-            "global": "^4.4.0",
-            "pkcs7": "^1.0.4"
-          }
-        },
-        "m3u8-parser": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.8.0.tgz",
-          "integrity": "sha512-UqA2a/Pw3liR6Df3gwxrqghCP17OpPlQj6RBPLYygf/ZSQ4MoSgvdvhvt35qV+3NaaA0FSZx93Ix+2brT1U7cA==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.5",
-            "global": "^4.4.0"
-          }
-        },
-        "mpd-parser": {
-          "version": "0.22.1",
-          "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.22.1.tgz",
-          "integrity": "sha512-fwBebvpyPUU8bOzvhX0VQZgSohncbgYwUyJJoTSNpmy7ccD2ryiCvM7oRkn/xQH5cv73/xU7rJSNCLjdGFor0Q==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "^3.0.5",
-            "@xmldom/xmldom": "^0.8.3",
-            "global": "^4.4.0"
-          }
-        },
-        "mux.js": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
-          "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
-          "requires": {
-            "@babel/runtime": "^7.11.2",
-            "global": "^4.4.0"
-          }
-        },
-        "videojs-font": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
-          "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA=="
-        }
-      }
     },
     "videojs-contrib-quality-levels": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "husky": "^1.3.1",
     "is-ci": "^3.0.0",
     "jsdoc": "^3.6.11",
+    "jsdoc-tsimport-plugin": "^1.0.5",
     "karma": "^6.4.0",
     "lint-staged": "^10.5.4",
     "markdown-table": "^1.1.3",

--- a/src/js/control-bar/text-track-controls/chapters-button.js
+++ b/src/js/control-bar/text-track-controls/chapters-button.js
@@ -9,7 +9,7 @@ import {toTitleCase} from '../../utils/str.js';
 /**
  * @typedef { import('../../player').default } Player
  * @typedef { import('../../menu/menu').default } Menu
- * @typedef { import('../text-track-menu-item/menu/').default } TextTrackMenuItem
+ * @typedef { import('./text-track-menu-item').default } TextTrackMenuItem
  */
 
 /**

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -7,8 +7,8 @@ import * as Dom from '../utils/dom.js';
 import window from 'global/window';
 
 /**
- * @typedef { import('./player').default } Player
- * @typedef { import('./tech/tech').default } Tech
+ * @typedef { import('../player').default } Player
+ * @typedef { import('../tech/tech').default } Tech
  */
 
 const darkGray = '#222';

--- a/src/js/utils/create-logger.js
+++ b/src/js/utils/create-logger.js
@@ -91,7 +91,7 @@ export default function createLogger(name) {
    * `undefined`
    *
    * @namespace
-   * @param    {(*|*[])} args
+   * @param    {...*} args
    *           One or more messages or objects that should be logged.
    */
   const log = function(...args) {
@@ -226,7 +226,7 @@ export default function createLogger(name) {
   /**
    * Logs error messages. Similar to `console.error`.
    *
-   * @param {(*|*[])} args
+   * @param {...*} args
    *        One or more messages or objects that should be logged as an error
    */
   log.error = (...args) => logByType('error', level, args);
@@ -234,7 +234,7 @@ export default function createLogger(name) {
   /**
    * Logs warning messages. Similar to `console.warn`.
    *
-   * @param {(*|*[])} args
+   * @param {...*} args
    *        One or more messages or objects that should be logged as a warning.
    */
   log.warn = (...args) => logByType('warn', level, args);
@@ -243,7 +243,7 @@ export default function createLogger(name) {
    * Logs debug messages. Similar to `console.debug`, but may also act as a comparable
    * log if `console.debug` is not available
    *
-   * @param {(*|*[])} args
+   * @param {...*} args
    *        One or more messages or objects that should be logged as debug.
    */
   log.debug = (...args) => logByType('debug', level, args);


### PR DESCRIPTION
## Description
The typedef import syntax we had to introduce for tsc output isn't compatible with jsdoc itself, see e.g. https://github.com/jsdoc/jsdoc/issues/1645 . This is breaking the `docs:api` task. 

## Specific Changes proposed
Adds a jsdoc plugin to transform the import syntax to be understood by jsdoc.
Fixes a few other errors in jsdoc.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
