### PR TITLE
fix: audio description track doesn't have icon on Safari browser

### DIFF
--- a/src/css/components/_audio.scss
+++ b/src/css/components/_audio.scss
@@ -2,13 +2,15 @@
   @extend .vjs-icon-audio;
 }
 
+.video-js .vjs-audio-button + .vjs-menu .vjs-description-menu-item .vjs-menu-item-text .vjs-icon-placeholder,
 .video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
   vertical-align: middle;
   display: inline-block;
   margin-bottom: -0.1em;
 }
 
-// Mark a main-desc-menu-item (main + description) item with a trailing Audio Description icon
+// Mark a main-desc-menu-item (main + description) or description item with a trailing Audio Description icon
+.video-js .vjs-audio-button + .vjs-menu .vjs-description-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before,
 .video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
   font-family: VideoJS;
   content: " \f12e";

--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -49,7 +49,7 @@ class AudioTrackMenuItem extends MenuItem {
     const el = super.createEl(type, props, attrs);
     const parentSpan = el.querySelector('.vjs-menu-item-text');
 
-    if (this.options_.track.kind === 'main-desc') {
+    if (['main-desc', 'description'].indexOf(this.options_.track.kind) >= 0) {
       parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-icon-placeholder'
       }, {


### PR DESCRIPTION
On Firefox/Chrome browser the HLS stream that contains an audio track with a description show AD icon in the menu list.
![image](https://user-images.githubusercontent.com/5346546/230642112-e998aa1d-b41d-4a2e-8f5c-6709bea3a860.png)
However, The same stream on Safari doesn't have the AD icon.

## Description
Safari without VHS (in native mode) creates an audio track with a `kind` attribute value equal to "description". 
Unfortunately, video.js handles track kind attribute value equal to "main-desc" only. 

## Specific Changes proposed
Add support for `kind: "description"`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
