### PR TITLE
fix(videojs): missing return in registerComponent

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -323,7 +323,7 @@ videojs.registerComponent = (name, comp) => {
     log.warn(`The ${name} tech was registered as a component. It should instead be registered using videojs.registerTech(name, tech)`);
   }
 
-  Component.registerComponent.call(Component, name, comp);
+  return Component.registerComponent.call(Component, name, comp);
 };
 
 videojs.getTech = Tech.getTech;

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2165,6 +2165,12 @@ QUnit.test('When VIDEOJS_NO_DYNAMIC_STYLE is set, apply sizing directly to the t
   window.VIDEOJS_NO_DYNAMIC_STYLE = originalVjsNoDynamicStyling;
 });
 
+QUnit.test('should return the registered component', function(assert) {
+  class CustomPlayer extends Player {}
+
+  assert.strictEqual(videojs.registerComponent('CustomPlayer', CustomPlayer), CustomPlayer, 'the component is returned');
+});
+
 QUnit.test('should allow to register custom player when any player has not been created', function(assert) {
   class CustomPlayer extends Player {}
   videojs.registerComponent('Player', CustomPlayer);


### PR DESCRIPTION
## Description

This PR fixes the missing return in the `videojs.registerComponent` function to be in line with the documentation, see

https://github.com/videojs/video.js/blob/1491d71b26a407111104dde7dbbbc0ee49b4c0c8/src/js/video.js#L304-L320

### Use case

```javascript

class CustomComponent extends videojs.getComponent('Component'){}

export default videojs.registerComponent(CustomComponent.name, CustomComponent);

```


## Specific Changes proposed
- add the missing return statement
- add test case

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
