### PR TITLE
fix(skip-forward): error when clicking after player reset

### DIFF
--- a/src/js/control-bar/skip-buttons/skip-forward.js
+++ b/src/js/control-bar/skip-buttons/skip-forward.js
@@ -46,6 +46,10 @@ class SkipForward extends Button {
    *        to be called
    */
   handleClick(event) {
+    if (isNaN(this.player_.duration())) {
+      return;
+    }
+
     const currentVideoTime = this.player_.currentTime();
     const liveTracker = this.player_.liveTracker;
     const duration = (liveTracker && liveTracker.isLive()) ? liveTracker.seekableEnd() : this.player_.duration();

--- a/test/unit/control-bar/skip-buttons/skip-forward-button.test.js
+++ b/test/unit/control-bar/skip-buttons/skip-forward-button.test.js
@@ -128,3 +128,21 @@ QUnit.test('localizes on languagechange', function(assert) {
 
   player.dispose();
 });
+
+QUnit.test('skips forward only if the duration is valid', function(assert) {
+  const player = TestHelpers.makePlayer({controlBar: {skipButtons: {forward: 5}}});
+  const currentTimeSpy = sinon.spy(player, 'currentTime');
+  const button = player.controlBar.skipForward;
+
+  button.trigger('click');
+
+  assert.ok(currentTimeSpy.notCalled, 'currentTime was not called');
+
+  player.duration(0);
+  button.trigger('click');
+
+  assert.ok(currentTimeSpy.called, 'currentTime was called');
+
+  currentTimeSpy.restore();
+  player.dispose();
+});


### PR DESCRIPTION
## Description
This PR fixes the error thrown when clicking the `skip-forward` button after the player has been reset.

[skip-forward.webm](https://user-images.githubusercontent.com/34163393/235620462-c2fc7814-2dc7-45dd-bc0f-5cc05e75e824.webm)

## Specific Changes proposed

- short-circuit the `handleClick` function if the `duration` is `NaN`
- add a test case

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
