### PR TITLE
fix: Document Picture-in-Picture: Use width/height instead of initialAspectRatio

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3062,7 +3062,8 @@ class Player extends Component {
 
       return window.documentPictureInPicture.requestWindow({
         // The aspect ratio won't be correct, Chrome bug https://crbug.com/1407629
-        initialAspectRatio: this.videoWidth() / this.videoHeight(),
+        width: this.videoWidth(),
+        height: this.videoHeight(),
         copyStyleSheets: true
       }).then(pipWindow => {
         this.el_.parentNode.insertBefore(pipContainer, this.el_);


### PR DESCRIPTION
The `initialAspectRatio` option was removed from the Document Picture-in-Picture spec in favour of `width` and `height`, so we should use them. See https://github.com/WICG/document-picture-in-picture/pull/36