### PR TITLE
fix(player): load method fails to reset the media element

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3534,6 +3534,14 @@ class Player extends Component {
    * Begin loading the src data.
    */
   load() {
+    // Workaround to use the load method with the VHS.
+    // Does not cover the case when the load method is called directly from the mediaElement.
+    if (this.tech_.vhs) {
+      this.src(this.currentSource());
+
+      return;
+    }
+
     this.techCall_('load');
   }
 

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3230,3 +3230,31 @@ QUnit.test('turning on audioPosterMode when audioOnlyMode is already on will tur
       assert.notOk(player.audioOnlyMode(), 'audioOnlyMode is false');
     });
 });
+
+QUnit.test('player#load resets the media element to its initial state', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
+  player.src({ src: 'http://vjs.zencdn.net/v/oceans2.mp4', type: 'video/mp4' });
+
+  // Declaring spies here avoids spying on previous calls
+  const techGet_ = sinon.spy(player, 'techCall_');
+  const src = sinon.spy(player, 'src');
+
+  player.load();
+
+  // Case when the VHS tech is not used
+  assert.ok(techGet_.calledOnce, 'techCall_ was called once');
+  assert.ok(src.notCalled, 'src was not called');
+
+  // Simulate the VHS tech
+  player.tech_.vhs = true;
+  player.load();
+
+  // Case when the VHS tech is used
+  assert.ok(techGet_.calledOnce, 'techCall_ remains the same');
+  assert.ok(src.calledOnce, 'src was called');
+
+  techGet_.restore();
+  src.restore();
+  player.dispose();
+});


### PR DESCRIPTION
## Description

This PR provides a workaround for the `load` method that fails to reset the media element to its initial state when the VHS is used.

This issue affects all devices using VHS tech to play Dash and HLS. It does not affect the playback of media that does not require VHS, such as mp4 or HLS on Apple devices.

This fix does not cover the case when the load method is called directly from the mediaElement.

[Screencast from 13. 05. 23 21:00:59.webm](https://github.com/videojs/video.js/assets/34163393/7d6d5e6c-6f92-4f03-b4fa-1e7a7327b88b)

### How to reproduce

```javascript

player.src('https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8');

player.cache_.src;
// "https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8"
player.cache_.source;
// { src: "https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8", type: "application/x-mpegURL" }
player.cache_.sources;
// [{ src: "https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8", type: "application/x-mpegURL" }]

player.load();

player.cache_.src;
// "blob:http://localhost:9999/bc47fd5c-f3eb-4be9-8fea-40444743105e"
player.cache_.source
// { src: "blob:http://localhost:9999/bc47fd5c-f3eb-4be9-8fea-40444743105e", type: "" }
player.cache_.sources
//[{ src: "blob:http://localhost:9999/bc47fd5c-f3eb-4be9-8fea-40444743105e", type: "" }]

player.src()
// "blob:http://localhost:9999/bc47fd5c-f3eb-4be9-8fea-40444743105e"
```

## Specific Changes proposed

- `load` method falls back to the `src` method when vhs tech is used because the specification requirements are met, see [mdn load](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load#usage_notes)
> Appropriate events will be sent to the media element itself as the load process proceeds:
> 
>  - If the element is already in the process of loading media, that load process is aborted and the [abort](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/abort_event) event is sent.
>  - If the element has already been initialized with media, the [emptied](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/emptied_event) event is sent.
> - If resetting the playback position to the beginning of the media actually changes the playback position (that is, it was not already at the beginning), a [timeupdate](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/timeupdate_event) event is sent.
> - Once media has been selected and loading is ready to begin, the [loadstart](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadstart_event) event is delivered.
> - From this point onward, events are sent just like any media load.
- add test case

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
