### PR TITLE
fix(jsdoc): Corrections to jsdoc

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -206,8 +206,11 @@ class Component {
    * @param {string|Event|Object} event
    *        The name of the event, an `Event`, or an object with a key of type set to
    *        an event name.
+   *
+   * @param {*} [data]
+   *        Optionally extra argument to pass through to an event listener
    */
-  trigger(event) {}
+  trigger(event, data) {}
 
   /**
    * Dispose of the `Component` and all child components.

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -207,10 +207,10 @@ class Component {
    *        The name of the event, an `Event`, or an object with a key of type set to
    *        an event name.
    *
-   * @param {*} [data]
+   * @param {Object} [hash]
    *        Optionally extra argument to pass through to an event listener
    */
-  trigger(event, data) {}
+  trigger(event, hash) {}
 
   /**
    * Dispose of the `Component` and all child components.

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -46,7 +46,7 @@ const isEvented = (object) =>
 /**
  * Adds a callback to run after the evented mixin applied.
  *
- * @param  {Object} object
+ * @param  {Object} target
  *         An object to Add
  * @param  {Function} callback
  *         The callback to run.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -853,11 +853,12 @@ class Player extends Component {
    * A getter/setter for the `Player`'s width. Returns the player's configured value.
    * To get the current width use `currentWidth()`.
    *
-   * @param {number} [value]
-   *        The value to set the `Player`'s width to.
+   * @param {number|string} [value]
+   *        CSS value to set the `Player`'s width to.
    *
-   * @return {number}
+   * @return {number|void}
    *         The current width of the `Player` when getting.
+   *         Void when setting
    */
   width(value) {
     return this.dimension('width', value);
@@ -867,11 +868,12 @@ class Player extends Component {
    * A getter/setter for the `Player`'s height. Returns the player's configured value.
    * To get the current height use `currentheight()`.
    *
-   * @param {number} [value]
-   *        The value to set the `Player`'s height to.
+   * @param {number|string} [value]
+   *        CSS value to set the `Player`'s height to.
    *
-   * @return {number}
+   * @return {number|void}
    *         The current height of the `Player` when getting.
+   *         Void when setting
    */
   height(value) {
     return this.dimension('height', value);
@@ -885,7 +887,7 @@ class Player extends Component {
    *        - 'width'
    *        - 'height'
    *
-   * @param {number} [value]
+   * @param {number|string} [value]
    *        Value for dimension specified in the first argument.
    *
    * @return {number}
@@ -2394,9 +2396,6 @@ class Player extends Component {
 
   /**
    * Pause the video playback
-   *
-   * @return {Player}
-   *         A reference to the player object this function was called on
    */
   pause() {
     this.techCall_('pause');
@@ -2427,15 +2426,16 @@ class Player extends Component {
   }
 
   /**
-   * Returns whether or not the user is "scrubbing". Scrubbing is
+   * Sets or returns whether or not the user is "scrubbing". Scrubbing is
    * when the user has clicked the progress bar handle and is
    * dragging it along the progress bar.
    *
    * @param {boolean} [isScrubbing]
    *        whether the user is or is not scrubbing
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The value of scrubbing when getting
+   *         Void when setting
    */
   scrubbing(isScrubbing) {
     if (typeof isScrubbing === 'undefined') {
@@ -2457,8 +2457,9 @@ class Player extends Component {
    * @param {number|string} [seconds]
    *        The time to seek to in seconds
    *
-   * @return {number}
+   * @return {number|void}
    *         - the current time in seconds when getting
+   *         - void when setting
    */
   currentTime(seconds) {
     if (typeof seconds !== 'undefined') {
@@ -2508,8 +2509,9 @@ class Player extends Component {
    * @param {number} [seconds]
    *        The duration of the video to set in seconds
    *
-   * @return {number}
+   * @return {number|void}
    *         - The duration of the video in seconds when getting
+   *         - Void when setting
    */
   duration(seconds) {
     if (seconds === undefined) {
@@ -2631,7 +2633,7 @@ class Player extends Component {
    *         - 1.0 is 100%/full
    *         - 0.5 is half volume or 50%
    *
-   * @return {number}
+   * @return {number|void}
    *         The current volume as a percent when getting
    */
   volume(percentAsDecimal) {
@@ -2639,7 +2641,7 @@ class Player extends Component {
 
     if (percentAsDecimal !== undefined) {
       // Force value to between 0 and 1
-      vol = Math.max(0, Math.min(1, parseFloat(percentAsDecimal)));
+      vol = Math.max(0, Math.min(1, percentAsDecimal));
       this.cache_.volume = vol;
       this.techCall_('setVolume', vol);
 
@@ -2662,9 +2664,10 @@ class Player extends Component {
    *        - true to mute
    *        - false to unmute
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         - true if mute is on and getting
    *         - false if mute is off and getting
+   *         - void if setting
    */
   muted(muted) {
     if (muted !== undefined) {
@@ -2695,10 +2698,10 @@ class Player extends Component {
    *        - true to mute
    *        - false to unmute
    *
-   * @return {boolean|Player}
+   * @return {boolean|void}
    *         - true if defaultMuted is on and getting
    *         - false if defaultMuted is off and getting
-   *         - A reference to the current player when setting
+   *         - void when setting
    */
   defaultMuted(defaultMuted) {
     if (defaultMuted !== undefined) {
@@ -2716,8 +2719,9 @@ class Player extends Component {
    *         - 1.0 is 100%/full
    *         - 0.5 is half volume or 50%
    *
-   * @return {number}
+   * @return {number|void}
    *         the current value of lastVolume as a percent when getting
+   *         void when setting
    *
    * @private
    */
@@ -2751,9 +2755,10 @@ class Player extends Component {
    * @param  {boolean} [isFS]
    *         Set the players current fullscreen state
    *
-   * @return {boolean}
+   * @return {boolean|vid}
    *         - true if fullscreen is on and getting
    *         - false if fullscreen is off and getting
+   *         - void when setting
    */
   isFullscreen(isFS) {
     if (isFS !== undefined) {
@@ -3014,9 +3019,10 @@ class Player extends Component {
    * @param  {boolean} [isPiP]
    *         Set the players current Picture-in-Picture state
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         - true if Picture-in-Picture is on and getting
    *         - false if Picture-in-Picture is off and getting
+   *         - void if setting
    */
   isInPictureInPicture(isPiP) {
     if (isPiP !== undefined) {
@@ -3685,8 +3691,9 @@ class Player extends Component {
    *        - true means that we should preload
    *        - false means that we should not preload
    *
-   * @return {string}
+   * @return {string|void}
    *         The preload attribute value when getting
+   *         Void when setting
    */
   preload(value) {
     if (value !== undefined) {
@@ -3710,8 +3717,9 @@ class Player extends Component {
    *        - 'any': call play() on every loadstart. if that fails call muted() then play().
    *        - *: values other than those listed here will be set `autoplay` to true
    *
-   * @return {boolean|string}
+   * @return {boolean|string|void}
    *         The current value of autoplay when getting
+   *         Vid when setting
    */
   autoplay(value) {
     // getter usage
@@ -3758,9 +3766,9 @@ class Player extends Component {
    *          which in most cases is inline. iOS Safari is a notable exception
    *          and plays fullscreen by default.
    *
-   * @return {string|Player}
+   * @return {string|void}
    *         - the current value of playsinline
-   *         - the player when setting
+   *         - void when setting
    *
    * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
    */
@@ -3780,8 +3788,9 @@ class Player extends Component {
    *        - true means that we should loop the video
    *        - false means that we should not loop the video
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The current value of loop when getting
+   *         Void when setting
    */
   loop(value) {
     if (value !== undefined) {
@@ -3800,8 +3809,9 @@ class Player extends Component {
    * @param {string} [src]
    *        Poster image source URL
    *
-   * @return {string}
+   * @return {string|void}
    *         The current value of poster when getting
+   *         Void when setting
    */
   poster(src) {
     if (src === undefined) {
@@ -3871,8 +3881,9 @@ class Player extends Component {
    *        - true to turn controls on
    *        - false to turn controls off
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The current value of controls when getting
+   *         Void when setting
    */
   controls(bool) {
     if (bool === undefined) {
@@ -3931,8 +3942,9 @@ class Player extends Component {
    *        - true to turn native controls on
    *        - false to turn native controls off
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The current value of native controls when getting
+   *         Void when setting
    */
   usingNativeControls(bool) {
     if (bool === undefined) {
@@ -3980,8 +3992,9 @@ class Player extends Component {
    *         A MediaError or a string/number to be turned
    *         into a MediaError
    *
-   * @return {MediaError|null}
+   * @return {MediaError|null|void}
    *         The current MediaError when getting (or null)
+   *         Void when setting
    */
   error(err) {
     if (err === undefined) {
@@ -4073,8 +4086,9 @@ class Player extends Component {
    *        - true if the user is active
    *        - false if the user is inactive
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The current value of userActive when getting
+   *         Void when setting
    */
   userActive(bool) {
     if (bool === undefined) {
@@ -4247,8 +4261,9 @@ class Player extends Component {
    * @param {number} [rate]
    *       New playback rate to set.
    *
-   * @return {number}
+   * @return {number|void}
    *         The current playback rate when getting or 1.0
+   *         Void when setting
    */
   playbackRate(rate) {
     if (rate !== undefined) {
@@ -4275,9 +4290,9 @@ class Player extends Component {
    * @param {number} [rate]
    *       New default playback rate to set.
    *
-   * @return {number|Player}
+   * @return {number|void}
    *         - The default playback rate when getting or 1.0
-   *         - the player when setting
+   *         - void when setting
    */
   defaultPlaybackRate(rate) {
     if (rate !== undefined) {
@@ -4297,8 +4312,9 @@ class Player extends Component {
    *        - true signals that this is an audio player
    *        - false signals that this is not an audio player
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         The current value of isAudio when getting
+   *         Void when setting
    */
   isAudio(bool) {
     if (bool !== undefined) {
@@ -4562,7 +4578,7 @@ class Player extends Component {
   }
 
   /**
-   * The player's language code.
+   * Set or get the player's language code.
    *
    * Changing the language will trigger
    * [languagechange]{@link Player#event:languagechange}
@@ -4575,8 +4591,9 @@ class Player extends Component {
    * @param {string} [code]
    *        the language code to set the player to
    *
-   * @return {string}
+   * @return {string|void}
    *         The current language code when getting
+   *         Void when setting
    */
   language(code) {
     if (code === undefined) {
@@ -4776,13 +4793,14 @@ class Player extends Component {
    * Get or set a flag indicating whether or not this player should adjust
    * its UI based on its dimensions.
    *
-   * @param  {boolean} value
+   * @param  {boolean} [value]
    *         Should be `true` if the player should adjust its UI based on its
    *         dimensions; otherwise, should be `false`.
    *
-   * @return {boolean}
+   * @return {boolean|void}
    *         Will be `true` if this player should adjust its UI based on its
    *         dimensions; otherwise, will be `false`.
+   *         Void if setting
    */
   responsive(value) {
 
@@ -5037,6 +5055,7 @@ class Player extends Component {
    * @param {boolean} enabled
    * @fires Player#debugon
    * @fires Player#debugoff
+   * @return {boolean|void}
    */
   debug(enabled) {
     if (enabled === undefined) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @file player.js
  */
@@ -432,9 +433,11 @@ class Player extends Component {
     this.resetCache_();
 
     // Set poster
+    /** @type string */
     this.poster_ = options.poster || '';
 
     // Set controls
+    /** @type {boolean} */
     this.controls_ = !!options.controls;
 
     // Original tag settings stored in options
@@ -856,9 +859,9 @@ class Player extends Component {
    * @param {number|string} [value]
    *        CSS value to set the `Player`'s width to.
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The current width of the `Player` when getting.
-   *         - Void when setting
+   *         - Nothing when setting
    */
   width(value) {
     return this.dimension('width', value);
@@ -871,9 +874,9 @@ class Player extends Component {
    * @param {number|string} [value]
    *        CSS value to set the `Player`'s height to.
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The current height of the `Player` when getting.
-   *         - Void when setting
+   *         - Nothing when setting
    */
   height(value) {
     return this.dimension('height', value);
@@ -2211,7 +2214,7 @@ class Player extends Component {
    * @param {string} [method]
    *        the method to call
    *
-   * @param {Object} arg
+   * @param {Object} [arg]
    *        the argument to pass
    *
    * @private
@@ -2433,9 +2436,9 @@ class Player extends Component {
    * @param {boolean} [isScrubbing]
    *        whether the user is or is not scrubbing
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The value of scrubbing when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   scrubbing(isScrubbing) {
     if (typeof isScrubbing === 'undefined') {
@@ -2457,9 +2460,9 @@ class Player extends Component {
    * @param {number|string} [seconds]
    *        The time to seek to in seconds
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - the current time in seconds when getting
-   *         - void when setting
+   *         - Nothing when setting
    */
   currentTime(seconds) {
     if (typeof seconds !== 'undefined') {
@@ -2509,9 +2512,9 @@ class Player extends Component {
    * @param {number} [seconds]
    *        The duration of the video to set in seconds
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The duration of the video in seconds when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   duration(seconds) {
     if (seconds === undefined) {
@@ -2633,7 +2636,7 @@ class Player extends Component {
    *         - 1.0 is 100%/full
    *         - 0.5 is half volume or 50%
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         The current volume as a percent when getting
    */
   volume(percentAsDecimal) {
@@ -2664,10 +2667,10 @@ class Player extends Component {
    *        - true to mute
    *        - false to unmute
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - true if mute is on and getting
    *         - false if mute is off and getting
-   *         - void if setting
+   *         - nothing if setting
    */
   muted(muted) {
     if (muted !== undefined) {
@@ -2698,14 +2701,14 @@ class Player extends Component {
    *        - true to mute
    *        - false to unmute
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - true if defaultMuted is on and getting
    *         - false if defaultMuted is off and getting
-   *         - void when setting
+   *         - Nothing when setting
    */
   defaultMuted(defaultMuted) {
     if (defaultMuted !== undefined) {
-      return this.techCall_('setDefaultMuted', defaultMuted);
+      this.techCall_('setDefaultMuted', defaultMuted);
     }
     return this.techGet_('defaultMuted') || false;
   }
@@ -2719,9 +2722,9 @@ class Player extends Component {
    *         - 1.0 is 100%/full
    *         - 0.5 is half volume or 50%
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The current value of lastVolume as a percent when getting
-   *         - Void when setting
+   *         - Nothing when setting
    *
    * @private
    */
@@ -2755,10 +2758,10 @@ class Player extends Component {
    * @param  {boolean} [isFS]
    *         Set the players current fullscreen state
    *
-   * @return {boolean|vid}
+   * @return {boolean|undefined}
    *         - true if fullscreen is on and getting
    *         - false if fullscreen is off and getting
-   *         - void when setting
+   *         - Nothing when setting
    */
   isFullscreen(isFS) {
     if (isFS !== undefined) {
@@ -3019,10 +3022,10 @@ class Player extends Component {
    * @param  {boolean} [isPiP]
    *         Set the players current Picture-in-Picture state
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - true if Picture-in-Picture is on and getting
    *         - false if Picture-in-Picture is off and getting
-   *         - void if setting
+   *         - nothing if setting
    */
   isInPictureInPicture(isPiP) {
     if (isPiP !== undefined) {
@@ -3366,7 +3369,7 @@ class Player extends Component {
    *        algorithms can take the `type` into account.
    *
    *        If not provided, this method acts as a getter.
-   * @param {boolean} isRetry
+   * @param {boolean} [isRetry]
    *        Indicates whether this is being called internally as a result of a retry
    *
    * @return {string|undefined}
@@ -3690,9 +3693,9 @@ class Player extends Component {
    * @param {'none'|'auto'|'metadata'} [value]
    *        Preload mode to pass to tech
    *
-   * @return {string|void}
+   * @return {string|undefined}
    *         - The preload attribute value when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   preload(value) {
     if (value !== undefined) {
@@ -3718,7 +3721,7 @@ class Player extends Component {
    *
    * @return {boolean|string|undefined}
    *         - The current value of autoplay when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   autoplay(value) {
     // getter usage
@@ -3765,9 +3768,9 @@ class Player extends Component {
    *          which in most cases is inline. iOS Safari is a notable exception
    *          and plays fullscreen by default.
    *
-   * @return {string|void}
+   * @return {string|undefined}
    *         - the current value of playsinline
-   *         - void when setting
+   *         - Nothing when setting
    *
    * @see [Spec]{@link https://html.spec.whatwg.org/#attr-video-playsinline}
    */
@@ -3786,9 +3789,9 @@ class Player extends Component {
    *        - true means that we should loop the video
    *        - false means that we should not loop the video
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The current value of loop when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   loop(value) {
     if (value !== undefined) {
@@ -3807,9 +3810,9 @@ class Player extends Component {
    * @param {string} [src]
    *        Poster image source URL
    *
-   * @return {string|void}
+   * @return {string|undefined}
    *         - The current value of poster when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   poster(src) {
     if (src === undefined) {
@@ -3879,9 +3882,9 @@ class Player extends Component {
    *        - true to turn controls on
    *        - false to turn controls off
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The current value of controls when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   controls(bool) {
     if (bool === undefined) {
@@ -3940,9 +3943,9 @@ class Player extends Component {
    *        - true to turn native controls on
    *        - false to turn native controls off
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The current value of native controls when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   usingNativeControls(bool) {
     if (bool === undefined) {
@@ -3990,9 +3993,9 @@ class Player extends Component {
    *         A MediaError or a string/number to be turned
    *         into a MediaError
    *
-   * @return {MediaError|null|void}
+   * @return {MediaError|null|undefined}
    *         - The current MediaError when getting (or null)
-   *         - Void when setting
+   *         - Nothing when setting
    */
   error(err) {
     if (err === undefined) {
@@ -4035,7 +4038,7 @@ class Player extends Component {
 
     // restoring to default
     if (err === null) {
-      this.error_ = err;
+      this.error_ = null;
       this.removeClass('vjs-error');
       if (this.errorDisplay) {
         this.errorDisplay.close();
@@ -4084,9 +4087,9 @@ class Player extends Component {
    *        - true if the user is active
    *        - false if the user is inactive
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The current value of userActive when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   userActive(bool) {
     if (bool === undefined) {
@@ -4214,7 +4217,8 @@ class Player extends Component {
     // http://ejohn.org/blog/learning-from-twitter/
     let inactivityTimeout;
 
-    this.setInterval(function() {
+    /** @this Player */
+    const activityCheck = function() {
       // Check to see if mouse/touch activity has happened
       if (!this.userActivity_) {
         return;
@@ -4246,7 +4250,9 @@ class Player extends Component {
         }
       }, timeout);
 
-    }, 250);
+    };
+
+    this.setInterval(activityCheck, 250);
   }
 
   /**
@@ -4259,9 +4265,9 @@ class Player extends Component {
    * @param {number} [rate]
    *       New playback rate to set.
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The current playback rate when getting or 1.0
-   *         - Void when setting
+   *         - Nothing when setting
    */
   playbackRate(rate) {
     if (rate !== undefined) {
@@ -4288,9 +4294,9 @@ class Player extends Component {
    * @param {number} [rate]
    *       New default playback rate to set.
    *
-   * @return {number|void}
+   * @return {number|undefined}
    *         - The default playback rate when getting or 1.0
-   *         - void when setting
+   *         - Nothing when setting
    */
   defaultPlaybackRate(rate) {
     if (rate !== undefined) {
@@ -4310,9 +4316,9 @@ class Player extends Component {
    *        - true signals that this is an audio player
    *        - false signals that this is not an audio player
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         - The current value of isAudio when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   isAudio(bool) {
     if (bool !== undefined) {
@@ -4589,9 +4595,9 @@ class Player extends Component {
    * @param {string} [code]
    *        the language code to set the player to
    *
-   * @return {string|void}
+   * @return {string|undefined}
    *         - The current language code when getting
-   *         - Void when setting
+   *         - Nothing when setting
    */
   language(code) {
     if (code === undefined) {
@@ -4795,10 +4801,10 @@ class Player extends Component {
    *         Should be `true` if the player should adjust its UI based on its
    *         dimensions; otherwise, should be `false`.
    *
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    *         Will be `true` if this player should adjust its UI based on its
    *         dimensions; otherwise, will be `false`.
-   *         Void if setting
+   *         Nothing if setting
    */
   responsive(value) {
 
@@ -5053,7 +5059,7 @@ class Player extends Component {
    * @param {boolean} enabled
    * @fires Player#debugon
    * @fires Player#debugoff
-   * @return {boolean|void}
+   * @return {boolean|undefined}
    */
   debug(enabled) {
     if (enabled === undefined) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * @file player.js
  */

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -857,8 +857,8 @@ class Player extends Component {
    *        CSS value to set the `Player`'s width to.
    *
    * @return {number|void}
-   *         The current width of the `Player` when getting.
-   *         Void when setting
+   *         - The current width of the `Player` when getting.
+   *         - Void when setting
    */
   width(value) {
     return this.dimension('width', value);
@@ -872,8 +872,8 @@ class Player extends Component {
    *        CSS value to set the `Player`'s height to.
    *
    * @return {number|void}
-   *         The current height of the `Player` when getting.
-   *         Void when setting
+   *         - The current height of the `Player` when getting.
+   *         - Void when setting
    */
   height(value) {
     return this.dimension('height', value);
@@ -2434,8 +2434,8 @@ class Player extends Component {
    *        whether the user is or is not scrubbing
    *
    * @return {boolean|void}
-   *         The value of scrubbing when getting
-   *         Void when setting
+   *         - The value of scrubbing when getting
+   *         - Void when setting
    */
   scrubbing(isScrubbing) {
     if (typeof isScrubbing === 'undefined') {
@@ -2720,8 +2720,8 @@ class Player extends Component {
    *         - 0.5 is half volume or 50%
    *
    * @return {number|void}
-   *         the current value of lastVolume as a percent when getting
-   *         void when setting
+   *         - The current value of lastVolume as a percent when getting
+   *         - Void when setting
    *
    * @private
    */
@@ -2997,9 +2997,9 @@ class Player extends Component {
   }
 
   /**
-   * Disable Picture-in-Picture mode.
+   * Get or set disable Picture-in-Picture mode.
    *
-   * @param {boolean} value
+   * @param {boolean} [value]
    *                  - true will disable Picture-in-Picture mode
    *                  - false will enable Picture-in-Picture mode
    */
@@ -3687,13 +3687,12 @@ class Player extends Component {
   /**
    * Get or set the preload attribute
    *
-   * @param {boolean} [value]
-   *        - true means that we should preload
-   *        - false means that we should not preload
+   * @param {'none'|'auto'|'metadata'} [value]
+   *        Preload mode to pass to tech
    *
    * @return {string|void}
-   *         The preload attribute value when getting
-   *         Void when setting
+   *         - The preload attribute value when getting
+   *         - Void when setting
    */
   preload(value) {
     if (value !== undefined) {
@@ -3709,7 +3708,7 @@ class Player extends Component {
    * modify the attribute on the tech. When this is a string the attribute on
    * the tech will be removed and `Player` will handle autoplay on loadstarts.
    *
-   * @param {boolean|string} [value]
+   * @param {boolean|'play'|'muted'|'any'} [value]
    *        - true: autoplay using the browser behavior
    *        - false: do not autoplay
    *        - 'play': call play() on every loadstart
@@ -3717,9 +3716,9 @@ class Player extends Component {
    *        - 'any': call play() on every loadstart. if that fails call muted() then play().
    *        - *: values other than those listed here will be set `autoplay` to true
    *
-   * @return {boolean|string|void}
-   *         The current value of autoplay when getting
-   *         Vid when setting
+   * @return {boolean|string|undefined}
+   *         - The current value of autoplay when getting
+   *         - Void when setting
    */
   autoplay(value) {
     // getter usage
@@ -3776,7 +3775,6 @@ class Player extends Component {
     if (value !== undefined) {
       this.techCall_('setPlaysinline', value);
       this.options_.playsinline = value;
-      return this;
     }
     return this.techGet_('playsinline');
   }
@@ -3789,8 +3787,8 @@ class Player extends Component {
    *        - false means that we should not loop the video
    *
    * @return {boolean|void}
-   *         The current value of loop when getting
-   *         Void when setting
+   *         - The current value of loop when getting
+   *         - Void when setting
    */
   loop(value) {
     if (value !== undefined) {
@@ -3810,8 +3808,8 @@ class Player extends Component {
    *        Poster image source URL
    *
    * @return {string|void}
-   *         The current value of poster when getting
-   *         Void when setting
+   *         - The current value of poster when getting
+   *         - Void when setting
    */
   poster(src) {
     if (src === undefined) {
@@ -3882,8 +3880,8 @@ class Player extends Component {
    *        - false to turn controls off
    *
    * @return {boolean|void}
-   *         The current value of controls when getting
-   *         Void when setting
+   *         - The current value of controls when getting
+   *         - Void when setting
    */
   controls(bool) {
     if (bool === undefined) {
@@ -3943,8 +3941,8 @@ class Player extends Component {
    *        - false to turn native controls off
    *
    * @return {boolean|void}
-   *         The current value of native controls when getting
-   *         Void when setting
+   *         - The current value of native controls when getting
+   *         - Void when setting
    */
   usingNativeControls(bool) {
     if (bool === undefined) {
@@ -3993,8 +3991,8 @@ class Player extends Component {
    *         into a MediaError
    *
    * @return {MediaError|null|void}
-   *         The current MediaError when getting (or null)
-   *         Void when setting
+   *         - The current MediaError when getting (or null)
+   *         - Void when setting
    */
   error(err) {
     if (err === undefined) {
@@ -4087,8 +4085,8 @@ class Player extends Component {
    *        - false if the user is inactive
    *
    * @return {boolean|void}
-   *         The current value of userActive when getting
-   *         Void when setting
+   *         - The current value of userActive when getting
+   *         - Void when setting
    */
   userActive(bool) {
     if (bool === undefined) {
@@ -4262,8 +4260,8 @@ class Player extends Component {
    *       New playback rate to set.
    *
    * @return {number|void}
-   *         The current playback rate when getting or 1.0
-   *         Void when setting
+   *         - The current playback rate when getting or 1.0
+   *         - Void when setting
    */
   playbackRate(rate) {
     if (rate !== undefined) {
@@ -4308,13 +4306,13 @@ class Player extends Component {
   /**
    * Gets or sets the audio flag
    *
-   * @param {boolean} bool
+   * @param {boolean} [bool]
    *        - true signals that this is an audio player
    *        - false signals that this is not an audio player
    *
    * @return {boolean|void}
-   *         The current value of isAudio when getting
-   *         Void when setting
+   *         - The current value of isAudio when getting
+   *         - Void when setting
    */
   isAudio(bool) {
     if (bool !== undefined) {
@@ -4592,8 +4590,8 @@ class Player extends Component {
    *        the language code to set the player to
    *
    * @return {string|void}
-   *         The current language code when getting
-   *         Void when setting
+   *         - The current language code when getting
+   *         - Void when setting
    */
   language(code) {
     if (code === undefined) {

--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -1,3 +1,4 @@
+
 /**
  * @file dom.js
  * @module dom
@@ -161,7 +162,7 @@ export function createEl(tagName = 'div', properties = {}, attributes = {}, cont
 /**
  * Injects text into an element, replacing any existing contents entirely.
  *
- * @param  {Element} el
+ * @param  {HTMLElement} el
  *         The element to add text content into
  *
  * @param  {string} text
@@ -342,18 +343,19 @@ export function getAttributes(tag) {
   // known boolean attributes
   // we can check for matching boolean properties, but not all browsers
   // and not all tags know about these attributes, so, we still want to check them manually
-  const knownBooleans = ',' + 'autoplay,controls,playsinline,loop,muted,default,defaultMuted' + ',';
+  const knownBooleans = ['autoplay', 'controls', 'playsinline', 'loop', 'muted', 'default', 'defaultMuted'];
 
   if (tag && tag.attributes && tag.attributes.length > 0) {
     const attrs = tag.attributes;
 
     for (let i = attrs.length - 1; i >= 0; i--) {
       const attrName = attrs[i].name;
+      /** @type {boolean|string} */
       let attrVal = attrs[i].value;
 
       // check for known booleans
       // the matching element property will return a value for typeof
-      if (typeof tag[attrName] === 'boolean' || knownBooleans.indexOf(',' + attrName + ',') !== -1) {
+      if (knownBooleans.includes(attrName)) {
         // the value of an included boolean attribute is typically an empty
         // string ('') which would equal false if we just check for a false value.
         // we also don't want support bad code like autoplay='false'
@@ -730,7 +732,7 @@ export function insertContent(el, content) {
 /**
  * Check if an event was a single left click.
  *
- * @param  {Event} event
+ * @param  {MouseEvent} event
  *         Event object.
  *
  * @return {boolean}

--- a/test/unit/events.test.js
+++ b/test/unit/events.test.js
@@ -60,8 +60,8 @@ QUnit.test('should be possible to pass data when you trigger an event', function
 
   const listener = function(evt, hash) {
     assert.ok(true, 'Callback triggered');
-    assert.deepEqual(fakeData1, hash.d1, 'Shoulbe be passed to the handler');
-    assert.deepEqual(fakeData2, hash.d2, 'Shoulbe be passed to the handler');
+    assert.deepEqual(fakeData1, hash.d1, 'Should be be passed to the handler');
+    assert.deepEqual(fakeData2, hash.d2, 'Should be be passed to the handler');
   };
 
   Events.on(el, ['event1', 'event2'], listener);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2209,6 +2209,29 @@ QUnit.test('should not allow to register custom player when any player has been 
   videojs.registerComponent('Player', Player);
 });
 
+QUnit.test('setters getters passed to tech', function(assert) {
+  const tag = TestHelpers.makeTag();
+  const fixture = document.getElementById('qunit-fixture');
+
+  fixture.appendChild(tag);
+
+  const player = videojs(tag, {
+    techOrder: ['techFaker']
+  });
+
+  const setSpy = sinon.spy(player.tech_, 'setDefaultMuted');
+  const getSpy = sinon.spy(player.tech_, 'defaultMuted');
+
+  player.defaultMuted(true);
+  player.defaultMuted();
+
+  assert.ok(setSpy.calledWith(true), 'setSpy called');
+  assert.ok(getSpy.called);
+
+  setSpy.restore();
+  getSpy.restore();
+});
+
 QUnit.test('techGet runs through middleware if allowedGetter', function(assert) {
   let cts = 0;
   let muts = 0;

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -48,6 +48,8 @@ class TechFaker extends Tech {
 
   setMuted() {}
 
+  setDefaultMuted() {}
+
   setAutoplay(v) {
     if (!v) {
       this.options_.autoplay = false;
@@ -118,6 +120,9 @@ class TechFaker extends Tech {
     return this.volume_ || 0;
   }
   muted() {
+    return false;
+  }
+  defaultMuted() {
     return false;
   }
   autoplay() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "skipLibCheck": true,
     "checkJs": false,
-    "preserveWatchOutput": true
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Description
Corrects some jsodc in Player, especially
- getter/setters not specifying that they won't return when setting
- getter/setters that stated they could return the player, very old behaviour

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
