### PR TITLE
fix(player): cache_.currentTime is not updated when the current time is set

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2461,29 +2461,30 @@ class Player extends Component {
    *         - the current time in seconds when getting
    */
   currentTime(seconds) {
-    if (typeof seconds !== 'undefined') {
-      if (seconds < 0) {
-        seconds = 0;
-      }
-      if (!this.isReady_ || this.changingSrc_ || !this.tech_ || !this.tech_.isReady_) {
-        this.cache_.initTime = seconds;
-        this.off('canplay', this.boundApplyInitTime_);
-        this.one('canplay', this.boundApplyInitTime_);
-        return;
-      }
-      this.techCall_('setCurrentTime', seconds);
-      this.cache_.initTime = 0;
+    if (seconds === undefined) {
+      // cache last currentTime and return. default to 0 seconds
+      //
+      // Caching the currentTime is meant to prevent a massive amount of reads on the tech's
+      // currentTime when scrubbing, but may not provide much performance benefit after all.
+      // Should be tested. Also something has to read the actual current time or the cache will
+      // never get updated.
+      this.cache_.currentTime = (this.techGet_('currentTime') || 0);
+      return this.cache_.currentTime;
+    }
+
+    if (seconds < 0) {
+      seconds = 0;
+    }
+
+    if (!this.isReady_ || this.changingSrc_ || !this.tech_ || !this.tech_.isReady_) {
+      this.cache_.initTime = seconds;
+      this.off('canplay', this.boundApplyInitTime_);
+      this.one('canplay', this.boundApplyInitTime_);
       return;
     }
 
-    // cache last currentTime and return. default to 0 seconds
-    //
-    // Caching the currentTime is meant to prevent a massive amount of reads on the tech's
-    // currentTime when scrubbing, but may not provide much performance benefit after all.
-    // Should be tested. Also something has to read the actual current time or the cache will
-    // never get updated.
-    this.cache_.currentTime = (this.techGet_('currentTime') || 0);
-    return this.cache_.currentTime;
+    this.techCall_('setCurrentTime', seconds);
+    this.cache_.initTime = 0;
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2485,6 +2485,10 @@ class Player extends Component {
 
     this.techCall_('setCurrentTime', seconds);
     this.cache_.initTime = 0;
+
+    if (isFinite(seconds)) {
+      this.cache_.currentTime = Number(seconds);
+    }
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2676,6 +2676,20 @@ QUnit.test('Should accept multiple calls to currentTime after player initializat
   assert.equal(player.currentTime(), 800, 'The last value passed is stored as the currentTime value');
 });
 
+QUnit.test('Should be able to set the cache currentTime after player initialization as soon the canplay event is fired', function(assert) {
+  const player = TestHelpers.makePlayer({});
+
+  player.src('xyz.mp4');
+  player.currentTime(500);
+
+  assert.strictEqual(player.getCache().currentTime, 0, 'cache currentTime value was not changed');
+
+  this.clock.tick(100);
+  player.trigger('canplay');
+
+  assert.strictEqual(player.getCache().currentTime, 500, 'cache currentTime value is the one passed after initialization');
+});
+
 QUnit.test('Should fire debugon event when debug mode is enabled', function(assert) {
   const player = TestHelpers.makePlayer({});
   const debugOnSpy = sinon.spy();


### PR DESCRIPTION
## Description

This PR fixes the delay in the update of `cache_.currentTime`. Updating `cache_.currentTime` as soon as the `currentTime` is set avoids having to wait for the `timeupdate` event, which results in:
    
- making `cache_.currentTime` more reliable
- updating the `progress bar` on mouse up after dragging when the media is paused.
    
See also: #6232, #6234, #6370, #6372, partially covers #8283

## Specific Changes proposed

- Refactor `currentTime` method to decrease the indentation level
- Updates `cache_.currentTime` when `currentTime` is used as a setter and the `seconds` parameter has a value that can be converted to a `Number`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
