### PR TITLE
feat: Seek bar smooth seeking

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -324,6 +324,10 @@ class SeekBar extends Slider {
 
     // Set new time (tell player to seek to new time)
     this.userSeek_(newTime);
+
+    if (this.player_.options_.enableSmoothSeeking) {
+      this.update();
+    }
   }
 
   enable() {

--- a/src/js/control-bar/time-controls/time-display.js
+++ b/src/js/control-bar/time-controls/time-display.js
@@ -26,7 +26,7 @@ class TimeDisplay extends Component {
   constructor(player, options) {
     super(player, options);
 
-    this.on(player, ['timeupdate', 'ended'], (e) => this.updateContent(e));
+    this.on(player, ['timeupdate', 'ended', 'seeking'], (e) => this.update(e));
     this.updateTextNode_();
   }
 
@@ -69,6 +69,20 @@ class TimeDisplay extends Component {
     this.textNode_ = null;
 
     super.dispose();
+  }
+
+  /**
+   * Updates the displayed time according to the `updateContent` function which is defined in the child class.
+   *
+   * @param {Event} [event]
+   *          The `timeupdate`, `ended` or `seeking` (if enableSmoothSeeking is true) event that caused this function to be called.
+   */
+  update(event) {
+    if (!this.player_.options_.enableSmoothSeeking && event.type === 'seeking') {
+      return;
+    }
+
+    this.updateContent(event);
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -5316,7 +5316,9 @@ Player.prototype.options_ = {
   breakpoints: {},
   responsive: false,
   audioOnlyMode: false,
-  audioPosterMode: false
+  audioPosterMode: false,
+  // Default smooth seeking to false
+  enableSmoothSeeking: false
 };
 
 [

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2509,10 +2509,6 @@ class Player extends Component {
 
     this.techCall_('setCurrentTime', seconds);
     this.cache_.initTime = 0;
-
-    if (isFinite(seconds)) {
-      this.cache_.currentTime = Number(seconds);
-    }
   }
 
   /**

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2509,6 +2509,10 @@ class Player extends Component {
 
     this.techCall_('setCurrentTime', seconds);
     this.cache_.initTime = 0;
+
+    if (isFinite(seconds)) {
+      this.cache_.currentTime = Number(seconds);
+    }
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3419,3 +3419,66 @@ QUnit.test('should not reset the error when the tech triggers an error that is n
   errorStub.restore();
   log.error.restore();
 });
+
+QUnit.test('smooth seeking set to false should not update the display time components or the seek bar', function(assert) {
+  const player = TestHelpers.makePlayer({});
+  const {
+    currentTimeDisplay,
+    remainingTimeDisplay,
+    progressControl: {
+      seekBar
+    }
+  } = player.controlBar;
+  const currentTimeDisplayUpdateContent = sinon.spy(currentTimeDisplay, 'updateContent');
+  const remainingTimeDisplayUpdateContent = sinon.spy(remainingTimeDisplay, 'updateContent');
+  const seekBarUpdate = sinon.spy(seekBar, 'update');
+
+  assert.false(player.options().enableSmoothSeeking, 'enableSmoothSeeking is false by default');
+
+  player.trigger('seeking');
+
+  assert.ok(currentTimeDisplayUpdateContent.notCalled, 'currentTimeDisplay updateContent was not called');
+  assert.ok(remainingTimeDisplayUpdateContent.notCalled, 'remainingTimeDisplay updateContent was not called');
+
+  seekBar.trigger('mousedown');
+  seekBar.trigger('mousemove');
+
+  assert.ok(seekBarUpdate.notCalled, 'seekBar update was not called');
+
+  currentTimeDisplayUpdateContent.restore();
+  remainingTimeDisplayUpdateContent.restore();
+  seekBarUpdate.restore();
+  player.dispose();
+});
+
+QUnit.test('smooth seeking set to true should update the display time components and the seek bar', function(assert) {
+  const player = TestHelpers.makePlayer({enableSmoothSeeking: true});
+  const {
+    currentTimeDisplay,
+    remainingTimeDisplay,
+    progressControl: {
+      seekBar
+    }
+  } = player.controlBar;
+  const currentTimeDisplayUpdateContent = sinon.spy(currentTimeDisplay, 'updateContent');
+  const remainingTimeDisplayUpdateContent = sinon.spy(remainingTimeDisplay, 'updateContent');
+  const seekBarUpdate = sinon.spy(seekBar, 'update');
+
+  assert.true(player.options().enableSmoothSeeking, 'enableSmoothSeeking is true');
+
+  player.duration(1);
+  player.trigger('seeking');
+
+  assert.ok(currentTimeDisplayUpdateContent.called, 'currentTimeDisplay updateContent was called');
+  assert.ok(remainingTimeDisplayUpdateContent.called, 'remainingTimeDisplay updateContent was called');
+
+  seekBar.trigger('mousedown');
+  seekBar.trigger('mousemove');
+
+  assert.ok(seekBarUpdate.called, 'seekBar update was called');
+
+  currentTimeDisplayUpdateContent.restore();
+  remainingTimeDisplayUpdateContent.restore();
+  seekBarUpdate.restore();
+  player.dispose();
+});


### PR DESCRIPTION
## Description

This PR adds a player option called `enableSmoothSeeking`, which is `false` by default, to provide a smoother seeking experience on mobile and desktop devices.

[player-smooth-seek-browserstack.webm](https://github.com/videojs/video.js/assets/34163393/0f1fc92b-58bf-4303-9b00-c5c92585adb7)


This PR includes the fix #8285 and should fix #8283.

### How to use it?

```javascript
// Enables the smooth seeking
const player = videojs('player', {enableSmoothSeeking: true});

// Disable the smooth seeking
player.options({enableSmoothSeeking: false});

```

## Specific Changes proposed

- **player.js** add an `option` called `enableSmoothSeeking`
- **time-display.js** add a listener to the `seeking` event if `enableSmoothSeeking` is `true` allowing to update the `CurrentTimeDisplay` and `RemainingTimeDisplay` in real time
- **seek-bar.js** `update` the seek bar on `mousemove` event  if `enableSmoothSeeking` is `true`
- add test cases
- refer to #8285 for the `player.currentTime` modification

### Benchmark

The number of calls to the `update` method when the player is `playing` versus when `seeking` with smooth seeking enabled. The test was performed 10 times in a row and consisted of a counter that incremented by one on each call. It was inserted in the anonymous function provided to `requestNamedAnimationFrame` of the `update` method. 

The duration of each round was 5 seconds. The `enableInterval_` it started when the `play` button was clicked and stopped at the end of the `setTimeout`. The `handleMouseMove` it started on the `mousedown`, then was followed by frantic movement on the seek bar and stopped at the end of the `setTimeout`.

|            | enableInterval_ | handleMouseMove |
|----------|-----------------|-----------------|
| Round 1  | 142             | 114             |
| Round 2  | 144             | 133             |
| Round 3  | 145             | 126             |
| Round 4  | 152             | 114             |
| Round 5  | 144             | 122             |
| Round 6  | 150             | 119             |
| Round 7  | 146             | 112             |
| Round 8  | 155             | 133             |
| Round 9  | 144             | 131             |
| Round 10 | 133             | 121             |

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
