### PR TITLE
fix: fix text track settings responsiveness when default font size is modified

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -53,6 +53,10 @@
 }
 
 // Form elements
+.vjs-text-track-settings select {
+  font-size: inherit;
+}
+
 .vjs-track-setting > select {
   margin-right: 1em;
   margin-bottom: 0.5em;
@@ -65,7 +69,7 @@
 
 .vjs-text-track-settings fieldset span {
   display: inline-block;
-  padding: 0 6px 8px;
+  padding: 0 .6em .8em;
 }
 
 // style the second select for text colors
@@ -76,11 +80,11 @@
 .vjs-text-track-settings legend {
   color: $primary-foreground-color;
   font-weight: bold;
-  font-size: 14px;
+  font-size: 1.2em;
 }
 
 .vjs-text-track-settings .vjs-label {
-  margin: 0 5px 5px 0;
+  margin: 0 .5em .5em 0;
 }
 
 .vjs-track-settings-controls button:focus,

--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -80,13 +80,7 @@
 }
 
 .vjs-text-track-settings .vjs-label {
-  clip: rect(1px 1px 1px 1px); // for Internet Explorer
-  clip: rect(1px, 1px, 1px, 1px);
   margin: 0 5px 5px 0;
-  border: 0;
-  height: 1px;
-  width: 1px;
-  overflow: hidden;
 }
 
 .vjs-track-settings-controls button:focus,


### PR DESCRIPTION
## Description

This PR fixes the responsiveness of the `text track settings` when the default font size of `.video-js` is modified and only the label size was updated.

[text-track-settings.webm](https://github.com/videojs/video.js/assets/34163393/62696880-919d-4be7-bd52-0ab449e16d28)


## Specific Changes proposed

- Remove css that was no longer useful since labels are no longer hidden, refer to #8101
- Use `em` instead of `px` to make sizes responsive

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
