### PR TITLE
fix: fix loading spinner responsiveness when default font size is modified

### DIFF
--- a/src/css/components/_loading.scss
+++ b/src/css/components/_loading.scss
@@ -3,20 +3,20 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  margin: -25px 0 0 -25px;
+  transform: translate(-50%, -50%);
   opacity: 0.85;
 
   // Need to fix centered page layouts
   text-align: left;
 
-  border: 6px solid rgba($primary-background-color, $primary-background-transparency);
+  border: .6em solid rgba($primary-background-color, $primary-background-transparency);
   // border: 6px solid rgba(43, 51, 63, 0.5);
 
   box-sizing: border-box;
   background-clip: padding-box;
-  width: 50px;
-  height: 50px;
-  border-radius: 25px;
+  width: 5em;
+  height: 5em;
+  border-radius: 50%;
   visibility: hidden;
 }
 
@@ -31,7 +31,7 @@
 .vjs-loading-spinner:after {
   content: "";
   position: absolute;
-  margin: -6px;
+  margin: -0.6em;
   box-sizing: inherit;
   width: inherit;
   height: inherit;


### PR DESCRIPTION
## Description

This PR fixes the responsiveness of the `loading spinner` when the default font size of `.video-js` is modified.

[loading-spinner.webm](https://github.com/videojs/video.js/assets/34163393/99b4947a-f6d2-495b-b132-30752ba0a706)

## Specific Changes proposed

- Use `em` instead of `px` to make the component responsive

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
