### PR TITLE
test: fix Safari test failures

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3548,7 +3548,7 @@ class Player extends Component {
   load() {
     // Workaround to use the load method with the VHS.
     // Does not cover the case when the load method is called directly from the mediaElement.
-    if (this.tech_.vhs) {
+    if (this.tech_ && this.tech_.vhs) {
       this.src(this.currentSource());
 
       return;


### PR DESCRIPTION
## Description

It looks like after #8274 was merged, tests began failing consistently in Safari. Upon investigation, it seems that code in the test harness was hitting `load()` before a fake tech had been created, causing it to throw and then the test to time out.

Oddly enough, the tests didn't fail in the PR... only after it was merged! 🤷 

## Specific Changes proposed

- Do a `null` check for the `tech_` before inspecting it.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
