### PR TITLE
fix(package): update videojs-contrib-quality-levels to 4.0.0 to eliminate deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15224,13 +15224,21 @@
               }
             }
           }
+        },
+        "videojs-contrib-quality-levels": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-3.0.0.tgz",
+          "integrity": "sha512-sNx38EYUx+Q+gmup1gVTv9P9/sPs28rM7gZOx1sedaHoKxEdYB+ysOGfHj6MSELBMNGMj6ZspdrpSiWguGvGxA==",
+          "requires": {
+            "global": "^4.4.0"
+          }
         }
       }
     },
     "videojs-contrib-quality-levels": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-3.0.0.tgz",
-      "integrity": "sha512-sNx38EYUx+Q+gmup1gVTv9P9/sPs28rM7gZOx1sedaHoKxEdYB+ysOGfHj6MSELBMNGMj6ZspdrpSiWguGvGxA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.0.0.tgz",
+      "integrity": "sha512-u5rmd8BjLwANp7XwuQ0Q/me34bMe6zg9PQdHfTS7aXgiVRbNTb4djcmfG7aeSrkpZjg+XCLezFNenlJaCjBHKw==",
       "requires": {
         "global": "^4.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mpd-parser": "^1.0.1",
     "mux.js": "^6.2.0",
     "safe-json-parse": "4.0.0",
-    "videojs-contrib-quality-levels": "3.0.0",
+    "videojs-contrib-quality-levels": "4.0.0",
     "videojs-font": "4.1.0",
     "videojs-vtt.js": "0.15.4"
   },


### PR DESCRIPTION
## Description
Fixed a warning when using quality-levels 3.x which used mergeOptions. It prepare for 9.0.0

## Specific Changes proposed
update videojs-contrib-quality-levels to ^4.0.0 in package.json

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
