### PR TITLE
fix(types): revert resolveJsonModule in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "declarationMap": true,
     "skipLibCheck": true,
     "checkJs": false,
-    "preserveWatchOutput": true,
-    "resolveJsonModule": true
+    "preserveWatchOutput": true
   }
 }


### PR DESCRIPTION
## Description
Removes `resolveJsonModule` from tsconfig.json, added in #8277.
Although adding that resolves one tsc complaint (relating to importing the version from 
package.json), for some reason with it present tsc will include `src/js` in the paths within 
`dist/types` 

## Requirements Checklist
- [xx] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
