### PR TITLE
fix(volume): vertical slider causes viewport overflow in rtl layout

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -51,7 +51,11 @@
     position: relative;
 
     &.vjs-volume-vertical {
-      left: -3.5em;
+      height: 8em;
+      width: 3em;
+
+      pointer-events: initial;
+
       @include transition(left 0s);
     }
     $transition-property: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
@@ -75,10 +79,6 @@
 }
 
 .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-  height: 8em;
-  width: 3em;
-  left: -3000em;
-
   $transition-property: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
   @include transition($transition-property)
 }
@@ -192,9 +192,10 @@
 }
 
 .video-js .vjs-volume-vertical {
-  width: 3em;
-  height: 8em;
+  left: -3.5em;
   bottom: 8em;
+
+  pointer-events: none;
 
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }


### PR DESCRIPTION
## Description

This PR fixes #7743 where a scroll bar appears when the text direction is RTL.

[Screencast from 13. 06. 23 19:02:52.webm](https://github.com/videojs/video.js/assets/34163393/85343a12-8193-487a-8f35-39c19f3f0b0d)


## Specific Changes proposed



## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
