### PR TITLE
fix: Use pagehide instead of unload for PiP

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3107,7 +3107,7 @@ class Player extends Component {
         this.player_.trigger('enterpictureinpicture');
 
         // Listen for the PiP closing event to move the video back.
-        pipWindow.addEventListener('unload', (event) => {
+        pipWindow.addEventListener('pagehide', (event) => {
           const pipVideo = event.target.querySelector('.video-js');
 
           pipContainer.replaceWith(pipVideo);
@@ -3142,7 +3142,7 @@ class Player extends Component {
    */
   exitPictureInPicture() {
     if (window.documentPictureInPicture && window.documentPictureInPicture.window) {
-      // With documentPictureInPicture, Player#leavepictureinpicture is fired in the unload handler
+      // With documentPictureInPicture, Player#leavepictureinpicture is fired in the pagehide handler
       window.documentPictureInPicture.window.close();
       return Promise.resolve();
     }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -2925,7 +2925,7 @@ QUnit.test('docPiP moves player and triggers events', function(assert) {
     return fakePiPWindow.document.body.querySelector(sel);
   };
   fakePiPWindow.close = function() {
-    fakePiPWindow.dispatchEvent(new Event('unload'));
+    fakePiPWindow.dispatchEvent(new Event('pagehide'));
     delete window.documentPictureInPicture.window;
   };
 


### PR DESCRIPTION
## Description
As noted in https://groups.google.com/a/chromium.org/g/blink-dev/c/JTPl7fM64Lc, we should use "pagehide" not "unload" JS event to monitor when PiP window gets closed.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
