### PR TITLE
fix(play-toggle): missing svg play icon

### DIFF
--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -27,6 +27,8 @@ class PlayToggle extends Button {
     // show or hide replay icon
     options.replay = options.replay === undefined || options.replay;
 
+    this.setIcon('play');
+
     this.on(player, 'play', (e) => this.handlePlay(e));
     this.on(player, 'pause', (e) => this.handlePause(e));
 


### PR DESCRIPTION
## Description

This PR fixes #8336, where the svg `play` icon is missing when player is initialized with class `vjs-has-started`.

## Specific Changes proposed

- add `setIcon` to the `play-toggle` component constructor

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
