### PR TITLE
fix(progress): mouse-time-display overlaps the play-progress svg icon

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -95,6 +95,7 @@
   height: 1em;
   pointer-events: none;
   line-height: 0.15em;
+  z-index: 1;
 }
 
 .video-js .vjs-load-progress {


### PR DESCRIPTION
## Description

This PR fixes when the mouse hovers over the `play-progress` svg icon, the `mouse-time-display` bar appears above it.

[Screencast from 02. 07. 23 20:16:42.webm](https://github.com/videojs/video.js/assets/34163393/12440cbf-03b5-402c-a676-5ad55563d857)


## Specific Changes proposed

- adds `z-index` to avoid overlap

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
