### PR TITLE
fix(lang): add skip button text for Portuguese

### DIFF
--- a/lang/pt-PT.json
+++ b/lang/pt-PT.json
@@ -37,5 +37,7 @@
   ", opens captions settings dialog": ", abre janela com definições de legendas",
   ", opens subtitles settings dialog": ", abre janela com definições de legendas",
   ", opens descriptions settings dialog": ", abre janela com definições de descrições",
-  ", selected": ", seleccionado"
+  ", selected": ", seleccionado",
+  "Skip backward {1} seconds": "Recuar de {1} segundos",
+  "Skip forward {1} seconds": "Avançar de {1} segundos"
 }


### PR DESCRIPTION
## Description

Adds Portuguese translation for skip buttons.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
