### PR TITLE
fix: Fullscreen styles for older Safari

### DIFF
--- a/src/css/components/_layout.scss
+++ b/src/css/components/_layout.scss
@@ -142,6 +142,8 @@ body.vjs-pip-window .video-js {
   height: 100% !important;
   // Undo any aspect ratio padding for fluid layouts
   padding-top: 0 !important;
+  // Older Safari (<= 15.6) needs display: block in fullscreen.
+  display: block;
 }
 
 .video-js.vjs-fullscreen.vjs-user-inactive {


### PR DESCRIPTION
## Description
Works around and issue with older Safari versions (=<15.6) with sizing the player fullscreen with `inline-block`.

Fixes #8339

## Specific Changes proposed
Sets `display: block` in fullscreen.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
