### PR TITLE
fix(tests): Skip a test on old Safari

### DIFF
--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -1,7 +1,9 @@
 /* eslint-env qunit */
 import document from 'global/document';
+import window from 'global/window';
 import sinon from 'sinon';
 import * as Dom from '../../../src/js/utils/dom.js';
+import { IS_SAFARI } from '../../../src/js/utils/browser.js';
 import TestHelpers from '../test-helpers.js';
 
 QUnit.module('utils/dom');
@@ -687,7 +689,11 @@ QUnit.test('isSingleLeftClick() checks return values for mousedown event', funct
   assert.ok(Dom.isSingleLeftClick(mouseEvent), 'a touch event on simulated mobiles is a single left click');
 });
 
-QUnit.test('Dom.copyStyleSheetsToWindow() copies all style sheets to a window', function(assert) {
+// The next test is skipped on Safari < 14, which has a broken document.styleSheets
+// copyStyleSheetsToWindow() is only used on browsers supporting documentPictureInPicture - Chromium 113+
+const skipOnOldSafari = IS_SAFARI && parseInt(window.navigator.userAgent.match(/Version\/(\d+)\./)[1], 10) < 14 ? 'skip' : 'test';
+
+QUnit[skipOnOldSafari]('Dom.copyStyleSheetsToWindow() copies all style sheets to a window', function(assert) {
   const fakeWindow = document.createElement('div');
   const done = assert.async();
 


### PR DESCRIPTION
## Description
Safari versions less than 14 have a broken `document.styleSheets` - not all style elements are included, which breaks a recent test. We're currently running tests on Brpwserstack on Safari 12 on main.

## Specific Changes proposed
Since we use the `copyStyleSheets` function only in browsers that support documentPictureInPicture, this simply skips the test on Safari < 14. Should Safari implement documentPictureInPicture in a future update this isn't a concern as `document.styleSheets` behaves properly on 14+.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
