### PR TITLE
fix(volume-panel): a long press on the volume button displays the volume slider on touch devices

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -34,7 +34,7 @@
   margin-left: -1px;
 }
 
-.video-js .vjs-volume-panel {
+.video-js:not(.vjs-touch-enabled) .vjs-volume-panel {
   &.vjs-hover .vjs-volume-control,
   &:active .vjs-volume-control,
   &:focus  .vjs-volume-control,


### PR DESCRIPTION
## Description

Prevents the `volume slider` from displaying when a long press is made on the `volume button`, forcing the user to make a long press or tap elsewhere on the player or page to make the `volume slider` disappear.

[Screencast from 16. 07. 23 13:24:51.webm](https://github.com/videojs/video.js/assets/34163393/8b9b026b-1bd5-4c2e-8ff9-016925b60829)

Refers to https://github.com/videojs/video.js/pull/8320#issuecomment-1625507456

## Specific Changes proposed

- adds class `.vjs-touch-enabled` to pseudo-class `:not` at the root of the rule displaying the `volume slider`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
