### PR TITLE
fix(loading-spinner): border size customization

### DIFF
--- a/src/css/components/_loading.scss
+++ b/src/css/components/_loading.scss
@@ -22,7 +22,10 @@
 
 .vjs-seeking .vjs-loading-spinner,
 .vjs-waiting .vjs-loading-spinner {
-  display: block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   // add a delay before actual show the spinner
   animation: vjs-spinner-show 0s linear 0.3s forwards;
 }
@@ -31,7 +34,6 @@
 .vjs-loading-spinner:after {
   content: "";
   position: absolute;
-  margin: -0.6em;
   box-sizing: inherit;
   width: inherit;
   height: inherit;


### PR DESCRIPTION
## Description

Allows to change the border size of the `loading-spinner` component without having to reflect the border size in pseudo-element's margin.

[Screencast from 19. 07. 23 18:08:10.webm](https://github.com/videojs/video.js/assets/34163393/c8432886-ff23-4988-b887-23f3ca1b2c6c)

## Specific Changes proposed

- uses display `flex` to facilitate centering of pseudo-elements
- deletes the pseudo-elements `margin`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
