### PR TITLE
fix: Check for VTTCue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15300,6 +15300,14 @@
           "requires": {
             "global": "^4.4.0"
           }
+        },
+        "videojs-vtt.js": {
+          "version": "0.15.4",
+          "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.4.tgz",
+          "integrity": "sha512-r6IhM325fcLb1D6pgsMkTQT1PpFdUdYZa1iqk7wJEu+QlibBwATPfPc9Bg8Jiym0GE5yP1AG2rMLu+QMVWkYtA==",
+          "requires": {
+            "global": "^4.3.1"
+          }
         }
       }
     },
@@ -15618,9 +15626,9 @@
       }
     },
     "videojs-vtt.js": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.4.tgz",
-      "integrity": "sha512-r6IhM325fcLb1D6pgsMkTQT1PpFdUdYZa1iqk7wJEu+QlibBwATPfPc9Bg8Jiym0GE5yP1AG2rMLu+QMVWkYtA==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz",
+      "integrity": "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==",
       "requires": {
         "global": "^4.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "safe-json-parse": "4.0.0",
     "videojs-contrib-quality-levels": "4.0.0",
     "videojs-font": "4.1.0",
-    "videojs-vtt.js": "0.15.4"
+    "videojs-vtt.js": "0.15.5"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -391,7 +391,7 @@ class TextTrack extends Track {
   addCue(originalCue) {
     let cue = originalCue;
 
-    if (cue.constructor.name !== 'VTTCue') {
+    if (cue.constructor && cue.constructor.name !== 'VTTCue') {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -391,7 +391,7 @@ class TextTrack extends Track {
   addCue(originalCue) {
     let cue = originalCue;
 
-    if (window.vttjs && !(originalCue instanceof window.vttjs.VTTCue)) {
+    if (cue.constructor.name !== 'VTTCue') {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -231,6 +231,21 @@ QUnit.test('original cue can be used to remove cue from cues list', function(ass
   assert.equal(tt.cues.length, 0, 'we have removed cue1');
 });
 
+QUnit.test('non-VTTCue can be used to remove cue from cues list', function(assert) {
+  const tt = new TextTrack({
+    tech: this.tech
+  });
+
+  const cue1 = { id: 1, text: 'test' };
+
+  assert.equal(tt.cues.length, 0, 'start with zero cues');
+  tt.addCue(cue1);
+  assert.equal(tt.cues.length, 1, 'we have one cue');
+
+  tt.removeCue(cue1);
+  assert.equal(tt.cues.length, 0, 'we have removed cue1');
+});
+
 QUnit.test('can only remove one cue at a time', function(assert) {
   const tt = new TextTrack({
     tech: this.tech

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -256,6 +256,9 @@ QUnit.test('can only remove one cue at a time', function(assert) {
 
   const cue1 = new Cue(0, 1, 'some-cue');
 
+  cue1.line = 15;
+  cue1.position = 10;
+
   assert.equal(tt.cues.length, 0, 'start with zero cues');
   tt.addCue(cue1);
   tt.addCue(cue1);

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -256,9 +256,6 @@ QUnit.test('can only remove one cue at a time', function(assert) {
 
   const cue1 = new Cue(0, 1, 'some-cue');
 
-  cue1.line = 15;
-  cue1.position = 10;
-
   assert.equal(tt.cues.length, 0, 'start with zero cues');
   tt.addCue(cue1);
   tt.addCue(cue1);


### PR DESCRIPTION
This was causing a bug when it came to VTT Cue positioning. This check was never true becasue the `window` instances of the VTTCue being checked, and the `window` instance here are never the same.

## Specific Changes proposed
A different way to check if the property being used is indeed a VTTCue.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
