### PR TITLE
fix(text): caption settings typo

### DIFF
--- a/docs/translations-needed.md
+++ b/docs/translations-needed.md
@@ -64,7 +64,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -135,7 +135,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -214,7 +214,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -309,7 +309,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -367,7 +367,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -394,9 +394,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
 | en-GB.json (has 1)      | Needs manual checking. Can safely use most default strings.                         |
-| es.json (missing 3)     | Playing in Picture-in-Picture                                                       |
-|                         | Skip backward {1} seconds                                                           |
-|                         | Skip forward {1} seconds                                                            |
+| es.json (missing 1)     | Playing in Picture-in-Picture                                                       |
 | et.json (missing 8)     | No content                                                                          |
 |                         | Color                                                                               |
 |                         | Opacity                                                                             |
@@ -413,12 +411,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| fa.json (missing 6)     | No content                                                                          |
-|                         | Color                                                                               |
-|                         | Opacity                                                                             |
-|                         | Text Background                                                                     |
-|                         | Caption Area Background                                                             |
-|                         | Playing in Picture-in-Picture                                                       |
+| fa.json (Complete)      |                                                                                     |
 | fi.json (missing 71)    | Audio Player                                                                        |
 |                         | Video Player                                                                        |
 |                         | Replay                                                                              |
@@ -464,7 +457,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -490,9 +483,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| fr.json (missing 3)     | Playing in Picture-in-Picture                                                       |
-|                         | Skip backward {1} seconds                                                           |
-|                         | Skip forward {1} seconds                                                            |
+| fr.json (missing 1)     | Playing in Picture-in-Picture                                                       |
 | gd.json (missing 10)    | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 |                         | No content                                                                          |
@@ -579,7 +570,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -659,7 +650,8 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| pl.json (missing 7)     | Color                                                                               |
+| pl.json (missing 8)     | Drop shadow                                                                         |
+|                         | Color                                                                               |
 |                         | Opacity                                                                             |
 |                         | Text Background                                                                     |
 |                         | Caption Area Background                                                             |
@@ -676,7 +668,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| pt-PT.json (missing 56) | Audio Player                                                                        |
+| pt-PT.json (missing 54) | Audio Player                                                                        |
 |                         | Video Player                                                                        |
 |                         | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
@@ -706,7 +698,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -730,9 +722,8 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Text Background                                                                     |
 |                         | Caption Area Background                                                             |
 |                         | Playing in Picture-in-Picture                                                       |
-|                         | Skip backward {1} seconds                                                           |
-|                         | Skip forward {1} seconds                                                            |
-| ro.json (missing 8)     | No content                                                                          |
+| ro.json (missing 9)     | Drop shadow                                                                         |
+|                         | No content                                                                          |
 |                         | Color                                                                               |
 |                         | Opacity                                                                             |
 |                         | Text Background                                                                     |
@@ -746,8 +737,9 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Text Background                                                                     |
 |                         | Caption Area Background                                                             |
 |                         | Playing in Picture-in-Picture                                                       |
-| sk.json (missing 12)    | Seek to live, currently behind live                                                 |
+| sk.json (missing 13)    | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
+|                         | Drop shadow                                                                         |
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 |                         | No content                                                                          |
@@ -817,7 +809,7 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Raised                                                                              |
 |                         | Depressed                                                                           |
 |                         | Uniform                                                                             |
-|                         | Dropshadow                                                                          |
+|                         | Drop shadow                                                                         |
 |                         | Font Family                                                                         |
 |                         | Proportional Sans-Serif                                                             |
 |                         | Monospace Sans-Serif                                                                |
@@ -876,8 +868,9 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| uk.json (missing 12)    | Seek to live, currently behind live                                                 |
+| uk.json (missing 13)    | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
+|                         | Drop shadow                                                                         |
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
 |                         | No content                                                                          |
@@ -888,8 +881,9 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| vi.json (missing 13)    | Seek to live, currently behind live                                                 |
+| vi.json (missing 14)    | Seek to live, currently behind live                                                 |
 |                         | Seek to live, currently playing live                                                |
+|                         | Drop shadow                                                                         |
 |                         | {1} is loading.                                                                     |
 |                         | Exit Picture-in-Picture                                                             |
 |                         | Picture-in-Picture                                                                  |
@@ -901,7 +895,8 @@ This default value is hardcoded as a default to the localize method in the SeekB
 |                         | Playing in Picture-in-Picture                                                       |
 |                         | Skip backward {1} seconds                                                           |
 |                         | Skip forward {1} seconds                                                            |
-| zh-CN.json (missing 1)  | Playing in Picture-in-Picture                                                       |
+| zh-CN.json (missing 2)  | Drop shadow                                                                         |
+|                         | Playing in Picture-in-Picture                                                       |
 | zh-TW.json (missing 1)  | Playing in Picture-in-Picture                                                       |
 
 <!-- END langtable -->

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -68,7 +68,7 @@
   "Raised": "بارز",
   "Depressed": "منخفض",
   "Uniform": "منتظم",
-  "Dropshadow": "ظل خلفي",
+  "Drop shadow": "ظل خلفي",
   "Font Family": "عائلة الخطوط",
   "Proportional Sans-Serif": "Proportional Sans-Serif",
   "Monospace Sans-Serif": "Monospace Sans-Serif",

--- a/lang/bn.json
+++ b/lang/bn.json
@@ -68,7 +68,7 @@
     "Raised": "বাড়ানো হয়েছে",
     "Depressed": "নামানো হয়েছে",
     "Uniform": "ইউনিফর্ম",
-    "Dropshadow": "ড্রপশ্যাডো",
+    "Drop shadow": "ড্রপশ্যাডো",
     "Font Family": "অক্ষরের পরিবার",
     "Proportional Sans-Serif": "সমানুপাতিক সানস-সেরিফ",
     "Monospace Sans-Serif": "মনোস্পেস সানস-সেরিফ",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -66,7 +66,7 @@
   "Raised": "Zvýšený",
   "Depressed": "Propadlý",
   "Uniform": "Rovnoměrný",
-  "Dropshadow": "Stínovaný",
+  "Drop shadow": "Stínovaný",
   "Font Family": "Rodina písma",
   "Proportional Sans-Serif": "Proporcionální bezpatkové",
   "Monospace Sans-Serif": "Monospace bezpatkové",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -66,7 +66,7 @@
   "Raised":"Uwch",
   "Depressed":"Is",
   "Uniform":"Unffurf",
-  "Dropshadow":"Cysgod cefn",
+  "Drop shadow":"Cysgod cefn",
   "Font Family":"Teulu y Ffont",
   "Proportional Sans-Serif":"Heb-Seriff Cyfraneddol",
   "Monospace Sans-Serif":"Heb-Seriff Unlled",

--- a/lang/de.json
+++ b/lang/de.json
@@ -61,7 +61,7 @@
   "Raised": "Erhoben",
   "Depressed": "Gedrückt",
   "Uniform": "Uniform",
-  "Dropshadow": "Schlagschatten",
+  "Drop shadow": "Schlagschatten",
   "Font Family": "Schriftfamilie",
   "Proportional Sans-Serif": "Proportionale Sans-Serif",
   "Monospace Sans-Serif": "Monospace Sans-Serif",

--- a/lang/en.json
+++ b/lang/en.json
@@ -68,7 +68,7 @@
   "Raised": "Raised",
   "Depressed": "Depressed",
   "Uniform": "Uniform",
-  "Dropshadow": "Dropshadow",
+  "Drop shadow": "Drop shadow",
   "Font Family": "Font Family",
   "Proportional Sans-Serif": "Proportional Sans-Serif",
   "Monospace Sans-Serif": "Monospace Sans-Serif",

--- a/lang/es.json
+++ b/lang/es.json
@@ -68,7 +68,7 @@
   "Raised": "En relieve",
   "Depressed": "Hundido",
   "Uniform": "Uniforme",
-  "Dropshadow": "Sombra paralela",
+  "Drop shadow": "Sombra paralela",
   "Font Family": "Familia de fuente",
   "Proportional Sans-Serif": "Sans-Serif proporcional",
   "Monospace Sans-Serif": "Sans-Serif monoespacio",

--- a/lang/et.json
+++ b/lang/et.json
@@ -68,7 +68,7 @@
   "Raised": "Kõrgem",
   "Depressed": "Madalam",
   "Uniform": "Ühtlane",
-  "Dropshadow": "Langeva varjuga",
+  "Drop shadow": "Langeva varjuga",
   "Font Family": "Fondipere",
   "Proportional Sans-Serif": "Seriifideta proportsionaalkiri",
   "Monospace Sans-Serif": "Seriifideta püsisammkiri",

--- a/lang/eu.json
+++ b/lang/eu.json
@@ -68,7 +68,7 @@
   "Raised": "Jasoa",
   "Depressed": "Hondoratua",
   "Uniform": "Uniformea",
-  "Dropshadow": "Itzalduna",
+  "Drop shadow": "Itzalduna",
   "Font Family": "Letra-tipoa",
   "Proportional Sans-Serif": "Sans-Serif proportzionala",
   "Monospace Sans-Serif": "Tarte berdineko Sans-Serif",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -68,7 +68,7 @@
   "Raised": "برجسته",
   "Depressed": "فرورفته",
   "Uniform": "یکنواخت",
-  "Dropshadow": "سایه‌دار",
+  "Drop shadow": "سایه‌دار",
   "Font Family": "نوع قلم",
   "Proportional Sans-Serif": "Sans-Serif متناسب",
   "Monospace Sans-Serif": "Sans-Serif هم‌عرض",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -68,7 +68,7 @@
   "Raised": "Élevé",
   "Depressed": "Enfoncé",
   "Uniform": "Uniforme",
-  "Dropshadow": "Ombre portée",
+  "Drop shadow": "Ombre portée",
   "Font Family": "Famille de polices",
   "Proportional Sans-Serif": "Polices à chasse variable sans empattement (Proportional Sans-Serif)",
   "Monospace Sans-Serif": "Polices à chasse fixe sans empattement (Monospace Sans-Serif)",

--- a/lang/gd.json
+++ b/lang/gd.json
@@ -68,7 +68,7 @@
   "Raised": "Àrdaichte",
   "Depressed": "Air a bhrùthadh",
   "Uniform": "Cunbhalach",
-  "Dropshadow": "Sgàil",
+  "Drop shadow": "Sgàil",
   "Font Family": "Teaghlach a’ chrutha-chlò",
   "Proportional Sans-Serif": "Sans-serif co-rèireach",
   "Monospace Sans-Serif": "Sans-serif aon-leud",

--- a/lang/gl.json
+++ b/lang/gl.json
@@ -68,7 +68,7 @@
   "Raised": "Érguida",
   "Depressed": "Caída",
   "Uniform": "Uniforme",
-  "Dropshadow": "Sombra caída",
+  "Drop shadow": "Sombra caída",
   "Font Family": "Familia de letras",
   "Proportional Sans-Serif": "Sans-Serif proporcional",
   "Monospace Sans-Serif": "Sans-Serif monoespazo (caixa fixa)",

--- a/lang/he.json
+++ b/lang/he.json
@@ -66,7 +66,7 @@
 	"Raised": "מורם",
 	"Depressed": "מורד",
 	"Uniform": "אחיד",
-	"Dropshadow": "הטלת צל",
+	"Drop shadow": "הטלת צל",
 	"Font Family": "משפחת גופן",
 	"Proportional Sans-Serif": "פרופורציוני וללא תגיות (Proportional Sans-Serif)",
 	"Monospace Sans-Serif": "ברוחב אחיד וללא תגיות (Monospace Sans-Serif)",

--- a/lang/hi.json
+++ b/lang/hi.json
@@ -68,7 +68,7 @@
   "Raised": "उठा हुआ",
   "Depressed": "उदास",
   "Uniform": "वर्दी",
-  "Dropshadow": "परछाई",
+  "Drop shadow": "परछाई",
   "Font Family": "फॉण्ट परिवार",
   "Proportional Sans-Serif": "प्रोपोरशनल साँस-सेरिफ",
   "Monospace Sans-Serif": "मोनोस्पास साँस-सेरिफ",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -61,7 +61,7 @@
   "Text Edge Style": "Szövegél stílus",
   "This is a modal window": "Ez egy felugró ablak",
   "Cyan": "Cián",
-  "Dropshadow": "Árnyék",
+  "Drop shadow": "Árnyék",
   "End of dialog window.": "Párbeszédablak vége.",
   "Progress Bar": "Folyamatjelző sáv",
   "Beginning of dialog window. Escape will cancel and close the window.": "Párbeszédablak eleje. Az Escape gomb befejezi és bezárja az ablakot.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -64,7 +64,7 @@
   "Text Edge Style": "Stile dei bordi del testo",
   "None": "Nessuno",
   "Uniform": "Uniforme",
-  "Dropshadow": "Ombreggiatura",
+  "Drop shadow": "Ombreggiatura",
   "Font Family": "Famiglia di caratteri",
   "Proportional Sans-Serif": "Sans-Serif proporzionale",
   "Monospace Sans-Serif": "Sans-Serif monospazio",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -68,7 +68,7 @@
   "Raised": "浮き出し",
   "Depressed": "浮き彫り",
   "Uniform": "均一",
-  "Dropshadow": "影付き",
+  "Drop shadow": "影付き",
   "Font Family": "フォントの種類",
   "Proportional Sans-Serif": "セリフなし可変幅フォント",
   "Monospace Sans-Serif": "セリフなし等幅フォント",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -68,7 +68,7 @@
   "Raised": "글자 위치 올림",
   "Depressed": "글자 위치 내림",
   "Uniform": "균일",
-  "Dropshadow": "그림자 효과 넣기",
+  "Drop shadow": "그림자 효과 넣기",
   "Font Family": "폰트 모음",
   "Proportional Sans-Serif": "비례 산세리프체",
   "Monospace Sans-Serif": "고정폭 산세리프체",

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -68,7 +68,7 @@
   "Raised": "Izvirzīts",
   "Depressed": "Samazināts",
   "Uniform": "Vienmērīgs",
-  "Dropshadow": "Ēnots",
+  "Drop shadow": "Ēnots",
   "Font Family": "Šrifts",
   "Proportional Sans-Serif": "Proportional Sans-Serif",
   "Monospace Sans-Serif": "Monospace Sans-Serif",

--- a/lang/nb.json
+++ b/lang/nb.json
@@ -68,7 +68,7 @@
   "Raised": "Uthevet",
   "Depressed": "Nedtrykt",
   "Uniform": "Enkel",
-  "Dropshadow": "Skygge",
+  "Drop shadow": "Skygge",
   "Font Family": "Skrifttype",
   "Proportional Sans-Serif": "Proporsjonal skrift uten seriffer",
   "Monospace Sans-Serif": "Fastbreddeskrift uten seriffer",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -68,7 +68,7 @@
   "Raised": "Verhoogd",
   "Depressed": "Ingedrukt",
   "Uniform": "Uniform",
-  "Dropshadow": "Schaduw",
+  "Drop shadow": "Schaduw",
   "Font Family": "Lettertype",
   "Proportional Sans-Serif": "Proportioneel sans-serif",
   "Monospace Sans-Serif": "Monospace sans-serif",

--- a/lang/nn.json
+++ b/lang/nn.json
@@ -68,7 +68,7 @@
   "Raised": "Utheva",
   "Depressed": "Nedtrykt",
   "Uniform": "Enkel",
-  "Dropshadow": "Skugge",
+  "Drop shadow": "Skugge",
   "Font Family": "Skrifttype",
   "Proportional Sans-Serif": "Proporsjonal skrift utan seriffar",
   "Monospace Sans-Serif": "Fastbreddeskrift utan seriffar",

--- a/lang/oc.json
+++ b/lang/oc.json
@@ -68,7 +68,7 @@
   "Raised": "Naut",
   "Depressed": "Enfonsat",
   "Uniform": "Unifòrme",
-  "Dropshadow": "Ombrat",
+  "Drop shadow": "Ombrat",
   "Font Family": "Familha de polissa",
   "Proportional Sans-Serif": "Sans-Serif proporcionala",
   "Monospace Sans-Serif": "Monospace Sans-Serif",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -67,7 +67,7 @@
   "Raised": "Elevado",
   "Depressed": "Acachapado",
   "Uniform": "Uniforme",
-  "Dropshadow": "Sombra de projeção",
+  "Drop shadow": "Sombra de projeção",
   "Font Family": "Família da Fonte",
   "Proportional Sans-Serif": "Sans-Serif(Sem serifa) Proporcional",
   "Monospace Sans-Serif": "Sans-Serif(Sem serifa) Monoespaçada",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -68,7 +68,7 @@
   "Raised": "Поднятый",
   "Depressed": "Пониженный",
   "Uniform": "Одинаковый",
-  "Dropshadow": "Тень",
+  "Drop shadow": "Тень",
   "Font Family": "Шрифт",
   "Proportional Sans-Serif": "Пропорциональный без засечек",
   "Monospace Sans-Serif": "Моноширинный без засечек",

--- a/lang/sl.json
+++ b/lang/sl.json
@@ -68,7 +68,7 @@
   "Raised": "Dvignjeno",
   "Depressed": "Vtisnjeno",
   "Uniform": "Enakomerno",
-  "Dropshadow": "S senco",
+  "Drop shadow": "S senco",
   "Font Family": "Družina pisave",
   "Small Caps": "Male črke",
   "Reset": "Ponastavi",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -21,7 +21,7 @@
   "Depressed": "Deprimerad",
   "Descriptions": "Beskrivningar",
   "Done": "Klar",
-  "Dropshadow": "DropSkugga",
+  "Drop shadow": "DropSkugga",
   "Duration": "Total tid",
   "End of dialog window.": "Slutet av dialogfönster.",
   "Font Family": "Typsnittsfamilj",

--- a/lang/te.json
+++ b/lang/te.json
@@ -68,7 +68,7 @@
   "Raised": "పెంచబడింది",
   "Depressed": "అణగారిన",
   "Uniform": "ఏకరీతి",
-  "Dropshadow": "డ్రాప్‌షాడో",
+  "Drop shadow": "డ్రాప్‌షాడో",
   "Font Family": "ఫాంట్ కుటుంబం",
   "Proportional Sans-Serif": "ప్రొపోర్షన్ సాన్స్-సెరిఫ్",
   "Monospace Sans-Serif": "మోనోస్పేస్ సాన్స్-సెరిఫ్",

--- a/lang/th.json
+++ b/lang/th.json
@@ -68,7 +68,7 @@
   "Raised": "ยกขึ้น",
   "Depressed": "ปล่อยออก",
   "Uniform": "รูปแบบ",
-  "Dropshadow": "เพิ่มเงา",
+  "Drop shadow": "เพิ่มเงา",
   "Font Family": "ตระกูลแบบอักษร",
   "Proportional Sans-Serif": "Sans-Serif ตามสัดส่วน",
   "Monospace Sans-Serif": "Sans-Serif ช่องว่างเดี่ยว",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -68,7 +68,7 @@
   "Raised": "Kabarık",
   "Depressed": "Yassı",
   "Uniform": "Düz",
-  "Dropshadow": "Gölgeli",
+  "Drop shadow": "Gölgeli",
   "Font Family": "Yazı Tipi",
   "Proportional Sans-Serif": "Orantılı Sans-Serif",
   "Monospace Sans-Serif": "Eşaralıklı Sans-Serif",

--- a/lang/zh-TW.json
+++ b/lang/zh-TW.json
@@ -67,7 +67,7 @@
   "Raised": "浮雕",
   "Depressed": "壓低",
   "Uniform": "均勻",
-  "Dropshadow": "下陰影",
+  "Drop shadow": "下陰影",
   "Font Family": "字型系列",
   "Proportional Sans-Serif": "調和間距無襯線字型",
   "Monospace Sans-Serif": "等寬無襯線字型",

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -87,7 +87,7 @@ const selectConfigs = {
       ['raised', 'Raised'],
       ['depressed', 'Depressed'],
       ['uniform', 'Uniform'],
-      ['dropshadow', 'Dropshadow']
+      ['dropshadow', 'Drop shadow']
     ]
   },
 


### PR DESCRIPTION
## Description
In caption settings, under 'Text Edge Style', the 'Dropshadow' option should be spelled 'Drop shadow'

## Specific Changes proposed
Changed 'Dropshadow' in caption settings to 'Drop shadow', and updated all language files.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
