### PR TITLE
fix(error): chromium reset mediaError when the poster is invalid

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2160,7 +2160,9 @@ class Player extends Component {
   handleTechError_() {
     const error = this.tech_.error();
 
-    this.error(error);
+    if (error) {
+      this.error(error);
+    }
   }
 
   /**

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3383,3 +3383,37 @@ QUnit.test('crossOrigin value should be maintained after loadMedia is called', f
   playerExample2.dispose();
   playerExample3.dispose();
 });
+
+QUnit.test('should not reset the error when the tech triggers an error that is null', function(assert) {
+  sinon.stub(log, 'error');
+
+  const player = TestHelpers.makePlayer();
+
+  player.src({
+    src: 'http://example.com/movie.unsupported-format',
+    type: 'video/unsupported-format'
+  });
+
+  this.clock.tick(60);
+
+  // Simulates Chromium's behavior when the poster is invalid
+
+  // is only there for context, but does nothing
+  player.poster('invalid');
+
+  const spyError = sinon.spy(player, 'error');
+  // Chromium behavior produced by the video element
+  const errorStub = sinon.stub(player.tech(true), 'error').callsFake(() => null);
+
+  player.tech(true).trigger('error');
+  // End
+
+  assert.ok(player.hasClass('vjs-error'), 'player has vjs-error class');
+  assert.ok(spyError.notCalled, 'error was not called');
+  assert.ok(player.error(), 'error is retained');
+
+  player.dispose();
+  spyError.restore();
+  errorStub.restore();
+  log.error.restore();
+});


### PR DESCRIPTION
## Description

Fixes #8409, when both the media URL and the poster return a response other than 200. The media error is overwritten by an empty error, leaving the player in an inconsistent state.

[Screencast from 20. 08. 23 18:35:52.webm](https://github.com/videojs/video.js/assets/34163393/f69976f6-0509-4c3a-854a-185c37386f23)

## Specific Changes proposed

- add a condition to `handleTechError_` to ensure that the `error` is truthy
- add a test case

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
