### PR TITLE
fix(control-bar): incorrect display when control bar display is locked

### DIFF
--- a/src/css/components/_control-bar.scss
+++ b/src/css/components/_control-bar.scss
@@ -10,6 +10,14 @@
   @include background-color-with-alpha($primary-background-color, $primary-background-transparency);
 }
 
+// Locks the display only if:
+//  - controls are not disabled
+//  - native controls are not used
+//  - there is no error
+.video-js:not(.vjs-controls-disabled, .vjs-using-native-controls, .vjs-error) .vjs-control-bar.vjs-lock-showing {
+  display: flex !important;
+}
+
 // Video has started playing or we are in audioOnlyMode
 .vjs-has-started .vjs-control-bar,
 .vjs-audio-only-mode .vjs-control-bar {


### PR DESCRIPTION
## Description

The control bar is not displayed correctly when the display is locked because `.vjs-lock-showing` uses `display` `block` instead of `flex`.

![Screenshot from 2023-09-10 16-03-40](https://github.com/videojs/video.js/assets/34163393/d43e4c52-ee5a-48ef-99cf-d2c279bce178)

## Specific Changes proposed

- use `display` `flex` instead of `display` `block` when the control bar has `.vjs-lock-showing` class
- ensure that the control bar is not displayed if the `player` has classes:
  - `.vjs-controls-disabled`
  - `.vjs-using-native-controls`
  - `.vjs-error`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
