### PR TITLE
fix: Resolves captions sizing issue when minified

### DIFF
--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -391,7 +391,7 @@ class TextTrack extends Track {
   addCue(originalCue) {
     let cue = originalCue;
 
-    if (cue.constructor && cue.constructor.name !== 'VTTCue') {
+    if (cue.constructor && cue.constructor !== window.vttjs.VTTCue) {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -391,7 +391,8 @@ class TextTrack extends Track {
   addCue(originalCue) {
     let cue = originalCue;
 
-    if (cue.constructor && cue.constructor !== window.vttjs.VTTCue) {
+    // Testing if the cue is a VTTCue in a way that survives minification
+    if (!('getCueAsHTML' in cue)) {
       cue = new window.vttjs.VTTCue(originalCue.startTime, originalCue.endTime, originalCue.text);
 
       for (const prop in originalCue) {


### PR DESCRIPTION
## Description
Fixes issue with sizing captions in #8425.

## Specific Changes proposed
Changes test to check for presence of `getCueAsHTML` instead of the constructor name, as the constructor name is changed when minified.
Open to suggested for a test for this, since the issue only manifested when minified. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
- [ ] Reviewed by Two Core Contributors
