### PR TITLE
fix(types): use typeof for registerComponent and registerPlugin

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -582,7 +582,6 @@ class Component {
   /**
    * Add a child `Component` inside the current `Component`.
    *
-   *
    * @param {string|Component} child
    *        The name or instance of a child to add.
    *
@@ -593,7 +592,8 @@ class Component {
    * @param {number} [index=this.children_.length]
    *        The index to attempt to add a child into.
    *
-   * @return {typeof Component}
+   *
+   * @return {Component}
    *         The `Component` that gets added as a child. When using a string the
    *         `Component` will get created by this process.
    */

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -593,7 +593,7 @@ class Component {
    * @param {number} [index=this.children_.length]
    *        The index to attempt to add a child into.
    *
-   * @return {Component}
+   * @return {typeof Component}
    *         The `Component` that gets added as a child. When using a string the
    *         `Component` will get created by this process.
    */

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -286,8 +286,8 @@ const DEFAULT_BREAKPOINTS = {
  *
  * After an instance has been created it can be accessed globally in three ways:
  * 1. By calling `videojs.getPlayer('example_video_1');`
- * 2. By calling `videojs('example_video_1');` (not recomended)
- * 2. By using it directly via  `videojs.players.example_video_1;`
+ * 2. By calling `videojs('example_video_1');` (not recommended)
+ * 2. By using it directly via `videojs.players.example_video_1;`
  *
  * @extends Component
  * @global

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -320,10 +320,10 @@ videojs.getComponent = Component.getComponent;
  * @param {string} name
  *        The class name of the component
  *
- * @param {Component} comp
+ * @param {typeof Component} comp
  *        The component class
  *
- * @return {Component}
+ * @return {typeof Component}
  *         The newly registered component
  */
 videojs.registerComponent = (name, comp) => {
@@ -410,9 +410,11 @@ videojs.deregisterPlugin = Plugin.deregisterPlugin;
  *
  * @param {string} name
  *        The plugin name
- *
- * @param {Plugin|Function} plugin
+*
+ * @param {typeof Plugin|Function} plugin
  *         The plugin sub-class or function
+ *
+ * @return {typeof Plugin|Function}
  */
 videojs.plugin = (name, plugin) => {
   log.warn('videojs.plugin() is deprecated; use videojs.registerPlugin() instead');


### PR DESCRIPTION
## Description
These accept and return the component/plugin class rather than an instance of the class. Currently, typescript will throw  `TS2345: Argument of type 'typeof MyComponent' is not assignable to parameter of type 'Component'.` when registering a component.

## Specific Changes proposed
jsdoc updates

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
