### PR TITLE
fix(types): Minor fix for types

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -160,7 +160,7 @@ class Component {
    * @param {string|string[]} type
    *        An event name or an array of event names.
    *
-   * @param {Function} fn
+   * @param {Function} [fn]
    *        The function to remove.
    */
   off(type, fn) {}
@@ -1843,7 +1843,7 @@ class Component {
    * @param {string} name
    *        The Name of the component to get.
    *
-   * @return {Component}
+   * @return {typeof Component}
    *         The `Component` that got registered under the given name.
    */
   static getComponent(name) {

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -161,7 +161,7 @@ class Component {
    *        An event name or an array of event names.
    *
    * @param {Function} [fn]
-   *        The function to remove.
+   *        The function to remove. If not specified, all listeners managed by Video.js will be removed.
    */
   off(type, fn) {}
 


### PR DESCRIPTION
## Description
Hello! We're using videojs but since the upgrade to v8, we've ran into some typing issues that we had to patch with @ts-ignore and such.
This PR fixes the issues we had with the .off() function always requiring a second param for function and the issues we have with the videojs.getComponent('Component') not returning the right type.
I'm not sure how to build from the jsdoc into the .d.ts files to check that the generated types are correct but I think these changes might work.
I'd also like to help fixing the missing ".remoteTextTracks()" function on the Player type and the missing export for video player options but I don't know how. If you give me some pointers, I'd be glad to help with this

## Specific Changes proposed
- remove the fn argument as required on the off function
- change the returned type of the getComponent function

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
