### PR TITLE
fix: adds workaround for non-spec-compliant userAgentData

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -154,7 +154,7 @@ export const TOUCH_ENABLED = Boolean(Dom.isReal() && (
 
 const UAD = window.navigator && window.navigator.userAgentData;
 
-if (UAD) {
+if (UAD && UAD.platform && UAD.brands) {
   // If userAgentData is present, use it instead of userAgent to avoid warnings
   // Currently only implemented on Chromium
   // userAgentData does not expose Android version, so ANDROID_VERSION remains `null`


### PR DESCRIPTION
## Description
On some Android phones, 'window. navigator. userAgentData' may be '{}', resulting in IS_ANDROID=UAD. platform==='Android' being false
<img width="975" alt="image" src="https://github.com/videojs/video.js/assets/13829341/57ee7b67-7134-4844-a1e4-b30d0dc08805">

## Specific Changes proposed
<img width="982" alt="image" src="https://github.com/videojs/video.js/assets/13829341/4519f01b-7a1b-4cd6-97b8-42e33bac8ec3">


## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
