### PR TITLE
fix(title-bar): component remains displayed after player reset

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3607,6 +3607,13 @@ class Player extends Component {
 
     this.error(null);
 
+    if (this.titleBar) {
+      this.titleBar.update({
+        title: undefined,
+        description: undefined
+      });
+    }
+
     if (isEvented(this)) {
       this.trigger('playerreset');
     }

--- a/test/unit/reset-ui.test.js
+++ b/test/unit/reset-ui.test.js
@@ -160,3 +160,24 @@ QUnit.test('Calling reset player method should reset both error display and play
 
   player.dispose();
 });
+
+QUnit.test('Calling reset player method should reset title bar', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  player.titleBar.update({
+    title: 'Title',
+    description: 'Description'
+  });
+
+  assert.notOk(player.titleBar.hasClass('vjs-hidden'), 'TitleBar is visible if not empty');
+  assert.strictEqual(player.titleBar.els.title.textContent, 'Title', 'TitleBar title element has content');
+  assert.strictEqual(player.titleBar.els.description.textContent, 'Description', 'TitleBar description element has content');
+
+  player.reset();
+
+  assert.ok(player.titleBar.hasClass('vjs-hidden'), 'TitleBar is not visible if empty');
+  assert.strictEqual(player.titleBar.els.title.textContent, '', 'TitleBar title element has no content');
+  assert.strictEqual(player.titleBar.els.description.textContent, '', 'TitleBar description element has no content');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description

When `player.reset` is called the `titleBar` component is not reset.

[Screencast from 04. 11. 23 17:03:48.webm](https://github.com/videojs/video.js/assets/34163393/e78d6088-ef4f-41f1-8ec9-36ed7ffa9725)


## Specific Changes proposed
- Sets the properties `title` and `description` to `undefined` when `player.titleBar.update` is called so that the component is properly reset.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
