### PR TITLE
fix(error-display): component remains displayed after player reset

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3604,6 +3604,9 @@ class Player extends Component {
     this.loadTech_(this.options_.techOrder[0], null);
     this.techCall_('reset');
     this.resetControlBarUI_();
+
+    this.error(null);
+
     if (isEvented(this)) {
       this.trigger('playerreset');
     }

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1910,6 +1910,7 @@ QUnit.test('player#reset loads the Html5 tech and then techCalls reset', functio
     options_: {
       techOrder: ['html5', 'youtube']
     },
+    error() {},
     resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;
@@ -1942,6 +1943,7 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
     options_: {
       techOrder: ['youtube', 'html5']
     },
+    error() {},
     resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;

--- a/test/unit/reset-ui.test.js
+++ b/test/unit/reset-ui.test.js
@@ -144,3 +144,19 @@ QUnit.test('Calling resetVolumeBar player method should reset volume bar', funct
 
   player.dispose();
 });
+
+QUnit.test('Calling reset player method should reset both error display and player error', function(assert) {
+  const player = TestHelpers.makePlayer({techOrder: ['html5']});
+
+  player.error('ERROR');
+
+  assert.notOk(player.errorDisplay.hasClass('vjs-hidden'), 'ErrorDisplay is displayed if there is an error');
+  assert.strictEqual(player.error().message, 'ERROR', 'player error has content');
+
+  player.reset();
+
+  assert.ok(player.errorDisplay.hasClass('vjs-hidden'), 'ErrorDisplay is not displayed if there is no error');
+  assert.strictEqual(player.error(), null, 'player error has content');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description

When `player.reset` is called, the `errorDisplay` component is not reset, and neither is `player.error`.

[Screencast from 04. 11. 23 17:08:14.webm](https://github.com/videojs/video.js/assets/34163393/1b6f22d8-d3f3-4167-aa72-790265e24d96)


## Specific Changes proposed

- Sets `player.error` to `null`, so that the `player.errorDisplay` and `player.error` are correctly reset.
- Adds an `error` function to the `testPlayer` stub to prevent tests from failing.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
