### PR TITLE
fix(big-play-button): component remains displayed after an error

### DIFF
--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -57,6 +57,6 @@
 }
 
 // Show big play button if video is paused and .vjs-show-big-play-button-on-pause is set on video element
-.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing) .vjs-big-play-button {
+.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing, .vjs-error) .vjs-big-play-button {
   display: block;
 }


### PR DESCRIPTION
## Description

This issue occurs when the `player` has the class `vjs-show-big-play-button-on-pause` and playback has started and then been set to `pause` and an `error` occurs.

[Screencast from 04. 11. 23 18:16:08.webm](https://github.com/videojs/video.js/assets/34163393/6b432f59-4fe6-45aa-a0ef-fc62947be087)

## Specific Changes proposed

- Avoids displaying `big-play-button` on error

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
