### PR TITLE
fix(big-play-button): component remains displayed when seeking

### DIFF
--- a/src/css/components/_big-play.scss
+++ b/src/css/components/_big-play.scss
@@ -57,6 +57,6 @@
 }
 
 // Show big play button if video is paused and .vjs-show-big-play-button-on-pause is set on video element
-.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause .vjs-big-play-button {
+.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing) .vjs-big-play-button {
   display: block;
 }


### PR DESCRIPTION
## Description

This issue happen when the `player` has the class `vjs-show-big-play-button-on-pause` and a `seek` occurs, resulting in the `loadingSpinner` being hidden behind the `bigPlayButton`.

[Screencast from 04. 11. 23 18:56:50.webm](https://github.com/videojs/video.js/assets/34163393/fabc6f3d-a3f5-4409-81dd-8ec12b230ff0)


## Specific Changes proposed

- Avoids displaying `bigPlayButton` while `seeking`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
