### PR TITLE
fix(error-display): update display on consecutive errors

### DIFF
--- a/src/js/error-display.js
+++ b/src/js/error-display.js
@@ -23,7 +23,10 @@ class ErrorDisplay extends ModalDialog {
    */
   constructor(player, options) {
     super(player, options);
-    this.on(player, 'error', (e) => this.open(e));
+    this.on(player, 'error', (e) => {
+      this.close();
+      this.open(e);
+    });
   }
 
   /**

--- a/test/unit/error-display.test.js
+++ b/test/unit/error-display.test.js
@@ -1,0 +1,63 @@
+/* eslint-env qunit */
+import TestHelpers from './test-helpers.js';
+
+QUnit.module('ErrorDisplay');
+
+QUnit.test('should update errorDisplay when several errors occur in succession', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+  const events = {
+    beforemodalopen: 0,
+    beforemodalclose: 0,
+    modalopen: 0,
+    modalclose: 0
+  };
+
+  player.errorDisplay.on(
+    ['beforemodalopen', 'beforemodalclose', 'modalopen', 'modalclose'],
+    ({ type }) => {
+      events[type] += 1;
+    }
+  );
+
+  // Dummy case for initial state
+  assert.strictEqual(player.error(), null, 'error is null');
+  assert.strictEqual(
+    player.errorDisplay.contentEl().textContent,
+    '',
+    'error display contentEl textContent is empty'
+  );
+  assert.strictEqual(events.beforemodalopen, 0, 'beforemodalopen was not called');
+  assert.strictEqual(events.modalopen, 0, 'modalopen was not called');
+  assert.strictEqual(events.beforemodalclose, 0, 'beforemodalclose was not called');
+  assert.strictEqual(events.modalclose, 0, 'modalclose was not called');
+
+  // Case for first error
+  player.error('Error 1');
+
+  assert.strictEqual(player.error().message, 'Error 1', 'error has message');
+  assert.strictEqual(
+    player.errorDisplay.contentEl().textContent,
+    'Error 1',
+    'error display contentEl textContent has content'
+  );
+  assert.strictEqual(events.beforemodalopen, 1, 'beforemodalopen was called once');
+  assert.strictEqual(events.modalopen, 1, 'modalopen was called once');
+  assert.strictEqual(events.beforemodalclose, 0, 'beforemodalclose was not called');
+  assert.strictEqual(events.modalclose, 0, 'modalclose was not called');
+
+  // Case for second error
+  player.error('Error 2');
+
+  assert.strictEqual(player.error().message, 'Error 2', 'error has new message');
+  assert.strictEqual(
+    player.errorDisplay.contentEl().textContent,
+    'Error 2',
+    'error display contentEl textContent has been updated with the new error message'
+  );
+  assert.strictEqual(events.beforemodalopen, 2, 'beforemodalopen has been called for the second time');
+  assert.strictEqual(events.modalopen, 2, 'modalopen has been called for the second time');
+  assert.strictEqual(events.beforemodalclose, 1, 'beforemodalclose was called once');
+  assert.strictEqual(events.modalclose, 1, 'modalclose was called once');
+
+  player.dispose();
+});


### PR DESCRIPTION
## Description

When consecutive errors occur, the `ErrorDisplay` component is not updated with the new error message. This results in an inconsistent state between the `player.error` and `player.errorDisplay.contentEl().textContent`.

|                         | player.error() | player.errorDisplay.content() | player.errorDisplay.contentEl().textContent |
| ----------------------- | -------------- | ----------------------------- | ------------------------------------------- |
| player.error('Error 1') | Error 1 ✔️      | Error 1 ✔️                     | Error 1 ✔️                                   |
| player.error('Error 2') | Error 2 ✔️      | Error 2 ✔️                     | Error 1 ❌                                  |

An example of a use case where updating the error message is useful is :
- user tries to play media 1 but the media doestn't exist
- user tries to play media 2 but the media is not compatible

[Screencast from 05. 11. 23 17:18:53.webm](https://github.com/videojs/video.js/assets/34163393/ad35670a-94a9-42b1-9b8a-dbfd9379ed06)


## Specific Changes proposed

- call the `close` function before each call to the `open` function.
  - if errorDisplay is not **open**, the `close` function does nothing
  - if errorDisplay is **open**, the `close` function executes and triggers the close events, then the open function executes and triggers the open events, ensuring that the content is updated.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
