### PR TITLE
fix(types): Adds track and track list types to typescript exports

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -5163,51 +5163,56 @@ class Player extends Component {
  *
  * @link https://html.spec.whatwg.org/multipage/embedded-content.html#videotracklist
  *
- * @return {VideoTrackList}
+ * @returns {import("./tracks/video-track-list").VideoTrackList}
  *         the current video track list
  *
  * @method Player.prototype.videoTracks
  */
+Player.prototype.videoTracks = () => {};
 
 /**
  * Get the {@link AudioTrackList}
  *
  * @link https://html.spec.whatwg.org/multipage/embedded-content.html#audiotracklist
  *
- * @return {AudioTrackList}
+ * @return {import("./tracks/audio-track-list").AudioTrackList}
  *         the current audio track list
  *
  * @method Player.prototype.audioTracks
  */
+Player.prototype.audioTracks = () => {};
 
 /**
  * Get the {@link TextTrackList}
  *
  * @link http://www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#dom-media-texttracks
  *
- * @return {TextTrackList}
+ * @return {import("./tracks/text-track-list").TextTrackList}
  *         the current text track list
  *
  * @method Player.prototype.textTracks
  */
+Player.prototype.textTracks = () => {};
 
 /**
  * Get the remote {@link TextTrackList}
  *
- * @return {TextTrackList}
+ * @return {import("./tracks/text-track-list").TextTrackList}
  *         The current remote text track list
  *
  * @method Player.prototype.remoteTextTracks
  */
+Player.prototype.remoteTextTracks = () => {};
 
 /**
  * Get the remote {@link HtmlTrackElementList} tracks.
  *
- * @return {HtmlTrackElementList}
+ * @return {import("./tracks/html-track-element-list").HtmlTrackElementList}
  *         The current remote text track element list
  *
  * @method Player.prototype.remoteTextTrackEls
  */
+Player.prototype.remoteTextTrackEls = () => {};
 
 TRACK_TYPES.names.forEach(function(name) {
   const props = TRACK_TYPES[name];

--- a/src/js/tracks/audio-track-list.js
+++ b/src/js/tracks/audio-track-list.js
@@ -31,7 +31,7 @@ const disableOthers = function(list, track) {
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#audiotracklist}
  * @extends TrackList
  */
-class AudioTrackList extends TrackList {
+export class AudioTrackList extends TrackList {
 
   /**
    * Create an instance of this class.

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -5,7 +5,7 @@
 /**
  * The current list of {@link HtmlTrackElement}s.
  */
-class HtmlTrackElementList {
+export class HtmlTrackElementList {
 
   /**
    * Create an instance of this class.

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -9,7 +9,7 @@ import TrackList from './track-list';
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#texttracklist}
  * @extends TrackList
  */
-class TextTrackList extends TrackList {
+export class TextTrackList extends TrackList {
 
   /**
    * Add a {@link TextTrack} to the `TextTrackList`

--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -10,7 +10,7 @@ import {isEvented} from '../mixins/evented';
  *
  * @extends EventTarget
  */
-class TrackList extends EventTarget {
+export class TrackList extends EventTarget {
   /**
    * Create an instance of this class
    *

--- a/src/js/tracks/video-track-list.js
+++ b/src/js/tracks/video-track-list.js
@@ -30,7 +30,7 @@ const disableOthers = function(list, track) {
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#videotracklist}
  * @extends TrackList
  */
-class VideoTrackList extends TrackList {
+export class VideoTrackList extends TrackList {
 
   /**
    * Create an instance of this class.

--- a/src/js/video.js
+++ b/src/js/video.js
@@ -24,9 +24,13 @@ import Plugin from './plugin';
 import * as Fn from './utils/fn.js';
 import * as Num from './utils/num.js';
 import * as Str from './utils/str.js';
+import TrackList from './tracks/track-list.js';
 import TextTrack from './tracks/text-track.js';
+import TextTrackList from './tracks/text-track-list.js';
 import AudioTrack from './tracks/audio-track.js';
+import AudioTrackList from './tracks/audio-track-list.js';
 import VideoTrack from './tracks/video-track.js';
+import VideoTrackList from './tracks/video-track-list.js';
 import { deprecateForMajor } from './utils/deprecate';
 import * as Time from './utils/time.js';
 import log, { createLogger } from './utils/log.js';
@@ -551,9 +555,13 @@ videojs.trigger = Events.trigger;
  */
 videojs.xhr = xhr;
 
+videojs.TrackList = TrackList;
 videojs.TextTrack = TextTrack;
+videojs.TextTrackList = TextTrackList;
 videojs.AudioTrack = AudioTrack;
+videojs.AudioTrackList = AudioTrackList;
 videojs.VideoTrack = VideoTrack;
+videojs.VideoTrackList = VideoTrackList;
 
 [
   'isEl',


### PR DESCRIPTION
## Description

We love Video.js where I work and are currently using TypeScript. There are several areas where the TypeScript support for Video.js is lacking, even to the point of some of the guides on the website not being able to be compiled by TypeScript).

Currently, the guides around Tracks and Track list (like Audio Tracks for example: https://videojs.com/guides/audio-tracks/#listen-for-an-audio-track-becoming-enabled) can't be used out of the box with video.js and TypeScript. This PR doesn't fully address the issue of not being able to use the code verbatim, but it exposes the main types that will better unblock TypeScript developers on using these scenarios.

I kept the changes small to try to keep any conversation focused before moving on to other missing issues. This has come up in other issues: https://github.com/videojs/video.js/pull/8466.

Many of the issues I see are around either: types that weren't exported from the package (and hence, can't be referenced/used from TypeScript code), or from JSDoc comments that aren't attached to any specific variable or type (and hence, it's picked up by the TypeScript compiler when generating outgoing types).

Usable (and shown in code completion) by TypeScript in VSCode.

JSDocs on website still show correct types (some changes that TypeScript wanted resulted in a changing of the types displayed in the JSDoc website, so I explicitly did NOT do any of those changes in this PR without any further discussion).

<img width="937" alt="Screen Shot 2023-11-01 at 2 44 59 PM" 
src="https://github.com/videojs/video.js/assets/69651/1bb132bd-c295-43b7-9519-00c1f138f9bc">

The change exposes the types just like Player and others that were already exposed in video.js. This allows the specific list types to be referenced and used like this in TypeScript:

```
const trackList: videojs.VideoTrackList = myPlayer.videoTracks();
```

This would have failed before as the Player type didn't export `audioTracks`/`textTracks`/`videoTracks`, and video.js also didn't expose the matching `*List` types either which made proper isolated testing in TypeScript much more difficult without jumping through hoops and creating our own types definitions.

Hopefully these will be fairly non-controversial.

## Specific Changes proposed

This first proposed change is based on a quick fix mentioned in the thread above: https://github.com/videojs/video.js/pull/8466.

The change resolves around these specific elements:

**Add placeholder prototypes before the `videoTracks`/`audioTracks`/`textTracks` are added to the prototype**

TypeScript compiler doesn't appear to pull JSDoc comments unless they are attached to something in the abstract syntax tree instead of floating in space.

**Export specific track types from their files and reference those types via `import` of JSDoc**
This is so TypeScript pulls them in when generating types. Leaving it just `AudioTrackList` like before resulted in the TypeScript compiler just generating the `audioTracks`/`videoTracks`/etc. properties as returning `any` from their methods.

There's a different way this can be done by importing the types, but it appears to then export them as well from the player.js file. That felt like a side-effect that wouldn't be appreciated, so I tried this less invasive way to keep the JavaScript interface as identical as possible from before.

I also ensured the above change doesn't break existing JSDoc documentation published to the website by generating the docs and exploring them locally.

**Export those newly exported types via src/js/video.js so they are exported and usable from TypeScript**

## Other Notes

There are some other changes needed around the TrackList to let it work out of the box from TypeScript (as there are issues around it not being documented as ArrayLike for looping over returned tracks). Those changes were starting to be a bit more invasive though, so I saved those for later and focused on just exposing these core types.

Obviously, feedback is most welcome :).

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
