### PR TITLE
fix(player): reset CSS classes at player.reset

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3599,6 +3599,10 @@ class Player extends Component {
     if (this.tech_) {
       this.tech_.clearTracks('text');
     }
+
+    this.removeClass('vjs-playing');
+    this.addClass('vjs-paused');
+
     this.resetCache_();
     this.poster('');
     this.loadTech_(this.options_.techOrder[0], null);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1911,6 +1911,8 @@ QUnit.test('player#reset loads the Html5 tech and then techCalls reset', functio
       techOrder: ['html5', 'youtube']
     },
     error() {},
+    addClass() {},
+    removeClass() {},
     resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;
@@ -1944,6 +1946,8 @@ QUnit.test('player#reset loads the first item in the techOrder and then techCall
       techOrder: ['youtube', 'html5']
     },
     error() {},
+    addClass() {},
+    removeClass() {},
     resetCache_() {},
     loadTech_(tech, source) {
       loadedTech = tech;


### PR DESCRIPTION
## Description

Allows CSS classes to be reset when `player.reset` is called, so that the player is close to its initial state.

## Specific Changes proposed

- remove `vjs-playing`
- add `vjs-paused`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
