### PR TITLE
feat: update VHS to v3.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,20 +1765,31 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.8.0.tgz",
-      "integrity": "sha512-sZ5xM6XQdAPSxXKm767J28OLCJKY5mMxu7LVAqlyEJommECylm5D/RtzqAyIWM6u4V85qsJR4Zn9k6yzAhEDOw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.9.0.tgz",
+      "integrity": "sha512-uOno4W6mdmoVXeD/2Jr+bmWxs6RdwWkhYXDE/2tibLyeXc5X9j+g3TRlM05OlJtt2jd/Y9OXgU1wptNxmFLGsw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
         "aes-decrypter": "4.0.1",
         "global": "^4.4.0",
         "m3u8-parser": "^7.1.0",
-        "mpd-parser": "^1.2.2",
+        "mpd-parser": "^1.3.0",
         "mux.js": "7.0.2",
         "video.js": "^7 || ^8"
       },
       "dependencies": {
+        "mpd-parser": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
+          "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@videojs/vhs-utils": "^4.0.0",
+            "@xmldom/xmldom": "^0.8.3",
+            "global": "^4.4.0"
+          }
+        },
         "mux.js": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
@@ -3252,7 +3263,7 @@
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "dev": true,
       "requires": {
         "traverse": ">=0.3.0 <0.4"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "3.8.0",
+    "@videojs/http-streaming": "3.9.0",
     "@videojs/vhs-utils": "^4.0.0",
     "@videojs/xhr": "2.6.0",
     "aes-decrypter": "^4.0.1",


### PR DESCRIPTION
## Description
Update videojs/http-streaming to v3.9.0 https://github.com/videojs/http-streaming/releases/tag/v3.9.0
This includes a feature in VHS that enhances correlation between `usable` keys returned from the CDM and keyIds in the manifest.

## Specific Changes proposed
Update package.json

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
