### PR TITLE
fix: time tooltip truncated

### DIFF
--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -66,7 +66,8 @@ class TimeTooltip extends Component {
     // of the player. We calculate any gap between the left edge of the player
     // and the left edge of the `SeekBar` and add the number of pixels in the
     // `SeekBar` before hitting the `seekBarPoint`
-    const spaceLeftOfPoint = (seekBarRect.left - playerRect.left) + seekBarPointPx;
+    let spaceLeftOfPoint = (seekBarRect.left - playerRect.left) + seekBarPointPx;
+    // (seekBarRect.left - playerRect.left) + seekBarPointPx;
 
     // This is the space right of the `seekBarPoint` available within the bounds
     // of the player. We calculate the number of pixels from the `seekBarPoint`
@@ -78,10 +79,11 @@ class TimeTooltip extends Component {
     // spaceRightOfPoint is always NaN for mouse time display
     // because the seekbarRect does not have a right property. This causes
     // the mouse tool tip to be truncated when it's close to the right edge of the player.
-    // In such cases, we ignore the `playerRect.right - seekBarRect.right` value when calculating
-    // spaceRightofPoint.
+    // In such cases, we ignore the `playerRect.right - seekBarRect.right` value when calculating.
+    // For the sake of consistency, we ignore seekBarRect.left - playerRect.left for the left edge.
     if (!spaceRightOfPoint) {
       spaceRightOfPoint = seekBarRect.width - seekBarPointPx;
+      spaceLeftOfPoint = seekBarPointPx;
     }
     // This is the number of pixels by which the tooltip will need to be pulled
     // further to the right to center it over the `seekBarPoint`.

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -75,6 +75,11 @@ class TimeTooltip extends Component {
     let spaceRightOfPoint = (seekBarRect.width - seekBarPointPx) +
       (playerRect.right - seekBarRect.right);
 
+    // spaceRightOfPoint is always NaN for mouse time display
+    // because the seekbarRect does not have a right property. This causes
+    // the mouse tool tip to be truncated when it's close to the right edge of the player.
+    // In such cases, we ignore the `playerRect.right - seekBarRect.right` value when calculating
+    // spaceRightofPoint.
     if (!spaceRightOfPoint) {
       spaceRightOfPoint = seekBarRect.width - seekBarPointPx;
     }

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -72,9 +72,12 @@ class TimeTooltip extends Component {
     // of the player. We calculate the number of pixels from the `seekBarPoint`
     // to the right edge of the `SeekBar` and add to that any gap between the
     // right edge of the `SeekBar` and the player.
-    const spaceRightOfPoint = (seekBarRect.width - seekBarPointPx) +
+    let spaceRightOfPoint = (seekBarRect.width - seekBarPointPx) +
       (playerRect.right - seekBarRect.right);
 
+    if (!spaceRightOfPoint) {
+      spaceRightOfPoint = seekBarRect.width - seekBarPointPx;
+    }
     // This is the number of pixels by which the tooltip will need to be pulled
     // further to the right to center it over the `seekBarPoint`.
     let pullTooltipBy = tooltipRect.width / 2;

--- a/src/js/control-bar/progress-control/time-tooltip.js
+++ b/src/js/control-bar/progress-control/time-tooltip.js
@@ -67,7 +67,6 @@ class TimeTooltip extends Component {
     // and the left edge of the `SeekBar` and add the number of pixels in the
     // `SeekBar` before hitting the `seekBarPoint`
     let spaceLeftOfPoint = (seekBarRect.left - playerRect.left) + seekBarPointPx;
-    // (seekBarRect.left - playerRect.left) + seekBarPointPx;
 
     // This is the space right of the `seekBarPoint` available within the bounds
     // of the player. We calculate the number of pixels from the `seekBarPoint`


### PR DESCRIPTION
## Description
 [spaceRightOfPoint](https://github.com/videojs/video.js/blob/main/src/js/control-bar/progress-control/time-tooltip.js#L75) is always `NaN` for [mouse time display](https://github.com/videojs/video.js/blob/main/src/js/control-bar/progress-control/progress-control.js#L84) (unlike playProgressBar's time display) because the [seekbarRect](https://github.com/videojs/video.js/blob/main/src/js/control-bar/progress-control/progress-control.js#L75) ([dom.findPosition(seekbar)](https://github.com/videojs/video.js/blob/main/src/js/utils/dom.js#L503)) does not have a `right` property. 
 
 And since spaceRightOfPosition is always `NaN`, when the mouse tool tip is moved close to edge of the right side player, it's position is not adjusted as it is on the left and so it get's cut off.
 
<img width="561" alt="truncated" src="https://github.com/videojs/video.js/assets/35213866/4ead3312-d6bf-41db-8798-91e5d974b6ce">


## Specific Changes proposed
The proposed change is to ignore the gap between the right edge of the `SeekBar` and the player (`playerRect.right - seekBarRect.right`) in such cases.

<img width="561" alt="fixed" src="https://github.com/videojs/video.js/assets/35213866/21121eeb-83bf-46af-830b-356050464ea5">

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
