### PR TITLE
Fix skip-forward button accessibility issue

### DIFF
--- a/src/js/control-bar/skip-buttons/skip-forward.js
+++ b/src/js/control-bar/skip-buttons/skip-forward.js
@@ -73,6 +73,8 @@ class SkipForward extends Button {
   }
 }
 
+SkipForward.prototype.controlText_ = 'Skip Forward';
+
 Component.registerComponent('SkipForward', SkipForward);
 
 export default SkipForward;


### PR DESCRIPTION
## Description
Got a complaint from a customer about the Wave tool being mad at some empty button.
Somehow the skip-backward button does have a default controlText. only the forward one was missing it.

## Specific Changes proposed
Add a default controlText for the button component

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors

| Before | After |
|--------|--------|
| <img width="1138" alt="image" src="https://github.com/videojs/video.js/assets/346835/7fefa721-74f2-407f-a4e5-6182e8a8cbf4"> | <img width="379" alt="image" src="https://github.com/videojs/video.js/assets/346835/2e2833c9-d732-49ea-9c22-73c893548083"> |
