### PR TITLE
feat(error): remove confusing decorative X from error display modal

### DIFF
--- a/src/css/components/_error.scss
+++ b/src/css/components/_error.scss
@@ -2,22 +2,3 @@
   font-size: 1.4em;
   text-align: center;
 }
-
-.vjs-error .vjs-error-display:before {
-  color: #fff;
-  content: 'X';
-  font-family: $text-font-family;
-  font-size: 4em;
-  left: 0;
-
-  // In order to center the play icon vertically we need to set the line height
-  // to the same as the button height
-  line-height: 1;
-  margin-top: -0.5em;
-  position: absolute;
-  text-shadow: 0.05em 0.05em 0.1em #000;
-  text-align: center;
-  top: 50%;
-  vertical-align: middle;
-  width: 100%;
-}


### PR DESCRIPTION
Modify _error:
-Remove the ‘x’ element from the error modal.

## Description
Remove not required  pseudo-class on error modal.

## Specific Changes proposed
Remove pseudo-class :before on vjs-error-display.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
