### PR TITLE
fix: Fixes form markup in text track settings

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -6,6 +6,7 @@ import Component from '../component';
 import ModalDialog from '../modal-dialog';
 import {createEl} from '../utils/dom';
 import * as Obj from '../utils/obj';
+import * as Guid from '../utils/guid.js';
 import log from '../utils/log';
 
 const LOCAL_STORAGE_KEY = 'vjs-text-track-settings';
@@ -303,6 +304,12 @@ class TextTrackSettings extends ModalDialog {
    * @param {string} key
    *        Configuration key to use during creation.
    *
+   * @param {string} [legendId]
+   *        Id of associated <legend>.
+   *
+   * @param {string} [type=label]
+   *        Type of labelling element, `label` or `legend`
+   *
    * @return {string}
    *         An HTML string.
    *
@@ -312,12 +319,13 @@ class TextTrackSettings extends ModalDialog {
     const config = selectConfigs[key];
     const id = config.id.replace('%s', this.id_);
     const selectLabelledbyIds = [legendId, id].join(' ').trim();
+    const guid = `vjs_select_${Guid.newGUID()}`;
 
     return [
-      `<${type} id="${id}" class="${type === 'label' ? 'vjs-label' : ''}">`,
+      `<${type} id="${id}"${type === 'label' ? ` for="${guid}" class="vjs-label"` : ''}>`,
       this.localize(config.label),
       `</${type}>`,
-      `<select aria-labelledby="${selectLabelledbyIds}">`
+      `<select aria-labelledby="${selectLabelledbyIds}" id="${guid}">`
     ].
       concat(config.options.map(o => {
         const optionId = id + '-' + o[1].replace(/\W+/g, '');

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -383,3 +383,17 @@ QUnit.test('should update on languagechange', function(assert) {
 
   player.dispose();
 });
+
+QUnit.test('should associate <label>s with <select>s', function(assert) {
+  const player = TestHelpers.makePlayer({
+    tracks
+  });
+
+  const firstLabelFor = player.textTrackSettings.el_.querySelector('label').getAttribute('for');
+
+  assert.ok(
+    videojs.dom.isEl(player.textTrackSettings.el_.querySelector(`#${firstLabelFor}`)),
+    'label has a `for` attribute matching an `id`'
+  );
+
+});


### PR DESCRIPTION
## Description
Removes two messages in Chrome's issues tab relating to the text track settings
- _A form field element should have an id or name attribute_
- _No label associated with a form field_

## Specific Changes proposed
Adds an `id` to each `<select>`, and sets the `id` as the `for` on associated `<label>`s. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
