### PR TITLE
fix: browser util flagging smart TV as Safari

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -140,6 +140,10 @@ export let IS_IPAD = false;
 // http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
 export let IS_IPHONE = false;
 
+export let IS_TIZEN = false;
+
+export let IS_WEBOS = false;
+
 /**
  * Whether or not this device is touch-enabled.
  *
@@ -235,7 +239,11 @@ if (!IS_CHROMIUM) {
     return version;
   }());
 
-  IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE;
+  IS_TIZEN = (/Tizen/i).test(USER_AGENT);
+
+  IS_WEBOS = (/Web0S/i).test(USER_AGENT);
+
+  IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDROID && !IS_EDGE && !IS_TIZEN && !IS_WEBOS;
 
   IS_WINDOWS = (/Windows/i).test(USER_AGENT);
 

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -140,8 +140,20 @@ export let IS_IPAD = false;
 // http://artsy.github.io/blog/2012/10/18/the-perils-of-ios-user-agent-sniffing/
 export let IS_IPHONE = false;
 
+/**
+ * Whether or not this is a Tizen device.
+ *
+ * @static
+ * @type {Boolean}
+ */
 export let IS_TIZEN = false;
 
+/**
+ * Whether or not this is a WebOS device.
+ *
+ * @static
+ * @type {Boolean}
+ */
 export let IS_WEBOS = false;
 
 /**


### PR DESCRIPTION
## Description
SmartTV user agent strings were being detected by `videojs.browser` as Safari.

## Specific Changes proposed
Checking the user agent string for `Tizen` and `WebOS` then checking for those flags when deducing whether the browser is actually Safari.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
