### PR TITLE
fix(player): adapt player height to control bar height in audioOnly mode

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -359,6 +359,8 @@ class Player extends Component {
     this.boundHandleTechTouchEnd_ = (e) => this.handleTechTouchEnd_(e);
     this.boundHandleTechTap_ = (e) => this.handleTechTap_(e);
 
+    this.boundUpdatePlayerHeightOnAudioOnlyMode_ = (e) => this.updatePlayerHeightOnAudioOnlyMode_(e);
+
     // default isFullscreen_ to false
     this.isFullscreen_ = false;
 
@@ -395,6 +397,7 @@ class Player extends Component {
 
     // Init state audioOnlyCache_
     this.audioOnlyCache_ = {
+      controlBarHeight: null,
       playerHeight: null,
       hiddenChildren: []
     };
@@ -4496,6 +4499,17 @@ class Player extends Component {
     return !!this.isAudio_;
   }
 
+  updatePlayerHeightOnAudioOnlyMode_() {
+    const controlBar = this.getChild('ControlBar');
+
+    if (!controlBar || this.audioOnlyCache_.controlBarHeight === controlBar.currentHeight()) {
+      return;
+    }
+
+    this.audioOnlyCache_.controlBarHeight = controlBar.currentHeight();
+    this.height(this.audioOnlyCache_.controlBarHeight);
+  }
+
   enableAudioOnlyUI_() {
     // Update styling immediately to show the control bar so we can get its height
     this.addClass('vjs-audio-only-mode');
@@ -4519,6 +4533,9 @@ class Player extends Component {
     });
 
     this.audioOnlyCache_.playerHeight = this.currentHeight();
+    this.audioOnlyCache_.controlBarHeight = controlBarHeight;
+
+    this.on('playerresize', this.boundUpdatePlayerHeightOnAudioOnlyMode_);
 
     // Set the player height the same as the control bar
     this.height(controlBarHeight);
@@ -4527,6 +4544,7 @@ class Player extends Component {
 
   disableAudioOnlyUI_() {
     this.removeClass('vjs-audio-only-mode');
+    this.off('playerresize', this.boundUpdatePlayerHeightOnAudioOnlyMode_);
 
     // Show player components that were previously hidden
     this.audioOnlyCache_.hiddenChildren.forEach(child => child.show());

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3401,6 +3401,33 @@ QUnit.test('turning on audioPosterMode when audioOnlyMode is already on will tur
     });
 });
 
+QUnit.test('player height should match control bar height when audioOnlyMode is enabled', function(assert) {
+  const player = TestHelpers.makePlayer({ responsive: true, width: 320, height: 240 });
+
+  player.trigger('ready');
+
+  player.audioOnlyMode(true).then(() => {
+    const initialPlayerHeight = player.currentHeight();
+
+    player.width(768);
+    player.el().style.fontSize = '20px';
+    player.trigger('playerresize');
+
+    assert.ok(initialPlayerHeight !== player.currentHeight(), 'player height is updated');
+  })
+    .then(() => player.audioOnlyMode(false))
+    .then(() => {
+      const initialPlayerHeight = player.currentHeight();
+
+      player.width(768);
+      player.el().style.fontSize = '20px';
+      player.trigger('playerresize');
+
+      assert.equal(player.currentHeight(), initialPlayerHeight, 'player height remains unchanged');
+      assert.ok(initialPlayerHeight !== player.controlBar.currentHeight(), 'player height is different from control bar height');
+    });
+});
+
 QUnit.test('player#load resets the media element to its initial state', function(assert) {
   const player = TestHelpers.makePlayer({});
 


### PR DESCRIPTION
## Description

Adapts the `player.height` to the `controlBar.currentHeight` when the `audioOnlyMode` is `enabled`. This ensures that the player height and control bar height are always in sync when the player is resized.

This issue occurs when the `responsive`, and `audioOnlyMode` options are set to `true`, and the base font size adapts based on the player’s size to create a more responsive user interface.

[Screencast from 27. 01. 24 13:28:25.webm](https://github.com/videojs/video.js/assets/34163393/2d365573-d0b8-426b-8b71-9114f98d82bc)

### How to reproduce

- open [codepen](https://codepen.io/amtins/pen/LYvBOKj)
- resize the page until a breakpoint is reached

```html
<style>
.video-js {
  font-size: 20px;
  width: 100%;
}

.vjs-layout-small,
.vjs-layout-medium,
.vjs-layout-large {
  font-size:10px;
}
</style>
<video id="player" class="video-js" controls></video>
<script>
  const player = videojs('player', { responsive: true, audioOnlyMode: true });

  player.src('https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8');
</script>
```

## Specific Changes proposed

- add `updatePlayerHeightOnAudioOnlyMode_` function that will update the player height according to the control bar height when the player is resized
- modify `enableAudioOnlyUI_`
  - add a `controlBarHeight` to `audioOnlyCache_` to keep track of the control bar height changes when the player is resized
  - add a `playerresize` listener
- modify `disableAudioOnlyUI_` to remove the `playerresize` listener

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
