### PR TITLE
fix: Loading spinner animation misalignment

### DIFF
--- a/src/css/components/_loading.scss
+++ b/src/css/components/_loading.scss
@@ -39,6 +39,8 @@
 .vjs-loading-spinner:after {
   content: "";
   position: absolute;
+  left: -0.6em;
+  top: -0.6em;
   box-sizing: inherit;
   width: inherit;
   height: inherit;


### PR DESCRIPTION
## Description
Add top/left positioning rules to the `.vjs-loading-spinner:before` and `.vjs-loading-spinner:after` to fix the loading spinner animated segment misalignment.

![Screenshot 2024-02-16 at 10 38 21 AM](https://github.com/videojs/video.js/assets/83311511/e51d86f3-2677-433d-b036-a689109040ec)

This seems to occur because the `border: 0.6em` rule on the `.vjs-loading-spinner` parent effectively pushes content inward with the current box-model interpretation, against a set height/width, like padding. Unlike padding, however, the edge of the element box is interpreted as _inside_ the border, not outside, so the spinner segment pseudo-elements inheriting its positioning rules are visually nudged downward and to the right. 

Adding negative top/left positioning rules to account for the border fixes the misalignment. It's most likely why there was a negative margin in place for the segments in the past.

![Screenshot 2024-02-16 at 10 39 28 AM](https://github.com/videojs/video.js/assets/83311511/598a592c-d592-497f-9758-f2ee861dfd87)

## Specific Changes proposed
Add top/left positioning rules targeting `.vjs-loading-spinner::before, .vjs-loading-spinner::after`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
