### PR TITLE
chore: Add action to validate PR titles

### DIFF
--- a/.github/actions/pr-titles.js
+++ b/.github/actions/pr-titles.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+(async function run() {
+  const title = github.context.payload.pull_request?.title;
+  const titleRegex = /^(chore|ci|docs|feat|fix|refactor|revert|test)(\(.+\))?!?: (.+)/;
+
+  if (!!title.match(titleRegex)) {
+    core.info('Pull request title is OK');
+  } else {
+    core.setFailed('Please use conventional commit style for the PR title so the merged change appears in the changelog. See https://www.conventionalcommits.org/.');
+  }
+})();

--- a/.github/workflows/pr-titles.yml
+++ b/.github/workflows/pr-titles.yml
@@ -1,0 +1,22 @@
+name: PR title check
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title-lint:
+    name: Should follow conventional commit spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i @actions/core @actions/github
+      - run: node .github/actions/pr-titles.js


### PR DESCRIPTION
## Description
Adds a GitHub action to validate that PR titles follow conventional commit, to make sure we don't merge a PR that wouldn't show up in the change log.

## Specific Changes proposed
Adds a simple action to validate the title with a regex. There are GitHub marketplace actions which will do this, but they have a lot of dependencies and configuration options we don't need for now.