### PR TITLE
feat(emulated-tracks): add class to force cues to be center aligned

### DIFF
--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -40,3 +40,9 @@ video::-webkit-media-text-track-display {
 .video-js.vjs-user-inactive.vjs-playing video::-webkit-media-text-track-display {
   @include transform(translateY(-1.5em));
 }
+
+// force cues to be center aligned
+.video-js.vjs-force-center-align-cues .vjs-text-track-cue {
+  text-align: center !important;
+  width: 80% !important;
+}


### PR DESCRIPTION
https://github.com/videojs/http-streaming/pull/1408 updated 608 captions to default to be left aligned. This may be unwanted by some folks and we should provide an easier way to force them to be centered. This PR adds a player level class that will override the text alignment to be `center`. It also overrides the `width` to `80%` because otherwise the cue box isn't set up correctly to be 10% from the right of the display area (a side effect of hardcoding a width value and using inset in the generation of the cues).

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
