### PR TITLE
fix: typo in error const

### DIFF
--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -15,6 +15,6 @@ export default {
   AdsPrerollError: 'ads-preroll-error',
   AdsMidrollError: 'ads-midroll-error',
   AdsPostrollError: 'ads-postroll-error',
-  AdsMacroReplacementFailed: 'ads-marco-replacement-failed',
+  AdsMacroReplacementFailed: 'ads-macro-replacement-failed',
   AdsResumeContentFailed: 'ads-resume-content-failed'
 };


### PR DESCRIPTION
## Description
Fix a nit typo in the errors const.


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
