### PR TITLE
fix: progress bar sometimes is not filled on 100%

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -52,7 +52,8 @@ class SeekBar extends Slider {
     this.update_ = Fn.bind_(this, this.update);
     this.update = Fn.throttle(this.update_, Fn.UPDATE_REFRESH_INTERVAL);
 
-    this.on(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
+    this.on(this.player_, ['durationchange', 'timeupdate'], this.update);
+    this.on(this.player_, ['ended'], this.update_);
     if (this.player_.liveTracker) {
       this.on(this.player_.liveTracker, 'liveedgechange', this.update);
     }
@@ -478,7 +479,8 @@ class SeekBar extends Slider {
   dispose() {
     this.disableInterval_();
 
-    this.off(this.player_, ['ended', 'durationchange', 'timeupdate'], this.update);
+    this.off(this.player_, ['durationchange', 'timeupdate'], this.update);
+    this.off(this.player_, ['ended'], this.update_);
     if (this.player_.liveTracker) {
       this.off(this.player_.liveTracker, 'liveedgechange', this.update);
     }


### PR DESCRIPTION
## Description
At the end of the video progress bar not in the end. 
This is random behavior and it is best visible on short videos.

![Screenshot from 2024-03-08 11-14-10](https://github.com/videojs/video.js/assets/5346546/d4b1fbe6-3d20-4bea-b949-a67d102800f7)

![Screenshot from 2024-03-08 11-15-21](https://github.com/videojs/video.js/assets/5346546/962fd1af-b801-4c3f-8826-4e20ea70913b)

## Specific Changes proposed
The player shouldn't throttle 'ended' event.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
