### PR TITLE
chore: add contrib-eme errors

### DIFF
--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -16,5 +16,9 @@ export default {
   AdsMidrollError: 'ads-midroll-error',
   AdsPostrollError: 'ads-postroll-error',
   AdsMacroReplacementFailed: 'ads-macro-replacement-failed',
-  AdsResumeContentFailed: 'ads-resume-content-failed'
+  AdsResumeContentFailed: 'ads-resume-content-failed',
+  // Errors used in contrib-eme:
+  EMEEncryptedError: 'eme-encrypted-error',
+  MSKeyError: 'ms-key-error',
+  WebkitKeyError: 'webkit-key-error'
 };

--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -9,7 +9,6 @@ export default {
   SegmentAppendError: 'segment-append-error',
   VttLoadError: 'vtt-load-error',
   VttCueParsingError: 'vtt-cue-parsing-error',
-  EMEKeySessionCreationError: 'eme-key-session-creation-error',
   // Errors used in contrib-ads:
   AdsBeforePrerollError: 'ads-before-preroll-error',
   AdsPrerollError: 'ads-preroll-error',
@@ -20,5 +19,13 @@ export default {
   // Errors used in contrib-eme:
   EMEEncryptedError: 'eme-encrypted-error',
   MSKeyError: 'ms-key-error',
-  WebkitKeyError: 'webkit-key-error'
+  WebkitKeyError: 'webkit-key-error',
+  EMEFailedToRequestMediaKeySystemAccess: 'eme-failed-request-media-key-system-access',
+  EMEFailedToCreateMediaKeys: 'eme-failed-create-media-keys',
+  EMEFailedToAttachMediaKeysToVideoElement: 'eme-failed-attach-media-keys-to-video',
+  EMEFailedToCreateMediaKeySession: 'eme-failed-create-media-key-session',
+  EMEFailedToSetServerCertificate: 'eme-failed-set-server-certificate',
+  EMEFailedToGenerateLicenseRequest: 'eme-failed-generate-license-request',
+  EMEFailedToUpdateSessionWithReceivedLicenseKeys: 'eme-failed-update-session',
+  EMEFailedToCloseSession: 'eme-failed-close-session'
 };


### PR DESCRIPTION
## Description
Add error constants for contrib-eme specific errors.

## Specific Changes proposed
Add constants that are representative of the separate keysystems for error reporting out of videojs-contrib-eme, also add errors specific to each step in the EME specific process.
Two notable omissions:
No errors for `remove` or `load` on the mediakeysession as they're not implemented in contrib-eme.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
