### PR TITLE
chore: update VHS to v3.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,9 +1765,9 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.11.3.tgz",
-      "integrity": "sha512-RYiRwcNzp5l6HZXHBkE+kjtzQV6PKE6kKLLRlKFDOYw2WH9bw0fb1cCICI/rsNR8PNLmyturYV4p2Vl+JpZQoA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.12.0.tgz",
+      "integrity": "sha512-V9utRounzaty+bk0u1Uu4CtCqNrE8YN8GzITEAxwwLgMD+KYPSlcD+LJN/YKpMsMTbGLRPm/brTZiaaK+XQiyQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
@@ -1775,7 +1775,7 @@
         "global": "^4.4.0",
         "m3u8-parser": "^7.1.0",
         "mpd-parser": "^1.3.0",
-        "mux.js": "7.0.2",
+        "mux.js": "7.0.3",
         "video.js": "^7 || ^8"
       },
       "dependencies": {
@@ -1791,9 +1791,9 @@
           }
         },
         "mux.js": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
-          "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+          "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
           "requires": {
             "@babel/runtime": "^7.11.2",
             "global": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "3.11.3",
+    "@videojs/http-streaming": "3.12.0",
     "@videojs/vhs-utils": "^4.0.0",
     "@videojs/xhr": "2.6.0",
     "aes-decrypter": "^4.0.1",


### PR DESCRIPTION
## Description
Update http-streaming to version 3.12.0

This includes changes regarding the `customPixelRatio` vhs property, as well as some mux.js fixes regarding 608 captions.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
