### PR TITLE
fix: add additional and remove unused error const

### DIFF
--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -17,9 +17,6 @@ export default {
   AdsMacroReplacementFailed: 'ads-macro-replacement-failed',
   AdsResumeContentFailed: 'ads-resume-content-failed',
   // Errors used in contrib-eme:
-  EMEEncryptedError: 'eme-encrypted-error',
-  MSKeyError: 'ms-key-error',
-  WebkitKeyError: 'webkit-key-error',
   EMEFailedToRequestMediaKeySystemAccess: 'eme-failed-request-media-key-system-access',
   EMEFailedToCreateMediaKeys: 'eme-failed-create-media-keys',
   EMEFailedToAttachMediaKeysToVideoElement: 'eme-failed-attach-media-keys-to-video',
@@ -27,5 +24,7 @@ export default {
   EMEFailedToSetServerCertificate: 'eme-failed-set-server-certificate',
   EMEFailedToGenerateLicenseRequest: 'eme-failed-generate-license-request',
   EMEFailedToUpdateSessionWithReceivedLicenseKeys: 'eme-failed-update-session',
-  EMEFailedToCloseSession: 'eme-failed-close-session'
+  EMEFailedToCloseSession: 'eme-failed-close-session',
+  EMEFailedToRemoveKeysFromSession: 'eme-failed-remove-keys',
+  EMEFailedToLoadSessionBySessionId: 'eme-failed-load-session'
 };


### PR DESCRIPTION
## Description
Add and remove some error constants specific to `videojs-contrib-eme` errors.

## Specific Changes proposed
Remove the keysystem specific errors as the keysystem is now passed as error metadata and add errors for `remove` and `load` calls on the `MediaKeySession`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
