### PR TITLE
fix: prevent error for root shadow elements when restorEl is enabled

### DIFF
--- a/src/js/video.js
+++ b/src/js/video.js
@@ -167,7 +167,7 @@ function videojs(id, options, ready) {
   // Store a copy of the el before modification, if it is to be restored in destroy()
   // If div ingest, store the parent div
   if (options.restoreEl === true) {
-    options.restoreEl = (el.parentNode && el.parentNode.hasAttribute('data-vjs-player') ? el.parentNode : el).cloneNode(true);
+    options.restoreEl = (el.parentNode && el.parentNode.hasAttribute && el.parentNode.hasAttribute('data-vjs-player') ? el.parentNode : el).cloneNode(true);
   }
 
   hooks('beforesetup').forEach((hookFunction) => {


### PR DESCRIPTION
## Description

Addresses an issue where activating the `restoreEl` option for an element at the root of a shadow DOM threw a "TypeError: el.parentNode.hasAttribute is not a function". The bug was due to the `parentNode` being a shadow root, which does not have the `hasAttribute` method.

## Specific Changes proposed

The fix implemented checks for the existence of the `hasAttribute` method on `parentNode`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [x] Reviewed by Two Core Contributors
