### PR TITLE
chore: update GitHub Actions version and remove xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       should-skip-job: ${{steps.skip-check.outputs.should_skip}}
     steps:
       - id: skip-check
-        uses: fkirc/skip-duplicate-actions@v5.3.0
+        uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
           github_token: ${{github.token}}
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - name: checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: read node version from .nvmrc
       run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
@@ -47,7 +47,7 @@ jobs:
       run: pulseaudio -D
 
     - name: setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '${{steps.nvm.outputs.NVMRC}}'
         cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: npm run test
 
     - name: coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: './test/dist/coverage/coverage-final.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,7 @@ jobs:
       run: npm i --prefer-offline --no-audit
 
     - name: run npm test
-      uses: coactions/setup-xvfb@v1
-      with:
-        run: npm run test
+      run: npm run test
 
     - name: coverage
       uses: codecov/codecov-action@v4

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -56,15 +56,6 @@ import './title-bar.js';
 // Import Html5 tech, at least for disposing the original video tag.
 import './tech/html5.js';
 
-// Just something as an uncovered change.
-let aa;
-
-if (1 === 1) {
-  aa = 'b';
-}
-
-window.console.log(aa);
-
 // The following tech events are simply re-triggered
 // on the player when they happen
 const TECH_EVENTS_RETRIGGER = [

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -56,6 +56,15 @@ import './title-bar.js';
 // Import Html5 tech, at least for disposing the original video tag.
 import './tech/html5.js';
 
+// Just something as an uncovered change.
+let aa;
+
+if (1 === 1) {
+  aa = 'b';
+}
+
+window.console.log(aa);
+
 // The following tech events are simply re-triggered
 // on the player when they happen
 const TECH_EVENTS_RETRIGGER = [


### PR DESCRIPTION
Updates actions to address GitHub's Node 16 deprecation.

Updating codecov to v4 hopefully improves the reliability uploading. This change means contributors wanting codecov in their forks need to add a `CODECOV_TOKEN` secret to their repository with their codecov token.

Removes the xvfb action as avfb is available by default on ubuntu in GitHub Actions.