### PR TITLE
fix(playback-rate-menu-button): ensure proper menu behavior on double click

### DIFF
--- a/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
+++ b/src/js/control-bar/playback-rate-menu/playback-rate-menu-button.js
@@ -25,6 +25,13 @@ class PlaybackRateMenuButton extends MenuButton {
   constructor(player, options) {
     super(player, options);
 
+    this.labelElId_ = 'vjs-playback-rate-value-label-' + this.id_;
+    this.labelEl_ = Dom.createEl('div', {
+      className: 'vjs-playback-rate-value',
+      id: this.labelElId_,
+      textContent: '1x'
+    });
+    this.menuButton_.el_.appendChild(this.labelEl_);
     this.menuButton_.el_.setAttribute('aria-describedby', this.labelElId_);
 
     this.updateVisibility();
@@ -33,28 +40,6 @@ class PlaybackRateMenuButton extends MenuButton {
     this.on(player, 'loadstart', (e) => this.updateVisibility(e));
     this.on(player, 'ratechange', (e) => this.updateLabel(e));
     this.on(player, 'playbackrateschange', (e) => this.handlePlaybackRateschange(e));
-  }
-
-  /**
-   * Create the `Component`'s DOM element
-   *
-   * @return {Element}
-   *         The element that was created.
-   */
-  createEl() {
-    const el = super.createEl();
-
-    this.labelElId_ = 'vjs-playback-rate-value-label-' + this.id_;
-
-    this.labelEl_ = Dom.createEl('div', {
-      className: 'vjs-playback-rate-value',
-      id: this.labelElId_,
-      textContent: '1x'
-    });
-
-    el.appendChild(this.labelEl_);
-
-    return el;
   }
 
   dispose() {


### PR DESCRIPTION
## Description

When the playback rate button is clicked twice, the menu does not close. This has an impact when a developer has disabled menu display on mouse-over, forcing the user to click elsewhere to close the menu.

### How to reproduce

- open [codepen](https://codepen.io/amtins/pen/KKYBogr)
- click the playback rate button

## Specific Changes proposed

- moves the `label` inside the button
- deletes function `createEl`

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
