### PR TITLE
feat(player): Make 'searchForTrackSelect_' private & use 'el' as parameter in function 'getIsFocusable'

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -1840,8 +1840,10 @@ class Component {
    * @return {boolean}
    *         If the component can be focused, will be `true`. Otherwise, `false`.
    */
-  getIsFocusable() {
-    return this.el_.tabIndex >= 0 && !(this.getIsDisabled() || this.getIsExpresslyInert());
+  getIsFocusable(el) {
+    const element = el || this.el_;
+
+    return element.tabIndex >= 0 && !(this.getIsDisabled() || this.getIsExpresslyInert());
   }
 
   /**

--- a/src/js/spatial-navigation.js
+++ b/src/js/spatial-navigation.js
@@ -188,7 +188,7 @@ class SpatialNavigation extends EventTarget {
 
       // If nextFocusedElement is the 'TextTrackSettings' component
       if (nextFocusedElement.classList.contains('vjs-text-track-settings') && !this.isPaused_) {
-        this.searchForTrackSelect();
+        this.searchForTrackSelect_();
       }
     }
 
@@ -288,7 +288,7 @@ class SpatialNavigation extends EventTarget {
      * or `null` if no suitable child is found.
      */
     function searchForSuitableChild(node) {
-      if (component.getIsFocusable() && component.getIsAvailableToBeFocused(node)) {
+      if (component.getIsFocusable(node) && component.getIsAvailableToBeFocused(node)) {
         return node;
       }
 
@@ -537,8 +537,10 @@ class SpatialNavigation extends EventTarget {
   /**
    * This gets called by 'handlePlayerBlur_' if 'spatialNavigation' is enabled.
    * Searches for the first 'TextTrackSelect' inside of modal to focus.
+   *
+   * @private
    */
-  searchForTrackSelect() {
+  searchForTrackSelect_() {
     const spatialNavigation = this;
 
     for (const component of (spatialNavigation.updateFocusableComponents())) {

--- a/test/unit/spatial-navigation.test.js
+++ b/test/unit/spatial-navigation.test.js
@@ -476,7 +476,7 @@ QUnit.test('should call `searchForTrackSelect()` if spatial navigation is enable
   Object.defineProperty(clickEvent, 'relatedTarget', {writable: false, value: element});
   Object.defineProperty(clickEvent, 'currentTarget', {writable: false, value: element});
 
-  const trackSelectSpy = sinon.spy(this.spatialNav, 'searchForTrackSelect');
+  const trackSelectSpy = sinon.spy(this.spatialNav, 'searchForTrackSelect_');
 
   const textTrackSelectComponent = new TextTrackSelect(this.player, {
     SelectOptions: ['Option 1', 'Option 2', 'Option 3'],


### PR DESCRIPTION
## Description
Minor update related to the 'spatial navigation' feature to make 'searchForTrackSelect_' private & use 'el' as parameter in function 'getIsFocusable', since in some cases there can be an issue only using 'this.el_' when the function is called.w

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
