### PR TITLE
fix: Support MacOS trackpad with tap-to-click

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -773,6 +773,11 @@ export function isSingleLeftClick(event) {
     return true;
   }
 
+  // MacOS Sonoma trackpad when "tap to click enabled"
+  if (event.type === 'mousedown' && event.button === 0 && event.buttons === 0) {
+    return true;
+  }
+
   if (event.button !== 0 || event.buttons !== 1) {
     // This is the reason we have those if else block above
     // if any special case we can catch and let it slide

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -658,12 +658,6 @@ QUnit.test('isSingleLeftClick() checks return values for mousedown event', funct
 
   // Left mouse click
   mouseEvent.button = 0;
-  mouseEvent.buttons = 0;
-
-  assert.notOk(Dom.isSingleLeftClick(mouseEvent), 'a left mouse click on an older browser (Safari) is a single left click');
-
-  // Left mouse click
-  mouseEvent.button = 0;
   mouseEvent.buttons = 1;
 
   assert.ok(Dom.isSingleLeftClick(mouseEvent), 'a left mouse click on browsers that supporting buttons property is a single left click');
@@ -685,6 +679,12 @@ QUnit.test('isSingleLeftClick() checks return values for mousedown event', funct
   mouseEvent.buttons = undefined;
 
   assert.ok(Dom.isSingleLeftClick(mouseEvent), 'a touch event on simulated mobiles is a single left click');
+
+  // MacOS trackpad "tap to click". Sonoma always does this, previous MacOS did this inconsistently, buttons was usally 1.
+  mouseEvent.button = 0;
+  mouseEvent.buttons = 0;
+
+  assert.ok(Dom.isSingleLeftClick(mouseEvent), 'a tap-to-click on Mac trackpad is a single left click');
 });
 
 QUnit.test('Dom.copyStyleSheetsToWindow() copies all style sheets to a window', function(assert) {


### PR DESCRIPTION
## Description
If a MacOS trackpad is using "tap to click", the tap/click was being ignored by the seek bar sometimes, so there would be no seek. This is because the `mousedown` MouseEvent has `{button: 0, buttons: 0}` or `{button: 0, buttons: 1}` inconsistently.

## Specific Changes proposed
- Adds a case in utils/dom to consider `(event.type === 'mousedown' && event.button === 0 && event.buttons === 0)` a click.
- Removes a conflicting test. That is covered by the test above it for the `mousemove` event.

Fixes #8691, #7736

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
