### PR TITLE
feat: add browser.IS_CHROMECAST_RECEIVER and class name for CSS targeting on a Chromecast receiver where Video.js is used

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -790,7 +790,8 @@ class Player extends Component {
       'IS_WEBOS',
       'IS_ANDROID',
       'IS_IPAD',
-      'IS_IPHONE'
+      'IS_IPHONE',
+      'IS_CHROMECAST_RECEIVER'
     ].filter(key => browser[key]).map(key => {
       return 'vjs-device-' + key.substring(3).toLowerCase().replace(/\_/g, '-');
     });

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -97,6 +97,14 @@ export let CHROMIUM_VERSION = null;
 export let CHROME_VERSION = null;
 
 /**
+ * Whether or not this is a Chromecast receiver application.
+ *
+ * @static
+ * @type {Boolean}
+ */
+export const IS_CHROMECAST_RECEIVER = Boolean(window.cast && window.cast.framework && window.cast.framework.CastReceiverContext);
+
+/**
  * The detected Internet Explorer version - or `null`.
  *
  * @static

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1045,6 +1045,19 @@ QUnit.test('should add iphone classname when on iphone', function(assert) {
   player.dispose();
 });
 
+QUnit.test('should add chromecast-receiver classname when on chromecast receiver', function(assert) {
+  assert.expect(1);
+
+  browser.stub_IS_CHROMECAST_RECEIVER(true);
+
+  const player = TestHelpers.makePlayer({});
+
+  assert.ok(player.hasClass('vjs-device-chromecast-receiver'), 'chromecast-receiver classname added');
+
+  browser.reset_IS_CHROMECAST_RECEIVER();
+  player.dispose();
+});
+
 QUnit.test('should add a svg-icons-enabled classname when svg icons are supported', function(assert) {
   // Stub a successful parsing of the SVG sprite.
   sinon.stub(window.DOMParser.prototype, 'parseFromString').returns({


### PR DESCRIPTION
## Description
Some people may want to use Video.js as part of their Chromecast receiver application - particularly for UI customization. This PR builds on #8676 by adding feature detection for a Chromecast receiver context.

I did not test this on a cast device as I do not own one!

## Specific Changes proposed
- Add `browser.IS_CHROMECAST_RECEIVER` boolean
- Add `vjs-device-chromecast-receiver` class name for players running on a Chromecast receiver device

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
