### PR TITLE
fix: Ensure aria-labelledby values in track settings are valid

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -86,7 +86,7 @@ const selectConfigs = {
 
   edgeStyle: {
     selector: '.vjs-edge-style > select',
-    id: '%s',
+    id: '',
     label: 'Text Edge Style',
     options: [
       ['none', 'None'],
@@ -99,7 +99,7 @@ const selectConfigs = {
 
   fontFamily: {
     selector: '.vjs-font-family > select',
-    id: 'captions-font-family-%s',
+    id: '',
     label: 'Font Family',
     options: [
       ['proportionalSansSerif', 'Proportional Sans-Serif'],
@@ -114,7 +114,7 @@ const selectConfigs = {
 
   fontPercent: {
     selector: '.vjs-font-percent > select',
-    id: 'captions-font-size-%s',
+    id: '',
     label: 'Font Size',
     options: [
       ['0.50', '50%'],

--- a/test/unit/tracks/text-track-select.test.js
+++ b/test/unit/tracks/text-track-select.test.js
@@ -23,3 +23,21 @@ QUnit.test('should associate with <select>s with <options>s', function(assert) {
     "select property 'aria-labelledby' is included in its option's property 'aria-labelledby'"
   );
 });
+
+QUnit.test('aria-labelledby values must be valid and unique', function(assert) {
+  const player = TestHelpers.makePlayer({
+    tracks
+  });
+  const albs = player.$$('.vjs-text-track-settings select[aria-labelledby]');
+
+  albs.forEach(el => {
+    const ids = el.getAttribute('aria-labelledby').split(' ');
+    const invalidIds = ids.find(id => {
+      return !(player.$(`#${id}`));
+    });
+
+    assert.notOk(invalidIds, `${el.id} has valid aria-labelledby ids`);
+
+    assert.ok((new Set(ids)).size === ids.length, `${el.id} does not contain duplicate ids`);
+  });
+});


### PR DESCRIPTION
## Description
Fixes new text track settings, so that `aria-labelledby` attributes contain only valid attributes. Currently there is one invalid id, and two els with duplicate ids.
Fixes #8708 

## Specific Changes proposed
Updates text-track-settings.js to set the `id` property to an empty string where there is no `label`, only a `legend` element.
Adds tests to validate aria-labelled by values.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
