### PR TITLE
feat: refactor error consts

### DIFF
--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -3,7 +3,7 @@ export default {
   NetworkRequestFailed: 'networkrequestfailed',
   NetworkRequestAborted: 'networkrequestaborted',
   NetworkRequestTimeout: 'networkrequesttimeout',
-  NetworkBodyParser: 'networkbodyparser',
+  NetworkBodyParserFailed: 'networkbodyparserfailed',
   StreamingHlsPlaylistParserError: 'streaminghlsplaylistparsererror',
   StreamingDashManifestParserError: 'streamingdashmanifestparsererror',
   StreamingContentSteeringParserError: 'streamingcontentsteeringparsererror',

--- a/src/js/consts/errors.js
+++ b/src/js/consts/errors.js
@@ -1,12 +1,16 @@
 export default {
-  UnsupportedSidxContainer: 'unsupported-sidx-container-error',
-  DashManifestSidxParsingError: 'dash-manifest-sidx-parsing-error',
-  HlsPlaylistRequestError: 'hls-playlist-request-error',
-  SegmentUnsupportedMediaFormat: 'segment-unsupported-media-format-error',
-  UnsupportedMediaInitialization: 'unsupported-media-initialization-error',
-  SegmentSwitchError: 'segment-switch-error',
-  SegmentExceedsSourceBufferQuota: 'segment-exceeds-source-buffer-quota-error',
-  SegmentAppendError: 'segment-append-error',
-  VttLoadError: 'vtt-load-error',
-  VttCueParsingError: 'vtt-cue-parsing-error'
+  NetworkBadStatus: 'networkbadstatus',
+  NetworkRequestFailed: 'networkrequestfailed',
+  NetworkRequestAborted: 'networkrequestaborted',
+  NetworkRequestTimeout: 'networkrequesttimeout',
+  NetworkBodyParser: 'networkbodyparser',
+  StreamingHlsPlaylistParserError: 'streaminghlsplaylistparsererror',
+  StreamingDashManifestParserError: 'streamingdashmanifestparsererror',
+  StreamingContentSteeringParserError: 'streamingcontentsteeringparsererror',
+  StreamingVttParserError: 'streamingvttparsererror',
+  StreamingFailedToSelectNextSegment: 'streamingfailedtoselectnextsegment',
+  StreamingFailedToDecryptSegment: 'streamingfailedtodecryptsegment',
+  StreamingFailedToTransmuxSegment: 'streamingfailedtotransmuxsegment',
+  StreamingFailedToAppendSegment: 'streamingfailedtoappendsegment',
+  StreamingCodecsChangeError: 'streamingcodecschangeerror'
 };


### PR DESCRIPTION
## Description
Refactor error constants to a generic streaming set.

## Specific Changes proposed
Remove unused error constants and replace with generic streaming errors.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
