### PR TITLE
fix: Remove Firefox warnings about deprecated event props

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -112,15 +112,19 @@ export function fixEvent(event) {
     // IE8 Doesn't like when you mess with native event properties
     // Firefox returns false for event.hasOwnProperty('type') and other props
     //  which makes copying more difficult.
-    // TODO: Probably best to create a whitelist of event props
+
+    // TODO: Probably best to create an allowlist of event props
+    const deprecatedProps = [
+      'layerX', 'layerY', 'keyLocation', 'path',
+      'webkitMovementX', 'webkitMovementY', 'mozPressure', 'mozInputSource'
+    ];
+
     for (const key in old) {
       // Safari 6.0.3 warns you if you try to copy deprecated layerX/Y
       // Chrome warns you if you try to copy deprecated keyboardEvent.keyLocation
       // and webkitMovementX/Y
       // Lighthouse complains if Event.path is copied
-      if (key !== 'layerX' && key !== 'layerY' && key !== 'keyLocation' &&
-          key !== 'webkitMovementX' && key !== 'webkitMovementY' &&
-          key !== 'path') {
+      if (!deprecatedProps.includes(key)) {
         // Chrome 32+ warns if you try to copy deprecated returnValue, but
         // we still want to if preventDefault isn't supported (IE8).
         if (!(key === 'returnValue' && old.preventDefault)) {


### PR DESCRIPTION
## Description
Adds `mozPressure` and `mozInputSource` to the list of event properties not to cover, as reading them triggers deprecation warnings.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
