### PR TITLE
fix(docs): Add workaround for ErrorMetadata typedef

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -61,6 +61,7 @@ module.exports = {
   plugins: [
     'plugins/markdown',
     'build/jsdoc-typeof-plugin',
+    'build/jsdoc-workarounds',
   ],
   markdown: {
     tags: ['example'],

--- a/build/jsdoc-workarounds.js
+++ b/build/jsdoc-workarounds.js
@@ -1,0 +1,13 @@
+/**
+ * This jsdoc plugin works around some typescript-flavoured jsdoc that isn't actual jsdoc,
+ * so docs:api doesn't fail
+ */
+exports.handlers = {
+  jsdocCommentFound: event => {
+    // Special case for media-error.js
+    event.comment = (event.comment || '').replace(
+      '@typedef {{errorType: string, [key: string]: any}} ErrorMetadata',
+      '@typedef {Object} ErrorMetadata\n * @property {string} errorType Error type'
+    );
+  }
+};


### PR DESCRIPTION
## Description

This typedef uses typescript syntax which jsdoc itself doesn't understand. That causes `npm docs:api` to exist with an error code, so docs.videojs.com doesn't update on Netlify.

https://github.com/videojs/video.js/blob/f05769d116e0beac7b9fcde1695db4da74ade124/src/js/media-error.js#L81

This adds a hack as a jsdoc plugin to replace the typedef with valid albeit less accurate jsdoc.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
