### PR TITLE
chore: update VHS to v3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,9 +1765,9 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.12.2.tgz",
-      "integrity": "sha512-P7l3qZdxW216b6KWPBBr+7Sj95exL25AWyD+hJsHA/Ghwrh8FsKplMleCE6JBumVT+5on1efMAPAFBlarv9c2w==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.0.tgz",
+      "integrity": "sha512-hBoCH9F7eX9f0xGoMBlqKto459HLgnieY08qQ8XNyRVCDWIRFL/7Q69K32V/o+iG3a+MU2VXuD1qxgm8vj4TAQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
@@ -15443,12 +15443,12 @@
       "dev": true
     },
     "video.js": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.10.0.tgz",
-      "integrity": "sha512-7UeG/flj/pp8tNGW8WKPP1VJb3x2FgLoqUWzpZqkoq5YIyf6MNzmIrKtxprl438T5RVkcj+OzV8IX4jYSAn4Sw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.12.0.tgz",
+      "integrity": "sha512-bLjfg3y09CAed1xZ4FujdTW7G9kgL0CJHaBnDKwBUgYuutijCutYPP5yQGCdN6VOi76uEuOpINwmTJSJia6zww==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.10.0",
+        "@videojs/http-streaming": "3.12.1",
         "@videojs/vhs-utils": "^4.0.0",
         "@videojs/xhr": "2.6.0",
         "aes-decrypter": "^4.0.1",
@@ -15458,15 +15458,15 @@
         "mpd-parser": "^1.2.2",
         "mux.js": "^7.0.1",
         "safe-json-parse": "4.0.0",
-        "videojs-contrib-quality-levels": "4.0.0",
+        "videojs-contrib-quality-levels": "4.1.0",
         "videojs-font": "4.1.0",
         "videojs-vtt.js": "0.15.5"
       },
       "dependencies": {
         "@videojs/http-streaming": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.10.0.tgz",
-          "integrity": "sha512-Lf1rmhTalV4Gw0bJqHmH4lfk/FlepUDs9smuMtorblAYnqDlE2tbUOb7sBXVYoXGdbWbdTW8jH2cnS+6HWYJ4Q==",
+          "version": "3.12.1",
+          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.12.1.tgz",
+          "integrity": "sha512-rpB5AMt0QZ9bMXzwiWhynF2NLNnm5g2DZjPOFX6OoFqqXhbe2ngY2nqm9lLRhRVe22YeysQCmAlvBNwGuWFI8Q==",
           "requires": {
             "@babel/runtime": "^7.12.5",
             "@videojs/vhs-utils": "4.0.0",
@@ -15474,7 +15474,7 @@
             "global": "^4.4.0",
             "m3u8-parser": "^7.1.0",
             "mpd-parser": "^1.3.0",
-            "mux.js": "7.0.2",
+            "mux.js": "7.0.3",
             "video.js": "^7 || ^8"
           },
           "dependencies": {
@@ -15490,22 +15490,14 @@
               }
             },
             "mux.js": {
-              "version": "7.0.2",
-              "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.2.tgz",
-              "integrity": "sha512-CM6+QuyDbc0qW1OfEjkd2+jVKzTXF+z5VOKH0eZxtZtnrG/ilkW/U7l7IXGtBNLASF9sKZMcK1u669cq50Qq0A==",
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz",
+              "integrity": "sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==",
               "requires": {
                 "@babel/runtime": "^7.11.2",
                 "global": "^4.4.0"
               }
             }
-          }
-        },
-        "videojs-contrib-quality-levels": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.0.0.tgz",
-          "integrity": "sha512-u5rmd8BjLwANp7XwuQ0Q/me34bMe6zg9PQdHfTS7aXgiVRbNTb4djcmfG7aeSrkpZjg+XCLezFNenlJaCjBHKw==",
-          "requires": {
-            "global": "^4.4.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "3.12.2",
+    "@videojs/http-streaming": "3.13.0",
     "@videojs/vhs-utils": "^4.0.0",
     "@videojs/xhr": "2.6.0",
     "aes-decrypter": "^4.0.1",


### PR DESCRIPTION
## Description
update VHS to v.3.13.0

## Specific Changes proposed
change VHS to 3.13.0 and `npm install`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
