### PR TITLE
fix: lockfile for vhs v3.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,9 +1765,9 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.12.2.tgz",
-      "integrity": "sha512-P7l3qZdxW216b6KWPBBr+7Sj95exL25AWyD+hJsHA/Ghwrh8FsKplMleCE6JBumVT+5on1efMAPAFBlarv9c2w==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.0.tgz",
+      "integrity": "sha512-hBoCH9F7eX9f0xGoMBlqKto459HLgnieY08qQ8XNyRVCDWIRFL/7Q69K32V/o+iG3a+MU2VXuD1qxgm8vj4TAQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",


### PR DESCRIPTION
## Description
Updating our Karma dependency accidentally overwrote the VHS version in the lock. See: https://github.com/videojs/video.js/pull/8743

## Specific Changes proposed
`npm install` and sync the lockfile to the package.json

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
