### PR TITLE
fix: improve ts output for create logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14165,9 +14165,9 @@
       }
     },
     "typescript": {
-      "version": "5.5.0-beta",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.0-beta.tgz",
-      "integrity": "sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q==",
+      "version": "5.5.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.1-rc.tgz",
+      "integrity": "sha512-7cbqBhh2QH0RaI7AD0ElJ2Ww/iRdW1w2wH/S2dv6EbdNQQlv39fx+V5VOepxLgfUvRkU5D5pxzgPuvHSAQOdpQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "shelljs": "^0.8.5",
     "shx": "^0.3.2",
     "sinon": "^11.1.1",
-    "typescript": "^5.5.0-beta",
+    "typescript": "^5.5.1-rc",
     "uglify-js": "^3.6.0",
     "unified": "^7.0.2",
     "videojs-generate-karma-config": "^8.1.0",

--- a/src/js/utils/create-logger.js
+++ b/src/js/utils/create-logger.js
@@ -104,9 +104,9 @@ export default function createLogger(name, delimiter = ':', styles = '') {
    * @param    {...*} args
    *           One or more messages or objects that should be logged.
    */
-  const log = function(...args) {
+  function log(...args) {
     logByType('log', level, args);
-  };
+  }
 
   // This is the logByType helper that the logging methods below use
   logByType = LogByTypeFactory(name, log, styles);
@@ -114,7 +114,7 @@ export default function createLogger(name, delimiter = ':', styles = '') {
   /**
    * Create a new subLogger which chains the old name to the new name.
    *
-   * For example, doing `videojs.log.createLogger('player')` and then using that logger will log the following:
+   * For example, doing `mylogger = videojs.log.createLogger('player')` and then using that logger will log the following:
    * ```js
    *  mylogger('foo');
    *  // > VIDEOJS: player: foo


### PR DESCRIPTION
## Description
Typescript =< 5.2 generated better types for `log` than >= 5.3. We're on 5.5 as that has the better import syntax.
Changing createLogger to use `function log()` rather than `const log = function()` outputs as before.

Also updates typescript to 5.5.1 (rc) from 5.5.0 (beta).

5.2, or 5.5 with this change
```
export default log;
declare const log: {
    (...args: any[]): void;
    createLogger(subName: string, subDelimiter?: string, subStyles?: string): any;
    createNewLogger(newName: string, newDelimiter?: string, newStyles?: string): any;
    levels: any;
    level(lvl?: "info" | "error" | "all" | "debug" | "warn" | "off"): string;
    history: {
        (): any[];
        filter(fname: string): any[];
        clear(): void;
        disable(): void;
        enable(): void;
    };
    error(...args: any[]): any;
    warn(...args: any[]): any;
    debug(...args: any[]): any;
};
export const createLogger: (subName: string, subDelimiter?: string, subStyles?: string) => any;
//# sourceMappingURL=log.d.ts.map%
```

5.3+, without this change
```
export default log;
declare function log(...args: any[]): void;
declare namespace log { }
export const createLogger: (subName: string, subDelimiter?: string, subStyles?: string) => any;
//# sourceMappingURL=log.d.ts.map%
```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
