### PR TITLE
chore: Update typescript to 5.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14165,9 +14165,9 @@
       }
     },
     "typescript": {
-      "version": "5.5.1-rc",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.1-rc.tgz",
-      "integrity": "sha512-7cbqBhh2QH0RaI7AD0ElJ2Ww/iRdW1w2wH/S2dv6EbdNQQlv39fx+V5VOepxLgfUvRkU5D5pxzgPuvHSAQOdpQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "shelljs": "^0.8.5",
     "shx": "^0.3.2",
     "sinon": "^11.1.1",
-    "typescript": "^5.5.1-rc",
+    "typescript": "^5.5.2",
     "uglify-js": "^3.6.0",
     "unified": "^7.0.2",
     "videojs-generate-karma-config": "^8.1.0",


### PR DESCRIPTION
## Description
Update to release of Typescript 5.5 (5.5.2) from rc (5.5.1). Diff shows no changes in types output.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
- [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
