### PR TITLE
fix(menu-item): Replace innerHTML of menu item to fix string bug on player

### DIFF
--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -74,6 +74,15 @@ class MenuItem extends ClickableComponent {
       textContent: this.localize(this.options_.label)
     });
 
+    const containsHexCode = (s) => {
+      return /\w*(&#x...)\w*/.test(s);
+    };
+
+    if (containsHexCode(menuItemEl.textContent)) {
+      // Replacement that allows innerHTML to be render properly.
+      menuItemEl.innerHTML = menuItemEl.textContent;
+    }
+
     // If using SVG icons, the element with vjs-icon-placeholder will be added separately.
     if (this.player_.options_.experimentalSvgIcons) {
       el.appendChild(menuItemEl);

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -4,7 +4,7 @@
 import ClickableComponent from '../clickable-component.js';
 import Component from '../component.js';
 import {createEl} from '../utils/dom.js';
-import { containsHexCode } from '../utils/str.js';
+import { containsHexCode, sanitizeString } from '../utils/str.js';
 
 /** @import Player from '../player' */
 
@@ -75,9 +75,11 @@ class MenuItem extends ClickableComponent {
       textContent: this.localize(this.options_.label)
     });
 
-    if (containsHexCode(menuItemEl.textContent)) {
+    const sanitizedString = sanitizeString(menuItemEl.textContent);
+
+    if (containsHexCode(sanitizedString)) {
       // Replacement that allows innerHTML to be render properly.
-      menuItemEl.innerHTML = menuItemEl.textContent;
+      menuItemEl.innerHTML = sanitizedString;
     }
 
     // If using SVG icons, the element with vjs-icon-placeholder will be added separately.

--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -4,6 +4,7 @@
 import ClickableComponent from '../clickable-component.js';
 import Component from '../component.js';
 import {createEl} from '../utils/dom.js';
+import { containsHexCode } from '../utils/str.js';
 
 /** @import Player from '../player' */
 
@@ -73,10 +74,6 @@ class MenuItem extends ClickableComponent {
       className: 'vjs-menu-item-text',
       textContent: this.localize(this.options_.label)
     });
-
-    const containsHexCode = (s) => {
-      return /\w*(&#x...)\w*/.test(s);
-    };
 
     if (containsHexCode(menuItemEl.textContent)) {
       // Replacement that allows innerHTML to be render properly.

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -62,5 +62,5 @@ export const titleCaseEquals = function(str1, str2) {
  *          Whether the string contains a Hex Code
  */
 export const containsHexCode = (string) => {
-  return /\w*(&#x[0-9a-fA-F]{2,4};)\w*/.test(string);
+  return /[a-zA-Z\040]*(&#x[0-9a-fA-F]{2,4};)[a-zA-Z\040]*/.test(string);
 };

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -62,5 +62,5 @@ export const titleCaseEquals = function(str1, str2) {
  *          Whether the string contains a Hex Code
  */
 export const containsHexCode = (string) => {
-  return /\w*(&#x.{2,4};)\w*/.test(string);
+  return /\w*(&#x[0-9a-fA-F]{2,4};)\w*/.test(string);
 };

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -52,3 +52,15 @@ export const toTitleCase = function(string) {
 export const titleCaseEquals = function(str1, str2) {
   return toTitleCase(str1) === toTitleCase(str2);
 };
+
+/**
+ *
+ * @param {string} string
+ *        The string that will be tested
+ *
+ * @return {boolean}
+ *          Whether the string contains a Hex Code
+ */
+export const containsHexCode = (string) => {
+  return /\w*(&#x.{2,4};)\w*/.test(string);
+};

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -64,3 +64,8 @@ export const titleCaseEquals = function(str1, str2) {
 export const containsHexCode = (string) => {
   return /[a-zA-Z\040]*(&#x[0-9a-fA-F]{2,4};)[a-zA-Z\040]*/.test(string);
 };
+
+export const sanitizeString = (string) => {
+  string = string.replace(/[^a-z0-9 áéíóúñü\&#;_]/gim, '');
+  return string.trim();
+};

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -62,10 +62,18 @@ export const titleCaseEquals = function(str1, str2) {
  *          Whether the string contains a Hex Code
  */
 export const containsHexCode = (string) => {
-  return /[a-zA-Z\040]*(&#x[0-9a-fA-F]{2,4};)[a-zA-Z\040]*/.test(string);
+  return /(&#x[0-9a-fA-F]{2,4};)/.test(string);
 };
 
+/**
+ *
+ * @param {string} string
+ *        The string that will be sanitized
+ *
+ * @return {string}
+ *        Modified string without problematic characters
+ */
 export const sanitizeString = (string) => {
-  string = string.replace(/[^a-z0-9 áéíóúñü\&#;_]/gim, '');
+  string = string.replace(/(?!&#x[0-9a-fA-F]{2,4};)([&\/><{}`=&])/, '');
   return string.trim();
 };


### PR DESCRIPTION
## Description
Replace innerHTML of menu item to fix string bug on player.

## Specific Changes proposed
With a condition using a regex replace innerHTML of menu item to fix string bug on player when content of the string contains HexCode.   

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
