### PR TITLE
fix: ensure transient button event listeners are removed on dispose

### DIFF
--- a/src/js/transient-button.js
+++ b/src/js/transient-button.js
@@ -53,7 +53,7 @@ class TransientButton extends Button {
 
     // When shown, the float button will be visible even if the user is inactive.
     // Clear this if there is any interaction.
-    player.on(['useractive', 'userinactive'], (e) => {
+    this.on(this.player_, ['useractive', 'userinactive'], (e) => {
       this.removeClass('force-display');
     });
   }


### PR DESCRIPTION
## Description
Transient button sets an event listener on the player directly instead of on itself, which doesn't get cleaned up when disposed.
Fixes #8795

## Specific Changes proposed
Call `on` on the component with player as the first arg, instead of calling `on` on the player directly.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
