### PR TITLE
fix: Listen to taps on track controls

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -332,12 +332,12 @@ class TextTrackSettings extends ModalDialog {
   }
 
   bindFunctionsToSelectsAndButtons() {
-    this.on(this.$('.vjs-done-button'), 'click', () => {
+    this.on(this.$('.vjs-done-button'), ['click', 'tap'], () => {
       this.saveSettings();
       this.close();
     });
 
-    this.on(this.$('.vjs-default-button'), 'click', () => {
+    this.on(this.$('.vjs-default-button'), ['click', 'tap'], () => {
       this.setDefaults();
       this.updateDisplay();
     });


### PR DESCRIPTION
## Description
The refactored text track controls aren't listening for tap events.

## Specific Changes proposed
Add tap handler to done and reset buttons.
Fixes #8808

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
