### PR TITLE
fix: Refactor evented to make mincompatable with Chrome 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14183,9 +14183,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.0.tgz",
+      "integrity": "sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==",
       "dev": true
     },
     "uglify-to-browserify": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "shx": "^0.3.2",
     "sinon": "^11.1.1",
     "typescript": "^5.5.2",
-    "uglify-js": "^3.6.0",
+    "uglify-js": "^3.19.0",
     "unified": "^7.0.2",
     "videojs-generate-karma-config": "^8.1.0",
     "videojs-languages": "^2.0.0",

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -183,7 +183,7 @@ const normalizeListenArgs = (self, args, fnName) => {
     [type, listener] = args;
   } else {
     // This was `[target, type, listener] = args;` but this block needs more than
-    // one statement zto produce minified output compatible with Chrome 53.
+    // one statement to produce minified output compatible with Chrome 53.
     // See https://github.com/videojs/video.js/pull/8810
     target = args[0];
     type = args[1];

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -182,7 +182,10 @@ const normalizeListenArgs = (self, args, fnName) => {
 
     [type, listener] = args;
   } else {
-    [target, type, listener] = args;
+    target = args[0];
+    type = args[1];
+    listener = args[2];
+    // [target, type, listener] = args;
   }
 
   validateTarget(target, self, fnName);

--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -182,10 +182,12 @@ const normalizeListenArgs = (self, args, fnName) => {
 
     [type, listener] = args;
   } else {
+    // This was `[target, type, listener] = args;` but this block needs more than
+    // one statement zto produce minified output compatible with Chrome 53.
+    // See https://github.com/videojs/video.js/pull/8810
     target = args[0];
     type = args[1];
     listener = args[2];
-    // [target, type, listener] = args;
   }
 
   validateTarget(target, self, fnName);


### PR DESCRIPTION
## Description
Chrome 53 doesn't like the minified output. Specifically, it throws `Uncaught SyntaxError: Unexpected token (` on the ternary in the minified version of `normalizeListenArgs()`
https://github.com/videojs/video.js/blob/e78bcc7b2d829fce01451cf105b918d8feec4548/src/js/mixins/evented.js#L165-L195

Line breaks added for clarify

```js
Tt = (e, t, s) => {
  var i = t.length < 3 || t[0] === e || t[0] === e.eventBusEl_;
  let r, n, a;
  return i ? (r = e.eventBusEl_, 3 <= t.length && t.shift(), [n, a] = t) : [r, n, a] = t, ft(r, e, s), yt(n, e, s), bt(a, e, s), a = _(e, a), {
    isTargetingSelf: I,
    target: r,
    type: n,
    listener: a
  }
},
```

Chrome would be happy with this if `[r, n, a] = t` were `([r, n, a] = t)`.

## Specific Changes proposed
Refactor `normalizeListenArgs()` slightly to use multiple statements to coerce uglify-js to include parentheses.
Also updates uglify-js, but that in itself isn't the fix.

Fixes #8783

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser - Browserstack Chrome 53
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
