### PR TITLE
fix(spatial-navigation): refocus available also to the close button of the error modal

### DIFF
--- a/src/js/spatial-navigation.js
+++ b/src/js/spatial-navigation.js
@@ -62,9 +62,20 @@ class SpatialNavigation extends EventTarget {
     this.player_.errorDisplay.on('aftermodalfill', () => {
       this.updateFocusableComponents();
 
-      // Focus the buttons of the modal
-      if (this.focusableComponents.length > 1) {
-        this.focusableComponents[1].focus();
+      if (this.focusableComponents.length) {
+        // The modal has focusable components:
+
+        if (this.focusableComponents.length > 1) {
+          // The modal has close button + some additional buttons.
+          // Focusing first additional button:
+
+          this.focusableComponents[1].focus();
+        } else {
+          // The modal has only close button,
+          // Focusing it:
+
+          this.focusableComponents[0].focus();
+        }
       }
     });
   }


### PR DESCRIPTION
## Description
This PR will make the refocus available not only to the buttons of the error modal but also to the close button of the error modal on the event of 'aftermodalfill'.

## Specific Changes proposed
Allow the spatial-navigation to refocus the error modal when error modal appears.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors