### PR TITLE
fix: allow captions in devices that use old chrome to be shown

### DIFF
--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -47,9 +47,11 @@ video::-webkit-media-text-track-display {
   width: 80% !important;
 }
 
-.video-js .vjs-text-track-display-inset {
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+@supports (inset: 10px) {
+  .video-js .vjs-text-track-display {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
 }

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -47,7 +47,7 @@ video::-webkit-media-text-track-display {
   width: 80% !important;
 }
 
-.video-js .inset-alternative {
+.video-js .vjs-text-track-display-inset {
   top: 0;
   right: 0;
   bottom: 0;

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -46,3 +46,10 @@ video::-webkit-media-text-track-display {
   text-align: center !important;
   width: 80% !important;
 }
+
+.video-js .vjs-text-track-display > div {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -48,7 +48,7 @@ video::-webkit-media-text-track-display {
 }
 
 @supports (inset: 10px) {
-  .video-js .vjs-text-track-display {
+  .video-js .vjs-text-track-display > div {
     top: 0;
     right: 0;
     bottom: 0;

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -47,8 +47,7 @@ video::-webkit-media-text-track-display {
   width: 80% !important;
 }
 
-.video-js .vjs-text-track-display > div {
-  position: absolute;
+.video-js .inset-alternative {
   top: 0;
   right: 0;
   bottom: 0;

--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -48,6 +48,7 @@ video::-webkit-media-text-track-display {
 }
 
 .video-js .vjs-text-track-display > div {
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -330,6 +330,9 @@ class TextTrackDisplay extends Component {
       // Clear inline style before getting actual height of textTrackDisplay
       textTrackDisplay.style = '';
 
+      // Add custom class to textTrackDisplay div child for not inset support styles
+      textTrackDisplay.firstChild.classList.add('inset-alternative');
+
       // textrack style updates, this styles are required to be inline
       tryUpdateStyle(textTrackDisplay, 'position', 'relative');
       tryUpdateStyle(textTrackDisplay, 'height', (playerHeight - controlBarHeight) + 'px');

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -330,9 +330,6 @@ class TextTrackDisplay extends Component {
       // Clear inline style before getting actual height of textTrackDisplay
       textTrackDisplay.style = '';
 
-      // Add custom class to textTrackDisplay div child for not inset support styles
-      textTrackDisplay.firstChild.classList.add('vjs-text-track-display-inset');
-
       // textrack style updates, this styles are required to be inline
       tryUpdateStyle(textTrackDisplay, 'position', 'relative');
       tryUpdateStyle(textTrackDisplay, 'height', (playerHeight - controlBarHeight) + 'px');

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -322,14 +322,27 @@ class TextTrackDisplay extends Component {
     }
 
     if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
-      const textTrack = window.document.querySelector('.vjs-text-track-display');
-      const textTrackHeight = textTrack.getBoundingClientRect().height;
+      const textTrackDisplay = this.el_;
+      const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
+      const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
 
-      // This styles are required to be inline
-      textTrack.style.position = 'relative';
-      textTrack.style.height = textTrackHeight + 'px';
-      textTrack.style.top = 'unset';
-      textTrack.style.bottom = '0px';
+      // textrack style updates, this styles are required to be inline
+      textTrackDisplay.style.position = 'relative';
+      textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
+      textTrackDisplay.style.top = 'unset';
+      textTrackDisplay.style.bottom = '0px';
+
+      // vjsTextTrackCue style updates
+      if (vjsTextTrackCues.length > 0) {
+        vjsTextTrackCues.forEach((vjsTextTrackCue) => {
+          const insetStyles = vjsTextTrackCue.style.inset.split(' ');
+
+          // expected value is always 3
+          if (insetStyles.length === 3) {
+            Object.assign(vjsTextTrackCue.style, { top: insetStyles[0], right: insetStyles[1], bottom: insetStyles[2], left: 'unset' });
+          }
+        });
+      }
     }
   }
 
@@ -494,19 +507,6 @@ class TextTrackDisplay extends Component {
       }
       if (this.player_.textTrackSettings) {
         this.updateDisplayState(track);
-      }
-    }
-
-    if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
-      const document_ = window.document;
-      const vjsTextTrackCue = document_.querySelector('.vjs-text-track-cue');
-
-      if (vjsTextTrackCue) {
-        const insetStyles = vjsTextTrackCue.style.inset.split(' ');
-
-        if (insetStyles.length === 3) {
-          Object.assign(vjsTextTrackCue.style, { top: insetStyles[0], right: insetStyles[1], bottom: insetStyles[2], left: 'unset' });
-        }
       }
     }
   }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -319,6 +319,23 @@ class TextTrackDisplay extends Component {
       }
       this.updateForTrack(descriptionsTrack);
     }
+
+    if (!window.CSS.supports('inset', '0')) {
+      const textTrack = window.document.querySelector('.vjs-text-track-display');
+      const player = window.document.querySelector('video-js');
+      const textTrackHeight = textTrack.getBoundingClientRect().height;
+
+      // This styles are required to be inline
+      textTrack.style.position = 'relative';
+      textTrack.style.height = textTrackHeight + 'px';
+      textTrack.style.top = 'unset';
+
+      if (player.classList.contains('vjs-fullscreen')) {
+        textTrack.style.bottom = textTrackHeight + 'px';
+      } else {
+        textTrack.style.bottom = '0px';
+      }
+    }
   }
 
   /**
@@ -482,6 +499,19 @@ class TextTrackDisplay extends Component {
       }
       if (this.player_.textTrackSettings) {
         this.updateDisplayState(track);
+      }
+    }
+
+    if (!window.CSS.supports('inset', '0')) {
+      const document_ = window.document;
+      const vjsTextTrackCue = document_.querySelector('.vjs-text-track-cue');
+
+      if (vjsTextTrackCue) {
+        const insetStyles = vjsTextTrackCue.style.inset.split(' ');
+
+        if (insetStyles.length === 3) {
+          Object.assign(vjsTextTrackCue.style, { top: insetStyles[0], right: insetStyles[1], bottom: insetStyles[2], left: 'unset' });
+        }
       }
     }
   }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -5,6 +5,7 @@ import Component from '../component';
 import * as Fn from '../utils/fn.js';
 import * as Dom from '../utils/dom.js';
 import window from 'global/window';
+import * as browser from '../utils/browser';
 
 /** @import Player from '../player' */
 
@@ -323,10 +324,22 @@ class TextTrackDisplay extends Component {
     if (!window.CSS.supports('inset', '10px')) {
       const textTrackDisplay = this.el_;
       const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
+      const controlBarHeight = this.player_.controlBar.el_.getBoundingClientRect().height;
+      const playerHeight = this.player_.el_.getBoundingClientRect().height;
 
       // Clear inline style before getting actual height of textTrackDisplay
       textTrackDisplay.style = '';
-      const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
+
+      // textrack style updates, this styles are required to be inline
+      tryUpdateStyle(textTrackDisplay, 'position', 'relative');
+      tryUpdateStyle(textTrackDisplay, 'height', (playerHeight - controlBarHeight) + 'px');
+      tryUpdateStyle(textTrackDisplay, 'top', 'unset');
+
+      if (browser.IS_SMART_TV) {
+        tryUpdateStyle(textTrackDisplay, 'bottom', playerHeight + 'px');
+      } else {
+        tryUpdateStyle(textTrackDisplay, 'bottom', '0px');
+      }
 
       // vjsTextTrackCue style updates
       if (vjsTextTrackCues.length > 0) {
@@ -342,12 +355,6 @@ class TextTrackDisplay extends Component {
           }
         });
       }
-
-      // textrack style updates, this styles are required to be inline
-      tryUpdateStyle(textTrackDisplay, 'position', 'relative');
-      tryUpdateStyle(textTrackDisplay, 'height', textTrackDisplayHeight + 'px');
-      tryUpdateStyle(textTrackDisplay, 'top', 'unset');
-      tryUpdateStyle(textTrackDisplay, 'bottom', '0px');
     }
   }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -5,7 +5,6 @@ import Component from '../component';
 import * as Fn from '../utils/fn.js';
 import * as Dom from '../utils/dom.js';
 import window from 'global/window';
-import * as browser from '../utils/browser';
 
 /** @import Player from '../player' */
 
@@ -321,9 +320,13 @@ class TextTrackDisplay extends Component {
       this.updateForTrack(descriptionsTrack);
     }
 
-    if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
+    if (!window.CSS.supports('inset', '10px')) {
       const textTrackDisplay = this.el_;
       const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
+
+      // Clear inline style before getting actual height of textTrackDisplay
+      textTrackDisplay.style = '';
+      const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
 
       // vjsTextTrackCue style updates
       if (vjsTextTrackCues.length > 0) {
@@ -336,6 +339,12 @@ class TextTrackDisplay extends Component {
           }
         });
       }
+
+      // textrack style updates, this styles are required to be inline
+      textTrackDisplay.style.position = 'relative';
+      textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
+      textTrackDisplay.style.top = 'unset';
+      textTrackDisplay.style.bottom = '0px';
     }
   }
 
@@ -347,17 +356,6 @@ class TextTrackDisplay extends Component {
     // inset-inline and inset-block are not supprted on old chrome, but these are
     // only likely to be used on TV devices
     if (!this.player_.videoHeight() || !window.CSS.supports('inset-inline: 10px')) {
-      if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
-        const textTrackDisplay = this.el_;
-        const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
-
-        // textrack style updates, this styles are required to be inline
-        textTrackDisplay.style.position = 'relative';
-        textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
-        textTrackDisplay.style.top = 'unset';
-        textTrackDisplay.style.bottom = '0px';
-      }
-
       return;
     }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -331,7 +331,7 @@ class TextTrackDisplay extends Component {
       textTrackDisplay.style = '';
 
       // Add custom class to textTrackDisplay div child for not inset support styles
-      textTrackDisplay.firstChild.classList.add('inset-alternative');
+      textTrackDisplay.firstChild.classList.add('vjs-text-track-display-inset');
 
       // textrack style updates, this styles are required to be inline
       tryUpdateStyle(textTrackDisplay, 'position', 'relative');

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -320,7 +320,7 @@ class TextTrackDisplay extends Component {
       this.updateForTrack(descriptionsTrack);
     }
 
-    if (window.CSS.supports('inset', '10px')) {
+    if (!window.CSS.supports('inset', '10px')) {
       const textTrackDisplay = this.el_;
       const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -5,6 +5,7 @@ import Component from '../component';
 import * as Fn from '../utils/fn.js';
 import * as Dom from '../utils/dom.js';
 import window from 'global/window';
+import * as browser from '../utils/browser';
 
 /** @import Player from '../player' */
 
@@ -320,21 +321,15 @@ class TextTrackDisplay extends Component {
       this.updateForTrack(descriptionsTrack);
     }
 
-    if (!window.CSS.supports('inset', '0')) {
+    if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
       const textTrack = window.document.querySelector('.vjs-text-track-display');
-      const player = window.document.querySelector('video-js');
       const textTrackHeight = textTrack.getBoundingClientRect().height;
 
       // This styles are required to be inline
       textTrack.style.position = 'relative';
       textTrack.style.height = textTrackHeight + 'px';
       textTrack.style.top = 'unset';
-
-      if (player.classList.contains('vjs-fullscreen')) {
-        textTrack.style.bottom = textTrackHeight + 'px';
-      } else {
-        textTrack.style.bottom = '0px';
-      }
+      textTrack.style.bottom = '0px';
     }
   }
 
@@ -502,7 +497,7 @@ class TextTrackDisplay extends Component {
       }
     }
 
-    if (!window.CSS.supports('inset', '0')) {
+    if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
       const document_ = window.document;
       const vjsTextTrackCue = document_.querySelector('.vjs-text-track-cue');
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -331,11 +331,14 @@ class TextTrackDisplay extends Component {
       // vjsTextTrackCue style updates
       if (vjsTextTrackCues.length > 0) {
         vjsTextTrackCues.forEach((vjsTextTrackCue) => {
-          const insetStyles = vjsTextTrackCue.style.inset.split(' ');
+          // verify if inset styles are inline
+          if (vjsTextTrackCue.style.inset) {
+            const insetStyles = vjsTextTrackCue.style.inset.split(' ');
 
-          // expected value is always 3
-          if (insetStyles.length === 3) {
-            Object.assign(vjsTextTrackCue.style, { top: insetStyles[0], right: insetStyles[1], bottom: insetStyles[2], left: 'unset' });
+            // expected value is always 3
+            if (insetStyles.length === 3) {
+              Object.assign(vjsTextTrackCue.style, { top: insetStyles[0], right: insetStyles[1], bottom: insetStyles[2], left: 'unset' });
+            }
           }
         });
       }

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -320,7 +320,7 @@ class TextTrackDisplay extends Component {
       this.updateForTrack(descriptionsTrack);
     }
 
-    if (!window.CSS.supports('inset', '10px')) {
+    if (window.CSS.supports('inset', '10px')) {
       const textTrackDisplay = this.el_;
       const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
 
@@ -341,10 +341,10 @@ class TextTrackDisplay extends Component {
       }
 
       // textrack style updates, this styles are required to be inline
-      textTrackDisplay.style.position = 'relative';
-      textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
-      textTrackDisplay.style.top = 'unset';
-      textTrackDisplay.style.bottom = '0px';
+      tryUpdateStyle(textTrackDisplay, 'position', 'relative');
+      tryUpdateStyle(textTrackDisplay, 'height', textTrackDisplayHeight + 'px');
+      tryUpdateStyle(textTrackDisplay, 'top', 'unset');
+      tryUpdateStyle(textTrackDisplay, 'bottom', '0px');
     }
   }
 

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -323,14 +323,7 @@ class TextTrackDisplay extends Component {
 
     if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
       const textTrackDisplay = this.el_;
-      const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
       const vjsTextTrackCues = textTrackDisplay.querySelectorAll('.vjs-text-track-cue');
-
-      // textrack style updates, this styles are required to be inline
-      textTrackDisplay.style.position = 'relative';
-      textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
-      textTrackDisplay.style.top = 'unset';
-      textTrackDisplay.style.bottom = '0px';
 
       // vjsTextTrackCue style updates
       if (vjsTextTrackCues.length > 0) {
@@ -354,6 +347,17 @@ class TextTrackDisplay extends Component {
     // inset-inline and inset-block are not supprted on old chrome, but these are
     // only likely to be used on TV devices
     if (!this.player_.videoHeight() || !window.CSS.supports('inset-inline: 10px')) {
+      if (browser.IS_SMART_TV && !window.CSS.supports('inset', '10px')) {
+        const textTrackDisplay = this.el_;
+        const textTrackDisplayHeight = textTrackDisplay.getBoundingClientRect().height;
+
+        // textrack style updates, this styles are required to be inline
+        textTrackDisplay.style.position = 'relative';
+        textTrackDisplay.style.height = textTrackDisplayHeight + 'px';
+        textTrackDisplay.style.top = 'unset';
+        textTrackDisplay.style.bottom = '0px';
+      }
+
       return;
     }
 

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -500,4 +500,32 @@ if (!Html5.supportsNativeTextTracks()) {
 
     player.dispose();
   });
+
+  QUnit.test('should use relative position for vjs-text-track-display element if browser is does not support inset property', function(assert) {
+    // Set conditions for the use of the style modifications
+    window.CSS.supports = () => false;
+    browser.IS_SMART_TV = () => true;
+
+    const player = TestHelpers.makePlayer();
+    const track1 = {
+      kind: 'captions',
+      label: 'English',
+      language: 'en',
+      src: 'en.vtt',
+      default: true
+    };
+
+    // Add the text track
+    player.addRemoteTextTrack(track1, true);
+
+    // Make sure the ready handler runs
+    this.clock.tick(1);
+
+    const textTrack = window.document.querySelector('.vjs-text-track-display');
+
+    assert.ok(textTrack.style.position === 'relative', 'Style of position for vjs-text-track-display element should be relative');
+    assert.ok(textTrack.style.top === 'unset', 'Style of position for vjs-text-track-display element should be unset');
+    assert.ok(textTrack.style.bottom === '0px', 'Style of bottom for vjs-text-track-display element should be 0px');
+    player.dispose();
+  });
 }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -501,7 +501,7 @@ if (!Html5.supportsNativeTextTracks()) {
     player.dispose();
   });
 
-  QUnit.test('should use relative position for vjs-text-track-display element if browser is does not support inset property', function(assert) {
+  QUnit.test('should use relative position for vjs-text-track-display element if browser does not support inset property', function(assert) {
     // Set conditions for the use of the style modifications
     window.CSS.supports = () => false;
     browser.IS_SMART_TV = () => true;

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -518,6 +518,12 @@ if (!Html5.supportsNativeTextTracks()) {
     // Add the text track
     player.addRemoteTextTrack(track1, true);
 
+    player.src({type: 'video/mp4', src: 'http://google.com'});
+    player.play();
+
+    // as if metadata was loaded
+    player.textTrackDisplay.updateDisplayOverlay();
+
     // Make sure the ready handler runs
     this.clock.tick(1);
 
@@ -526,6 +532,49 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(textTrack.style.position === 'relative', 'Style of position for vjs-text-track-display element should be relative');
     assert.ok(textTrack.style.top === 'unset', 'Style of position for vjs-text-track-display element should be unset');
     assert.ok(textTrack.style.bottom === '0px', 'Style of bottom for vjs-text-track-display element should be 0px');
+    player.dispose();
+  });
+
+  QUnit.test('track cue should use values of top, right, botton, left if browser does not support inset property', function(assert) {
+    // Set conditions for the use of the style modifications
+    window.CSS.supports = () => false;
+    browser.IS_SMART_TV = () => true;
+
+    const player = TestHelpers.makePlayer();
+    const track1 = {
+      kind: 'captions',
+      label: 'English',
+      language: 'en',
+      src: 'en.vtt',
+      default: true
+    };
+
+    // Add the text track
+    player.addRemoteTextTrack(track1, true);
+
+    player.src({type: 'video/mp4', src: 'http://google.com'});
+    player.play();
+
+    // mock caption
+    const textTrackDisplay = window.document.querySelector('.vjs-text-track-display').firstChild;
+    const node = document.createElement('div');
+
+    node.classList.add('vjs-text-track-cue');
+    node.style.inset = '1px 2px 3px';
+    const textnode = document.createTextNode('Sample text');
+
+    node.appendChild(textnode);
+    textTrackDisplay.appendChild(node);
+
+    // avoid captions clear
+    player.textTrackDisplay.clearDisplay = () => '';
+
+    // as if metadata was loaded
+    player.textTrackDisplay.updateDisplay();
+
+    assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.left === 'unset', 'Style of left for vjs-text-track-cue element should be unset');
+    assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.top === '1px', 'Style of top for vjs-text-track-cue element should be 1px');
+    assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.right === '2px', 'Style of right for vjs-text-track-cue element should be 2px');
     player.dispose();
   });
 }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -575,7 +575,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.left === 'unset', 'Style of left for vjs-text-track-cue element should be unset');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.top === '1px', 'Style of top for vjs-text-track-cue element should be 1px');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.right === '2px', 'Style of right for vjs-text-track-cue element should be 2px');
-    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('inset-alternative'), 'Child of textTrackDisplay should contain class of inset-alternative');
+    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('vjs-text-track-display-inset'), 'Child of textTrackDisplay should contain class of inset-alternative');
     player.dispose();
   });
 }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -575,6 +575,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.left === 'unset', 'Style of left for vjs-text-track-cue element should be unset');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.top === '1px', 'Style of top for vjs-text-track-cue element should be 1px');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.right === '2px', 'Style of right for vjs-text-track-cue element should be 2px');
+    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('inset-alternative'), 'Child of textTrackDisplay should contain class of inset-alternative');
     player.dispose();
   });
 }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -575,7 +575,7 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.left === 'unset', 'Style of left for vjs-text-track-cue element should be unset');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.top === '1px', 'Style of top for vjs-text-track-cue element should be 1px');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.right === '2px', 'Style of right for vjs-text-track-cue element should be 2px');
-    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('vjs-text-track-display-inset'), 'Child of textTrackDisplay should contain class of inset-alternative');
+    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('vjs-text-track-display-inset'), 'Child of textTrackDisplay should contain class of vjs-text-track-display-inset');
     player.dispose();
   });
 }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -575,7 +575,6 @@ if (!Html5.supportsNativeTextTracks()) {
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.left === 'unset', 'Style of left for vjs-text-track-cue element should be unset');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.top === '1px', 'Style of top for vjs-text-track-cue element should be 1px');
     assert.ok(player.textTrackDisplay.el_.querySelector('.vjs-text-track-cue').style.right === '2px', 'Style of right for vjs-text-track-cue element should be 2px');
-    assert.ok(player.textTrackDisplay.el_.firstChild.classList.contains('vjs-text-track-display-inset'), 'Child of textTrackDisplay should contain class of vjs-text-track-display-inset');
     player.dispose();
   });
 }


### PR DESCRIPTION
## Description
In the specific case of using an old chrome version this minor changes will allow the captions to be shown.

## Specific Changes proposed
Small fix when using videojs in an old browser that does not support the css 'inset' property.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
