### PR TITLE
chore: update http-streaming to v3.13.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,9 +1791,9 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.2.tgz",
-      "integrity": "sha512-eCfQp61w00hg7Y9npmLnsJ6UvDF+SsFYzu7mQJgVXxWpVm9AthYWA3KQEKA7F7Sy6yzlm/Sps8BHs5ItelNZgQ==",
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.3.tgz",
+      "integrity": "sha512-L7H+iTeqHeZ5PylzOx+pT3CVyzn4TALWYTJKkIc1pDaV/cTVfNGtG+9/vXPAydD+wR/xH1M9/t2JH8tn/DCT4w==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "4.0.0",
@@ -15101,12 +15101,12 @@
       "dev": true
     },
     "video.js": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.16.1.tgz",
-      "integrity": "sha512-yAhxu4Vhyx5DdOgPn2PcRKHx3Vzs9tpvCWA0yX+sv5bIeBkg+IWdEX+MHGZgktgDQ/R8fJDxDbEASyvxXnFn1A==",
+      "version": "8.17.2",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.17.2.tgz",
+      "integrity": "sha512-oa4BGAr5H965OBcn83qM9xMMtjtSCRh0zMLnyouD9itQJ994FY/NlYo+XSPujk4NpsBGHSUF/+rGy0Wu5Mrzqg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.13.1",
+        "@videojs/http-streaming": "3.13.2",
         "@videojs/vhs-utils": "^4.0.0",
         "@videojs/xhr": "2.7.0",
         "aes-decrypter": "^4.0.1",
@@ -15121,9 +15121,9 @@
       },
       "dependencies": {
         "@videojs/http-streaming": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.1.tgz",
-          "integrity": "sha512-G7YrgNEq9ETaUmtkoTnTuwkY9U+xP7Xncedzgxio/Rmz2Gn2zmodEbBIVQinb2UDznk7X8uY5XBr/Ew6OD/LWg==",
+          "version": "3.13.2",
+          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.2.tgz",
+          "integrity": "sha512-eCfQp61w00hg7Y9npmLnsJ6UvDF+SsFYzu7mQJgVXxWpVm9AthYWA3KQEKA7F7Sy6yzlm/Sps8BHs5ItelNZgQ==",
           "requires": {
             "@babel/runtime": "^7.12.5",
             "@videojs/vhs-utils": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "3.13.2",
+    "@videojs/http-streaming": "3.13.3",
     "@videojs/vhs-utils": "^4.0.0",
     "@videojs/xhr": "2.7.0",
     "aes-decrypter": "^4.0.1",


### PR DESCRIPTION
## Description
Update http-streaming to v3.13.3

## Specific Changes proposed
- Update package.json and package-lock.json with new version of VHS.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
