### PR TITLE
fix: ensure spatial navigation starts without error without an ErrorD…

### DIFF
--- a/src/js/spatial-navigation.js
+++ b/src/js/spatial-navigation.js
@@ -59,25 +59,27 @@ class SpatialNavigation extends EventTarget {
     this.player_.on('focusin', this.handlePlayerFocus_.bind(this));
     this.player_.on('focusout', this.handlePlayerBlur_.bind(this));
     this.isListening_ = true;
-    this.player_.errorDisplay.on('aftermodalfill', () => {
-      this.updateFocusableComponents();
+    if (this.player_.errorDisplay) {
+      this.player_.errorDisplay.on('aftermodalfill', () => {
+        this.updateFocusableComponents();
 
-      if (this.focusableComponents.length) {
-        // The modal has focusable components:
+        if (this.focusableComponents.length) {
+          // The modal has focusable components:
 
-        if (this.focusableComponents.length > 1) {
-          // The modal has close button + some additional buttons.
-          // Focusing first additional button:
+          if (this.focusableComponents.length > 1) {
+            // The modal has close button + some additional buttons.
+            // Focusing first additional button:
 
-          this.focusableComponents[1].focus();
-        } else {
-          // The modal has only close button,
-          // Focusing it:
+            this.focusableComponents[1].focus();
+          } else {
+            // The modal has only close button,
+            // Focusing it:
 
-          this.focusableComponents[0].focus();
+            this.focusableComponents[0].focus();
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   /**

--- a/test/unit/spatial-navigation.test.js
+++ b/test/unit/spatial-navigation.test.js
@@ -612,3 +612,11 @@ QUnit.test('If component passes the required functions it should be added to foc
   assert.strictEqual(this.spatialNav.focusableComponents.length, 1, 'focusableComponents array should have 1 component');
   assert.strictEqual(this.spatialNav.focusableComponents[0].name_, 'firstComponent', 'the name of the component in focusableComponents array should be "firstComponent"');
 });
+
+QUnit.test('Doesn\'t error if no ErrorDisplay component is present', function(assert) {
+  this.player.errorDisplay.dispose();
+  delete this.player.errorDisplay;
+
+  this.spatialNav.start();
+  assert.ok(true, 'started without throwing when errorDisplay not present');
+});


### PR DESCRIPTION
…isplay component

## Description
By default a Video.js player has an ErrorDisplay, but in the event it is created without one, an error will be thrown when starting spatial navigation.

## Specific Changes proposed
Only add an event listener to `player.errorDisplay` if it exists.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
