### PR TITLE
fix: check for closeable() before calling in spatialnavigation

### DIFF
--- a/src/js/spatial-navigation.js
+++ b/src/js/spatial-navigation.js
@@ -118,7 +118,8 @@ class SpatialNavigation extends EventTarget {
       const action = SpatialNavKeyCodes.getEventName(actualEvent);
 
       this.performMediaAction_(action);
-    } else if (SpatialNavKeyCodes.isEventKey(actualEvent, 'Back') && event.target && event.target.closeable()) {
+    } else if (SpatialNavKeyCodes.isEventKey(actualEvent, 'Back') &&
+        event.target && typeof event.target.closeable === 'function' && event.target.closeable()) {
       actualEvent.preventDefault();
       event.target.close();
     }


### PR DESCRIPTION
## Description
Passing the back key causes an error in spatial navigation if the event target does not have a `closeable` function.

## Specific Changes proposed
Add a check before calling.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
