### PR TITLE
chore: update version number in readme on release

### DIFF
--- a/build/readme-version.js
+++ b/build/readme-version.js
@@ -1,0 +1,16 @@
+/*
+Replaces the version number in the readme with the current package version.
+Looks for patterns like `/8.17.3/` and `/video.js@8.17.3/`
+*/
+
+const fs = require('fs');
+const path = require('path');
+const version = require('../package.json').version;
+
+let doc = fs.readFileSync(path.join(__dirname, '..', 'README.md'), 'utf8');
+
+doc = doc
+  .replace(/\/video.js@\d\.\d+\.\d+\//g, `/video.js@${version}/`)
+  .replace(/\/\d\.\d+\.\d+\//g, `/${version}/`);
+
+fs.writeFileSync(path.join(__dirname, '..', 'README.md'), doc, 'utf8');

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "netlify": "node ./build/netlify.js",
     "netlify-docs": "node ./build/netlify-docs.js",
     "prepublishOnly": "run-p build",
-    "version": "is-prerelease || npm run changelog && git add CHANGELOG.md",
+    "version": "is-prerelease || npm run changelog && node build/readme-version.js && git add CHANGELOG.md README.md",
     "zip": "cd dist && cross-env bestzip \"./video-js-${npm_package_version}.zip\" * && cd .."
   },
   "repository": {


### PR DESCRIPTION
## Description
Updates the version number where it appears in URLs in the README, when `nom version` is ran. It's looking specifically for patterns like `/8.17.3/` and `/video.js@8.17.3/`; if we change the README we need to consider this script.

## Specific Changes proposed
New script at build/readme-version.js

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
