### PR TITLE
Rollup: Specify AMD id

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -137,6 +137,9 @@ export default cliargs => [
     input: 'src/js/index.js',
     output: {
       format: 'umd',
+      amd: {
+        id: 'videojs'
+      },
       file: 'dist/video.js',
       name: 'videojs',
       banner,


### PR DESCRIPTION
## Description
Today, video.js exports itself as an AMD module (if the site supports AMD) via the UMD header:

```js
(function (global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
  typeof define === 'function' && define.amd ? define(factory) :
  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.videojs = factory());
})(this, (function () { 'use strict';
```

The second clause which runs if AMD/RequireJS is active, is a `define(factory)` function call.  This is an "anonymous" definition of the module.  Being anonymous will break on sites using the lightweight RequireJS shim called [almond](https://github.com/requirejs/almond), which expect all modules to be named.

This can be challenging if video.js is being pulled into the site via a third-party, i.e. as part of ads.

Prior to using Browserify/Rollup, video.js had implemented a change to ensure `define('videojs', factory)` was used:

https://github.com/videojs/video.js/pull/1844

However, after the switch to Browserify, that small change was lost:

https://github.com/videojs/video.js/pull/3826

This error is seen by others, i.e. https://github.com/videojs/video.js/issues/1843#issuecomment-1041424944

## Specific Changes proposed

This PR simply ensures video.js is named for AMD via the `rollup.config.js`.

The UMD definition changes to this:

```js
(function (global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
  typeof define === 'function' && define.amd ? define('videojs', factory) :
  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.videojs = factory());
})(this, (function () { 'use strict';
```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
