### PR TITLE
fix: use backup styles when inset is not supported

### DIFF
--- a/src/css/components/_text-track.scss
+++ b/src/css/components/_text-track.scss
@@ -47,7 +47,7 @@ video::-webkit-media-text-track-display {
   width: 80% !important;
 }
 
-@supports (inset: 10px) {
+@supports not (inset: 10px) {
   .video-js .vjs-text-track-display > div {
     top: 0;
     right: 0;


### PR DESCRIPTION
## Description
Small fix to use backup styles only when inset is not supported.

## Specific Changes proposed
Use backup styles only when inset is not supported.

## Requirements Checklist
- [x] Feature implemented / Bug fixed