### PR TITLE
fix: decode string when containing hexcode

### DIFF
--- a/src/js/menu/menu-item.js
+++ b/src/js/menu/menu-item.js
@@ -4,6 +4,7 @@
 import ClickableComponent from '../clickable-component.js';
 import Component from '../component.js';
 import {createEl} from '../utils/dom.js';
+import { containsHexCode, decodeString } from '../utils/str.js';
 
 /** @import Player from '../player' */
 
@@ -68,10 +69,18 @@ class MenuItem extends ClickableComponent {
       tabIndex: -1
     }, props), attrs);
 
+    const createTextContent = () => {
+      if (containsHexCode(this.options_.label)) {
+        return this.localize(decodeString(this.options_.label));
+      }
+
+      return this.localize(this.options_.label);
+    };
+
     // swap icon with menu item text.
     const menuItemEl = createEl('span', {
       className: 'vjs-menu-item-text',
-      textContent: this.localize(this.options_.label)
+      textContent: createTextContent()
     });
 
     // If using SVG icons, the element with vjs-icon-placeholder will be added separately.

--- a/src/js/utils/str.js
+++ b/src/js/utils/str.js
@@ -52,3 +52,30 @@ export const toTitleCase = function(string) {
 export const titleCaseEquals = function(str1, str2) {
   return toTitleCase(str1) === toTitleCase(str2);
 };
+
+/**
+ *
+ * @param {string} string
+ *        The string that will be tested
+ *
+ * @return {boolean}
+ *          Whether the string contains a Hex Code
+ */
+export const containsHexCode = (string) => {
+  return /(&#x[0-9a-fA-F]{2,4};)/.test(string);
+};
+
+/**
+ *
+ * @param {string} string
+ *        The string that will be decoded
+ *
+ * @return {string}
+ *        Decoded string without problematic characters
+ */
+export const decodeString = (string) => {
+  // eslint-disable-next-line no-undef
+  const doc = new DOMParser().parseFromString(string, 'text/html');
+
+  return doc.documentElement.textContent;
+};


### PR DESCRIPTION
## Description
Bugfix for when menu-item.js generates a vjs-menu-item-text with hexcode characters.

## Specific Changes proposed
Decode string when containing hexcode in menu-item.js

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
