### PR TITLE
fix: Don't request fullscreen from document PIP window

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2003,7 +2003,8 @@ class Player extends Component {
   }
 
   /**
-   * Handle a double-click on the media element to enter/exit fullscreen
+   * Handle a double-click on the media element to enter/exit fullscreen,
+   * or exit documentPictureInPicture mode
    *
    * @param {Event} event
    *        the event that caused this function to trigger
@@ -2045,7 +2046,12 @@ class Player extends Component {
         ) {
 
           this.options_.userActions.doubleClick.call(this, event);
-
+        } else if (this.isInPictureInPicture() && !document.pictureInPictureElement) {
+          // Checking the presence of `window.documentPictureInPicture.window` complicates
+          // tests, checking `document.pictureInPictureElement` also works. It wouldn't
+          // be null in  regular picture in picture.
+          // Exit picture in picture mode. This gesture can't trigger pip on the main window.
+          this.exitPictureInPicture();
         } else if (this.isFullscreen()) {
           this.exitFullscreen();
         } else {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -2049,7 +2049,7 @@ class Player extends Component {
         } else if (this.isInPictureInPicture() && !document.pictureInPictureElement) {
           // Checking the presence of `window.documentPictureInPicture.window` complicates
           // tests, checking `document.pictureInPictureElement` also works. It wouldn't
-          // be null in  regular picture in picture.
+          // be null in regular picture in picture.
           // Exit picture in picture mode. This gesture can't trigger pip on the main window.
           this.exitPictureInPicture();
         } else if (this.isFullscreen()) {

--- a/test/unit/player-user-actions.test.js
+++ b/test/unit/player-user-actions.test.js
@@ -151,6 +151,19 @@ QUnit.test('by default, double-click opens fullscreen', function(assert) {
   assert.strictEqual(this.player.exitFullscreen.callCount, 1, 'has exited fullscreen');
 });
 
+QUnit.test('in document picture in picture mode, double-click exits pip', function(assert) {
+  this.player.isInPictureInPicture = () => true;
+  this.player.exitPictureInPicture = sinon.spy();
+  this.player.requestFullscreen = sinon.spy();
+  this.player.exitFullscreen = sinon.spy();
+
+  this.player.handleTechDoubleClick_({target: this.player.tech_.el_});
+
+  assert.strictEqual(this.player.exitPictureInPicture.callCount, 1, 'has exited pip once');
+  assert.strictEqual(this.player.requestFullscreen.callCount, 0, 'has not entered fullscreen');
+  assert.strictEqual(this.player.exitFullscreen.callCount, 0, 'has not exited fullscreen');
+});
+
 QUnit.test('when controls are disabled, double-click does nothing', function(assert) {
   let fullscreen = false;
 


### PR DESCRIPTION
## Description
Double clicking the document pip window requests fullscreen but this fails. The gesture on the pip window can't initiate fullscreen.
Fixes #8877

## Specific Changes proposed
Change the default double click action to just exit pip. This is the same behaviour as before without the error, as requestFullScreen() calls exitPictureInPicture();

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
