### PR TITLE
feat: Add methods to add and remove <source> elements

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3711,6 +3711,36 @@ class Player extends Component {
   }
 
   /**
+   * Add a <source> element to the <video> element.
+   *
+   * @param {string} srcUrl
+   *        The URL of the video source.
+   *
+   * @param {string} [mimeType]
+   *        The MIME type of the video source. Optional but recommended.
+   */
+  addSourceElement(srcUrl, mimeType) {
+    if (this.tech_) {
+      this.tech_.addSourceElement(srcUrl, mimeType);
+    }
+  }
+
+  /**
+   * Remove a <source> element from the <video> element by its URL.
+   *
+   * @param {string} srcUrl
+   *        The URL of the source to remove.
+   *
+   * @return {boolean}
+   *         Returns true if the source element was successfully removed, false otherwise.
+   */
+  removeSourceElement(srcUrl) {
+    if (this.tech_) {
+      return this.tech_.removeSourceElement(srcUrl);
+    }
+  }
+
+  /**
    * Begin loading the src data.
    */
   load() {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3718,11 +3718,16 @@ class Player extends Component {
    *
    * @param {string} [mimeType]
    *        The MIME type of the video source. Optional but recommended.
+   *
+   * @return {boolean}
+   *         Returns true if the source element was successfully added, false otherwise.
    */
   addSourceElement(srcUrl, mimeType) {
-    if (this.tech_) {
-      this.tech_.addSourceElement(srcUrl, mimeType);
+    if (!this.tech_) {
+      return false;
     }
+
+    return this.tech_.addSourceElement(srcUrl, mimeType);
   }
 
   /**
@@ -3735,9 +3740,11 @@ class Player extends Component {
    *         Returns true if the source element was successfully removed, false otherwise.
    */
   removeSourceElement(srcUrl) {
-    if (this.tech_) {
-      return this.tech_.removeSourceElement(srcUrl);
+    if (!this.tech_) {
+      return false;
     }
+
+    return this.tech_.removeSourceElement(srcUrl);
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -786,16 +786,25 @@ class Html5 extends Tech {
   /**
    * Add a <source> element to the <video> element.
    *
-   * @param {Tech~SourceObject} [srcObj]
-   *        The source object to append as a <source> element. Must have a `src` and it is recommended to have a `type` property.
+   * @param {string} srcUrl
+   *        The URL of the video source.
+   *
+   * @param {string} [mimeType]
+   *        The MIME type of the video source. Optional but recommended.
    */
-  addSrcAsSourceElement(srcObj) {
-    if (!srcObj || !srcObj.src) {
-      log.error('Invalid source object. Must contain `src` property.');
+  addSourceElement(srcUrl, mimeType) {
+    if (!srcUrl) {
+      log.error('Invalid source URL.');
       return;
     }
 
-    const sourceElement = Dom.createEl('source', srcObj);
+    const sourceAttributes = { src: srcUrl };
+
+    if (mimeType) {
+      sourceAttributes.type = mimeType;
+    }
+
+    const sourceElement = Dom.createEl('source', {}, sourceAttributes);
 
     this.el_.appendChild(sourceElement);
   }

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -791,11 +791,14 @@ class Html5 extends Tech {
    *
    * @param {string} [mimeType]
    *        The MIME type of the video source. Optional but recommended.
+   *
+   * @return {boolean}
+   *         Returns true if the source element was successfully added, false otherwise.
    */
   addSourceElement(srcUrl, mimeType) {
     if (!srcUrl) {
       log.error('Invalid source URL.');
-      return;
+      return false;
     }
 
     const sourceAttributes = { src: srcUrl };
@@ -807,6 +810,8 @@ class Html5 extends Tech {
     const sourceElement = Dom.createEl('source', {}, sourceAttributes);
 
     this.el_.appendChild(sourceElement);
+
+    return true;
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -786,21 +786,48 @@ class Html5 extends Tech {
   /**
    * Add a <source> element to the <video> element.
    *
-   * @param {Tech~SourceObject} [src]
-   *        The source object to append as a <source> element. Should have a `src` and `type`.
+   * @param {Tech~SourceObject} [srcObj]
+   *        The source object to append as a <source> element. Must have a `src` and it is recommended to have a `type` property.
    */
-  addSrcAsSourceElement(src) {
-    if (!src || !src.type || !src.src) {
-      log.error('Invalid source object. Must contain `src` and `type` properties.');
+  addSrcAsSourceElement(srcObj) {
+    if (!srcObj || !srcObj.src) {
+      log.error('Invalid source object. Must contain `src` property.');
       return;
     }
 
-    const sourceElement = document.createElement('source');
-
-    sourceElement.type = src.type;
-    sourceElement.src = src.src;
+    const sourceElement = Dom.createEl('source', srcObj);
 
     this.el_.appendChild(sourceElement);
+  }
+
+  /**
+   * Remove a <source> element from the <video> element by its URL.
+   *
+   * @param {string} srcUrl
+   *        The URL of the source to remove.
+   *
+   * @return {boolean}
+   *         Returns true if the source element was successfully removed, false otherwise.
+   */
+  removeSourceElement(srcUrl) {
+    if (!srcUrl) {
+      log.error('Source URL is required to remove the source element.');
+      return false;
+    }
+
+    const sourceElements = this.el_.querySelectorAll('source');
+
+    for (const sourceElement of sourceElements) {
+      if (sourceElement.src === srcUrl) {
+        this.el_.removeChild(sourceElement);
+
+        return true;
+      }
+    }
+
+    log.warn(`No matching source element found with src: ${srcUrl}`);
+
+    return false;
   }
 
   /**

--- a/src/js/tech/html5.js
+++ b/src/js/tech/html5.js
@@ -784,6 +784,26 @@ class Html5 extends Tech {
   }
 
   /**
+   * Add a <source> element to the <video> element.
+   *
+   * @param {Tech~SourceObject} [src]
+   *        The source object to append as a <source> element. Should have a `src` and `type`.
+   */
+  addSrcAsSourceElement(src) {
+    if (!src || !src.type || !src.src) {
+      log.error('Invalid source object. Must contain `src` and `type` properties.');
+      return;
+    }
+
+    const sourceElement = document.createElement('source');
+
+    sourceElement.type = src.type;
+    sourceElement.src = src.src;
+
+    this.el_.appendChild(sourceElement);
+  }
+
+  /**
    * Reset the tech by removing all sources and then calling
    * {@link Html5.resetMediaElement}.
    */

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3611,3 +3611,31 @@ QUnit.test('smooth seeking set to true should update the display time components
   player.dispose();
 });
 
+QUnit.test('addSourceElement calls tech method with correct args', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const addSourceElementSpy = sinon.spy(player.tech_, 'addSourceElement');
+  const srcUrl = 'http://example.com/video.mp4';
+  const mimeType = 'video/mp4';
+
+  player.addSourceElement(srcUrl, mimeType);
+
+  assert.ok(addSourceElementSpy.calledOnce, 'addSourceElement method called');
+  assert.ok(addSourceElementSpy.calledWith(srcUrl, mimeType), 'addSourceElement called with correct arguments');
+
+  addSourceElementSpy.restore();
+  player.dispose();
+});
+
+QUnit.test('removeSourceElement calls tech method with correct args', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const removeSourceElementSpy = sinon.spy(player.tech_, 'removeSourceElement');
+  const srcUrl = 'http://example.com/video.mp4';
+
+  player.removeSourceElement(srcUrl);
+
+  assert.ok(removeSourceElementSpy.calledOnce, 'removeSourceElement method called');
+  assert.ok(removeSourceElementSpy.calledWith(srcUrl), 'removeSourceElement called with correct arguments');
+
+  removeSourceElementSpy.restore();
+  player.dispose();
+});

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -3626,6 +3626,19 @@ QUnit.test('addSourceElement calls tech method with correct args', function(asse
   player.dispose();
 });
 
+QUnit.test('addSourceElement returns false if no tech', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const srcUrl = 'http://example.com/video.mp4';
+  const mimeType = 'video/mp4';
+
+  player.tech_ = undefined;
+
+  const added = player.addSourceElement(srcUrl, mimeType);
+
+  assert.notOk(added, 'Returned false');
+  player.dispose();
+});
+
 QUnit.test('removeSourceElement calls tech method with correct args', function(assert) {
   const player = TestHelpers.makePlayer();
   const removeSourceElementSpy = sinon.spy(player.tech_, 'removeSourceElement');
@@ -3637,5 +3650,18 @@ QUnit.test('removeSourceElement calls tech method with correct args', function(a
   assert.ok(removeSourceElementSpy.calledWith(srcUrl), 'removeSourceElement called with correct arguments');
 
   removeSourceElementSpy.restore();
+  player.dispose();
+});
+
+QUnit.test('removeSourceElement returns false if no tech', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const srcUrl = 'http://example.com/video.mp4';
+  const mimeType = 'video/mp4';
+
+  player.tech_ = undefined;
+
+  const removed = player.removeSourceElement(srcUrl, mimeType);
+
+  assert.notOk(removed, 'Returned false');
   player.dispose();
 });

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -905,3 +905,51 @@ QUnit.test('supportsFullScreen is always with `webkitEnterFullScreen`', function
 
   tech.el_ = oldEl;
 });
+
+QUnit.test('addSrcAsSourceElement adds a valid source element', function(assert) {
+  const videoEl = document.createElement('video');
+
+  tech.el_ = videoEl;
+
+  const sourceObj = {src: 'http://example.com/video.mp4', type: 'video/mp4'};
+
+  tech.addSrcAsSourceElement(sourceObj);
+
+  const sourceElement = videoEl.querySelector('source');
+
+  assert.ok(sourceElement, 'A source element was added');
+  assert.equal(sourceElement.src, 'http://example.com/video.mp4', 'Source element has correct src');
+  assert.equal(sourceElement.type, 'video/mp4', 'Source element has correct type');
+});
+
+QUnit.test('addSrcAsSourceElement does not add a source element for invalid source objects', function(assert) {
+  const videoEl = document.createElement('video');
+
+  tech.el_ = videoEl;
+
+  // Missing src
+  const sourceObjNoSrc = {type: 'video/mp4'};
+
+  tech.addSrcAsSourceElement(sourceObjNoSrc);
+
+  let sourceElement = videoEl.querySelector('source');
+
+  assert.notOk(sourceElement, 'No source element was added for missing src');
+
+  // Missing type
+  const sourceObjNoType = {src: 'http://example.com/video.mp4'};
+
+  tech.addSrcAsSourceElement(sourceObjNoType);
+  sourceElement = videoEl.querySelector('source');
+  assert.notOk(sourceElement, 'No source element was added for missing type');
+
+  // Null source object
+  tech.addSrcAsSourceElement(null);
+  sourceElement = videoEl.querySelector('source');
+  assert.notOk(sourceElement, 'No source element was added for null source object');
+
+  // Undefined source object
+  tech.addSrcAsSourceElement(undefined);
+  sourceElement = videoEl.querySelector('source');
+  assert.notOk(sourceElement, 'No source element was added for undefined source object');
+});

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -906,47 +906,45 @@ QUnit.test('supportsFullScreen is always with `webkitEnterFullScreen`', function
   tech.el_ = oldEl;
 });
 
-QUnit.test('addSrcAsSourceElement adds a valid source element with src and type', function(assert) {
+QUnit.test('addSourceElement adds a valid source element with srcUrl and mimeType', function(assert) {
   const videoEl = document.createElement('video');
 
   tech.el_ = videoEl;
 
-  const sourceObj = { src: 'http://example.com/video.mp4', type: 'video/mp4' };
+  const srcUrl = 'http://example.com/video.mp4';
+  const mimeType = 'video/mp4';
 
-  tech.addSrcAsSourceElement(sourceObj);
+  tech.addSourceElement(srcUrl, mimeType);
 
   const sourceElement = videoEl.querySelector('source');
 
   assert.ok(sourceElement, 'A source element was added');
-  assert.equal(sourceElement.src, 'http://example.com/video.mp4', 'Source element has correct src');
-  assert.equal(sourceElement.type, 'video/mp4', 'Source element has correct type');
+  assert.equal(sourceElement.src, srcUrl, 'Source element has correct src');
+  assert.equal(sourceElement.type, mimeType, 'Source element has correct type');
 });
 
-QUnit.test('addSrcAsSourceElement adds a valid source element without a type', function(assert) {
+QUnit.test('addSourceElement adds a valid source element without a mimeType', function(assert) {
   const videoEl = document.createElement('video');
 
   tech.el_ = videoEl;
 
-  const sourceObjNoType = { src: 'http://example.com/video2.mp4' };
+  const srcUrl = 'http://example.com/video2.mp4';
 
-  tech.addSrcAsSourceElement(sourceObjNoType);
+  tech.addSourceElement(srcUrl);
 
   const sourceElement = videoEl.querySelector('source');
 
   assert.ok(sourceElement, 'A source element was added even without a type');
-  assert.equal(sourceElement.src, 'http://example.com/video2.mp4', 'Source element has correct src');
+  assert.equal(sourceElement.src, srcUrl, 'Source element has correct src');
   assert.notOk(sourceElement.type, 'Source element does not have a type attribute');
 });
 
-QUnit.test('addSrcAsSourceElement does not add a source element for invalid source objects', function(assert) {
+QUnit.test('addSourceElement does not add a source element for invalid source URL', function(assert) {
   const videoEl = document.createElement('video');
 
   tech.el_ = videoEl;
 
-  // Missing src
-  const sourceObjNoSrc = { type: 'video/mp4' };
-
-  tech.addSrcAsSourceElement(sourceObjNoSrc);
+  tech.addSourceElement('');
 
   const sourceElement = videoEl.querySelector('source');
 
@@ -958,11 +956,8 @@ QUnit.test('removeSourceElement removes a source element by its URL', function(a
 
   tech.el_ = videoEl;
 
-  const sourceObj1 = { src: 'http://example.com/video1.mp4', type: 'video/mp4' };
-  const sourceObj2 = { src: 'http://example.com/video2.mp4', type: 'video/mp4' };
-
-  tech.addSrcAsSourceElement(sourceObj1);
-  tech.addSrcAsSourceElement(sourceObj2);
+  tech.addSourceElement('http://example.com/video1.mp4');
+  tech.addSourceElement('http://example.com/video2.mp4');
 
   let sourceElement = videoEl.querySelector('source[src="http://example.com/video1.mp4"]');
 
@@ -980,9 +975,7 @@ QUnit.test('removeSourceElement does not remove a source element if URL does not
 
   tech.el_ = videoEl;
 
-  const sourceObj = { src: 'http://example.com/video.mp4', type: 'video/mp4' };
-
-  tech.addSrcAsSourceElement(sourceObj);
+  tech.addSourceElement('http://example.com/video.mp4');
 
   const removed = tech.removeSourceElement('http://example.com/invalid.mp4');
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -914,10 +914,10 @@ QUnit.test('addSourceElement adds a valid source element with srcUrl and mimeTyp
   const srcUrl = 'http://example.com/video.mp4';
   const mimeType = 'video/mp4';
 
-  tech.addSourceElement(srcUrl, mimeType);
-
+  const added = tech.addSourceElement(srcUrl, mimeType);
   const sourceElement = videoEl.querySelector('source');
 
+  assert.ok(added, 'Returned true');
   assert.ok(sourceElement, 'A source element was added');
   assert.equal(sourceElement.src, srcUrl, 'Source element has correct src');
   assert.equal(sourceElement.type, mimeType, 'Source element has correct type');
@@ -930,10 +930,10 @@ QUnit.test('addSourceElement adds a valid source element without a mimeType', fu
 
   const srcUrl = 'http://example.com/video2.mp4';
 
-  tech.addSourceElement(srcUrl);
-
+  const added = tech.addSourceElement(srcUrl);
   const sourceElement = videoEl.querySelector('source');
 
+  assert.ok(added, 'Returned true');
   assert.ok(sourceElement, 'A source element was added even without a type');
   assert.equal(sourceElement.src, srcUrl, 'Source element has correct src');
   assert.notOk(sourceElement.type, 'Source element does not have a type attribute');
@@ -944,10 +944,10 @@ QUnit.test('addSourceElement does not add a source element for invalid source UR
 
   tech.el_ = videoEl;
 
-  tech.addSourceElement('');
-
+  const added = tech.addSourceElement('');
   const sourceElement = videoEl.querySelector('source');
 
+  assert.notOk(added, 'Returned false');
   assert.notOk(sourceElement, 'No source element was added for missing src');
 });
 

--- a/test/unit/tech/html5.test.js
+++ b/test/unit/tech/html5.test.js
@@ -906,12 +906,12 @@ QUnit.test('supportsFullScreen is always with `webkitEnterFullScreen`', function
   tech.el_ = oldEl;
 });
 
-QUnit.test('addSrcAsSourceElement adds a valid source element', function(assert) {
+QUnit.test('addSrcAsSourceElement adds a valid source element with src and type', function(assert) {
   const videoEl = document.createElement('video');
 
   tech.el_ = videoEl;
 
-  const sourceObj = {src: 'http://example.com/video.mp4', type: 'video/mp4'};
+  const sourceObj = { src: 'http://example.com/video.mp4', type: 'video/mp4' };
 
   tech.addSrcAsSourceElement(sourceObj);
 
@@ -922,34 +922,69 @@ QUnit.test('addSrcAsSourceElement adds a valid source element', function(assert)
   assert.equal(sourceElement.type, 'video/mp4', 'Source element has correct type');
 });
 
+QUnit.test('addSrcAsSourceElement adds a valid source element without a type', function(assert) {
+  const videoEl = document.createElement('video');
+
+  tech.el_ = videoEl;
+
+  const sourceObjNoType = { src: 'http://example.com/video2.mp4' };
+
+  tech.addSrcAsSourceElement(sourceObjNoType);
+
+  const sourceElement = videoEl.querySelector('source');
+
+  assert.ok(sourceElement, 'A source element was added even without a type');
+  assert.equal(sourceElement.src, 'http://example.com/video2.mp4', 'Source element has correct src');
+  assert.notOk(sourceElement.type, 'Source element does not have a type attribute');
+});
+
 QUnit.test('addSrcAsSourceElement does not add a source element for invalid source objects', function(assert) {
   const videoEl = document.createElement('video');
 
   tech.el_ = videoEl;
 
   // Missing src
-  const sourceObjNoSrc = {type: 'video/mp4'};
+  const sourceObjNoSrc = { type: 'video/mp4' };
 
   tech.addSrcAsSourceElement(sourceObjNoSrc);
 
-  let sourceElement = videoEl.querySelector('source');
+  const sourceElement = videoEl.querySelector('source');
 
   assert.notOk(sourceElement, 'No source element was added for missing src');
+});
 
-  // Missing type
-  const sourceObjNoType = {src: 'http://example.com/video.mp4'};
+QUnit.test('removeSourceElement removes a source element by its URL', function(assert) {
+  const videoEl = document.createElement('video');
 
-  tech.addSrcAsSourceElement(sourceObjNoType);
-  sourceElement = videoEl.querySelector('source');
-  assert.notOk(sourceElement, 'No source element was added for missing type');
+  tech.el_ = videoEl;
 
-  // Null source object
-  tech.addSrcAsSourceElement(null);
-  sourceElement = videoEl.querySelector('source');
-  assert.notOk(sourceElement, 'No source element was added for null source object');
+  const sourceObj1 = { src: 'http://example.com/video1.mp4', type: 'video/mp4' };
+  const sourceObj2 = { src: 'http://example.com/video2.mp4', type: 'video/mp4' };
 
-  // Undefined source object
-  tech.addSrcAsSourceElement(undefined);
-  sourceElement = videoEl.querySelector('source');
-  assert.notOk(sourceElement, 'No source element was added for undefined source object');
+  tech.addSrcAsSourceElement(sourceObj1);
+  tech.addSrcAsSourceElement(sourceObj2);
+
+  let sourceElement = videoEl.querySelector('source[src="http://example.com/video1.mp4"]');
+
+  assert.ok(sourceElement, 'Source element for video1.mp4 was added');
+
+  const removed = tech.removeSourceElement('http://example.com/video1.mp4');
+
+  assert.ok(removed, 'Source element was successfully removed');
+  sourceElement = videoEl.querySelector('source[src="http://example.com/video1.mp4"]');
+  assert.notOk(sourceElement, 'Source element for video1.mp4 was removed');
+});
+
+QUnit.test('removeSourceElement does not remove a source element if URL does not match', function(assert) {
+  const videoEl = document.createElement('video');
+
+  tech.el_ = videoEl;
+
+  const sourceObj = { src: 'http://example.com/video.mp4', type: 'video/mp4' };
+
+  tech.addSrcAsSourceElement(sourceObj);
+
+  const removed = tech.removeSourceElement('http://example.com/invalid.mp4');
+
+  assert.notOk(removed, 'No source element was removed for non-matching URL');
 });

--- a/test/unit/tech/tech-faker.js
+++ b/test/unit/tech/tech-faker.js
@@ -111,6 +111,8 @@ class TechFaker extends Tech {
     }
     return 'movie.mp4';
   }
+  addSourceElement() {}
+  removeSourceElement() {}
   load() {
   }
   currentSrc() {


### PR DESCRIPTION
## Description
It is useful to have methods for appending and removing `<source>` elements to the `<video>` element, as they are sometimes required to enable certain playback features, for example, using [Airplay with MSE](https://webkit.org/blog/15036/how-to-use-media-source-extensions-with-airplay).

## Specific Changes proposed
Add new methods-- `addSourceElement()` and `removeSourceElement()` to the player and tech. The former will take a source object and create and append a new `<source>` element to the `<video>` element, and the latter will take a source url and remove any `<source>` element with a matching `src`.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
