### PR TITLE
chore: update mpd-parser to v1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9739,9 +9739,9 @@
       }
     },
     "mpd-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.0.tgz",
-      "integrity": "sha512-WgeIwxAqkmb9uTn4ClicXpEQYCEduDqRKfmUdp4X8vmghKfBNXZLYpREn9eqrDx/Tf5LhzRcJLSpi4ohfV742Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.1.tgz",
+      "integrity": "sha512-1FuyEWI5k2HcmhS1HkKnUAQV7yFPfXPht2DnRRGtoiiAAW+ESTbtEXIDpRkwdU+XyrQuwrIym7UkoPKsZ0SyFw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "aes-decrypter": "^4.0.2",
     "global": "4.4.0",
     "m3u8-parser": "^7.2.0",
-    "mpd-parser": "^1.2.2",
+    "mpd-parser": "^1.3.1",
     "mux.js": "^7.0.1",
     "videojs-contrib-quality-levels": "4.1.0",
     "videojs-font": "4.2.0",


### PR DESCRIPTION
## Description

Update MPD parser to v1.3.1

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
