### PR TITLE
chore(package): update http-streaming to v3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,16 +1791,16 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.14.2.tgz",
-      "integrity": "sha512-c+sg+rrrSrRekBZxd+sNpzjRteIcOEQRJllqCBcz6MrgSaGJGDzV1xhGSAFnxX8E/xfqQeF060us5474WwYi3Q==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.15.0.tgz",
+      "integrity": "sha512-6rjaqEa87gVFqDFsHaLKXGrDqL3NhNZRNi6wkMw+uyt1lrLD2OFY0SfRQRNl7Vmmx0pt5FRJoRJYlnKsowyElA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.1.1",
         "aes-decrypter": "^4.0.2",
         "global": "^4.4.0",
         "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.3.0",
+        "mpd-parser": "^1.3.1",
         "mux.js": "7.0.3",
         "video.js": "^7 || ^8"
       }
@@ -14825,11 +14825,6 @@
         "prepend-http": "^2.0.0"
       }
     },
-    "url-toolkit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
-    },
     "urljoin": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/urljoin/-/urljoin-0.1.5.tgz",
@@ -15055,74 +15050,22 @@
       "dev": true
     },
     "video.js": {
-      "version": "8.17.4",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.17.4.tgz",
-      "integrity": "sha512-AECieAxKMKB/QgYK36ci50phfpWys6bFT6+pGMpSafeFYSoZaQ2Vpl83T9Qqcesv4TO7oNtiycnVeaBnrva2oA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.18.1.tgz",
+      "integrity": "sha512-oQ4M/HD2fFgEPHfmVMWxGykRFIpOmVhK0XZ4PSsPTgN2jH6E6+92f/RI2mDXDb0yu+Fxv9fxMUm0M7Z2K3Zo9w==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "3.13.3",
-        "@videojs/vhs-utils": "^4.0.0",
+        "@videojs/http-streaming": "^3.14.2",
+        "@videojs/vhs-utils": "^4.1.1",
         "@videojs/xhr": "2.7.0",
-        "aes-decrypter": "^4.0.1",
+        "aes-decrypter": "^4.0.2",
         "global": "4.4.0",
-        "m3u8-parser": "^7.1.0",
+        "m3u8-parser": "^7.2.0",
         "mpd-parser": "^1.2.2",
         "mux.js": "^7.0.1",
         "videojs-contrib-quality-levels": "4.1.0",
         "videojs-font": "4.2.0",
         "videojs-vtt.js": "0.15.5"
-      },
-      "dependencies": {
-        "@videojs/http-streaming": {
-          "version": "3.13.3",
-          "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.13.3.tgz",
-          "integrity": "sha512-L7H+iTeqHeZ5PylzOx+pT3CVyzn4TALWYTJKkIc1pDaV/cTVfNGtG+9/vXPAydD+wR/xH1M9/t2JH8tn/DCT4w==",
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "@videojs/vhs-utils": "4.0.0",
-            "aes-decrypter": "4.0.1",
-            "global": "^4.4.0",
-            "m3u8-parser": "^7.1.0",
-            "mpd-parser": "^1.3.0",
-            "mux.js": "7.0.3",
-            "video.js": "^7 || ^8"
-          },
-          "dependencies": {
-            "@videojs/vhs-utils": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
-              "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
-              "requires": {
-                "@babel/runtime": "^7.12.5",
-                "global": "^4.4.0",
-                "url-toolkit": "^2.2.1"
-              }
-            },
-            "aes-decrypter": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.1.tgz",
-              "integrity": "sha512-H1nh/P9VZXUf17AA5NQfJML88CFjVBDuGkp5zDHa7oEhYN9TTpNLJknRY1ie0iSKWlDf6JRnJKaZVDSQdPy6Cg==",
-              "requires": {
-                "@babel/runtime": "^7.12.5",
-                "@videojs/vhs-utils": "^3.0.5",
-                "global": "^4.4.0",
-                "pkcs7": "^1.0.4"
-              },
-              "dependencies": {
-                "@videojs/vhs-utils": {
-                  "version": "3.0.5",
-                  "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-                  "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
-                  "requires": {
-                    "@babel/runtime": "^7.12.5",
-                    "global": "^4.4.0",
-                    "url-toolkit": "^2.2.1"
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     },
     "videojs-contrib-quality-levels": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "^3.14.2",
+    "@videojs/http-streaming": "^3.15.0",
     "@videojs/vhs-utils": "^4.1.1",
     "@videojs/xhr": "2.7.0",
     "aes-decrypter": "^4.0.2",


### PR DESCRIPTION
## Description
Bump the VHS dependency version to v3.15.0

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
