### PR TITLE
fix(text-track-settings): localization not correctly applied

### DIFF
--- a/src/js/tracks/text-track-fieldset.js
+++ b/src/js/tracks/text-track-fieldset.js
@@ -87,7 +87,7 @@ class TextTrackFieldset extends Component {
         const label = Dom.createEl('label', {
           id,
           className: 'vjs-label',
-          textContent: selectConfig.label
+          textContent: this.localize(selectConfig.label)
         });
 
         label.setAttribute('for', guid);

--- a/src/js/tracks/text-track-select.js
+++ b/src/js/tracks/text-track-select.js
@@ -68,7 +68,7 @@ class TextTrackSelect extends Component {
           {
             id: optionId,
             value: this.localize(optionText[0]),
-            textContent: optionText[1]
+            textContent: this.localize(optionText[1])
           }
         );
 

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -375,10 +375,16 @@ QUnit.test('should update on languagechange', function(assert) {
     tracks
   });
 
-  videojs.addLanguage('test', {'Font Size': 'FONTSIZE'});
+  videojs.addLanguage('test', {
+    'Font Size': 'FONTSIZE',
+    'Color': 'COLOR',
+    'White': 'WHITE'
+  });
   player.language('test');
 
   assert.equal(player.$('.vjs-font-percent legend').textContent, 'FONTSIZE', 'settings dialog updates on languagechange');
+  assert.equal(player.$('.vjs-text-color label').textContent, 'COLOR', 'settings dialog label updates on languagechange');
+  assert.equal(player.$('.vjs-text-color select option').textContent, 'WHITE', 'settings dialog select updates on languagechange');
 
   player.dispose();
 });


### PR DESCRIPTION
## Description

Localization is not applied correctly in fieldset labels and select options. As a result, the text track setting modal dialog is only half translated.

![Screenshot from 2024-10-29 19-35-34](https://github.com/user-attachments/assets/ecd3fecd-b81c-49e2-a0f1-8fc60c407c43)

## Specific Changes proposed

- add `localize` at `label` level in `TextTrackFieldset`
- add `localize` at `option` level in `TextTrackSelect`
- add test cases

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
