### PR TITLE
fix: change http to https in examples

### DIFF
--- a/docs/examples/elephantsdream/index.html
+++ b/docs/examples/elephantsdream/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8" />
   <title>Video.js Text Descriptions, Chapters &amp; Captions Example</title>
 
-  <link href="http://vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
-  <script src="http://vjs.zencdn.net/7.0/video.min.js"></script>
+  <link href="https://vjs.zencdn.net/7.0/video-js.min.css" rel="stylesheet">
+  <script src="https://vjs.zencdn.net/7.0/video.min.js"></script>
 
 </head>
 <body>

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -10,8 +10,8 @@
 <body>
 
   <video id="example_video_1" class="video-js" controls preload="none" width="640" height="264" poster="http://vjs.zencdn.net/v/oceans.png" data-setup="{}">
-    <source src="http://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
-    <source src="http://vjs.zencdn.net/v/oceans.webm" type="video/webm">
+    <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
+    <source src="https://vjs.zencdn.net/v/oceans.webm" type="video/webm">
     <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <track kind="captions" src="../shared/example-captions.vtt" srclang="en" label="English">
     <track kind="subtitles" src="../shared/example-captions.vtt" srclang="en" label="English">

--- a/docs/examples/simple-embed/index.html
+++ b/docs/examples/simple-embed/index.html
@@ -12,7 +12,7 @@
   <video id="example_video_1" class="video-js" controls preload="none" width="640" height="264" poster="http://vjs.zencdn.net/v/oceans.png" data-setup="{}">
     <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4">
     <source src="https://vjs.zencdn.net/v/oceans.webm" type="video/webm">
-    <source src="http://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
+    <source src="https://vjs.zencdn.net/v/oceans.ogv" type="video/ogg">
     <track kind="captions" src="../shared/example-captions.vtt" srclang="en" label="English">
     <track kind="subtitles" src="../shared/example-captions.vtt" srclang="en" label="English">
     <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="https://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>


### PR DESCRIPTION
## Description
Two examples use http and not https.

## Specific Changes proposed
`href=http` changed to `href=https` in two places in two files.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
