### PR TITLE
fix: Fix Escape handling in menus 

### DIFF
--- a/src/js/menu/menu-button.js
+++ b/src/js/menu/menu-button.js
@@ -297,7 +297,7 @@ class MenuButton extends Component {
   handleKeyDown(event) {
 
     // Escape or Tab unpress the 'button'
-    if (event.key === 'Esc' || event.key === 'Tab') {
+    if (event.key === 'Escape' || event.key === 'Tab') {
       if (this.buttonPressed_) {
         this.unpressButton();
       }
@@ -328,7 +328,7 @@ class MenuButton extends Component {
    */
   handleMenuKeyUp(event) {
     // Escape hides popup menu
-    if (event.key === 'Esc' || event.key === 'Tab') {
+    if (event.key === 'Escape' || event.key === 'Tab') {
       this.removeClass('vjs-hover');
     }
   }
@@ -356,7 +356,7 @@ class MenuButton extends Component {
    */
   handleSubmenuKeyDown(event) {
     // Escape or Tab unpress the 'button'
-    if (event.key === 'Esc' || event.key === 'Tab') {
+    if (event.key === 'Escape' || event.key === 'Tab') {
       if (this.buttonPressed_) {
         this.unpressButton();
       }

--- a/test/unit/menu.test.js
+++ b/test/unit/menu.test.js
@@ -235,7 +235,7 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
 
     assert.ok(clickListenerSpy.calledOnce, 'click event listener should be called');
     assert.strictEqual(clickListenerSpy.getCall(0).args[0].target, menuItem.el(), 'event target should be the `menuItem`');
-    assert.ok(unpressButtonSpy.calledOnce, '`menuButton`.`unpressButtion` has been called');
+    assert.ok(unpressButtonSpy.calledOnce, '`menuButton`.`unpressButton` has been called');
     assert.ok(focusSpy.calledOnce, '`menuButton`.`focus` has been called');
 
     unpressButtonSpy.restore();
@@ -264,4 +264,22 @@ QUnit.test('should remove old event listeners when the menu item adds to the new
   newMenu.dispose();
   oldMenu.dispose();
   menuButton.dispose();
+});
+
+QUnit.test('Escape should close menu', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const menuButton = new MenuButton(player, {});
+  const unpressButtonSpy = sinon.spy(menuButton, 'unpressButton');
+
+  menuButton.createItems = () => [new MenuItem(player, {})];
+  menuButton.update();
+  menuButton.handleClick(new window.PointerEvent('click'));
+  menuButton.menu.children()[0].el_.dispatchEvent(new window.KeyboardEvent('keydown', {
+    key: 'Escape',
+    bubbles: true,
+    cancelable: true
+  }));
+
+  assert.ok(unpressButtonSpy.calledOnce, '`menuButton`.`unpressButton` has been called');
+
 });


### PR DESCRIPTION
## Description
Fixes that Escape being pressed isn't closing menus due to incorrect `event.key` name.
Fixes #8915

## Specific Changes proposed
Replaces `Esc` with `Escape`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
