### PR TITLE
chore(package): Update @videojs/http-streaming to 3.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,9 +1791,9 @@
       }
     },
     "@videojs/http-streaming": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.15.0.tgz",
-      "integrity": "sha512-6rjaqEa87gVFqDFsHaLKXGrDqL3NhNZRNi6wkMw+uyt1lrLD2OFY0SfRQRNl7Vmmx0pt5FRJoRJYlnKsowyElA==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.16.0.tgz",
+      "integrity": "sha512-VL8l+JGbc9KqZ1fY2pYgBS1u3i6iQ/5mRAE6bwrI5R0RAtKxur1hjipVGwkkJSYRzwLgArt5Wg5abEjfoJN7yA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@videojs/vhs-utils": "^4.1.1",
@@ -1801,8 +1801,19 @@
         "global": "^4.4.0",
         "m3u8-parser": "^7.2.0",
         "mpd-parser": "^1.3.1",
-        "mux.js": "7.0.3",
+        "mux.js": "7.1.0",
         "video.js": "^7 || ^8"
+      },
+      "dependencies": {
+        "mux.js": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-7.1.0.tgz",
+          "integrity": "sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
+            "global": "^4.4.0"
+          }
+        }
       }
     },
     "@videojs/vhs-utils": {
@@ -15050,18 +15061,18 @@
       "dev": true
     },
     "video.js": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.18.1.tgz",
-      "integrity": "sha512-oQ4M/HD2fFgEPHfmVMWxGykRFIpOmVhK0XZ4PSsPTgN2jH6E6+92f/RI2mDXDb0yu+Fxv9fxMUm0M7Z2K3Zo9w==",
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.19.1.tgz",
+      "integrity": "sha512-MVuayhXpzTBv5Jk3nYEU2akawPhuBBlizEbpQGx2i+6FiBmqxGjkrkLdDLOzG54ut7xapjp26IfWQLGSpeLmcQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/http-streaming": "^3.14.2",
+        "@videojs/http-streaming": "^3.15.0",
         "@videojs/vhs-utils": "^4.1.1",
         "@videojs/xhr": "2.7.0",
         "aes-decrypter": "^4.0.2",
         "global": "4.4.0",
         "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.2.2",
+        "mpd-parser": "^1.3.1",
         "mux.js": "^7.0.1",
         "videojs-contrib-quality-levels": "4.1.0",
         "videojs-font": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/http-streaming": "^3.15.0",
+    "@videojs/http-streaming": "^3.16.0",
     "@videojs/vhs-utils": "^4.1.1",
     "@videojs/xhr": "2.7.0",
     "aes-decrypter": "^4.0.2",


### PR DESCRIPTION
## Description
n/a

## Specific Changes proposed
n/a

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
