### PR TITLE
fix display on player load

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -128,6 +128,7 @@ class TextTrackDisplay extends Component {
     player.on('loadedmetadata', (e) => {
       this.updateDisplayOverlay();
       this.preselectTrack(e);
+      this.updateDisplay(e);
     });
 
     // This used to be called during player init, but was causing an error


### PR DESCRIPTION
## Description
bug fix. We have the behaivor outlined with a video of the behaivor in https://github.com/sul-dlss/sul-embed/issues/2258

## Specific Changes proposed
- the metadata listener triggers after the text track. The updating of the inset-inline without updating the track causes problems. 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
