### PR TITLE
fix: hide mouse tooltip on touch devices when not scrubbing

### DIFF
--- a/src/css/components/_progress.scss
+++ b/src/css/components/_progress.scss
@@ -178,7 +178,8 @@
   display: block;
 }
 
-.video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display {
+.video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display,
+.video-js.vjs-touch-enabled:not(.vjs-scrubbing) .vjs-progress-control .vjs-mouse-display {
   visibility: hidden;
   opacity: 0;
   $trans: visibility 1.0s, opacity 1.0s;


### PR DESCRIPTION
Problem: the vjs-user-inactive class triggering the hiding of the tooltip is added much later on touch devices, therefore the mouse tooltip stays visible on its last seek target position whenever the user taps the screen to access the controls.

This change ensures that the mouse tooltip is only visible when the user is actually scrubbing.