### PR TITLE
fix: Improve getFileExtension() readability and handle leading dot extensions.

### DIFF
--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -47,7 +47,7 @@ export const getAbsoluteURL = function(url) {
  */
 export const getFileExtension = function(path) {
   if (typeof path === 'string') {
-    const splitPathRe = /^(\/?)([\s\S]*?)((?:\.{1,2}|[^\/]+?)(\.([^\.\/\?]+)))(?:[\/]*|[\?].*)$/;
+    const splitPathRe = /^(\/?)([\s\S]*?)((?:\.{1,2}|[^\/]+?)(\.*([^\.\/\?]+)))(?:[\/]*|[\?].*)$/;
     const pathParts = splitPathRe.exec(path);
 
     if (pathParts) {
@@ -74,3 +74,4 @@ export const getFileExtension = function(path) {
 export const isCrossOrigin = function(url, winLoc = window.location) {
   return parseUrl(url).origin !== winLoc.origin;
 };
+

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -47,14 +47,12 @@ export const getAbsoluteURL = function(url) {
  */
 export const getFileExtension = function(path) {
   if (typeof path === 'string') {
-    const splitPathRe = /^(\/?)([\s\S]*?)((?:\.{1,2}|[^\/]+?)(\.*([^\.\/\?]+)))(?:[\/]*|[\?].*)$/;
-    const pathParts = splitPathRe.exec(path);
+    const cleanPath = path.split('?')[0];
 
-    if (pathParts) {
-      return pathParts.pop().toLowerCase();
-    }
+    const match = cleanPath.match(/\.([^.\/]+)$/);
+
+    return match ? match[1].toLowerCase() : '';
   }
-
   return '';
 };
 

--- a/src/js/utils/url.js
+++ b/src/js/utils/url.js
@@ -47,7 +47,7 @@ export const getAbsoluteURL = function(url) {
  */
 export const getFileExtension = function(path) {
   if (typeof path === 'string') {
-    const cleanPath = path.split('?')[0];
+    const cleanPath = path.split('?')[0].replace(/\/+$/, '');
 
     const match = cleanPath.match(/\.([^.\/]+)$/);
 

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -57,6 +57,7 @@ QUnit.test('should get the file extension of the passed path', function(assert) 
   assert.equal(Url.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
   assert.equal(Url.getFileExtension('http://www.test.com/video/.mp4'), 'mp4');
   assert.equal(Url.getFileExtension('http://www.test.com/video/.mp4/'), 'mp4');
+  assert.equal(Url.getFileExtension('http://www.test.com/video.mp4/'), 'mp4');
 
   // edge cases
   assert.equal(Url.getFileExtension('http://...'), '');

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -55,6 +55,7 @@ QUnit.test('should get the file extension of the passed path', function(assert) 
   assert.equal(Url.getFileExtension('foo/.bar/test.video.flv?foo=bar'), 'flv');
   assert.equal(Url.getFileExtension('http://www.test.com/video.mp4'), 'mp4');
   assert.equal(Url.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
+  assert.equal(Url.getFileExtension('http://www.test.com/video/.mp4'), 'mp4');
 
   // edge cases
   assert.equal(Url.getFileExtension('http://...'), '');

--- a/test/unit/utils/url.test.js
+++ b/test/unit/utils/url.test.js
@@ -56,6 +56,7 @@ QUnit.test('should get the file extension of the passed path', function(assert) 
   assert.equal(Url.getFileExtension('http://www.test.com/video.mp4'), 'mp4');
   assert.equal(Url.getFileExtension('http://foo/bar/test.video.wgg'), 'wgg');
   assert.equal(Url.getFileExtension('http://www.test.com/video/.mp4'), 'mp4');
+  assert.equal(Url.getFileExtension('http://www.test.com/video/.mp4/'), 'mp4');
 
   // edge cases
   assert.equal(Url.getFileExtension('http://...'), '');


### PR DESCRIPTION
## Description
More robust edge case handling for getFileExtension().

**Case** : Type is not provided explicitly in {src,type} object.
In this case getFileExtension() is called to fetch the extension so as to get the type.

For certain cases, fn does not returns the correct extension.
For Eg: 
1. https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8

In this case fn returns "". 
I have simplified getFileExtension() so that fn will return m3u8 in this case as well.

## Specific Changes proposed
Simplified getFileExtension() for better readability and to handle more edge cases.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [x] Reviewed by Two Core Contributors
