### PR TITLE
Fix broken link in changelog for version 8.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Features
 
-* Add methods to add and remove <source> elements ([#8886](https://github.com/videojs/video.js/issues/8886)) ([eddda97](https://github.com/videojs/video.js/commit/eddda97)), closes [1000#0](https://github.com/1000/issues/0)
+* Add methods to add and remove <source> elements ([#8886](https://github.com/videojs/video.js/issues/8886)) ([eddda97](https://github.com/videojs/video.js/commit/eddda97)), closes [#8886](https://github.com/videojs/video.js/issues/8886)
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Description
Please describe the change as necessary.
This pull request fixes a broken link found in the CHANGELOG.md for version 8.19.0. 

The link has been updated to ensure it directs users to the correct resource. This change enhances the documentation accuracy and improves user experience.

## Specific Changes proposed
- Updated the link in the CHANGELOG.md file to point to the correct issue.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
