### PR TITLE
fix: controlText for text track modal

### DIFF
--- a/src/js/tracks/text-track-settings-controls.js
+++ b/src/js/tracks/text-track-settings-controls.js
@@ -16,10 +16,8 @@ class TrackSettingsControls extends Component {
     super(player, options);
 
     // Create DOM elements
-    const defaultsDescription = this.localize('restore all settings to the default values');
-
     const resetButton = new Button(player, {
-      controlText: defaultsDescription,
+      controlText: this.localize('restore all settings to the default values'),
       className: 'vjs-default-button'
     });
 
@@ -28,14 +26,15 @@ class TrackSettingsControls extends Component {
 
     this.addChild(resetButton);
 
+    const doneText = this.localize('Done');
     const doneButton = new Button(player, {
-      controlText: defaultsDescription,
+      controlText: doneText,
       className: 'vjs-done-button'
     });
 
     // Remove unrequired style classes
     doneButton.el().classList.remove('vjs-control', 'vjs-button');
-    doneButton.el().textContent = this.localize('Done');
+    doneButton.el().textContent = doneText;
 
     this.addChild(doneButton);
   }


### PR DESCRIPTION
## Description
Fixes text track modal controlText.

## Specific Changes proposed
Only apply reset text to the `Reset` button and done text to the `Done` button.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
