### PR TITLE
feat: toJSON methods for text track serialization

### DIFF
--- a/src/css/components/_volume.scss
+++ b/src/css/components/_volume.scss
@@ -160,7 +160,6 @@
   }
 }
 
-// here
 // Update placement of circle icon when using SVG icons
 .vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
   right: -0.3em;

--- a/src/js/tracks/text-track-list-converter.js
+++ b/src/js/tracks/text-track-list-converter.js
@@ -18,7 +18,7 @@
  *         A serializable javascript representation of the TextTrack.
  * @private
  */
-const trackToJson_ = function(track) {
+const trackToJson = function(track) {
   const ret = [
     'kind', 'label', 'language', 'id',
     'inBandMetadataTrackDispatchType', 'mode', 'src'
@@ -61,7 +61,7 @@ const textTracksToJson = function(tech) {
 
   const trackObjs = Array.prototype.map.call(trackEls, (t) => t.track);
   const tracks = Array.prototype.map.call(trackEls, function(trackEl) {
-    const json = trackToJson_(trackEl.track);
+    const json = trackToJson(trackEl.track);
 
     if (trackEl.src) {
       json.src = trackEl.src;
@@ -71,7 +71,7 @@ const textTracksToJson = function(tech) {
 
   return tracks.concat(Array.prototype.filter.call(tech.textTracks(), function(track) {
     return trackObjs.indexOf(track) === -1;
-  }).map(trackToJson_));
+  }).map(trackToJson));
 };
 
 /**
@@ -97,4 +97,4 @@ const jsonToTextTracks = function(json, tech) {
   return tech.textTracks();
 };
 
-export default {textTracksToJson, jsonToTextTracks, trackToJson_};
+export default {textTracksToJson, jsonToTextTracks, trackToJson};

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -58,8 +58,8 @@ class TextTrackList extends TrackList {
   }
 
   /**
-   * Makes the text track list serializable.
-   * This transforms each track into a serializable object.
+   * Creates a serializable array of objects that contains serialized copies
+   * of each text track.
    *
    * @return {Object[]} A serializable list of objects for the text track list
    */

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -56,5 +56,32 @@ class TextTrackList extends TrackList {
       }
     }
   }
+
+  /**
+   * Makes the text track list serializable.
+   * This transforms each track into a serializable object.
+   *
+   * @return {Object[]} A serializable list of objects for the text track list
+   */
+  toJSON() {
+    const trackCopies = [];
+
+    this.tracks_.forEach((track) => {
+      const copy = track.toJSON();
+
+      trackCopies.push(copy);
+    });
+
+    return trackCopies;
+  }
+
+  /**
+   * A method to serialize the text track list.
+   *
+   * @return {string} The serialized list of text tracks
+   */
+  serialize() {
+    return JSON.stringify(this.toJSON());
+  }
 }
 export default TextTrackList;

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -66,15 +66,5 @@ class TextTrackList extends TrackList {
   toJSON() {
     return this.tracks_.map((track) => track.toJSON());
   }
-
-  /**
-   * A method to serialize the text track list.
-   *
-   * @return {string} The serialized list of text tracks
-   */
-  serialize() {
-    // Stringify calls toJSON if it exists, so the method above will be used.
-    return JSON.stringify(this);
-  }
 }
 export default TextTrackList;

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -64,15 +64,7 @@ class TextTrackList extends TrackList {
    * @return {Object[]} A serializable list of objects for the text track list
    */
   toJSON() {
-    const trackCopies = [];
-
-    this.tracks_.forEach((track) => {
-      const copy = track.toJSON();
-
-      trackCopies.push(copy);
-    });
-
-    return trackCopies;
+    return this.tracks_.map((track) => track.toJSON());
   }
 
   /**
@@ -81,7 +73,8 @@ class TextTrackList extends TrackList {
    * @return {string} The serialized list of text tracks
    */
   serialize() {
-    return JSON.stringify(this.toJSON());
+    // Stringify calls toJSON if it exists, so the method above will be used.
+    return JSON.stringify(this);
   }
 }
 export default TextTrackList;

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -7,6 +7,7 @@ import {TextTrackKind, TextTrackMode} from './track-enums';
 import log from '../utils/log.js';
 import window from 'global/window';
 import Track from './track.js';
+import textTrackConverter from './text-track-list-converter.js';
 import { isCrossOrigin } from '../utils/url.js';
 import XHR from '@videojs/xhr';
 import {merge} from '../utils/obj';
@@ -426,29 +427,8 @@ class TextTrack extends Track {
    * @return {Object} The track information as a serializable object
    */
   toJSON() {
-    const track = this;
-    // Get inherited properties as well as the ones in this class.
-    const props = Object.getOwnPropertyNames(track);
-    const copy = {};
 
-    props.forEach((prop) => {
-      // Do not include tech_, this is the property with circular references.
-      if (track.hasOwnProperty(prop) && prop !== 'tech_') {
-        copy[prop] = track[prop];
-      }
-    });
-
-    return copy;
-  }
-
-  /**
-   * Serializes the text track.
-   *
-   * @return {string} The serialized string for the text track
-   */
-  serialize() {
-    // Stringify calls toJSON if it exists, so the method above will be used.
-    return JSON.stringify(this);
+    return textTrackConverter.trackToJson(this);
   }
 
   /**

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -421,6 +421,36 @@ class TextTrack extends Track {
   }
 
   /**
+   * Makes the text track serializable by removing circular dependencies.
+   *
+   * @return {Object} The track information as a serializable object
+   */
+  toJSON() {
+    const track = this;
+    // Get inherited properties as well as the ones in this class.
+    const props = Object.getOwnPropertyNames(track);
+    const copy = {};
+
+    props.forEach((prop) => {
+      // Do not include tech_, this is the property with circular references.
+      if (track.hasOwnProperty(prop) && prop !== 'tech_') {
+        copy[prop] = track[prop];
+      }
+    });
+
+    return copy;
+  }
+
+  /**
+   * Serializes the text track.
+   *
+   * @return {string} The serialized string for the text track
+   */
+  serialize() {
+    return JSON.stringify(this.toJSON());
+  }
+
+  /**
    * Remove a cue from our internal list
    *
    * @param {TextTrack~Cue} removeCue

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -422,12 +422,12 @@ class TextTrack extends Track {
   }
 
   /**
-   * Makes the text track serializable by removing circular dependencies.
+   * Creates a copy of the text track and makes it serializable
+   * by removing circular dependencies.
    *
    * @return {Object} The track information as a serializable object
    */
   toJSON() {
-
     return textTrackConverter.trackToJson(this);
   }
 

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -447,7 +447,8 @@ class TextTrack extends Track {
    * @return {string} The serialized string for the text track
    */
   serialize() {
-    return JSON.stringify(this.toJSON());
+    // Stringify calls toJSON if it exists, so the method above will be used.
+    return JSON.stringify(this);
   }
 
   /**

--- a/test/unit/tracks/text-track-list-converter.test.js
+++ b/test/unit/tracks/text-track-list-converter.test.js
@@ -32,7 +32,7 @@ if (Html5.supportsNativeTextTracks()) {
     track.srclang = 'en';
     track.label = 'English';
 
-    assert.deepEqual(cleanup(c.trackToJson_(track.track)), {
+    assert.deepEqual(cleanup(c.trackToJson(track.track)), {
       kind: 'captions',
       label: 'English',
       language: 'en',
@@ -181,7 +181,7 @@ QUnit.test('trackToJson_ produces correct representation for emulated track obje
     }
   });
 
-  assert.deepEqual(cleanup(c.trackToJson_(track)), {
+  assert.deepEqual(cleanup(c.trackToJson(track)), {
     src: 'example.com/english.vtt',
     kind: 'captions',
     label: 'English',

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -5,6 +5,8 @@ import EventTarget from '../../../src/js/event-target.js';
 import TechFaker from '../tech/tech-faker';
 import sinon from 'sinon';
 
+// here
+
 QUnit.module('Text Track List', {
   beforeEach() {
     this.clock = sinon.useFakeTimers();
@@ -59,4 +61,47 @@ QUnit.test('trigger "change" event when mode changes on a TextTrack', function(a
   assert.equal(changes, 2, 'two change events should have fired');
   ttl.removeTrack(tt);
   tech.dispose();
+});
+
+QUnit.test('toJSON', function(assert) {
+  const tech = new TechFaker();
+  const ttl = new TextTrackList([]);
+
+  let textTrackListJSON = ttl.toJSON();
+
+  assert.ok(textTrackListJSON.length === 0, 'an empty array is returned when the list is empty');
+
+  const tt1 = new TextTrack({tech});
+
+  ttl.addTrack(tt1);
+  textTrackListJSON = ttl.toJSON();
+
+  assert.equal(textTrackListJSON[0].id, tt1.id, 'text track in array of JSON should match the original track');
+  assert.notOk(textTrackListJSON[0].tech_, 'tech_ should not exist on the text track value in the JSON list');
+
+  const tt2 = new TextTrack({tech});
+  const tt3 = new TextTrack({tech});
+
+  ttl.addTrack(tt2);
+  ttl.addTrack(tt3);
+  textTrackListJSON = ttl.toJSON();
+
+  assert.equal(textTrackListJSON[1].id, tt2.id, 'text track in second spot of array should match the original track');
+  assert.equal(textTrackListJSON[2].id, tt3.id, 'text track in third spot of array should match the original track');
+});
+
+QUnit.test('toJSON', function(assert) {
+  const tech = new TechFaker();
+  const tt1 = new TextTrack({tech});
+  const tt2 = new TextTrack({tech});
+  const tt3 = new TextTrack({tech});
+  const ttl = new TextTrackList([tt1, tt2, tt3]);
+
+  const serializedTrackList = ttl.serialize();
+
+  assert.notOk(serializedTrackList.includes('"tech_":'), 'tech_ does not exist in the serialized data');
+
+  assert.ok(serializedTrackList.includes(`"id":"${tt1.id}"`), 'serialzed track is found for text track 1');
+  assert.ok(serializedTrackList.includes(`"id":"${tt2.id}"`), 'serialzed track is found for text track 2');
+  assert.ok(serializedTrackList.includes(`"id":"${tt3.id}"`), 'serialzed track is found for text track 3');
 });

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -5,8 +5,6 @@ import EventTarget from '../../../src/js/event-target.js';
 import TechFaker from '../tech/tech-faker';
 import sinon from 'sinon';
 
-// here
-
 QUnit.module('Text Track List', {
   beforeEach() {
     this.clock = sinon.useFakeTimers();

--- a/test/unit/tracks/text-track-list.test.js
+++ b/test/unit/tracks/text-track-list.test.js
@@ -88,14 +88,14 @@ QUnit.test('toJSON', function(assert) {
   assert.equal(textTrackListJSON[2].id, tt3.id, 'text track in third spot of array should match the original track');
 });
 
-QUnit.test('toJSON', function(assert) {
+QUnit.test('serialize', function(assert) {
   const tech = new TechFaker();
   const tt1 = new TextTrack({tech});
   const tt2 = new TextTrack({tech});
   const tt3 = new TextTrack({tech});
   const ttl = new TextTrackList([tt1, tt2, tt3]);
 
-  const serializedTrackList = ttl.serialize();
+  const serializedTrackList = JSON.stringify(ttl);
 
   assert.notOk(serializedTrackList.includes('"tech_":'), 'tech_ does not exist in the serialized data');
 

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -768,7 +768,7 @@ QUnit.test('toJSON', function(assert) {
   // Properties we want copied are copied correctly
   assert.equal(tt.id, jsonTrack.id, 'the id for the copied track stayed the same');
   assert.equal(tt.mode, jsonTrack.mode, 'the mode for the copied track stayed the same');
-  assert.equal(tt.cues_, jsonTrack.cues_, 'the cues for the copied track stayed the same');
+  assert.equal(tt.kind, jsonTrack.kind, 'the kind for the copied track stayed the same');
 
   // The tech_ property stays on the original track, but is removed from the copy
   assert.ok(tt.tech_, 'the tech exists on the original track');
@@ -791,7 +791,7 @@ QUnit.test('serialize', function(assert) {
     endTime: 2.555
   });
 
-  const serializedTrack = tt.serialize();
+  const serializedTrack = JSON.stringify(tt);
 
   // Ensure tech was not removed from the actual track
   assert.ok(tt.tech_, 'the tech exists on the original track');
@@ -799,7 +799,7 @@ QUnit.test('serialize', function(assert) {
   // Values from the track should be found in the serialized string
   assert.ok(serializedTrack.includes(`"id":"${tt.id}"`), 'serialized data should include id');
   assert.ok(serializedTrack.includes(`"mode":"${tt.mode}"`), 'serialized data should include mode');
-  assert.ok(serializedTrack.includes(`"cues":${JSON.stringify(tt.cues)}`), 'serialized data should include cues');
+  assert.ok(serializedTrack.includes(`"kind":"${tt.kind}"`), 'serialized data should include cues');
 
   // tech_ should not be found in the serialized string
   assert.notOk(serializedTrack.includes('"tech_":'), 'serialized data should not include tech_');

--- a/test/unit/tracks/text-track.test.js
+++ b/test/unit/tracks/text-track.test.js
@@ -746,3 +746,61 @@ QUnit.test('stops processing if vttjs loading errored out', function(assert) {
   testTech.off();
   log.error = oldLogError;
 });
+
+QUnit.test('toJSON', function(assert) {
+  const tt = new TextTrack({
+    tech: this.tech
+  });
+
+  tt.addCue({
+    id: '1',
+    startTime: 1,
+    endTime: 2.555
+  });
+  tt.addCue({
+    id: '2',
+    startTime: 2.555,
+    endTime: 2.555
+  });
+
+  const jsonTrack = tt.toJSON();
+
+  // Properties we want copied are copied correctly
+  assert.equal(tt.id, jsonTrack.id, 'the id for the copied track stayed the same');
+  assert.equal(tt.mode, jsonTrack.mode, 'the mode for the copied track stayed the same');
+  assert.equal(tt.cues_, jsonTrack.cues_, 'the cues for the copied track stayed the same');
+
+  // The tech_ property stays on the original track, but is removed from the copy
+  assert.ok(tt.tech_, 'the tech exists on the original track');
+  assert.notOk(jsonTrack.tech_, 'the tech does not exist on the copied track');
+});
+
+QUnit.test('serialize', function(assert) {
+  const tt = new TextTrack({
+    tech: this.tech
+  });
+
+  tt.addCue({
+    id: '1',
+    startTime: 1,
+    endTime: 2.555
+  });
+  tt.addCue({
+    id: '2',
+    startTime: 2.555,
+    endTime: 2.555
+  });
+
+  const serializedTrack = tt.serialize();
+
+  // Ensure tech was not removed from the actual track
+  assert.ok(tt.tech_, 'the tech exists on the original track');
+
+  // Values from the track should be found in the serialized string
+  assert.ok(serializedTrack.includes(`"id":"${tt.id}"`), 'serialized data should include id');
+  assert.ok(serializedTrack.includes(`"mode":"${tt.mode}"`), 'serialized data should include mode');
+  assert.ok(serializedTrack.includes(`"cues":${JSON.stringify(tt.cues)}`), 'serialized data should include cues');
+
+  // tech_ should not be found in the serialized string
+  assert.notOk(serializedTrack.includes('"tech_":'), 'serialized data should not include tech_');
+});


### PR DESCRIPTION
## Description

Adds `toJSON` method to both the `TextTrack` and `TextTrackList` classes. The `toJSON` method creates a serializable JSON object from the track or track list.

There was an issue when attempting to serialize (JSON.stringify()) `player.textTracks()` due to circular references in `textTracks.tech_`. These methods create serializable copies of textTracks so a user has a way to serialize this data.

Since JSON.stringify calls `toJSON` natively, it will use this new overidden `toJSON` method instead of the native method. `JSON.stringify(player.textTracks())` will now be a valid serialized string. Previously, it threw an error.

## Specific Changes proposed

- Add `toJSON` methods to `TextTrack` and `TextTrackList` classes
- Tests for the above methods

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
