### PR TITLE
fix: only change focus from BPB if not tap or mouse click

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -46,8 +46,8 @@ class BigPlayButton extends Button {
   handleClick(event) {
     const playPromise = this.player_.play();
 
-    // exit early if clicked via the mouse
-    if (this.mouseused_ && 'clientX' in event && 'clientY' in event) {
+    // exit early if tapped or clicked via the mouse
+    if (event.type === 'tap' || this.mouseused_ && 'clientX' in event && 'clientY' in event) {
       silencePromise(playPromise);
 
       if (this.player_.tech(true)) {


### PR DESCRIPTION
References #9006. Minor extension of #4497.

## Specific Changes proposed
Don't set focus after tapping on the big play button

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, ~IE~)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
