### PR TITLE
fix: update text-track-cue styles on useractive

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -124,6 +124,8 @@ class TextTrackDisplay extends Component {
     };
 
     player.on('loadstart', (e) => this.toggleDisplay(e));
+    player.on('useractive', updateDisplayTextHandler);
+    player.on('userinactive', updateDisplayTextHandler);
     player.on('texttrackchange', updateDisplayTextHandler);
     player.on('loadedmetadata', (e) => {
       this.updateDisplayOverlay();

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -264,7 +264,7 @@ class TextTrackDisplay extends Component {
   }
 
   /**
-   * Update the displayed TextTrack when a either a {@link Player#texttrackchange},
+   * Update the displayed {@link TextTrack} when either a {@link Player#texttrackchange},
    * a {@link Player#fullscreenchange}, a {@link Player#useractive}, or a
    * {@link Player#userinactive} is fired.
    *

--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -264,11 +264,14 @@ class TextTrackDisplay extends Component {
   }
 
   /**
-   * Update the displayed TextTrack when a either a {@link Player#texttrackchange} or
-   * a {@link Player#fullscreenchange} is fired.
+   * Update the displayed TextTrack when a either a {@link Player#texttrackchange},
+   * a {@link Player#fullscreenchange}, a {@link Player#useractive}, or a
+   * {@link Player#userinactive} is fired.
    *
    * @listens Player#texttrackchange
    * @listens Player#fullscreenchange
+   * @listens Player#useractive
+   * @listens Player#userinactive
    */
   updateDisplay() {
     const tracks = this.player_.textTracks();


### PR DESCRIPTION
## Description
This is an attempt to fix https://github.com/videojs/video.js/issues/6207
Added event handlers for 'useractive' and 'userinactive' events to update text tracks display position so that they reposition when the control bar is shown or hidden

