### PR TITLE
fix: release workfow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       NETLIFY_BASE: 'videojs-preview.netlify.app'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write      # Required for creating a release
       id-token: write      # Required for provenance
       packages: write      # Required for publishing
     steps:


### PR DESCRIPTION
## Description
Our automated release workflow has been failing for a while. A search of the error message turned up https://github.com/softprops/action-gh-release/issues/236, which suggests that the "contents" permissions for the workflow need to be set to "write".

⚠️ This change may break the intent of #8911, but it's not clear to me from that PR whether a permission of `read` is necessary for the provenance protection.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
