### PR TITLE
fix: update release workflow `discussion` permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write      # Required for creating a release
+      discussions: write   # Required for creating a release
       id-token: write      # Required for provenance
       packages: write      # Required for publishing
     steps:


### PR DESCRIPTION
## Description
#9027 only fixed one issue with the release workflow. [The last release run](https://github.com/videojs/video.js/actions/runs/14489334201/job/40641922135#step:10:26) failed with:
```
👩‍🏭 Creating new GitHub release for tag v8.23.2...
⚠️ GitHub release failed with status: 404
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v8.23.2...
⚠️ GitHub release failed with status: 422
[{"resource":"Release","code":"already_exists","field":"tag_name"}]
```
The initial 404 appears to have be caused by a lack of [permission for discussions](https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions), and then subsequent tries fail because the tag already exists.

## Specific Changes proposed
Add `write` permission for `discussions`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
