### PR TITLE
fix(player): remove outdated JAWS workaround on Chrome/Windows

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -14,7 +14,6 @@ import * as Dom from './utils/dom.js';
 import * as Fn from './utils/fn.js';
 import * as Guid from './utils/guid.js';
 import * as browser from './utils/browser.js';
-import {IS_CHROME, IS_WINDOWS} from './utils/browser.js';
 import log, { createLogger } from './utils/log.js';
 import {toTitleCase, titleCaseEquals} from './utils/str.js';
 import { createTimeRange } from './utils/time.js';
@@ -753,15 +752,6 @@ class Player extends Component {
     // set tabindex to -1 to remove the video element from the focus order
     tag.setAttribute('tabindex', '-1');
     attrs.tabindex = '-1';
-
-    // Workaround for #4583 on Chrome (on Windows) with JAWS.
-    // See https://github.com/FreedomScientific/VFO-standards-support/issues/78
-    // Note that we can't detect if JAWS is being used, but this ARIA attribute
-    // doesn't change behavior of Chrome if JAWS is not being used
-    if (IS_CHROME && IS_WINDOWS) {
-      tag.setAttribute('role', 'application');
-      attrs.role = 'application';
-    }
 
     // Remove width/height attrs from tag so CSS can make it 100% width/height
     tag.removeAttribute('width');


### PR DESCRIPTION
The player was previously configured with role="application" on Chrome/Windows to work around an old JAWS issue that prevented users from pausing/stopping video playback.

This JAWS issue ([FreedomScientific/standards-support#78](https://github.com/FreedomScientific/standards-support/issues/78)) was resolved in 2020. Keeping this workaround now causes degraded behavior for modern assistive technologies by forcing an application role unnecessarily.

This change removes the conditional assignment of role="application" to improve interoperability with modern screen readers.

Fixes #9055.

Description
This PR removes an outdated workaround added to src/js/player.js which set role="application" on Chrome/Windows to address a resolved JAWS screen reader bug. Retaining this workaround now negatively impacts accessibility by forcing some screen readers into an unnecessary application mode, causing inconsistent and degraded user experiences.

Specific Changes proposed
Remove the conditional assignment of role="application" in src/js/player.js for Chrome/Windows.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
