### PR TITLE
fix(component.js): Updated JS Doc for removeChild()

### DIFF
--- a/src/js/component.js
+++ b/src/js/component.js
@@ -689,7 +689,7 @@ class Component {
    * Remove a child `Component` from this `Component`s list of children. Also removes
    * the child `Component`s element from this `Component`s element.
    *
-   * @param {Component} component
+   * @param {string|Component} component
    *        The child `Component` to remove.
    */
   removeChild(component) {

--- a/src/js/component.js
+++ b/src/js/component.js
@@ -690,7 +690,7 @@ class Component {
    * the child `Component`s element from this `Component`s element.
    *
    * @param {string|Component} component
-   *        The child `Component` to remove.
+   *       The name or instance of a child to remove.
    */
   removeChild(component) {
     if (typeof component === 'string') {


### PR DESCRIPTION
## Description
removeChild() in component.js was missing the string as an acceptable parameter due to which ts complaints.

Example : player.removeChild('controlBar');

Error : **Argument of type 'string' is not assignable to parameter of type 'Component'**


 
## Specific Changes proposed

1. Added `string` in the jsdoc for removeChild() in component.ts.
2. Updated comment for removeChild().

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
