### PR TITLE
fix: Potential ReDoS Vulnerability or Inefficient Regular Expression in Project: Need for Assessment and Mitigation

### DIFF
--- a/build/jsdoc-typeof-plugin.js
+++ b/build/jsdoc-typeof-plugin.js
@@ -3,7 +3,7 @@
  */
 exports.handlers = {
   jsdocCommentFound: event => {
-    event.comment = (event.comment || '').replace(/\{.*typeof\s+([^\s\|]+).*\}/g, typeExpression => {
+    event.comment = (event.comment || '').replace(/\{(?:(?!\{).)*typeof\s+([^\s\|]+)(?:(?![^\s\|]).)*\}/g, typeExpression => {
       return typeExpression.replace(/typeof\s+([^\s\|\}]+)/g, (expression, className) => {
         return 'Class<' + className + '>';
       });

--- a/test/build/jsdoc-typeof-plugin.test.js
+++ b/test/build/jsdoc-typeof-plugin.test.js
@@ -1,0 +1,17 @@
+const QUnit = require('qunit');
+const plugin = require('../../build/jsdoc-typeof-plugin.js');
+const { handlers } = plugin;
+
+QUnit.module('build/jsdoc-typeof-plugin', () => {
+
+  QUnit.test('ReDos attack', assert => {
+    const evt = { comment: '{'.repeat(100000) + 't' };
+    const t0 = performance.now();
+
+    handlers.jsdocCommentFound(evt);
+    const dt = performance.now() - t0;
+
+    assert.ok(dt < 5000, `expected < 5000ms, got ${dt.toFixed(1)}ms`);
+  });
+
+});


### PR DESCRIPTION
## Description
I am writing to report a potential Regular Expression Denial of Service (ReDoS) vulnerability or Inefficient Regular Expression in the project. When using specially crafted input strings in the context, it may lead to extremely high CPU usage, application freezing, or denial of service attacks.

https://github.com/videojs/video.js/blob/3380d33d6f9c2c22a50b35a759519b90723f33a4/build/jsdoc-typeof-plugin.js#L6

gist:https://gist.github.com/mmmsssttt404/2115fe1bbc0afdecda2128d5084b18a0

<img width="808" height="604" alt="屏幕截图 2025-08-19 215415" src="https://github.com/user-attachments/assets/7efb571f-0fb7-4dd4-ad25-4709b4abb96e" />

```javascript
1.git clone https://github.com/mmmsssttt404/video.js.git
2.cd video.js
3.npm install
4.npx qunit test/build/jsdoc-typeof-plugin.test.js
5.npm test
``` 

## Specific Changes proposed
Please list the specific changes involved in this pull request.

change regex to:
https://github.com/mmmsssttt404/video.js/blob/d9ae655a3710d42adeb7e7be31fe316515ccf801/build/jsdoc-typeof-plugin.js#L6

then:
<img width="542" height="175" alt="屏幕截图 2025-08-20 114636" src="https://github.com/user-attachments/assets/694f4055-67b9-4187-bb7b-6576ce967178" />
<img width="695" height="457" alt="屏幕截图 2025-08-20 114810" src="https://github.com/user-attachments/assets/b0f8ea9a-8def-49a5-b63e-f0a68bc4fcab" />


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [x] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
