### PR TITLE
docs: Clarify copyright, CLA, and project stewardship

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -35,7 +35,7 @@ module.exports = {
       ],
       favicon: 'https://videojs.com/favicon.ico',
       footer:
-        '<span class="copyright"><a href="https://videojs.com">Video.js</a> is a free and open source HTML5 video player. © <a href="https://brightcove.com" target="_blank">Brightcove, Inc</a>. <a href="https://github.com/videojs/video.js/blob/master/LICENSE" class="button blue" target="_blank">View license</a></span>',
+        '<span class="copyright"><a href="https://videojs.com">Video.js</a> is a free and open source HTML5 video player. © Video.js Contributors. <a href="https://github.com/videojs/video.js/blob/master/LICENSE" class="button blue" target="_blank">View license</a></span>',
       include_css: ['./build/docs/styles/videojs.css'],
       displayModuleHeade: true,
       meta: [

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Brightcove, Inc.
+Copyright 2010-present Video.js contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -11,3 +11,9 @@ Copyright Brightcove, Inc.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+------------------------------------------------------------------
+Trademark Notice:
+“Video.js” is a registered trademark of Brightcove Inc.
+The project is maintained independently by the open-source community,
+governed by the Video.js Technical Steering Committee.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,13 @@ If you're ready to dive in, the [Getting Started][getting-started] page and [doc
 
 Video.js is a free and open source library, and we appreciate any help you're willing to give - whether it's fixing bugs, improving documentation, or suggesting new features. Check out the [contributing guide][contributing] for more!
 
-_Video.js uses [BrowserStack][browserstack] for compatibility testing._
+No contributor license agreement (CLA) has ever been required for contributions to Video.js.
+
+By submitting a pull request, you agree that your contribution is provided under the
+[Apache 2.0 License](LICENSE) and may be included in future releases.
+
+Contributions and project decisions are overseen by the
+[Video.js Technical Steering Committee (TSC)](https://github.com/videojs/admin/blob/main/GOVERNANCE.md).
 
 ## [Code of Conduct][coc]
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Video.js was started in May 2010 and since then:
 * [Contributing](#contributing)
 * [Code of Conduct](#code-of-conduct)
 * [License](#license)
+* [Sponsorship](#sponsorship)
 
 ## [Quick Start][getting-started]
 
@@ -102,15 +103,12 @@ If you're ready to dive in, the [Getting Started][getting-started] page and [doc
 
 ## [Contributing][contributing]
 
-Video.js is a free and open source library, and we appreciate any help you're willing to give - whether it's fixing bugs, improving documentation, or suggesting new features. Check out the [contributing guide][contributing] for more!
-
-No contributor license agreement (CLA) has ever been required for contributions to Video.js.
+Video.js is a free and open source library, and we appreciate any help you're willing to give - whether it's fixing bugs, improving documentation, or suggesting new features. Check out the [contributing guide][contributing] for more! Contributions and project decisions are overseen by the
+[Video.js Technical Steering Committee (TSC)](https://github.com/videojs/admin/blob/main/GOVERNANCE.md).
 
 By submitting a pull request, you agree that your contribution is provided under the
-[Apache 2.0 License](LICENSE) and may be included in future releases.
-
-Contributions and project decisions are overseen by the
-[Video.js Technical Steering Committee (TSC)](https://github.com/videojs/admin/blob/main/GOVERNANCE.md).
+[Apache 2.0 License](LICENSE) and may be included in future releases. No contributor license agreement (CLA) has ever been required for contributions to Video.js. See the [Developer's Certificate of Origin 1.1
+](https://github.com/videojs/admin/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11).
 
 ## [Code of Conduct][coc]
 
@@ -118,9 +116,21 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 ## [License][license]
 
-Video.js is [licensed][license] under the Apache License, Version 2.0.
+Video.js is [licensed][license] under the Apache License, Version 2.0. "Video.js" is a registered trademark of [Brightcove, Inc][bc].
 
-Video.js is a registered trademark of [Brightcove, Inc][bc].
+## Sponsorship
+
+Project development is sponsored by the role of [Corporate Shepherd](https://github.com/videojs/admin/blob/main/GOVERNANCE.md#corporate-shepherd), held by various companies throughout the project history:
+
+* 2010-2012: Zencoder Inc.
+* 2013-2025: [Brightcove Inc.][bc]
+* 2025-present: [Mux Inc.][mux]
+
+Video.js uses [BrowserStack][browserstack] for compatibility testing.
+
+The free CDN-hosted copy of the libray is sponsored by [Fastly][fastly].
+
+Website hosting is sponsored by [Netlify][netlify]
 
 [bc]: https://www.brightcove.com/
 
@@ -139,6 +149,10 @@ Video.js is a registered trademark of [Brightcove, Inc][bc].
 [license]: LICENSE
 
 [logo]: https://videojs.com/logo-white.png
+
+[mux]: https://www.mux.com/
+
+[netlify]: https://www.netlify.com
 
 [npm-icon]: https://nodei.co/npm/video.js.png?downloads=true&downloadRank=true
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./dist/video.es.js",
   "style": "./dist/video-js.css",
   "types": "./dist/types/video.d.ts",
-  "copyright": "Copyright Brightcove, Inc. <https://www.brightcove.com/>",
+  "copyright": "Copyright 2010-present Video.js contributors",
   "license": "Apache-2.0",
   "keywords": [
     "dash",


### PR DESCRIPTION
Update the LICENSE file and project documentation to more accurately reflect the history and current governance of Video.js.

Brightcove has never required contributors to sign a Contributor License Agreement (CLA) or transfer copyright. As a result, the existing “Copyright Brightcove, Inc.” line was misleading, since Brightcove doesn’t own all contributions.

This change:
Keeps the Apache 2.0 license text exactly as-is.
Updates the attribution to accurately reflect the distributed ownership of the codebase. Aligns with common open source practice for projects without a CLA or copyright assignment. Acknowledges that Brightcove has registered the Video.js trademark.

This is a documentation-only change — it does not affect licensing terms, the license type (Apache 2.0), or project usage.
