### PR TITLE
fix: type properly tracks_ on TrackList

### DIFF
--- a/src/js/tracks/audio-track-list.js
+++ b/src/js/tracks/audio-track-list.js
@@ -31,7 +31,7 @@ const disableOthers = function(list, track) {
  * The current list of {@link AudioTrack} for a media file.
  *
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#audiotracklist}
- * @extends TrackList
+ * @extends TrackList<AudioTrack>
  */
 class AudioTrackList extends TrackList {
 

--- a/src/js/tracks/text-track-list.js
+++ b/src/js/tracks/text-track-list.js
@@ -9,7 +9,7 @@ import TrackList from './track-list';
  * The current list of {@link TextTrack} for a media file.
  *
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#texttracklist}
- * @extends TrackList
+ * @extends TrackList<TextTrack>
  */
 class TextTrackList extends TrackList {
 

--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -10,13 +10,14 @@ import {isEvented} from '../mixins/evented';
  * Common functionaliy between {@link TextTrackList}, {@link AudioTrackList}, and
  * {@link VideoTrackList}
  *
+ * @template [T=Track] extends Track
  * @extends EventTarget
  */
 class TrackList extends EventTarget {
   /**
    * Create an instance of this class
    *
-   * @param { Track[] } tracks
+   * @param { T[] } tracks
    *        A list of tracks to initialize the list with.
    *
    * @abstract
@@ -24,6 +25,10 @@ class TrackList extends EventTarget {
   constructor(tracks = []) {
     super();
 
+    /**
+     * @type {T[]} tracks_
+     *        The list of tracks.
+     */
     this.tracks_ = [];
 
     /**
@@ -46,7 +51,7 @@ class TrackList extends EventTarget {
   /**
    * Add a {@link Track} to the `TrackList`
    *
-   * @param {Track} track
+   * @param {T} track
    *        The audio, video, or text track to add to the list.
    *
    * @fires TrackList#addtrack
@@ -104,7 +109,7 @@ class TrackList extends EventTarget {
   /**
    * Remove a {@link Track} from the `TrackList`
    *
-   * @param {Track} rtrack
+   * @param {T} rtrack
    *        The audio, video, or text track to remove from the list.
    *
    * @fires TrackList#removetrack
@@ -134,7 +139,7 @@ class TrackList extends EventTarget {
      *
      * @event TrackList#removetrack
      * @type {Event}
-     * @property {Track} track
+     * @property {T} track
      *           A reference to track that was removed.
      */
     this.trigger({

--- a/src/js/tracks/video-track-list.js
+++ b/src/js/tracks/video-track-list.js
@@ -30,7 +30,7 @@ const disableOthers = function(list, track) {
  * The current list of {@link VideoTrack} for a video.
  *
  * @see [Spec]{@link https://html.spec.whatwg.org/multipage/embedded-content.html#videotracklist}
- * @extends TrackList
+ * @extends TrackList<VideoTrack>
  */
 class VideoTrackList extends TrackList {
 


### PR DESCRIPTION
## Description
Use a generic in TrackList to provide better typing for _tracks.

## Specific Changes proposed
The TrackList type has changed, I added a generic to provide stronger typing for the kind of track it stores.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
