### PR TITLE
fix: currentTimeDisplay shows 0:00 after seek

### DIFF
--- a/src/js/control-bar/progress-control/seek-bar.js
+++ b/src/js/control-bar/progress-control/seek-bar.js
@@ -56,7 +56,7 @@ class SeekBar extends Slider {
     super(player, options);
 
     this.shouldDisableSeekWhileScrubbing_ = shouldDisableSeekWhileScrubbing;
-    this.pendingSeekTime_ = null;
+    this.pendingSeekTime = this.getCurrentTime_;
 
     this.setEventHandlers_();
   }


### PR DESCRIPTION
## Description

Steps to reproduce originally posted by @johanberonius at https://github.com/videojs/video.js/issues/8988#issuecomment-3402464579

- Pause player
- Click progress bar and hold mouse button down
- Current time display is updated correctly
- Release mouse button
- Current time display is reset to zero
- Play video
- Current time display is updated again

This patch integrates to proposed workaround by @johanberonius.

The issue was not caused by adding the option
`disableSeekWhileScrubbingOnMobile` per se, but is a side-effect of the improvements added in 77c99d2829f56d1037361c33ccd96c6ea966ecb7.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
