### PR TITLE
ci: remove npm token from GHA release.yml to test trusted publisher workflow without it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
       # publish runs build for us via a prepublishOnly script
       - name: npm release
         run: npm publish --provenance --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: get current changelog
         run: node -e "console.log(require('./build/current-changelog.js')())" > CHANGELOG-LATEST.md


### PR DESCRIPTION
## Description
GHA update to test new `npmjs` registry [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) setup.

## Specific Changes proposed
Use Trusted Publishers for GHA releases instead of soon to be invalid classic tokens.

## Requirements Checklist
N/A
