### PR TITLE
feat: logarithmic volume support

### DIFF
--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -6,6 +6,7 @@ import Component from '../../component.js';
 import * as Dom from '../../utils/dom.js';
 import {clamp} from '../../utils/num.js';
 import {IS_IOS, IS_ANDROID} from '../../utils/browser.js';
+import {LinearVolumeTransfer, LogarithmicVolumeTransfer} from '../../utils/volume-transfer.js';
 
 /** @import Player from '../../player' */
 
@@ -31,6 +32,7 @@ class VolumeBar extends Slider {
    */
   constructor(player, options) {
     super(player, options);
+    this.initVolumeTransfer_();
     this.on('slideractive', (e) => this.updateLastVolume_(e));
     this.on(player, 'volumechange', (e) => this.updateARIAAttributes(e));
     player.ready(() => this.updateARIAAttributes());
@@ -98,7 +100,11 @@ class VolumeBar extends Slider {
     }
 
     this.checkMuted();
-    this.player_.volume(this.calculateDistance(event));
+
+    const sliderPosition = this.calculateDistance(event);
+    const linearVolume = this.volumeTransfer_.toLinear(sliderPosition);
+
+    this.player_.volume(linearVolume);
   }
 
   /**
@@ -120,7 +126,10 @@ class VolumeBar extends Slider {
     if (this.player_.muted()) {
       return 0;
     }
-    return this.player_.volume();
+
+    const linearVolume = this.player_.volume();
+
+    return this.volumeTransfer_.toLogarithmic(linearVolume);
   }
 
   /**
@@ -128,7 +137,14 @@ class VolumeBar extends Slider {
    */
   stepForward() {
     this.checkMuted();
-    this.player_.volume(this.player_.volume() + 0.1);
+
+    const currentSlider = this.getPercent();
+
+    const newSlider = Math.min(currentSlider + 0.1, 1);
+
+    const linearVolume = this.volumeTransfer_.toLinear(newSlider);
+
+    this.player_.volume(linearVolume);
   }
 
   /**
@@ -136,7 +152,19 @@ class VolumeBar extends Slider {
    */
   stepBack() {
     this.checkMuted();
-    this.player_.volume(this.player_.volume() - 0.1);
+
+    const currentSlider = this.getPercent();
+
+    const newSlider = Math.max(currentSlider - 0.1, 0);
+
+    if (newSlider < 0.05) {
+      this.player_.volume(0);
+      return;
+    }
+
+    const linearVolume = this.volumeTransfer_.toLinear(newSlider);
+
+    this.player_.volume(linearVolume);
   }
 
   /**
@@ -181,6 +209,20 @@ class VolumeBar extends Slider {
     });
   }
 
+  /**
+   * Initialize the volume transfer function
+   *
+   * @private
+   */
+  initVolumeTransfer_() {
+    if (this.player_.options_.logarithmicVolume) {
+      const dbRange = this.player_.options_.logarithmicVolumeRange;
+
+      this.volumeTransfer_ = new LogarithmicVolumeTransfer(dbRange);
+    } else {
+      this.volumeTransfer_ = new LinearVolumeTransfer();
+    }
+  }
 }
 
 /**

--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -102,7 +102,7 @@ class VolumeBar extends Slider {
     this.checkMuted();
 
     const sliderPosition = this.calculateDistance(event);
-    const linearVolume = this.volumeTransfer_.toLinear(sliderPosition);
+    const linearVolume = this.volumeTransfer_.sliderToVolume(sliderPosition);
 
     this.player_.volume(linearVolume);
   }
@@ -129,7 +129,7 @@ class VolumeBar extends Slider {
 
     const linearVolume = this.player_.volume();
 
-    return this.volumeTransfer_.toLogarithmic(linearVolume);
+    return this.volumeTransfer_.volumeToSlider(linearVolume);
   }
 
   /**
@@ -142,7 +142,7 @@ class VolumeBar extends Slider {
 
     const newSlider = Math.min(currentSlider + 0.1, 1);
 
-    const linearVolume = this.volumeTransfer_.toLinear(newSlider);
+    const linearVolume = this.volumeTransfer_.sliderToVolume(newSlider);
 
     this.player_.volume(linearVolume);
   }
@@ -162,7 +162,7 @@ class VolumeBar extends Slider {
       return;
     }
 
-    const linearVolume = this.volumeTransfer_.toLinear(newSlider);
+    const linearVolume = this.volumeTransfer_.sliderToVolume(newSlider);
 
     this.player_.volume(linearVolume);
   }

--- a/src/js/utils/volume-transfer.js
+++ b/src/js/utils/volume-transfer.js
@@ -1,0 +1,105 @@
+/**
+ * Base class for volume transfer functions
+ */
+class VolumeTransfer {
+  /**
+   * Convert logarithmic (slider) to linear (tech)
+   *
+   * @param {number} logarithmic - Volume from 0-1
+   * @return {number} Linear volume from 0-1
+   */
+  toLinear(logarithmic) {
+    throw new Error('Must be implemented by subclass');
+  }
+
+  /**
+   * Convert linear (tech) to logarithmic (slider)
+   *
+   * @param {number} linear - Volume from 0-1
+   * @return {number} Logarithmic volume from 0-1
+   */
+  toLogarithmic(linear) {
+    throw new Error('Must be implemented by subclass');
+  }
+
+  getName() {
+    return 'base';
+  }
+}
+
+/**
+ * Linear transfer - no conversion (current default behavior)
+ */
+class LinearVolumeTransfer extends VolumeTransfer {
+  toLinear(value) {
+    return value;
+  }
+
+  toLogarithmic(value) {
+    return value;
+  }
+
+  getName() {
+    return 'linear';
+  }
+}
+
+/**
+ * Logarithmic transfer using decibel scaling
+ */
+class LogarithmicVolumeTransfer extends VolumeTransfer {
+  constructor(dbRange = 50) {
+    super();
+    this.dbRange = dbRange;
+    this.offset = Math.pow(10, -dbRange / 20);
+  }
+
+  /**
+   * Convert logarithmic slider position to linear volume for tech
+   *
+   * @param {number} sliderPosition - Slider position (0-1)
+   * @return {number} Linear volume (0-1)
+   */
+  toLinear(sliderPosition) {
+    if (sliderPosition <= 0) {
+      return 0;
+    }
+
+    if (sliderPosition >= 1) {
+      return 1;
+    }
+
+    const dB = sliderPosition * this.dbRange - this.dbRange;
+    const linear = Math.pow(10, dB / 20);
+
+    return linear;
+  }
+
+  /**
+   * Convert linear volume from tech to logarithmic slider position
+   *
+   * @param {number} linear - Linear volume (0-1)
+   * @return {number} Slider position (0-1)
+   */
+  toLogarithmic(linear) {
+    if (linear <= 0) {
+      return 0;
+    }
+
+    if (linear >= 1) {
+      return 1;
+    }
+
+    const dB = 20 * Math.log10(linear);
+    const position = (dB + this.dbRange) / this.dbRange;
+
+    return position;
+  }
+
+  getName() {
+    return 'logarithmic';
+  }
+}
+
+export default VolumeTransfer;
+export { LinearVolumeTransfer, LogarithmicVolumeTransfer };

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -1046,3 +1046,17 @@ QUnit.test('VolumeBar stepBack() decreases volume correctly with logarithmic tra
 
   player.dispose();
 });
+
+QUnit.test('VolumeBar stepBack() sets volume to 0 when slider would go below threshold', function(assert) {
+  const player = TestHelpers.makePlayer();
+
+  const volumeBar = player.controlBar.volumePanel.volumeControl.volumeBar;
+
+  player.volume(0.02);
+
+  volumeBar.stepBack();
+
+  assert.equal(player.volume(), 0, 'volume is set to 0 when reduced slider is below threshold');
+
+  player.dispose();
+});

--- a/test/unit/tech/volume-transfer.test.js
+++ b/test/unit/tech/volume-transfer.test.js
@@ -1,0 +1,190 @@
+/* eslint-env qunit */
+import VolumeTransfer, {
+  LinearVolumeTransfer,
+  LogarithmicVolumeTransfer
+} from '../../../src/js/utils/volume-transfer.js';
+
+import QUnit from 'qunit';
+
+QUnit.module('VolumeTransfer');
+
+// Base class tests
+QUnit.test('VolumeTransfer base class throws errors', function(assert) {
+  const transfer = new VolumeTransfer();
+
+  assert.throws(
+    () => transfer.toLinear(0.5),
+    /Must be implemented by subclass/,
+    'toLinear throws error on base class'
+  );
+
+  assert.throws(
+    () => transfer.toLogarithmic(0.5),
+    /Must be implemented by subclass/,
+    'toLogarithmic throws error on base class'
+  );
+
+  assert.strictEqual(
+    transfer.getName(),
+    'base',
+    'getName returns "base"'
+  );
+});
+
+QUnit.test('LinearVolumeTransfer is identity function', function(assert) {
+  const transfer = new LinearVolumeTransfer();
+
+  [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0].forEach(value => {
+    assert.strictEqual(
+      transfer.toLinear(value),
+      value,
+      `toLinear(${value}) returns ${value}`
+    );
+
+    assert.strictEqual(
+      transfer.toLogarithmic(value),
+      value,
+      `toLogarithmic(${value}) returns ${value}`
+    );
+  });
+
+  assert.strictEqual(
+    transfer.getName(),
+    'linear',
+    'getName returns "linear"'
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer constructor sets dbRange and offset', function(assert) {
+  const transfer1 = new LogarithmicVolumeTransfer();
+
+  assert.strictEqual(transfer1.dbRange, 50, 'default dbRange is 50');
+  assert.ok(transfer1.offset > 0, 'offset is calculated and > 0');
+
+  const transfer2 = new LogarithmicVolumeTransfer(60);
+
+  assert.strictEqual(transfer2.dbRange, 60, 'custom dbRange is set');
+
+  assert.strictEqual(
+    transfer1.getName(),
+    'logarithmic',
+    'getName returns "logarithmic"'
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer passes through (0,0)', function(assert) {
+  const transfer = new LogarithmicVolumeTransfer(50);
+
+  assert.strictEqual(
+    transfer.toLinear(0),
+    0,
+    'toLinear(0) returns exactly 0'
+  );
+
+  assert.strictEqual(
+    transfer.toLogarithmic(0),
+    0,
+    'toLogarithmic(0) returns exactly 0'
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer passes through (1,1)', function(assert) {
+  const transfer = new LogarithmicVolumeTransfer(50);
+
+  assert.strictEqual(
+    transfer.toLinear(1),
+    1,
+    'toLinear(1) returns exactly 1'
+  );
+
+  assert.strictEqual(
+    transfer.toLogarithmic(1),
+    1,
+    'toLogarithmic(1) returns exactly 1'
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer is invertible', function(assert) {
+  const transfer = new LogarithmicVolumeTransfer(50);
+
+  [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0].forEach(slider => {
+    const linear = transfer.toLinear(slider);
+    const back = transfer.toLogarithmic(linear);
+
+    assert.close(
+      back,
+      slider,
+      0.00001,
+      `Round trip for ${slider}: ${slider} -> ${linear.toFixed(4)} -> ${back.toFixed(4)}`
+    );
+  });
+});
+
+QUnit.test('LogarithmicVolumeTransfer provides finer control at low volumes', function(assert) {
+  const transfer = new LogarithmicVolumeTransfer(50);
+
+  const linear50 = transfer.toLinear(0.5);
+
+  assert.ok(
+    linear50 < 0.1,
+    `Slider at 50% gives linear < 10%: ${(linear50 * 100).toFixed(2)}%`
+  );
+
+  const linear25 = transfer.toLinear(0.25);
+
+  assert.ok(
+    linear25 < 0.01,
+    `Slider at 25% gives linear < 1%: ${(linear25 * 100).toFixed(2)}%`
+  );
+
+  const delta1 = transfer.toLinear(0.1) - transfer.toLinear(0);
+  const delta2 = transfer.toLinear(0.2) - transfer.toLinear(0.1);
+
+  assert.ok(
+    delta1 < 0.01 && delta2 < 0.01,
+    'Small slider movements at low volumes give small linear changes'
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer with different dbRanges', function(assert) {
+  const transfer40 = new LogarithmicVolumeTransfer(40);
+  const transfer50 = new LogarithmicVolumeTransfer(50);
+  const transfer60 = new LogarithmicVolumeTransfer(60);
+
+  const linear40 = transfer40.toLinear(0.5);
+  const linear50 = transfer50.toLinear(0.5);
+  const linear60 = transfer60.toLinear(0.5);
+
+  assert.ok(
+    linear40 > linear50 && linear50 > linear60,
+    `Higher dbRange gives more control at low volumes: ${linear40.toFixed(4)} > ${linear50.toFixed(4)} > ${linear60.toFixed(4)}`
+  );
+});
+
+QUnit.test('LogarithmicVolumeTransfer handles edge cases', function(assert) {
+  const transfer = new LogarithmicVolumeTransfer(50);
+
+  assert.strictEqual(
+    transfer.toLinear(-0.1),
+    0,
+    'Negative slider values return 0'
+  );
+
+  assert.strictEqual(
+    transfer.toLinear(1.1),
+    1,
+    'Slider values > 1 return 1'
+  );
+
+  assert.strictEqual(
+    transfer.toLogarithmic(-0.1),
+    0,
+    'Negative linear values return 0'
+  );
+
+  assert.strictEqual(
+    transfer.toLogarithmic(1.1),
+    1,
+    'Linear values > 1 return 1'
+  );
+});


### PR DESCRIPTION
## Description

Addresses: https://github.com/videojs/video.js/issues/8498

This PR adds support for logarithmic (perceptual) volume control to Video.js, providing a more natural audio experience that better matches human perception of loudness. When enabled via the `logarithmicVolume` option, the volume slider uses decibel-based scaling where linear slider movements produce logarithmic volume changes, making volume adjustments feel more consistent across the entire range.

### The Problem:
As discussed in [issue #8498](https://github.com/videojs/video.js/issues/8498), traditional linear volume control doesn't match how humans perceive sound. With linear scaling:
- Moving from 10% to 20% can feel like a huge jump in loudness
- Moving from 80% to 90% is barely noticeable
- Fine control at low volumes is difficult, making it hard to find a comfortable quiet listening level

## Specific Changes proposed
Logarithmic volume control solves this by using decibel (dB) scaling, the audio engineering standard that matches human hearing perception ([source](https://dcordero.me/posts/logarithmic_volume_control.html)). This implementation provides finer control at lower volumes where precision matters most - the first 50% of the slider covers roughly 0-6% of actual volume. This solution remains fully backward compatible - linear volume remains the default behavior.

Usage: 
```javascript
const player = videojs('my-video', {
  logarithmicVolume: true,
  logarithmicVolumeRange: 50
});
```

New `VolumeTransfer` class:
- `src/js/utils/volume-transfer.js` - Volume transfer functions for converting between slider position and player volume
- includes `VolumeTransfer` (base class), `LinearVolumeTransfer` (default, maintains current behavior), and `LogarithmicVolumeTransfer` (decibel-based scaling)

Updates to `VolumeBar`:
- `src/js/controls/volume-control/volume-bar.js`
- Added `initVolumeTransfer_()` to initialize transfer function based on `logarithmicVolume` option
- Updated `handleMouseMove()`, `getPercent()`, `stepForward()`, and `stepBack()` to use transfer functions

New Player Options:
- Added `logarithmicVolume` option (boolean, default: false)
Added `logarithmicVolumeRange` option (number, default: 50)

Tests: 
`test/unit/utils/volume-transfer.test.js` - Test suite covering both transfer implementations

Test Page:
https://christriants.github.io/video.js/sandbox/logarithmic-volume.html

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
