### PR TITLE
fix: prevent current time display showing 0:00 during seek

### DIFF
--- a/src/js/control-bar/time-controls/current-time-display.js
+++ b/src/js/control-bar/time-controls/current-time-display.js
@@ -35,7 +35,7 @@ class CurrentTimeDisplay extends TimeDisplay {
 
     if (this.player_.ended()) {
       time = this.player_.duration();
-    } else if (event && event.target && typeof event.target.pendingSeekTime === 'function') {
+    } else if (event && event.target && typeof event.target.pendingSeekTime === 'function' && event.target.pendingSeekTime() !== null) {
       time = event.target.pendingSeekTime();
     } else {
       time = (this.player_.scrubbing()) ? this.player_.getCache().currentTime : this.player_.currentTime();

--- a/test/unit/controls.test.js
+++ b/test/unit/controls.test.js
@@ -681,6 +681,28 @@ QUnit.test('Remaing time negative sign can be optional', function(assert) {
   player.dispose();
 });
 
+QUnit.test('Current time display shouldn\'t flash zero on seek', function(assert) {
+  const player = TestHelpers.makePlayer({ techOrder: ['html5'] });
+  const currentTimeDisplay = player.controlBar.currentTimeDisplay;
+  const spy = sinon.spy(currentTimeDisplay, 'updateTextNode_');
+
+  player.ended = () => false;
+  player.currentTime = () => 10;
+
+  currentTimeDisplay.updateContent({
+    target: {
+      pendingSeekTime: () => null
+    }
+  });
+
+  this.clock.tick(1);
+
+  assert.ok(spy.calledWith(10), 'control was updated with currentTime');
+  assert.notOk(spy.calledWith(null), 'control was not updated with null');
+  assert.notStrictEqual(currentTimeDisplay.formattedTime_, '0:00', 'display text not set to 0:00');
+
+});
+
 QUnit.module('SmartTV UI Updates (Progress Bar & Time Display)', function(hooks) {
   let player;
   let seekBar;


### PR DESCRIPTION
Fixes #9133. #8988 causes the current time display to show 0:00 while seeking as it's getting the current time from a method on seek bar that won't always return a useful value.

Adds a null check to allow fall through to getting currentTime.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
