### PR TITLE
fix: convert Tracklist length to a getter and fix event docs

### DIFF
--- a/src/js/tracks/track-list.js
+++ b/src/js/tracks/track-list.js
@@ -26,21 +26,18 @@ class TrackList extends EventTarget {
 
     this.tracks_ = [];
 
-    /**
-     * @memberof TrackList
-     * @member {number} length
-     *         The current number of `Track`s in the this Trackist.
-     * @instance
-     */
-    Object.defineProperty(this, 'length', {
-      get() {
-        return this.tracks_.length;
-      }
-    });
-
     for (let i = 0; i < tracks.length; i++) {
       this.addTrack(tracks[i]);
     }
+  }
+
+  /**
+   * The current number of `Track`s in this TrackList.
+   *
+   * @type {number}
+   */
+  get length() {
+    return this.tracks_.length;
   }
 
   /**
@@ -83,10 +80,10 @@ class TrackList extends EventTarget {
     /**
      * Triggered when a track label is changed.
      *
-     * @event TrackList#addtrack
+     * @event TrackList#labelchange
      * @type {Event}
      * @property {Track} track
-     *           A reference to track that was added.
+     *           A reference to track whose label was changed.
      */
     track.labelchange_ = () => {
       this.trigger({


### PR DESCRIPTION
## Description
This PR fixes issue #9059 by ensuring the length property is properly exposed in the generated TypeScript definition files for `TrackList`.

Additionally, this PR fixes a typo, and corrects the `@event` tag for the `labelchange` event handler.

## Specific Changes proposed
We can convert `length` to a getter method. By replacing the `Object.defineProperty` call in the constructor with `get length()` getter, we can make the property visible to the type generator.

After this change, the generated `track-list.d.ts` will include `get length(): number;`.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
