### PR TITLE
fix: simplify getBoundingClientRect wrapper

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -439,40 +439,15 @@ export function unblockTextSelection() {
  * the method is supported at all (it is in all browsers we claim to support)
  * and that the element is in the DOM before continuing.
  *
- * This wrapper function also shims properties which are not provided by some
- * older browsers (namely, IE8).
- *
- * Additionally, some browsers do not support adding properties to a
- * `ClientRect`/`DOMRect` object; so, we shallow-copy it with the standard
- * properties (except `x` and `y` which are not widely supported). This helps
- * avoid implementations where keys are non-enumerable.
- *
  * @param  {Element} el
  *         Element whose `ClientRect` we want to calculate.
  *
- * @return {Object|undefined}
- *         Always returns a plain object - or `undefined` if it cannot.
+ * @return {DOMRect|undefined}
+ *         The `DOMRect` for the element - or `undefined` if it cannot.
  */
 export function getBoundingClientRect(el) {
   if (el && el.getBoundingClientRect && el.parentNode) {
-    const rect = el.getBoundingClientRect();
-    const result = {};
-
-    ['bottom', 'height', 'left', 'right', 'top', 'width'].forEach(k => {
-      if (rect[k] !== undefined) {
-        result[k] = rect[k];
-      }
-    });
-
-    if (!result.height) {
-      result.height = parseFloat(computedStyle(el, 'height'));
-    }
-
-    if (!result.width) {
-      result.width = parseFloat(computedStyle(el, 'width'));
-    }
-
-    return result;
+    return el.getBoundingClientRect();
   }
 }
 

--- a/test/unit/utils/dom.test.js
+++ b/test/unit/utils/dom.test.js
@@ -609,31 +609,23 @@ QUnit.test('$() and $$()', function(assert) {
   );
 });
 
-QUnit.test('getBoundingClientRect() returns an object for elements that support it', function(assert) {
+QUnit.test('getBoundingClientRect() returns the native DOMRect for elements that support it', function(assert) {
+  const mockRect = {
+    bottom: 3,
+    height: 10,
+    left: 4,
+    right: 2,
+    top: 1,
+    width: 20
+  };
   const mockEl = {
-    getBoundingClientRect: sinon.spy(() => {
-      return {
-        bottom: 3,
-        height: 10,
-        left: 4,
-        right: 2,
-        top: 1,
-        width: 20
-      };
-    }),
+    getBoundingClientRect: sinon.spy(() => mockRect),
     parentNode: true
   };
 
   const actual = Dom.getBoundingClientRect(mockEl);
 
-  // The expected result is what is returned by the mock element.
-  const expected = mockEl.getBoundingClientRect.firstCall.returnValue;
-
-  assert.notStrictEqual(actual, expected, 'the object returned by the mock element was cloned and not returned directly');
-
-  Object.keys(expected).forEach(k => {
-    assert.strictEqual(actual[k], expected[k], `the "${k}" returned by the Dom util matches what was returned by the mock element`);
-  });
+  assert.strictEqual(actual, mockRect, 'returns the native DOMRect directly');
 });
 
 QUnit.test('isSingleLeftClick() returns false for mousemove event', function(assert) {


### PR DESCRIPTION
## Summary

- Remove the `computedStyle` fallback that was added for IE8 compatibility (no longer supported)
- Return the native `DOMRect` directly instead of shallow-copying to a plain object
- Update the unit test to reflect the new behavior

All call sites (`seek-bar.js`, `time-tooltip.js`, `volume-bar.js`, `volume-level-tooltip.js`) only read properties from the returned rect — none mutate it — so returning the native `DOMRect` is safe.

## Test plan

- [x] Verified no call site mutates the returned rect
- [x] Existing unit tests pass (updated `getBoundingClientRect` test)
- [ ] Seek bar scrubbing works correctly
- [ ] Volume bar interaction works correctly
- [ ] Time tooltip positioning works correctly

Fixes #9149