### PR TITLE
fix(audio-tracks): missing AD icon in Safari

### DIFF
--- a/src/css/components/_audio.scss
+++ b/src/css/components/_audio.scss
@@ -10,6 +10,7 @@
 }
 
 // Mark a main-desc-menu-item (main + description) or description item with a trailing Audio Description icon
+.video-js .vjs-audio-button + .vjs-menu .vjs-description-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before,
 .video-js .vjs-audio-button + .vjs-menu .vjs-descriptions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before,
 .video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
   font-family: VideoJS;

--- a/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
+++ b/src/js/control-bar/audio-track-controls/audio-track-menu-item.js
@@ -51,7 +51,7 @@ class AudioTrackMenuItem extends MenuItem {
     const el = super.createEl(type, props, attrs);
     const parentSpan = el.querySelector('.vjs-menu-item-text');
 
-    if (['main-desc', 'descriptions'].indexOf(this.options_.track.kind) >= 0) {
+    if (['main-desc', 'descriptions', 'description'].indexOf(this.options_.track.kind) >= 0) {
       parentSpan.appendChild(Dom.createEl('span', {
         className: 'vjs-icon-placeholder'
       }, {


### PR DESCRIPTION
## Description

In Safari, when an audio-described track is present among the audio tracks, the AD icon is not displayed.

The cause is that Safari provides `description` as the `kind` instead of `descriptions` as defined by the WHATWG HTML specification.

However, there is a difference between the W3C specification, which defines `description`, and the WHATWG specification, which defines `descriptions`.

Refer to:
- https://www.w3.org/TR/html5-author/media-elements.html#value-track-kind-description
- https://html.spec.whatwg.org/multipage/media.html#value-track-kind-descriptions

## Specific Changes proposed

- update of `AudioTrackMenuItem` to recognize `description` as a valid `kind`, allowing the AD icon to be shown in Safari

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
