### PR TITLE
fix: force text track updateDisplay to recalculate on playerresize

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -273,9 +273,10 @@ class TextTrackDisplay extends Component {
    * @listens Player#useractive
    * @listens Player#userinactive
    */
-  updateDisplay() {
+  updateDisplay(event) {
     const tracks = this.player_.textTracks();
     const allowMultipleShowingTracks = this.options_.allowMultipleShowingTracks;
+    const forceCueRecompute = event && event.type === 'playerresize';
 
     this.clearDisplay();
 
@@ -290,7 +291,7 @@ class TextTrackDisplay extends Component {
         }
         showingTracks.push(track);
       }
-      this.updateForTrack(showingTracks);
+      this.updateForTrack(showingTracks, forceCueRecompute);
       return;
     }
 
@@ -318,12 +319,12 @@ class TextTrackDisplay extends Component {
       if (this.getAttribute('aria-live') !== 'off') {
         this.setAttribute('aria-live', 'off');
       }
-      this.updateForTrack(captionsSubtitlesTrack);
+      this.updateForTrack(captionsSubtitlesTrack, forceCueRecompute);
     } else if (descriptionsTrack) {
       if (this.getAttribute('aria-live') !== 'assertive') {
         this.setAttribute('aria-live', 'assertive');
       }
-      this.updateForTrack(descriptionsTrack);
+      this.updateForTrack(descriptionsTrack, forceCueRecompute);
     }
 
     if (!(window.CSS !== undefined && window.CSS.supports('inset', '10px'))) {
@@ -485,7 +486,7 @@ class TextTrackDisplay extends Component {
    * @param {TextTrack|TextTrack[]} tracks
    *        Text track object or text track array to be added to the list.
    */
-  updateForTrack(tracks) {
+  updateForTrack(tracks, forceCueRecompute = false) {
     if (!Array.isArray(tracks)) {
       tracks = [tracks];
     }
@@ -503,7 +504,13 @@ class TextTrackDisplay extends Component {
       const track = tracks[i];
 
       for (let j = 0; j < track.activeCues.length; ++j) {
-        cues.push(track.activeCues[j]);
+        const cue = track.activeCues[j];
+
+        if (forceCueRecompute && cue) {
+          cue.hasBeenReset = true;
+        }
+
+        cues.push(cue);
       }
     }
 

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -106,6 +106,29 @@ QUnit.test('shows the default caption track first', function(assert) {
 });
 
 if (!Html5.supportsNativeTextTracks()) {
+  QUnit.test('playerresize forces cue recompute on updateForTrack', function(assert) {
+    const player = TestHelpers.makePlayer();
+    const textTrackDisplay = player.textTrackDisplay;
+    const updateForTrackSpy = sinon.spy(textTrackDisplay, 'updateForTrack');
+    const showingTrack = {
+      mode: 'showing',
+      kind: 'captions',
+      activeCues: []
+    };
+
+    textTrackDisplay.clearDisplay = () => '';
+    sinon.stub(player, 'textTracks').returns([showingTrack]);
+
+    textTrackDisplay.updateDisplay({type: 'playerresize'});
+
+    assert.ok(updateForTrackSpy.calledOnce, 'updateForTrack was called');
+    assert.strictEqual(updateForTrackSpy.firstCall.args[1], true, 'cue recompute flag is true on playerresize');
+
+    updateForTrackSpy.restore();
+    player.textTracks.restore();
+    player.dispose();
+  });
+
   QUnit.test('text track display should attach screen orientation change event handler', function(assert) {
     const oldScreen = window.screen;
     const removeHandlerSpy = sinon.spy();


### PR DESCRIPTION
Otherwise processCues reuses the old position and size.

## Description
1. Go to https://legacy.videojs.org/advanced/?video=bipbop-advanced
2. Activate the cc1 caption track
3. Pause to more easily see the effect
4. Activate fullscreen or resize the window such that the player resizes
5. The caption position and size isn't recalculated

<kbd><img width="40%" alt="Screenshot_20260304_163748" src="https://github.com/user-attachments/assets/20483dab-c8ba-4831-8a09-43af6cd79c9c" /></kbd>


## Specific Changes proposed
Force recalculation in vtt.js in this function:

```js
  // Determine if we need to compute the display states of the cues. This could
  // be the case if a cue's state has been changed since the last computation or
  // if it has not been computed yet.
  function shouldCompute(cues) {
    for (var i = 0; i < cues.length; i++) {
      if (cues[i].hasBeenReset || !cues[i].displayState) {
        return true;
      }
    }
    return false;
  }
```

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
