### PR TITLE
fix(types): 'Cannot find name Player' error in type generation

### DIFF
--- a/src/js/control-bar/fullscreen-toggle.js
+++ b/src/js/control-bar/fullscreen-toggle.js
@@ -5,7 +5,7 @@ import Button from '../button.js';
 import Component from '../component.js';
 import document from 'global/document';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * Toggle fullscreen video

--- a/src/js/control-bar/live-display.js
+++ b/src/js/control-bar/live-display.js
@@ -5,7 +5,7 @@ import Component from '../component';
 import * as Dom from '../utils/dom.js';
 import document from 'global/document';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 // TODO - Future make it click to snap to live
 

--- a/src/js/control-bar/mute-toggle.js
+++ b/src/js/control-bar/mute-toggle.js
@@ -7,7 +7,7 @@ import * as Dom from '../utils/dom.js';
 import checkMuteSupport from './volume-control/check-mute-support';
 import * as browser from '../utils/browser.js';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * A button component for muting the audio.

--- a/src/js/control-bar/picture-in-picture-toggle.js
+++ b/src/js/control-bar/picture-in-picture-toggle.js
@@ -6,7 +6,7 @@ import Component from '../component.js';
 import document from 'global/document';
 import window from 'global/window';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * Toggle Picture-in-Picture mode

--- a/src/js/control-bar/play-toggle.js
+++ b/src/js/control-bar/play-toggle.js
@@ -5,7 +5,7 @@ import Button from '../button.js';
 import Component from '../component.js';
 import {silencePromise} from '../utils/promise';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * Button to toggle between play and pause.

--- a/src/js/control-bar/seek-to-live.js
+++ b/src/js/control-bar/seek-to-live.js
@@ -5,7 +5,7 @@ import Button from '../button';
 import Component from '../component';
 import * as Dom from '../utils/dom.js';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * Displays the live indicator when duration is Infinity.

--- a/src/js/control-bar/track-button.js
+++ b/src/js/control-bar/track-button.js
@@ -5,7 +5,7 @@ import MenuButton from '../menu/menu-button.js';
 import Component from '../component.js';
 import * as Fn from '../utils/fn.js';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 /**
  * The base class for buttons that toggle specific  track types (e.g. subtitles).

--- a/src/js/control-bar/volume-panel.js
+++ b/src/js/control-bar/volume-panel.js
@@ -6,7 +6,7 @@ import {isPlain} from '../utils/obj';
 import * as Events from '../utils/events.js';
 import document from 'global/document';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 
 // Required children
 import './volume-control/volume-control.js';

--- a/src/js/tracks/text-track-fieldset.js
+++ b/src/js/tracks/text-track-fieldset.js
@@ -3,7 +3,7 @@ import * as Dom from '../utils/dom';
 import * as Guid from '../utils/guid';
 import TextTrackSelect from './text-track-select';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 /** @import { ContentDescriptor } from '../utils/dom' */
 
 /**

--- a/src/js/tracks/text-track-select.js
+++ b/src/js/tracks/text-track-select.js
@@ -2,7 +2,7 @@ import Component from '../component';
 import * as Dom from '../utils/dom';
 import { newGUID } from '../utils/guid';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 /** @import { ContentDescriptor } from  '../utils/dom' */
 
 /**

--- a/src/js/tracks/text-track-settings-colors.js
+++ b/src/js/tracks/text-track-settings-colors.js
@@ -2,7 +2,7 @@ import Component from '../component';
 import * as Dom from '../utils/dom';
 import TextTrackFieldset from './text-track-fieldset';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 /** @import { ContentDescriptor } from  '../utils/dom' */
 
 /**

--- a/src/js/tracks/text-track-settings-font.js
+++ b/src/js/tracks/text-track-settings-font.js
@@ -2,7 +2,7 @@ import Component from '../component';
 import * as Dom from '../utils/dom';
 import TextTrackFieldset from './text-track-fieldset';
 
-/** @import Player from './player' */
+/** @import Player from '../player' */
 /** @import { ContentDescriptor } from  '../utils/dom' */
 
 /**


### PR DESCRIPTION
## Description

Fix the type generation errors (e.g., TS2304 "Cannot find name 'Player'") that occur when extending video.js classes and generating typings.

## Specific Changes proposed

- update JSDoc `@import Player` paths from relative `./player` to `../player` in `control-bar` and `tracks` components.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
