### PR TITLE
fix(a11y): remove aria-live from VolumeBar

### DIFF
--- a/src/js/control-bar/volume-control/volume-bar.js
+++ b/src/js/control-bar/volume-control/volume-bar.js
@@ -46,8 +46,7 @@ class VolumeBar extends Slider {
     return super.createEl('div', {
       className: 'vjs-volume-bar vjs-slider-bar'
     }, {
-      'aria-label': this.localize('Volume Level'),
-      'aria-live': 'polite'
+      'aria-label': this.localize('Volume Level')
     });
   }
 


### PR DESCRIPTION
Removes `aria-live="polite"` from the VolumeBar to fix repeated volume announcements with NVDA in Chrome/Firefox.

**Problem:** VolumeBar uses `aria-live="polite"` and updates `aria-valuenow` and `aria-valuetext` on every `volumechange`. NVDA has a long-standing bug ([nvaccess/nvda#7996](https://github.com/nvaccess/nvda/issues/7996)) where updates inside `aria-live="polite"` regions are announced multiple times (e.g. "50%, 50%, 50%" while adjusting volume).

**Solution:** Remove `aria-live` from VolumeBar. Sliders with `role="slider"` already expose their value through the accessibility API via `aria-valuenow` and `aria-valuetext`, and screen readers announce value changes when the control has focus. The live region is redundant in this case and triggers the NVDA bug.

**References:**
- [nvaccess/nvda#7996](https://github.com/nvaccess/nvda/issues/7996) – NVDA repeated announcements in polite live regions
- [videojs/video.js#8912](https://github.com/videojs/video.js/issues/8912) – Screen reader announces control names repeatedly (related)

## Changes proposed

- Removed `'aria-live': 'polite'` from the attributes object in `VolumeBar.createEl()` in `src/js/control-bar/volume-control/volume-bar.js`
- `aria-label`, `aria-valuenow`, and `aria-valuetext` are unchanged

## Requirements Checklist

- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed (no tests assert `aria-live`; VolumeBar tests still pass)
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessibility or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors