### PR TITLE
Add Maxim legacy browser CI/CD testing

### DIFF
--- a/.github/workflows/maxim-legacy-browser-tests.yml
+++ b/.github/workflows/maxim-legacy-browser-tests.yml
@@ -1,0 +1,108 @@
+name: Maxim Legacy Browser Tests
+
+on:
+  push:
+    branches: [main, maxim-legacy-browser-tests]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REGISTRY: 864899829402.dkr.ecr.us-west-2.amazonaws.com
+  TARGET_URL: http://172.17.0.1:9999
+
+jobs:
+  legacy-browser-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build video.js
+        run: npm run build-dev
+
+      - name: Prepare sandbox
+        run: cp sandbox/index.html.example sandbox/index.html
+
+      - name: Start local web server
+        run: |
+          docker run -d --name local-app -p 9999:80 \
+            -v ${{ github.workspace }}:/usr/share/nginx/html:ro \
+            nginx:alpine
+          sleep 2
+          curl -sf http://localhost:9999/sandbox/index.html > /dev/null
+          echo "Video.js sandbox running at http://localhost:9999"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        run: |
+          aws ecr get-login-password --region ${{ env.AWS_REGION }} \
+            | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}
+
+      - name: Pull browser images
+        run: |
+          for img in chromium-38 chromium-44 chromium-46 chromium-53 chromium-66 wpe-webkit; do
+            docker pull ${{ env.ECR_REGISTRY }}/tanagram/maxim/${img}:latest
+          done
+
+      - name: Pull maxim runner image
+        run: docker pull ${{ env.ECR_REGISTRY }}/tanagram/maxim/runner:latest
+
+      - name: Run Maxim legacy browser tests
+        run: |
+          mkdir -p ${{ github.workspace }}/maxim-results
+          docker run --rm \
+            --network host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v ${{ github.workspace }}/maxim-results:/results \
+            -e TARGET_URL=${{ env.TARGET_URL }}/sandbox/index.html \
+            ${{ env.ECR_REGISTRY }}/tanagram/maxim/runner:latest \
+              --config configs/smoke-test.yaml \
+              --url ${{ env.TARGET_URL }}/sandbox/index.html \
+              --browsers cr38,cr44,cr46,cr53,cr66,wpe \
+              --parallel 5 \
+              --output /results/
+
+      - name: Stop local web server
+        if: always()
+        run: docker rm -f local-app || true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maxim-results
+          path: ${{ github.workspace }}/maxim-results/
+
+      - name: Publish JUnit report
+        if: always()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: ${{ github.workspace }}/maxim-results/results.xml
+          check_name: Legacy Browser Tests
+
+      - name: Check for failures
+        run: |
+          RESULTS="${{ github.workspace }}/maxim-results/results.json"
+          if [ -f "$RESULTS" ]; then
+            FAILED=$(jq '.summary.failed' "$RESULTS")
+            if [ "$FAILED" != "0" ]; then
+              echo "::error::Maxim detected ${FAILED} legacy browser test failure(s)"
+              exit 1
+            fi
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ lang/zh-Han*.json
 
 # netlify deploy
 deploy/
+sandbox/index.html


### PR DESCRIPTION
Builds video.js, serves the sandbox page via nginx, and runs maxim smoke tests across Chromium 38-66 and WPE WebKit legacy browsers.

Amp-Thread-ID: https://ampcode.com/threads/T-019d4ff4-eb0b-76dc-a8f3-17a8d0b0313f

## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors
