### PR TITLE
feat(poster): add support for marking player as maincontent

### DIFF
--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -27,9 +27,9 @@ class PosterImage extends ClickableComponent {
   constructor(player, options) {
     super(player, options);
 
-    const { maincontent } = (options && options.playerOptions) || {};
+    const { mainContent } = (options && options.playerOptions) || {};
 
-    this.isMainContent = maincontent;
+    this.isMainContent = mainContent;
 
     this.update();
 

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -27,6 +27,10 @@ class PosterImage extends ClickableComponent {
   constructor(player, options) {
     super(player, options);
 
+    const { maincontent } = (options && options.playerOptions) || {};
+
+    this.isMainContent = maincontent;
+
     this.update();
 
     this.update_ = (e) => this.update(e);
@@ -138,7 +142,8 @@ class PosterImage extends ClickableComponent {
         },
         {},
         Dom.createEl('img', {
-          loading: 'lazy',
+          loading: this.isMainContent ? 'eager' : 'lazy',
+          fetchPriority: this.isMainContent ? 'high' : 'auto',
           crossOrigin: this.crossOrigin()
         }, {
           alt: ''

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -31,8 +31,8 @@ QUnit.test('should create and update a poster image', function(assert) {
   posterImage.dispose();
 });
 
-QUnit.test('should mark img as prioritized request when maincontent is true', function(assert) {
-  const posterImage = new PosterImage(this.mockPlayer, { playerOptions: { maincontent: true } });
+QUnit.test('should mark img as prioritized request when mainContent is true', function(assert) {
+  const posterImage = new PosterImage(this.mockPlayer, { playerOptions: { mainContent: true } });
 
   assert.equal(posterImage.$('img').loading, 'eager', 'img is loading eager');
   assert.equal(posterImage.$('img').fetchPriority, 'high', 'img has fetchpriority high');

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -31,6 +31,15 @@ QUnit.test('should create and update a poster image', function(assert) {
   posterImage.dispose();
 });
 
+QUnit.test('should mark img as prioritized request when maincontent is true', function(assert) {
+  const posterImage = new PosterImage(this.mockPlayer, { playerOptions: { maincontent: true } });
+
+  assert.equal(posterImage.$('img').loading, 'eager', 'img is loading eager');
+  assert.equal(posterImage.$('img').fetchPriority, 'high', 'img has fetchpriority high');
+
+  posterImage.dispose();
+});
+
 QUnit.test('should mirror crossOrigin', function(assert) {
   assert.strictEqual(this.mockPlayer.posterImage.$('img').crossOrigin, null, 'crossOrigin not set when not present in options');
   assert.strictEqual(this.mockPlayer.posterImage.crossOrigin(), null, 'crossOrigin not set from getter when not present in options');


### PR DESCRIPTION
## Description
When maincontent is set to true the poster img element will get [loading=eager](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#eager) and [fetchpriority=high](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority#high) to decrease [LCP](https://web.dev/articles/lcp) time.

### Usage

#### maincontent: true

```
    var player = videojs(vid, { maincontent: true });
```

<img width="670" height="135" alt="image" src="https://github.com/user-attachments/assets/b1a3eee4-5225-4888-be80-9cc14d6a2dcb" />

#### Default mode

```
    var player = videojs(vid);
```

<img width="670" height="135" alt="image" src="https://github.com/user-attachments/assets/3ba2f178-6be6-49de-8ff7-d8b5dd1c276b" />


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [x] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors

I'm not sure if any example should be created, and if so where to put it. The same goes with the documentation.

closes #9171 