### PR TITLE
docs(types): document Player.error(null) for clearing MediaError

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4219,13 +4219,13 @@ class Player extends Component {
   }
 
   /**
-   * Set or get the current MediaError
+   * Set, clear, or get the current MediaError
    *
    * @fires Player#error
    *
-   * @param  {MediaError|string|number} [err]
+   * @param  {MediaError|string|number|null} [err]
    *         A MediaError or a string/number to be turned
-   *         into a MediaError
+   *         into a MediaError. Pass `null` to clear the current error state.
    *
    * @return {MediaError|null|undefined}
    *         - The current MediaError when getting (or null)


### PR DESCRIPTION
Updated documentation for MediaError handling to clarify parameters.

## Description
`player.error` supports `null` as an input to clear the current `MediaError`, however, this is not revealed in the docs which can impact type build. 

