### PR TITLE
fix: handle Mac trackpad tap-to-click in isSingleLeftClick

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -775,15 +775,12 @@ export function isSingleLeftClick(event) {
     return true;
   }
 
-  // `mouseup` event on a single left click has
-  // `button` and `buttons` equal to 0
-  if (event.type === 'mouseup' && event.button === 0 &&
+  // `button` and `buttons` are both 0 on `mouseup` (release) and on
+  // `mousedown` when a Mac trackpad tap-to-click fires {button:0, buttons:0}.
+  // The only event type where {0,0} should be rejected is `mousemove`,
+  // because it signals that the button was released during a drag.
+  if (event.type !== 'mousemove' && event.button === 0 &&
       event.buttons === 0) {
-    return true;
-  }
-
-  // MacOS Sonoma trackpad when "tap to click enabled"
-  if (event.type === 'mousedown' && event.button === 0 && event.buttons === 0) {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes #7736.

Mac trackpad tap-to-click fires `mousedown` with `{button: 0, buttons: 0}` instead of the expected `{button: 0, buttons: 1}`. The current `isSingleLeftClick` has separate blocks for `mouseup` and `mousedown` handling this `{0, 0}` case — this PR consolidates them into a single `event.type !== 'mousemove'` guard.

The `{0, 0}` rejection is only meaningful for `mousemove` events (detecting button release during a drag). For all other event types (`mousedown`, `mouseup`, etc.), `{button: 0, buttons: 0}` is a valid single left click.

This approach was suggested by @gkatsev in https://github.com/videojs/video.js/issues/7736#issuecomment-1115386139.

## Changes

- `src/js/utils/dom.js`: Replace `event.type === 'mouseup'` with `event.type !== 'mousemove'` for the `{0, 0}` check, removing the separate `mousedown` block

## Test plan

- [x] Existing tests cover all three event types: `mousemove {0,0}` → false, `mouseup {0,0}` → true, `mousedown {0,0}` → true
- [ ] Manual verification on Mac with tap-to-click enabled — seek bar and volume slider respond on first tap