### PR TITLE
fix: use aria-live="polite" for descriptions text track display

### DIFF
--- a/src/js/tracks/text-track-display.js
+++ b/src/js/tracks/text-track-display.js
@@ -320,8 +320,8 @@ class TextTrackDisplay extends Component {
       }
       this.updateForTrack(captionsSubtitlesTrack);
     } else if (descriptionsTrack) {
-      if (this.getAttribute('aria-live') !== 'assertive') {
-        this.setAttribute('aria-live', 'assertive');
+      if (this.getAttribute('aria-live') !== 'polite') {
+        this.setAttribute('aria-live', 'polite');
       }
       this.updateForTrack(descriptionsTrack);
     }

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -620,3 +620,39 @@ if (!Html5.supportsNativeTextTracks()) {
     player.dispose();
   });
 }
+
+QUnit.test('aria-live is set to "off" for captions/subtitles tracks and "polite" for descriptions tracks', function(assert) {
+  const player = TestHelpers.makePlayer();
+  const display = player.textTrackDisplay;
+
+  // Stub clearDisplay and updateForTrack so no WebVTT processing occurs
+  display.clearDisplay = () => {};
+  display.updateForTrack = () => {};
+
+  const tracks = player.textTracks();
+
+  // Add a captions track and make it active
+  player.addRemoteTextTrack({ kind: 'captions', language: 'en', label: 'English' }, true);
+  tracks[0].mode = 'showing';
+
+  display.updateDisplay();
+  assert.strictEqual(
+    display.el_.getAttribute('aria-live'),
+    'off',
+    'aria-live should be "off" when a captions track is active to avoid interrupting screen reader announcements'
+  );
+
+  // Switch to a descriptions track
+  tracks[0].mode = 'disabled';
+  player.addRemoteTextTrack({ kind: 'descriptions', language: 'en', label: 'English Descriptions' }, true);
+  tracks[1].mode = 'showing';
+
+  display.updateDisplay();
+  assert.strictEqual(
+    display.el_.getAttribute('aria-live'),
+    'polite',
+    'aria-live should be "polite" for descriptions tracks so announcements queue without interrupting other screen reader output'
+  );
+
+  player.dispose();
+});


### PR DESCRIPTION
Fixes #7843                                                                                                                             
                                                                  
  Using `aria-live="assertive"` on the text track display container caused
  screen readers to interrupt all other announcements every time a descriptions                                                           
  cue updated. This made audio descriptions inaccessible in practice — users   
  lost context from other page announcements.                                                                                             
                                                                  
  Changed to `aria-live="polite"` so descriptions are queued and announced
  without interrupting ongoing screen reader output, per WCAG 4.1.3.                                                                      
  Captions and subtitles tracks correctly remain at `aria-live="off"` since
  users relying on those tracks do not need screen reader announcement of                                                                 
  caption text.                                                                                                                           
   
  Specific Changes proposed:                                                                                                              
  - `src/js/tracks/text-track-display.js`: Changed `aria-live="assertive"`
    to `aria-live="polite"` in `updateDisplay()` for descriptions tracks  
  - `test/unit/tracks/text-track-display.test.js`: Added QUnit test verifying                                                             
    aria-live is "off" for captions tracks and "polite" for descriptions tracks
                                                                                                                                          
  Requirements Checklist:                                                                                                                 
  - [x] Feature implemented / Bug fixed                                                                                                   
    - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)                                                             
    - [x] Unit Tests updated or fixed                                        
    - [ ] Docs/guides updated                                                                                                             
    - [ ] Example created    
    - [x] Has no DOM changes which impact accessibility or trigger warnings                                                               
    - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
  - [ ] Reviewed by Two Core Contributors          