### PR TITLE
fix(dom): copyStyleSheetsToWindow may fail if win.document.head is null

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -880,13 +880,15 @@ export function computedStyle(el, prop) {
  *
  */
 export function copyStyleSheetsToWindow(win) {
+  const head = win.document.head || win.document.documentElement;
+  if (!head) return;
   [...document.styleSheets].forEach((styleSheet) => {
     try {
       const cssRules = [...styleSheet.cssRules].map((rule) => rule.cssText).join('');
       const style = document.createElement('style');
 
       style.textContent = cssRules;
-      win.document.head.appendChild(style);
+      head.appendChild(style);
     } catch (e) {
       const link = document.createElement('link');
 
@@ -895,7 +897,7 @@ export function copyStyleSheetsToWindow(win) {
       // For older Safari this has to be the string; on other browsers setting the MediaList works
       link.media = styleSheet.media.mediaText;
       link.href = styleSheet.href;
-      win.document.head.appendChild(link);
+      head.appendChild(link);
     }
   });
 }


### PR DESCRIPTION
Fixes #9186

Why
`copyStyleSheetsToWindow()` appends `<style>` and `<link>` elements to `win.document.head` without checking if `head` exists. If the target window (e.g. a Picture-in-Picture window) is closing or in an invalid state, `win.document.head` is `null`, causing an uncaught TypeError.

Changes
Resolve `head` once at the top of the function with `win.document.head || win.document.documentElement` as fallback. Return early if both are null.

Updated component: `src/js/utils/dom.js`

Testing
Null `win.document.head` no longer throws. The function gracefully exits when the target window is unavailable.

Surface area
- DOM utilities
- Bug fix