### PR TITLE
Fix one() for array events on target objects

### DIFF
--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -318,19 +318,23 @@ const EventedMixin = {
 
     // Targeting another evented object.
     } else {
-      // TODO: This wrapper is incorrect! It should only
-      //       remove the wrapper for the event type that called it.
-      //       Instead all listeners are removed on the first trigger!
-      //       see https://github.com/videojs/video.js/issues/5962
-      const wrapper = (...largs) => {
-        this.off(target, type, wrapper);
-        listener.apply(null, largs);
+      const listenOnce = (typeName) => {
+        const wrapper = (...largs) => {
+          this.off(target, typeName, wrapper);
+          listener.apply(null, largs);
+        };
+
+        // Use the same function ID as the listener so we can remove it later
+        // it using the ID of the original listener.
+        wrapper.guid = listener.guid;
+        listen(target, 'one', typeName, wrapper);
       };
 
-      // Use the same function ID as the listener so we can remove it later
-      // it using the ID of the original listener.
-      wrapper.guid = listener.guid;
-      listen(target, 'one', type, wrapper);
+      if (Array.isArray(type)) {
+        type.forEach(listenOnce);
+      } else {
+        listenOnce(type);
+      }
     }
   },
 

--- a/test/unit/mixins/evented.test.js
+++ b/test/unit/mixins/evented.test.js
@@ -332,9 +332,6 @@ QUnit.test('one() can add a listener to one event type on a different target obj
   });
 });
 
-// TODO: This test is incorrect! this listener should be called twice,
-//       but instead all listeners are removed on the first trigger!
-//       see https://github.com/videojs/video.js/issues/5962
 QUnit.test('one() can add a listener to an array of event types on a different target object', function(assert) {
   const a = this.targets.a = evented({});
   const b = this.targets.b = evented({});
@@ -350,10 +347,15 @@ QUnit.test('one() can add a listener to an array of event types on a different t
   a.trigger('x');
   a.trigger('y');
 
-  assert.strictEqual(spy.callCount, 1, 'the listener was called the expected number of times');
+  assert.strictEqual(spy.callCount, 2, 'the listener was called the expected number of times');
 
   validateListenerCall(spy.getCall(0), a, {
     type: 'x',
+    target: b.eventBusEl_
+  });
+
+  validateListenerCall(spy.getCall(1), a, {
+    type: 'y',
     target: b.eventBusEl_
   });
 });


### PR DESCRIPTION
## Summary
- register a separate one-time wrapper for each cross-target event type
- keep off-by-original-listener support by preserving the listener guid
- update the regression test for `one()` with an array of event types

Fixes #9183

## Tests
- `npm run lint-errors`
- `CHROME_BIN='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' ./node_modules/.bin/karma start test/karma.conf.js --browsers ChromeHeadless --single-run --client.qunit.filter='one() can add a listener to an array of event types on a different target object'`
- `CHROME_BIN='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' ./node_modules/.bin/karma start test/karma.conf.js --browsers ChromeHeadless --single-run --client.qunit.filter='mixins: evented'`
- `npm run build:js`