### PR TITLE
fix(slider): add null check for this.bar.el_ before accessing ownerDocument

### DIFF
--- a/src/js/slider/slider.js
+++ b/src/js/slider/slider.js
@@ -87,6 +87,9 @@ class Slider extends Component {
     if (!this.enabled()) {
       return;
     }
+    if (!this.bar || !this.bar.el_) {
+      return;
+    }
     const doc = this.bar.el_.ownerDocument;
 
     this.off('mousedown', this.handleMouseDown_);
@@ -151,6 +154,9 @@ class Slider extends Component {
    * @fires Slider#slideractive
    */
   handleMouseDown(event) {
+    if (!this.bar || !this.bar.el_) {
+      return;
+    }
     const doc = this.bar.el_.ownerDocument;
 
     if (event.type === 'mousedown') {


### PR DESCRIPTION
Fixes #9184

## Why
Both `disable()` and `handleMouseDown()` access `this.bar.el_.ownerDocument` without checking if `this.bar` or `this.bar.el_` exists. If a subclass or custom slider is created without a proper bar child component, `this.bar` would be `undefined`, causing a TypeError.

## Changes
- `disable()`: early return if `this.bar` or `this.bar.el_` is null/undefined
- `handleMouseDown()`: early return if `this.bar` or `this.bar.el_` is null/undefined

## Testing
No longer throws when bar is missing or has no element. Consistent with the existing null check in `update()` at line 245.

### Surface area
- Slider / UI component
- Bug fix