### PR TITLE
fix(player): fix operator precedence confusion in fullscreen checks

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -3035,7 +3035,7 @@ class Player extends Component {
       }
 
       return promise;
-    } else if (this.tech_.supportsFullScreen() && !this.options_.preferFullWindow === true) {
+    } else if (this.tech_.supportsFullScreen() && this.options_.preferFullWindow !== true) {
       // we can't take the video.js controls fullscreen but we can go fullscreen
       // with native controls
       this.techCall_('enterFullScreen');
@@ -3093,7 +3093,7 @@ class Player extends Component {
       }
 
       return promise;
-    } else if (this.tech_.supportsFullScreen() && !this.options_.preferFullWindow === true) {
+    } else if (this.tech_.supportsFullScreen() && this.options_.preferFullWindow !== true) {
       this.techCall_('exitFullScreen');
     } else {
       this.exitFullWindow();


### PR DESCRIPTION
Fixes #9182

## Description
Replace `!this.options_.preferFullWindow === true` with `this.options_.preferFullWindow !== true` in two locations (`requestFullscreenHelper_` and `exitFullscreenHelper_`) to fix operator precedence confusion.

The `!` operator has higher precedence than `===`, so the original expression was parsed as `(!this.options_.preferFullWindow) === true`, which produces the same result for boolean values but is confusing and error-prone.

## Changes
- `src/js/player.js`: Lines 3038, 3096