### PR TITLE
fix(player): add null safety when accessing srcObj.src and srcObj.type

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1580,8 +1580,8 @@ class Player extends Component {
     let type = '';
 
     if (typeof src !== 'string') {
-      src = srcObj.src;
-      type = srcObj.type;
+      src = srcObj?.src ?? '';
+      type = srcObj?.type ?? '';
     }
 
     // make sure all the caches are set to default values


### PR DESCRIPTION
Fixes #9185

## Description
When `srcObj` is a non-string object in `updateSourceCaches_()`, the code accesses `srcObj.src` and `srcObj.type` without checking if these properties exist. If `srcObj` is `null`, `{}`, or an object with different keys, `src` and `type` will be `undefined`, leading to silent failures.

## Changes
- `src/js/player.js`: Add optional chaining (`?.`) and nullish coalescing (`??`) for safer access to `srcObj.src` and `srcObj.type`.