### PR TITLE
fix(player): guard against disposed tech in handleTechSourceset_ callback

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1695,6 +1695,11 @@ class Player extends Component {
             return;
           }
 
+          // tech_ may have been disposed while waiting for the async callback
+          if (!this.tech_) {
+            return;
+          }
+
           const techSrc = this.techGet_('currentSrc');
 
           this.lastSource_.tech = techSrc;


### PR DESCRIPTION
Fixes #9187

## Description
The `this.tech_.any()` callback in `handleTechSourceset_` is set up asynchronously. If the tech is disposed before the callback fires, `this.tech_` may be `false` and `this.lastSource_` may be invalid, causing errors when accessing `this.techGet_('currentSrc')` and `this.lastSource_.tech`.

## Changes
- `src/js/player.js`: Add early return guard when `this.tech_` is falsy before accessing it in the async callback.