### PR TITLE
fix(player): guard against missing src/type in updateSourceCaches_

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1580,8 +1580,8 @@ class Player extends Component {
     let type = '';
 
     if (typeof src !== 'string') {
-      src = srcObj.src;
-      type = srcObj.type;
+      src = srcObj?.src ?? '';
+      type = srcObj?.type ?? '';
     }
 
     // make sure all the caches are set to default values


### PR DESCRIPTION
When `srcObj` doesn't have `src` or `type` keys, both get set to `undefined`, which then poisons the source cache in unexpected ways. Added optional chaining + nullish coalescing fallback to empty string to match how the rest of the method handles missing values.

Closes #9185