### PR TITLE
fix(dom): guard against null document.head in copyStyleSheetsToWindow

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -880,13 +880,19 @@ export function computedStyle(el, prop) {
  *
  */
 export function copyStyleSheetsToWindow(win) {
+  const head = win.document.head || win.document.documentElement;
+
+  if (!head) {
+    return;
+  }
+
   [...document.styleSheets].forEach((styleSheet) => {
     try {
       const cssRules = [...styleSheet.cssRules].map((rule) => rule.cssText).join('');
       const style = document.createElement('style');
 
       style.textContent = cssRules;
-      win.document.head.appendChild(style);
+      head.appendChild(style);
     } catch (e) {
       const link = document.createElement('link');
 
@@ -895,7 +901,7 @@ export function copyStyleSheetsToWindow(win) {
       // For older Safari this has to be the string; on other browsers setting the MediaList works
       link.media = styleSheet.media.mediaText;
       link.href = styleSheet.href;
-      win.document.head.appendChild(link);
+      head.appendChild(link);
     }
   });
 }


### PR DESCRIPTION
If `win.document.head` is null, the `appendChild` call throws. Resolved the insertion target once before the loop (`head || documentElement`) and bail early if neither is available.

Closes #9186