### PR TITLE
fix(player): guard against disposed tech in handleTechSourceset_ callback

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1695,9 +1695,17 @@ class Player extends Component {
             return;
           }
 
+          // The tech may have been disposed between when this listener was
+          // registered and when it fires; bail out if that has happened.
+          if (!this.tech_) {
+            return;
+          }
+
           const techSrc = this.techGet_('currentSrc');
 
-          this.lastSource_.tech = techSrc;
+          if (this.lastSource_) {
+            this.lastSource_.tech = techSrc;
+          }
           this.updateSourceCaches_(techSrc);
         });
       }


### PR DESCRIPTION
The `loadstart` async callback in `handleTechSourceset_` could fire after the tech was disposed, causing it to write to `this.tech_` or `this.lastSource_.tech` on a dead object. Added an early return guard for `!this.tech_` and a null check on `this.lastSource_` before writing.

Closes #9187