### PR TITLE
fix(player): strip stale layout class when breakpoints() is re-set

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -5031,7 +5031,7 @@ class Player extends Component {
       return Object.assign(this.breakpoints_);
     }
 
-    this.breakpoint_ = '';
+    this.removeCurrentBreakpoint_();
     this.breakpoints_ = Object.assign({}, DEFAULT_BREAKPOINTS, breakpoints);
 
     // When breakpoint definitions change, we need to update the currently

--- a/test/unit/player-breakpoints.test.js
+++ b/test/unit/player-breakpoints.test.js
@@ -64,6 +64,28 @@ QUnit.test('setting breakpoints/responsive via option', function(assert) {
   player.dispose();
 });
 
+QUnit.test('changing breakpoints removes the previous layout class', function(assert) {
+  const currentWidth = 200;
+
+  this.player.currentWidth = () => currentWidth;
+  this.player.responsive(true);
+
+  assert.strictEqual(this.player.currentBreakpoint(), 'tiny', 'initial breakpoint set');
+  assert.ok(this.player.hasClass('vjs-layout-tiny'), 'initial layout class applied');
+
+  // Re-setting breakpoints lands on a different breakpoint for the same width.
+  this.player.breakpoints({tiny: 100});
+
+  assert.strictEqual(this.player.currentBreakpoint(), 'xsmall', 'breakpoint recomputed');
+  assert.ok(this.player.hasClass('vjs-layout-x-small'), 'new layout class applied');
+  assert.notOk(this.player.hasClass('vjs-layout-tiny'), 'previous layout class removed');
+  assert.strictEqual(
+    this.player.el().className.match(/vjs-layout-\S+/g).length,
+    1,
+    'exactly one layout class remains on the player'
+  );
+});
+
 QUnit.test('changing the player size triggers breakpoints', function(assert) {
   let currentWidth;
 


### PR DESCRIPTION
## Description

Calling `player.breakpoints()` after a `vjs-layout-*` class has already been applied leaves the old layout class on the player alongside the newly computed one, so the player ends up carrying two conflicting layout classes (e.g. both `vjs-layout-tiny` and `vjs-layout-large`).

This matters because VideoJS's own CSS keys off these classes — for example `.vjs-volume-control` is hidden whenever a small-layout class (`tiny`/`x-small`/`small`) is present. A stale small-layout class left behind by a later `breakpoints()` call silently hides controls that should be visible.

## Root cause

The `breakpoints()` setter reset `this.breakpoint_` to `''` directly before calling `updateCurrentBreakpoint_()`:

```js
this.breakpoint_ = '';
this.breakpoints_ = Object.assign({}, DEFAULT_BREAKPOINTS, breakpoints);
this.updateCurrentBreakpoint_();
```

`updateCurrentBreakpoint_()` only removes the existing layout class when there is a current breakpoint recorded (`if (currentBreakpoint) { this.removeClass(...) }`). Because the setter had just cleared `breakpoint_`, that removal branch is skipped — the old class is orphaned and the recomputed class is added on top.

## Fix

Use the existing `removeCurrentBreakpoint_()` helper, which removes the current layout class *and* clears `breakpoint_`, so the setter cleans up after itself before recomputing. This is the same primitive `responsive(false)` already uses.

```js
this.removeCurrentBreakpoint_();
this.breakpoints_ = Object.assign({}, DEFAULT_BREAKPOINTS, breakpoints);
this.updateCurrentBreakpoint_();
```

## Behavioral change / compatibility

This restores the documented invariant that a player carries exactly one `vjs-layout-*` class at a time. The prior two-class state was only reachable through this bug (re-calling `breakpoints()` after a layout class had been applied) and was non-deterministic — which stale class lingered depended on the call history — so no stable, targetable contract is being removed. The classes are mutually-exclusive size buckets, and the realistic consumer workaround (CSS to un-hide a control the stale small-layout class was suppressing) becomes redundant rather than broken.

## Specific Changes proposed

- `src/js/player.js`: `breakpoints()` setter now calls `removeCurrentBreakpoint_()` instead of bare-assigning `breakpoint_ = ''`.
- `test/unit/player-breakpoints.test.js`: added a regression test asserting that re-setting breakpoints removes the previous layout class and leaves exactly one `vjs-layout-*` class on the player.

## Requirements Checklist

- [x] Feature implemented / Bug fixed
- [x] Reviewed by Two Core Contributors
- [x] Added/updated tests
- [x] Reviewed by a video.js maintainer
