### PR TITLE
fix(lang): add missing Japanese (ja) translation for "Playing in Picture-in-Picture"

### DIFF
--- a/lang/ja.json
+++ b/lang/ja.json
@@ -91,6 +91,7 @@
   "Opacity": "不透明度",
   "Text Background": "テキスト背景",
   "Caption Area Background": "キャプション領域背景",
+  "Playing in Picture-in-Picture": "ピクチャーインピクチャーで再生中",
   "Skip forward {1} seconds": "{1}秒進む",
   "Skip backward {1} seconds": "{1}秒戻る"
 }


### PR DESCRIPTION
`lang/en.json` has the string `"Playing in Picture-in-Picture"`, but `lang/ja.json` was missing it. It was added in #8113 (document picture-in-picture support), which updated `en.json` and `de.json` but not the Japanese file, so the string falls back to English for Japanese users.

This adds the Japanese translation, keeping the wording consistent with the existing PiP entries already in `ja.json` (`"Picture-in-Picture"` -> `"ピクチャーインピクチャー"`, `"Exit Picture-in-Picture"` -> `"ピクチャーインピクチャー機能の終了"`). The meaning matches the German string added in the same PR (`"Wird im Bild-im-Bild-Modus wiedergegeben"`).

After this change `ja.json` covers every key present in `en.json`.
