### PR TITLE
fix(player): guard error() against being called after dispose()

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -4236,6 +4236,14 @@ class Player extends Component {
       return this.error_ || null;
     }
 
+    // Bail out if the player has already been disposed: an async
+    // source-resolution/DRM/texttrack callback can still call error()
+    // after dispose() has nulled out this.el_, and both branches below
+    // reach into the DOM element via addClass/removeClass.
+    if (this.isDisposed()) {
+      return;
+    }
+
     // allow hooks to modify error object
     hooks('beforeerror').forEach((hookFunction) => {
       const newErr = hookFunction(this, err);

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1268,8 +1268,8 @@ QUnit.test('player should handle different error types', function(assert) {
   player.dispose();
 });
 
-QUnit.test('error() should not throw when called after the player has been disposed', function(assert) {
-  assert.expect(1);
+QUnit.test('error() should be a no-op when called after the player has been disposed', function(assert) {
+  assert.expect(2);
   const player = TestHelpers.makePlayer({});
 
   // prevent error log messages in the console
@@ -1282,6 +1282,10 @@ QUnit.test('error() should not throw when called after the player has been dispo
   player.error(1);
 
   assert.ok(true, 'error() did not throw after dispose()');
+  // Matches the existing isDisposed() bail-out convention elsewhere in the
+  // codebase (e.g. text-track.js's timeupdateHandler): once disposed, the
+  // whole call is a no-op, not just the DOM-touching part of it.
+  assert.equal(player.error(), null, 'error() did not record an error for an already-disposed player');
 
   log.error.restore();
 });

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -1268,6 +1268,24 @@ QUnit.test('player should handle different error types', function(assert) {
   player.dispose();
 });
 
+QUnit.test('error() should not throw when called after the player has been disposed', function(assert) {
+  assert.expect(1);
+  const player = TestHelpers.makePlayer({});
+
+  // prevent error log messages in the console
+  sinon.stub(log, 'error');
+
+  player.dispose();
+
+  // A source-resolution/DRM/texttrack async callback racing against
+  // dispose() can still call error() after this.el_ has been nulled out.
+  player.error(1);
+
+  assert.ok(true, 'error() did not throw after dispose()');
+
+  log.error.restore();
+});
+
 QUnit.test('beforeerror hook allows us to modify errors', function(assert) {
   const player = TestHelpers.makePlayer({});
   const beforeerrorHook = function(p, err) {


### PR DESCRIPTION
## Description

Fixes #9213. `player.error(err)` throws `TypeError: Cannot read properties of null (reading 'classList')` if called after `player.dispose()`. An async source-resolution, DRM license, or texttrack callback racing against a component unmount/dispose is enough to trigger it, matching the reporter's exact stack trace.

`dispose()` sets `this.el_ = null`, but `error()` has no disposed check and both of its non-getter branches reach into the DOM element (`this.addClass('vjs-error')` / `this.removeClass('vjs-error')`).

## Specific Changes proposed

- Added an `isDisposed()` guard near the top of `error()`, matching the same bail-out convention already used elsewhere in the codebase (`text-track.js`'s `timeupdateHandler`): once disposed, the whole call is a no-op, not just the DOM-touching part of it.
- Added a regression test asserting `error()` neither throws nor records an error when called on an already-disposed player.

## Testing

- Reproduced the exact crash in a real browser first (not just reasoning about it), confirmed the error message matches the issue precisely.
- Ran the full existing unit test suite via a real headless Chrome (karma/QUnit): 1388/1389 passing (1 pre-existing skip), both before and after the fix.
- Confirmed the new test fails with the exact reported crash when the guard is removed, and passes with it in place.
- Verified end-to-end against both the dev build (`dist/video.js`) and the production minified build (`dist/video.min.js`) in a real browser, not just the test suite.
- `tsc` (type definitions) and `vjsstandard` (lint) both clean, no new warnings introduced.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome)
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated (no public API change, nothing to document)
- [ ] Example created (not applicable, this is a defensive bug fix, not a new feature)
- [x] Has no DOM changes which impact accessibility or trigger warnings
- [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors