### PR TITLE
docs: point Quick Start zencdn links at hosted 8.23.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Video.js was started in May 2010 and since then:
 Thanks to the awesome folks over at [Fastly][fastly], there's a free, CDN hosted version of Video.js that anyone can use. Add these tags to your document's `<head>`:
 
 ```html
-<link href="//vjs.zencdn.net/8.23.9/video-js.min.css" rel="stylesheet">
-<script src="//vjs.zencdn.net/8.23.9/video.min.js"></script>
+<link href="//vjs.zencdn.net/8.23.6/video-js.min.css" rel="stylesheet">
+<script src="//vjs.zencdn.net/8.23.6/video.min.js"></script>
 ```
 
 Alternatively, you can include Video.js by getting it from [npm](https://videojs.com/getting-started/#install-via-npm), downloading it from [GitHub releases](https://github.com/videojs/video.js/releases) or by including it via [unpkg](https://unpkg.com) or another JavaScript CDN, like CDNjs.


### PR DESCRIPTION
## Description

The README Quick Start still points `vjs.zencdn.net` at 8.23.9. That path currently returns 403, so the first CDN example does not load CSS/JS.

Verified today:
- `8.23.6` is available on `vjs.zencdn.net` (200)
- `8.23.7` through `8.23.9` return 403

This updates only the Fastly/zencdn Quick Start tags to 8.23.6. The unpkg and cdnjs examples stay on 8.23.9, which those hosts do serve.

## Specific Changes proposed

- README Quick Start: `vjs.zencdn.net/8.23.9` -> `vjs.zencdn.net/8.23.6` for CSS and JS

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
  - [ ] Has no DOM changes which impact accessiblilty or trigger warnings (e.g. Chrome issues tab)
  - [ ] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors

Fixes #9051