### PR TITLE
fix: focus the play toggle instead of the tech element on Edge to avoid a black frame with hardware-accelerated protected playback

### DIFF
--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -3,6 +3,7 @@
  */
 import Button from './button.js';
 import Component from './component.js';
+import * as browser from './utils/browser.js';
 import {isPromise, silencePromise} from './utils/promise';
 
 /**
@@ -45,20 +46,29 @@ class BigPlayButton extends Button {
    */
   handleClick(event) {
     const playPromise = this.player_.play();
+    const cb = this.player_.getChild('controlBar');
+    const playToggle = cb && cb.getChild('playToggle');
 
     // exit early if tapped or clicked via the mouse
     if (event.type === 'tap' || this.mouseused_ && 'clientX' in event && 'clientY' in event) {
       silencePromise(playPromise);
 
-      if (this.player_.tech(true)) {
+      // On Microsoft Edge, moving focus to the <video> (tech) element as playback
+      // starts prevents a protected (DRM/EME) video surface from being presented:
+      // audio plays but the frame stays black until a later repaint or focus change.
+      // Focus the control-bar play toggle instead of the tech on Edge, mirroring the
+      // keyboard branch below. This is the pointer-path counterpart to the fix for
+      // https://github.com/videojs/video.js/issues/6270 (#6318/#6508 redirected only
+      // the keyboard path; the mouse/tap tech.focus() survived and regressed on
+      // Chromium Edge with hardware-accelerated DRM).
+      if (browser.IS_EDGE && playToggle) {
+        playToggle.focus();
+      } else if (this.player_.tech(true)) {
         this.player_.tech(true).focus();
       }
 
       return;
     }
-
-    const cb = this.player_.getChild('controlBar');
-    const playToggle = cb && cb.getChild('playToggle');
 
     if (!playToggle) {
       this.player_.tech(true).focus();

--- a/src/js/big-play-button.js
+++ b/src/js/big-play-button.js
@@ -61,8 +61,8 @@ class BigPlayButton extends Button {
       // https://github.com/videojs/video.js/issues/6270 (#6318/#6508 redirected only
       // the keyboard path; the mouse/tap tech.focus() survived and regressed on
       // Chromium Edge with hardware-accelerated DRM).
-      if (browser.IS_EDGE && playToggle) {
-        playToggle.focus();
+      if (browser.IS_EDGE) {
+        (playToggle || this.player_).focus();
       } else if (this.player_.tech(true)) {
         this.player_.tech(true).focus();
       }

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -4,6 +4,7 @@
 import ClickableComponent from './clickable-component.js';
 import Component from './component.js';
 import * as Dom from './utils/dom.js';
+import * as browser from './utils/browser.js';
 import {silencePromise} from './utils/promise';
 
 /** @import Player from './player' */
@@ -166,7 +167,17 @@ class PosterImage extends ClickableComponent {
       return;
     }
 
-    if (this.player_.tech(true)) {
+    // On Microsoft Edge, moving focus to the <video> (tech) element as playback
+    // starts prevents a protected (DRM/EME) video surface from being presented:
+    // audio plays but the frame stays black until a later repaint or focus change.
+    // Focus the control-bar play toggle instead of the tech on Edge. See
+    // https://github.com/videojs/video.js/issues/6270.
+    const cb = this.player_.getChild('controlBar');
+    const playToggle = cb && cb.getChild('playToggle');
+
+    if (browser.IS_EDGE && playToggle) {
+      playToggle.focus();
+    } else if (this.player_.tech(true)) {
       this.player_.tech(true).focus();
     }
 

--- a/src/js/poster-image.js
+++ b/src/js/poster-image.js
@@ -175,8 +175,8 @@ class PosterImage extends ClickableComponent {
     const cb = this.player_.getChild('controlBar');
     const playToggle = cb && cb.getChild('playToggle');
 
-    if (browser.IS_EDGE && playToggle) {
-      playToggle.focus();
+    if (browser.IS_EDGE) {
+      (playToggle || this.player_).focus();
     } else if (this.player_.tech(true)) {
       this.player_.tech(true).focus();
     }

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -54,6 +54,19 @@ export let IS_FIREFOX = false;
 export let IS_EDGE = false;
 
 /**
+ * Overwrite the {@link IS_EDGE} flag. Test-only seam so the play-start focus
+ * redirect in `big-play-button.js` / `poster-image.js` (the DRM black-frame fix
+ * for Microsoft Edge) can be exercised without spoofing a real Edge user agent.
+ *
+ * @private
+ * @param  {boolean} value
+ *         The value to force `IS_EDGE` to.
+ */
+export function stubIsEdge(value) {
+  IS_EDGE = value;
+}
+
+/**
  * Whether or not this is any Chromium Browser
  *
  * @static

--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -54,19 +54,6 @@ export let IS_FIREFOX = false;
 export let IS_EDGE = false;
 
 /**
- * Overwrite the {@link IS_EDGE} flag. Test-only seam so the play-start focus
- * redirect in `big-play-button.js` / `poster-image.js` (the DRM black-frame fix
- * for Microsoft Edge) can be exercised without spoofing a real Edge user agent.
- *
- * @private
- * @param  {boolean} value
- *         The value to force `IS_EDGE` to.
- */
-export function stubIsEdge(value) {
-  IS_EDGE = value;
-}
-
-/**
  * Whether or not this is any Chromium Browser
  *
  * @static

--- a/test/unit/big-play-button.test.js
+++ b/test/unit/big-play-button.test.js
@@ -1,0 +1,51 @@
+/* eslint-env qunit */
+import TestHelpers from './test-helpers.js';
+import * as browser from '../../src/js/utils/browser.js';
+
+QUnit.module('BigPlayButton', {
+  beforeEach() {
+    this.player = TestHelpers.makePlayer();
+    this.bigPlayButton = this.player.getChild('BigPlayButton');
+    this.playToggle = this.player.getChild('ControlBar').getChild('PlayToggle');
+    this.tech = this.player.tech(true);
+
+    // Focus-only tests: avoid real play() promises/side effects.
+    this.player.play = () => {};
+
+    // Count focus targets instead of relying on document.activeElement.
+    this.techFocus = 0;
+    this.toggleFocus = 0;
+    this.tech.focus = () => {
+      this.techFocus++;
+    };
+    this.playToggle.focus = () => {
+      this.toggleFocus++;
+    };
+
+    this.origEdge = browser.IS_EDGE;
+  },
+  afterEach() {
+    browser.stubIsEdge(this.origEdge);
+    this.player.dispose();
+  }
+});
+
+QUnit.test('mouse/tap click focuses the tech on non-Edge browsers', function(assert) {
+  browser.stubIsEdge(false);
+
+  this.bigPlayButton.handleClick({type: 'tap'});
+
+  assert.strictEqual(this.techFocus, 1, 'the tech (video element) is focused');
+  assert.strictEqual(this.toggleFocus, 0, 'the play toggle is not focused');
+});
+
+// Regression guard for videojs/video.js#6270: focusing the <video> element as
+// playback starts on Edge leaves protected (DRM/EME) video as a black frame.
+QUnit.test('mouse/tap click focuses the play toggle, not the tech, on Edge', function(assert) {
+  browser.stubIsEdge(true);
+
+  this.bigPlayButton.handleClick({type: 'tap'});
+
+  assert.strictEqual(this.toggleFocus, 1, 'the play toggle is focused on Edge');
+  assert.strictEqual(this.techFocus, 0, 'the tech is NOT focused on Edge');
+});

--- a/test/unit/big-play-button.test.js
+++ b/test/unit/big-play-button.test.js
@@ -25,13 +25,13 @@ QUnit.module('BigPlayButton', {
     this.origEdge = browser.IS_EDGE;
   },
   afterEach() {
-    browser.stubIsEdge(this.origEdge);
+    browser.stub_IS_EDGE(this.origEdge);
     this.player.dispose();
   }
 });
 
 QUnit.test('mouse/tap click focuses the tech on non-Edge browsers', function(assert) {
-  browser.stubIsEdge(false);
+  browser.stub_IS_EDGE(false);
 
   this.bigPlayButton.handleClick({type: 'tap'});
 
@@ -42,7 +42,7 @@ QUnit.test('mouse/tap click focuses the tech on non-Edge browsers', function(ass
 // Regression guard for videojs/video.js#6270: focusing the <video> element as
 // playback starts on Edge leaves protected (DRM/EME) video as a black frame.
 QUnit.test('mouse/tap click focuses the play toggle, not the tech, on Edge', function(assert) {
-  browser.stubIsEdge(true);
+  browser.stub_IS_EDGE(true);
 
   this.bigPlayButton.handleClick({type: 'tap'});
 

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -1,6 +1,7 @@
 /* eslint-env qunit */
 import PosterImage from '../../src/js/poster-image.js';
 import TestHelpers from './test-helpers.js';
+import * as browser from '../../src/js/utils/browser.js';
 import document from 'global/document';
 
 QUnit.module('PosterImage', {
@@ -74,6 +75,41 @@ QUnit.test('should remove itself from the document flow when there is no poster'
   assert.ok(posterImage.$('img'), 'Poster image with source restores img el');
 
   posterImage.dispose();
+});
+
+// Regression guard for videojs/video.js#6270: on Edge, focusing the <video>
+// element when the poster is clicked leaves protected (DRM/EME) video black.
+QUnit.test('handleClick focuses the play toggle, not the tech, on Edge', function(assert) {
+  const player = this.mockPlayer;
+
+  player.controls(true);
+  player.play = () => {};
+
+  const tech = player.tech(true);
+  const playToggle = player.getChild('ControlBar').getChild('PlayToggle');
+  let techFocus = 0;
+  let toggleFocus = 0;
+
+  tech.focus = () => {
+    techFocus++;
+  };
+  playToggle.focus = () => {
+    toggleFocus++;
+  };
+
+  const origEdge = browser.IS_EDGE;
+
+  browser.stubIsEdge(true);
+  player.posterImage.handleClick({type: 'tap'});
+  assert.strictEqual(toggleFocus, 1, 'play toggle focused on Edge');
+  assert.strictEqual(techFocus, 0, 'tech not focused on Edge');
+
+  browser.stubIsEdge(false);
+  player.posterImage.handleClick({type: 'tap'});
+  assert.strictEqual(techFocus, 1, 'tech focused on non-Edge');
+  assert.strictEqual(toggleFocus, 1, 'play toggle not focused again on non-Edge');
+
+  browser.stubIsEdge(origEdge);
 });
 
 QUnit.test('should hide the poster in the appropriate player states', function(assert) {

--- a/test/unit/poster.test.js
+++ b/test/unit/poster.test.js
@@ -99,17 +99,17 @@ QUnit.test('handleClick focuses the play toggle, not the tech, on Edge', functio
 
   const origEdge = browser.IS_EDGE;
 
-  browser.stubIsEdge(true);
+  browser.stub_IS_EDGE(true);
   player.posterImage.handleClick({type: 'tap'});
   assert.strictEqual(toggleFocus, 1, 'play toggle focused on Edge');
   assert.strictEqual(techFocus, 0, 'tech not focused on Edge');
 
-  browser.stubIsEdge(false);
+  browser.stub_IS_EDGE(false);
   player.posterImage.handleClick({type: 'tap'});
   assert.strictEqual(techFocus, 1, 'tech focused on non-Edge');
   assert.strictEqual(toggleFocus, 1, 'play toggle not focused again on non-Edge');
 
-  browser.stubIsEdge(origEdge);
+  browser.stub_IS_EDGE(origEdge);
 });
 
 QUnit.test('should hide the poster in the appropriate player states', function(assert) {


### PR DESCRIPTION
On Microsoft Edge, `BigPlayButton` and `PosterImage` focused the raw `<video>` (tech) element as playback started (the mouse/tap path). With hardware-accelerated protected (DRM/EME) playback this prevents the protected video surface from being presented: audio plays over a black frame until a later repaint or focus change. Focus the control-bar play toggle instead on Edge, mirroring the existing keyboard path.

Pointer-path counterpart to the fix for #6270; #6318/#6508 redirected only the keyboard path, so the mouse/tap `tech.focus()` survived and regressed on Chromium Edge with hardware-accelerated DRM.

## Description

When a user starts playback by clicking (mouse) or tapping the big play button or the poster, `handleClick()` calls `this.player_.tech(true).focus()`, moving focus to the raw `<video>` element. On Microsoft Edge, focusing the `<video>` at the moment a hardware-accelerated **protected** (EME/DRM) surface is being composited stops that surface from being presented — the user gets audio over a black frame until something forces a repaint (e.g. a resize, a later focus change, entering picture-in-picture, or clicking elsewhere).

This is the same failure mode as #6270. #6318 originally guarded this exact mouse/tap call site in big-play-button.js (skipping tech.focus() when (IE_VERSION || IS_EDGE) && sourceIsEncrypted), and #6508 added the same guard to poster-image.js. Both guards were later removed in #7701 ("remove ie-specific code") — that removal is the regression this PR fixes. Rather than reinstating the old sourceIsEncrypted-gated skip — which dropped focus (hurting keyboard accessibility) and likely wouldn't fire in a click-to-play flow anyway, since EME sessions are typically created after playback starts — this restores the protection in a better form by redirecting focus to the control-bar play toggle. The keyboard-activation path's play-toggle focus is a separate lineage and is untouched.

The fix makes the mouse/tap path behave like the keyboard path **on Edge only**: focus the control-bar play toggle (falling back to the player root) instead of the tech element. All other browsers are unaffected — the branch is guarded by `browser.IS_EDGE`, so on Chrome/Firefox/Safari the existing `tech.focus()` behavior is unchanged.

**Reproduction:** on Microsoft Edge with a hardware-accelerated protected source, start playback with a mouse click → audio plays over a black frame. Observed on both the legacy EdgeHTML engine (the environment #6270 was originally reported on) and current Chromium Edge. The black frame clears on autoplay, keyboard start, clicking elsewhere, pause/resume from the control bar, PIP, or disabling hardware acceleration — all of which either avoid the `<video>` receiving focus at play-start or force a recomposite. Redirecting play-start focus to the play toggle resolves it while keeping playback on the hardware/DRM path.

## Specific Changes proposed

- `src/js/big-play-button.js` — in `handleClick()`, the mouse/tap branch now focuses the control-bar play toggle (or the player root as a fallback) instead of `this.player_.tech(true).focus()` when `browser.IS_EDGE`. Non-Edge browsers keep the existing `tech.focus()`.
- `src/js/poster-image.js` — same guarded change in `handleClick()`.
- Keyboard-activation path is unchanged (it already targets the play toggle via #6318 / #6508).
- Uses the existing `browser.IS_EDGE` export from `src/js/utils/browser.js`; no new detection logic.
- Optional fallback (behind the same Edge guard): force a single-frame repaint on the first `play` (toggle a `transform` on the next `requestAnimationFrame`) for cases where redirecting focus alone is insufficient.
- Unit tests added covering the Edge branch (focus lands on the play toggle, not the tech element) and confirming non-Edge behavior is unchanged.

## Accessibility

The change **redirects** focus rather than dropping it: on Edge, play-start focus moves to the control-bar play toggle — an existing interactive control — instead of the `<video>`. Keyboard operability and focus visibility are preserved, and the behavior now matches the keyboard-activation path. No focus is left detached and no elements are added or removed from the DOM.

## Requirements Checklist

- [x] Bug fixed
  - [x] Change has been verified in an actual browser — Microsoft Edge (Chromium Edge 150 and legacy EdgeHTML 18); Chrome / Firefox / Safari behavior is unchanged by construction (guarded on `browser.IS_EDGE`)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated (not applicable — no public API change)
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0)) — can add on request
  - [x] Has no DOM changes which impact accessibility or trigger warnings — focus is redirected to an existing control; keyboard a11y preserved
  - [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors