### PR TITLE
fix: add missing case in Dom.isSingleLeftClick for Mac trackpad

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -787,6 +787,11 @@ export function isSingleLeftClick(event) {
     return true;
   }
 
+  // Mac trackpad tap to click with buttons === 1
+  if (event.button === 0 && event.buttons === 1) {
+    return true;
+  }
+
   if (event.button !== 0 || event.buttons !== 1) {
     // This is the reason we have those if else block above
     // if any special case we can catch and let it slide


### PR DESCRIPTION
Fix #7736

On Mac trackpad, tapping may produce mousedown event with button=0 and buttons=1,
which was not handled by isSingleLeftClick. This causes multiple taps needed to
interact with the seek bar and volume control.

Add explicit check for this case to return true.