### PR TITLE
Fix JSDoc param names that do not match the signatures

### DIFF
--- a/src/js/control-bar/text-track-controls/subs-caps-button.js
+++ b/src/js/control-bar/text-track-controls/subs-caps-button.js
@@ -24,9 +24,6 @@ class SubsCapsButton extends TextTrackButton {
    *
    * @param {Object} [options]
    *        The key/value store of player options.
-   *
-   * @param {Function} [ready]
-   *        The function to call when this component is ready.
    */
   constructor(player, options = {}) {
     super(player, options);

--- a/src/js/tracks/html-track-element-list.js
+++ b/src/js/tracks/html-track-element-list.js
@@ -10,7 +10,7 @@ class HtmlTrackElementList {
   /**
    * Create an instance of this class.
    *
-   * @param {HtmlTrackElement[]} [tracks=[]]
+   * @param {HtmlTrackElement[]} [trackElements=[]]
    *        A list of `HtmlTrackElement` to instantiate the list with.
    */
   constructor(trackElements = []) {

--- a/src/js/tracks/text-track.js
+++ b/src/js/tracks/text-track.js
@@ -388,7 +388,7 @@ class TextTrack extends Track {
   /**
    * Add a cue to the internal list of cues.
    *
-   * @param {TextTrack~Cue} cue
+   * @param {TextTrack~Cue} originalCue
    *        The cue to add to our internal list
    */
   addCue(originalCue) {


### PR DESCRIPTION
Left two that the same check flags. `Slider#handleMouseMove` documents `mouseDown` because subclasses take it and the base is an empty stub, and `removeRemoteTextTrack` names its parameter `obj` but falls back to treating the whole argument as the track, so `track` reads closer to what callers actually pass.
