### PR TITLE
fix: keep listeners when off() gets a falsy target

### DIFF
--- a/src/js/mixins/evented.js
+++ b/src/js/mixins/evented.js
@@ -400,8 +400,11 @@ const EventedMixin = {
    */
   off(targetOrType, typeOrListener, listener) {
 
-    // Targeting this evented object.
-    if (!targetOrType || isValidEventType(targetOrType)) {
+    // Targeting this evented object. As in `normalizeListenArgs()`, three
+    // arguments always mean the first one is a target, so a falsy target is
+    // not mistaken for an omitted event type - which would remove every
+    // listener on this object.
+    if ((!targetOrType && arguments.length < 3) || isValidEventType(targetOrType)) {
       Events.off(this.eventBusEl_, targetOrType, typeOrListener);
 
     // Targeting another evented object.

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1432,6 +1432,11 @@ class Player extends Component {
    * @private
    */
   removeTechControlsListeners_() {
+    // There is nothing to remove before a tech has been loaded.
+    if (!this.tech_) {
+      return;
+    }
+
     // We don't want to just use `this.off()` because there might be other needed
     // listeners added by techs that extend this.
     this.off(this.tech_, 'tap', this.boundHandleTechTap_);

--- a/test/unit/mixins/evented.test.js
+++ b/test/unit/mixins/evented.test.js
@@ -136,6 +136,27 @@ QUnit.test('off() errors', function(assert) {
   });
 });
 
+QUnit.test('off() errors for a falsy target instead of removing every listener', function(assert) {
+  const a = this.targets.a = evented({});
+  const spy = sinon.spy();
+
+  a.on('x', spy);
+
+  // Three arguments always mean the first one is a target - the same rule
+  // `on()`, `one()`, and `any()` follow - so a falsy target is invalid.
+  [undefined, null, false, 0, ''].forEach(function(falsyTarget) {
+    assert.throws(
+      () => a.off(falsyTarget, 'x', () => {}),
+      errors.target('Object', 'off'),
+      'expected error'
+    );
+  });
+
+  a.trigger('x');
+
+  assert.strictEqual(spy.callCount, 1, 'the unrelated listener was not removed');
+});
+
 QUnit.test('on() can add a listener to one event type on this object', function(assert) {
   const a = this.targets.a = evented({});
   const spy = sinon.spy();

--- a/test/unit/player.test.js
+++ b/test/unit/player.test.js
@@ -924,6 +924,27 @@ QUnit.test('should set controls and trigger events', function(assert) {
   player.dispose();
 });
 
+QUnit.test('removeTechControlsListeners_() without a tech keeps other listeners', function(assert) {
+  const player = TestHelpers.makePlayer({ controls: true });
+  const spy = sinon.spy();
+  const tech = player.tech_;
+
+  player.on('foo', spy);
+
+  // The state reported in #4627: the tech is gone while the controls are
+  // being torn down. The undefined tech was passed to `off()` as a target,
+  // which took it for an omitted event type and removed every listener.
+  player.tech_ = undefined;
+  player.removeTechControlsListeners_();
+  player.tech_ = tech;
+
+  player.trigger('foo');
+
+  assert.strictEqual(spy.callCount, 1, 'the unrelated listener was not removed');
+
+  player.dispose();
+});
+
 QUnit.test('should toggle user the user state between active and inactive', function(assert) {
   const player = TestHelpers.makePlayer({});
 


### PR DESCRIPTION
## Description

`EventedMixin.off()` read a falsy first argument as "no target given", so `off(undefined, 'x', listener)` fell through to `Events.off(eventBusEl_, undefined, 'x')`, where an undefined type means *remove everything*. One bad target silently wiped every listener on the object.

`on()`, `one()` and `any()` avoid this: `normalizeListenArgs()` reads three arguments as target/type/listener and throws `Invalid target`. On `main`, all five falsy targets throw for those three, none for `off`.

`Player.removeTechControlsListeners_()` hits that path when the controls are torn down before a tech exists, which is what #4627 reports.

Fixes #4627.

## Specific Changes proposed

- `off()` only targets itself for a falsy first argument when fewer than three arguments were given, matching `normalizeListenArgs()`. An invalid target now throws, as the existing `off() errors` test already expects for `{}`.
- `removeTechControlsListeners_()` returns early when there is no tech.

Known limit left alone: `off(undefined, listener)` (two arguments) still removes all listeners, since omitting the type is legitimate there.

## Requirements Checklist
- [x] Bug fixed
  - [x] Verified in a real browser (Chrome Headless 151)
  - [x] Unit tests added

Both new tests fail without the fix (`Expected: Error("Invalid target for Object#off; ...")` / `Actual: undefined`, and the surviving listener count is `Actual: 0`) and pass with it. Full suite 1393 passing, `npm run lint` 0 errors.
