### PR TITLE
refactor(browser): stop detecting Internet Explorer

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -107,11 +107,15 @@ export const IS_CHROMECAST_RECEIVER = Boolean(window.cast && window.cast.framewo
 /**
  * The detected Internet Explorer version - or `null`.
  *
+ * Always `null`: Internet Explorer support was removed in Video.js 8
+ * and Video.js does not run in any version of IE. This export is kept
+ * for backwards compatibility only.
+ *
  * @static
  * @deprecated
  * @type {number|null}
  */
-export let IE_VERSION = null;
+export const IE_VERSION = null;
 
 /**
  * Whether or not this is desktop Safari.
@@ -253,18 +257,6 @@ if (!IS_CHROMIUM) {
       return parseFloat(match[2]);
     }
     return null;
-  }());
-
-  IE_VERSION = (function() {
-    const result = (/MSIE\s(\d+)\.\d/).exec(USER_AGENT);
-    let version = result && parseFloat(result[1]);
-
-    if (!version && (/Trident\/7.0/i).test(USER_AGENT) && (/rv:11.0/).test(USER_AGENT)) {
-      // IE 11 has a different user agent string than other IE versions
-      version = 11.0;
-    }
-
-    return version;
   }());
 
   IS_TIZEN = (/Tizen/i).test(USER_AGENT);


### PR DESCRIPTION
## Summary
`src/js/utils/browser.js` still sniffs the user agent for MSIE/Trident on every load to compute `IE_VERSION`. This PR removes the sniff and makes `IE_VERSION` a constant `null` (the export is kept, so no API surface is removed).

## Why this is safe
- IE support was removed in Video.js 8 — the changelog notes "Update preset env, drop IE11 and older browser support" (#7708), and the 8.0 notes state Video.js will fail in all versions of Internet Explorer.
- `IE_VERSION` is already marked `@deprecated` in the JSDoc.
- There is no internal usage of `IE_VERSION` anywhere in `src/`.
- The only environments in which the sniff could produce a non-`null` value are environments where Video.js cannot run at all — so in any working player, `IE_VERSION` is already always `null`.

## Note
`test/unit/video.test.js` has one condition that ORs `videojs.browser.IE_VERSION` with `IS_ANY_SAFARI`; its behavior is unchanged (the value was already `null` in every browser CI runs). Happy to clean that reference up as well if preferred.

Found while auditing long-lived workarounds in popular open-source projects.
