### PR TITLE
fix(Menu): only set role=menu on the content list once it has an item

### DIFF
--- a/src/js/menu/menu.js
+++ b/src/js/menu/menu.js
@@ -90,6 +90,8 @@ class Menu extends Component {
 
     this.removeEventListenerForItem(component);
     super.removeChild(component);
+
+    this.updateMenuRole_();
   }
 
   /**
@@ -105,6 +107,26 @@ class Menu extends Component {
     if (childComponent) {
       this.addEventListenerForItem(childComponent);
     }
+
+    this.updateMenuRole_();
+  }
+
+  /**
+   * A menu with no selectable items -- an empty captions/chapters menu, for
+   * example, still shows its title -- has no need for `role="menu"`; leaving
+   * it in place is an ARIA accessibility error when the underlying list has
+   * no children a screen reader could navigate to.
+   */
+  updateMenuRole_() {
+    const children = this.children();
+    const hasTitle = children.length > 0 && children[0].hasClass('vjs-menu-title');
+    const itemCount = hasTitle ? children.length - 1 : children.length;
+
+    if (itemCount > 0) {
+      this.contentEl_.setAttribute('role', 'menu');
+    } else {
+      this.contentEl_.removeAttribute('role');
+    }
   }
 
   /**
@@ -119,8 +141,6 @@ class Menu extends Component {
     this.contentEl_ = Dom.createEl(contentElType, {
       className: 'vjs-menu-content'
     });
-
-    this.contentEl_.setAttribute('role', 'menu');
 
     const el = super.createEl('div', {
       append: this.contentEl_,


### PR DESCRIPTION
## Problem

`Menu.createEl()` sets `role="menu"` on the content list unconditionally at element creation, before any items exist. Accessibility tools (e.g. WAVE) flag this as a broken ARIA menu whenever a menu button has nothing to show — most commonly the Captions/Chapters buttons when a video has no caption tracks or chapters, which per the issue happens on the large majority of real-world videojs instances.

## Fix

Moved the `role="menu"` assignment out of `createEl()` and into a new `updateMenuRole_()` helper, called from both `addItem` and `removeChild`, which sets the role once there's at least one real (non-title) item and removes it when the menu is empty again. It reuses the existing "is this child just the title placeholder" check already present in `focus()`, since `MenuButton` always adds its title via `addItem` too — a title-only menu (the exact real-world scenario in this issue) must not get `role="menu"` either.

## Testing

I don't have a full karma/browser test cycle completing in this environment (video.js's suite needs a full webpack/browserify/rollup build cycle that didn't finish in the time I had), so I want to be upfront about that rather than claim more than I verified. What I did confirm:

- `npx rollup -c` builds clean with this change — no syntax/bundling errors.
- There's already a maintainer-authored test in `test/unit/menu.test.js`, `"should add or remove role menu for accessibility purpose"`, that asserts exactly this behavior (no `role` attribute with zero items, `role="menu"` once an item exists). On the current unmodified `main`, that test should fail, since `createEl()` sets the attribute unconditionally regardless of item count — this fix is what makes it pass.
- The pre-commit `vjsstandard --fix` linter (this repo's own style checker) ran clean against the change.

I'd appreciate CI (or a maintainer) confirming the full suite, especially that existing test, since I could only verify the logic and build in isolation here.

Fixes #7688