### PR TITLE
chore(package): update @xmldom/xmldom to 0.8.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,9 +1833,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA=="
     },
     "JSONStream": {
       "version": "1.3.5",


### PR DESCRIPTION
## Description
Remediates [GHSA-x4fp-j954-r2f4](https://github.com/advisories/GHSA-x4fp-j954-r2f4) / CVE-2026-83619 (HIGH): a quadratic-backtracking ReDoS in the `@xmldom/xmldom` 0.8.x end-tag whitespace-trim regex, reachable via `DOMParser.parseFromString`, which `mpd-parser` uses to parse DASH manifests. Fixed upstream in 0.8.15.

`@xmldom/xmldom` is a transitive dependency here (`video.js` -> `@videojs/http-streaming` -> `mpd-parser`, range `^0.8.3`), and the vulnerable copy is inlined into the published `dist/video.js` UMD bundle (and alt builds) at whatever version `package-lock.json` pins. This needs a release to reach consumers.

Fixes #9176.

## Specific Changes proposed
- Lockfile-only bump: `@xmldom/xmldom` 0.8.13 -> 0.8.15.
- No `package.json` change — the dependency is transitive, and `mpd-parser`'s existing `^0.8.3` range already admits the patched version.
- Lockfile kept at `lockfileVersion: 1`, since this repo's CI/release toolchain runs under Node 14 / npm 6, which requires the v1 format.

Note: #9190 proposes the same remediation but adds `@xmldom/xmldom` as a direct dependency pinned to 0.9.x and converts the lockfile to v3 (plus an unrelated karma edit). This PR is the minimal, lockfile-only alternative that avoids both of those side effects.

## Requirements Checklist
- [x] Bug fixed (dependency vulnerability remediated)
- [ ] Change has been verified in an actual browser (Chrome, Firefox, IE) — not applicable, lockfile-only change
- [ ] Unit Tests updated or fixed — not applicable, no test-observable behavior change
- [ ] Docs/guides updated — not applicable
- [ ] Example created — not applicable
- [x] Has no DOM changes which impact accessibility or trigger warnings
- [x] Has no changes to JSDoc which cause `npm run docs:api` to error
- [ ] Reviewed by Two Core Contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)